### PR TITLE
Clean up JUnit assertions

### DIFF
--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -36,6 +36,7 @@ import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -63,7 +64,7 @@ public class LauncherTest {
                 Thread.sleep(100);
             long start = System.currentTimeMillis();
             p.kill();
-            assertTrue(p.join()!=0);
+            assertNotEquals(0, p.join());
             long end = System.currentTimeMillis();
             long terminationTime = end - start;
             assertTrue("Join did not finish promptly. The completion time (" + terminationTime + "ms) is longer than expected 15s", terminationTime < 15000);

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -148,7 +148,7 @@ public class UtilTest {
     public void testEncodeSpaces() {
         final String urlWithSpaces = "http://hudson/job/Hudson Job";
         String encoded = Util.encode(urlWithSpaces);
-        assertEquals(encoded, "http://hudson/job/Hudson%20Job");
+        assertEquals("http://hudson/job/Hudson%20Job", encoded);
     }
 
     /**

--- a/core/src/test/java/hudson/model/AbstractItemTest.java
+++ b/core/src/test/java/hudson/model/AbstractItemTest.java
@@ -121,7 +121,7 @@ public class AbstractItemTest {
         } catch (IOException e) {
 
             //THEN
-            assertEquals(e.getMessage(),"Trying to rename an item that does not support this operation.");
+            assertEquals("Trying to rename an item that does not support this operation.", e.getMessage());
             assertEquals("NameNotEditableItem",item.getName());
         }
     }
@@ -140,7 +140,7 @@ public class AbstractItemTest {
         } catch (Failure f) {
 
             //THEN
-            assertEquals(f.getMessage(),"Trying to rename an item that does not support this operation.");
+            assertEquals("Trying to rename an item that does not support this operation.", f.getMessage());
             assertEquals("NameNotEditableItem",item.getName());
         }
     }

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -267,7 +268,7 @@ public class RunTest {
         treeSet.add(r1);
         treeSet.add(r2);
 
-        assertTrue(r1.compareTo(r2) != 0);
+        assertNotEquals(0, r1.compareTo(r2));
         assertEquals(2, treeSet.size());
     }
 

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -115,24 +115,24 @@ public class RunTest {
     @Test
     public void artifactListDisambiguation1() throws Exception {
         List<? extends Run<?, ?>.Artifact> a = createArtifactList("a/b/c.xml", "d/f/g.xml", "h/i/j.xml");
-        assertEquals(a.get(0).getDisplayPath(), "c.xml");
-        assertEquals(a.get(1).getDisplayPath(), "g.xml");
-        assertEquals(a.get(2).getDisplayPath(), "j.xml");
+        assertEquals("c.xml", a.get(0).getDisplayPath());
+        assertEquals("g.xml", a.get(1).getDisplayPath());
+        assertEquals("j.xml", a.get(2).getDisplayPath());
     }
 
     @Test
     public void artifactListDisambiguation2() throws Exception {
         List<? extends Run<?, ?>.Artifact> a = createArtifactList("a/b/c.xml", "d/f/g.xml", "h/i/g.xml");
-        assertEquals(a.get(0).getDisplayPath(), "c.xml");
-        assertEquals(a.get(1).getDisplayPath(), "f/g.xml");
-        assertEquals(a.get(2).getDisplayPath(), "i/g.xml");
+        assertEquals("c.xml", a.get(0).getDisplayPath());
+        assertEquals("f/g.xml", a.get(1).getDisplayPath());
+        assertEquals("i/g.xml", a.get(2).getDisplayPath());
     }
 
     @Test
     public void artifactListDisambiguation3() throws Exception {
         List<? extends Run<?, ?>.Artifact> a = createArtifactList("a.xml", "a/a.xml");
-        assertEquals(a.get(0).getDisplayPath(), "a.xml");
-        assertEquals(a.get(1).getDisplayPath(), "a/a.xml");
+        assertEquals("a.xml", a.get(0).getDisplayPath());
+        assertEquals("a/a.xml", a.get(1).getDisplayPath());
     }
 
     @Issue("JENKINS-26777")

--- a/core/src/test/java/hudson/search/SearchTest.java
+++ b/core/src/test/java/hudson/search/SearchTest.java
@@ -50,7 +50,7 @@ public class SearchTest {
 
         SuggestedItem x = Search.find(si, "abc def ghi");
         assertNotNull(x);
-        assertEquals(x.getUrl(),"/abc-def-ghi");
+        assertEquals("/abc-def-ghi", x.getUrl());
 
         List<SuggestedItem> l = Search.suggest(si, "abc def ghi");
         assertEquals(2,l.size());

--- a/core/src/test/java/hudson/util/PackedMapTest.java
+++ b/core/src/test/java/hudson/util/PackedMapTest.java
@@ -28,7 +28,7 @@ public class PackedMapTest {
         PackedMap<String,String> p = PackedMap.of(o);
         assertEquals("b",p.get("a"));
         assertEquals("d", p.get("c"));
-        assertEquals(p.size(),2);
+        assertEquals(2, p.size());
         for (Entry<String,String> e : p.entrySet()) {
             System.out.println(e.getKey()+'='+e.getValue());
         }

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -49,8 +49,8 @@ public class RobustReflectionConverterTest {
     @Test
     public void robustUnmarshalling() {
         Point p = read(new XStream2());
-        assertEquals(p.x,1);
-        assertEquals(p.y,2);
+        assertEquals(1, p.x);
+        assertEquals(2, p.y);
     }
 
     private Point read(XStream xs) {

--- a/core/src/test/java/org/acegisecurity/util/FieldUtilsTest.java
+++ b/core/src/test/java/org/acegisecurity/util/FieldUtilsTest.java
@@ -14,7 +14,7 @@ public class FieldUtilsTest {
     public void setProtectedFieldValue_Should_fail_silently_to_set_public_final_fields_in_InnerClass() throws Exception {
         InnerClassWithPublicFinalField sut = new InnerClassWithPublicFinalField();
         FieldUtils.setProtectedFieldValue("myField", sut, "test");
-        assertEquals(sut.getMyField(), "original");
+        assertEquals("original", sut.getMyField());
     }
 
     @Test
@@ -22,14 +22,14 @@ public class FieldUtilsTest {
     public void setProtectedFieldValue_Should_fail_silently_to_set_public_final_fields_in_OuterClass() throws Exception {
         OuterClassWithPublicFinalField sut = new OuterClassWithPublicFinalField();
         FieldUtils.setProtectedFieldValue("myField", sut, "test");
-        assertEquals(sut.getMyField(), "original");
+        assertEquals("original", sut.getMyField());
     }
 
     @Test
     public void setProtectedFieldValue_Should_Succeed() throws Exception {
         InnerClassWithProtectedField sut = new InnerClassWithProtectedField();
         FieldUtils.setProtectedFieldValue("myProtectedField", sut, "test");
-        assertEquals(sut.getMyNonFinalField(), "test");
+        assertEquals("test", sut.getMyNonFinalField());
     }
 
     @Test

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -658,7 +658,7 @@ public class PluginManagerTest {
         Assert.assertNull("This test requires the plugin with ID 'legacy' to not exist in update sites", uc.getPlugin("legacy"));
 
         // ensure data is loaded - probably unnecessary, but closer to reality
-        Assert.assertSame(uc.getSite("default").updateDirectlyNow().kind, FormValidation.Kind.OK);
+        Assert.assertSame(FormValidation.Kind.OK, uc.getSite("default").updateDirectlyNow().kind);
 
         // This would throw NPE
         uc.getPluginsWithUnavailableUpdates();

--- a/test/src/test/java/hudson/init/InitMilestoneTest.java
+++ b/test/src/test/java/hudson/init/InitMilestoneTest.java
@@ -20,11 +20,11 @@ public class InitMilestoneTest {
 
         List<InitMilestone> attained = r.jenkins.getExtensionList(Initializers.class).get(0).getAttained();
 
-        assertEquals(attained.get(0), InitMilestone.EXTENSIONS_AUGMENTED);
-        assertEquals(attained.get(1), InitMilestone.SYSTEM_CONFIG_LOADED);
-        assertEquals(attained.get(2), InitMilestone.SYSTEM_CONFIG_ADAPTED);
-        assertEquals(attained.get(3), InitMilestone.JOB_LOADED);
-        assertEquals(attained.get(4), InitMilestone.JOB_CONFIG_ADAPTED);
+        assertEquals(InitMilestone.EXTENSIONS_AUGMENTED, attained.get(0));
+        assertEquals(InitMilestone.SYSTEM_CONFIG_LOADED, attained.get(1));
+        assertEquals(InitMilestone.SYSTEM_CONFIG_ADAPTED, attained.get(2));
+        assertEquals(InitMilestone.JOB_LOADED, attained.get(3));
+        assertEquals(InitMilestone.JOB_CONFIG_ADAPTED, attained.get(4));
     }
 
     // Using @Initializer in static methods to check all the InitMilestones are loaded in all tests instances and make them fail,

--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -64,7 +64,7 @@ public class LogRecorderManagerTest {
         form.getSelectByName("level").getOptionByValue("finest").setSelected(true);
         j.submit(form);
 
-        assertEquals(logger.getLevel(), Level.FINEST);
+        assertEquals(Level.FINEST, logger.getLevel());
     }
 
     @Issue({"JENKINS-18274", "JENKINS-63458"})

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -100,7 +100,7 @@ public class CauseTest {
         Cause causeA = new Cause.UserIdCause(null);
         causeA.print(listener);
 
-        assertEquals(baos.toString().trim(),"Started by user unknown or anonymous");
+        assertEquals("Started by user unknown or anonymous", baos.toString().trim());
         baos.reset();
 
         //SYSTEM userid  - getDisplayName() should be SYSTEM
@@ -114,7 +114,7 @@ public class CauseTest {
         Cause causeC = new Cause.UserIdCause("abc123");
         causeC.print(listener);
 
-        assertEquals(baos.toString().trim(),"Started by user unknown or anonymous");
+        assertEquals("Started by user unknown or anonymous", baos.toString().trim());
         baos.reset();
 
         //More or less standard operation

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -193,7 +193,7 @@ public class DirectoryBrowserSupportTest {
 
         HtmlPage page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.html");
         for (String header : new String[]{"Content-Security-Policy", "X-WebKit-CSP", "X-Content-Security-Policy"}) {
-            assertEquals("Header set: " + header, page.getWebResponse().getResponseHeaderValue(header), DirectoryBrowserSupport.DEFAULT_CSP_VALUE);
+            assertEquals("Header set: " + header, DirectoryBrowserSupport.DEFAULT_CSP_VALUE, page.getWebResponse().getResponseHeaderValue(header));
         }
 
         String propName = DirectoryBrowserSupport.class.getName() + ".CSP";

--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -91,7 +91,7 @@ public class ExecutorTest {
         FreeStyleBuild b = r.get();
 
         // make sure this information is recorded
-        assertEquals(b.getResult(), Result.FAILURE);
+        assertEquals(Result.FAILURE, b.getResult());
         InterruptedBuildAction iba = b.getAction(InterruptedBuildAction.class);
         assertEquals(1,iba.getCauses().size());
         assertEquals(((UserInterruption) iba.getCauses().get(0)).getUser(), johnny);
@@ -116,7 +116,7 @@ public class ExecutorTest {
         FreeStyleBuild b = r.get();
 
         String log = b.getLog();
-        assertEquals(b.getResult(), Result.FAILURE);
+        assertEquals(Result.FAILURE, b.getResult());
         assertThat(log, containsString("Finished: FAILURE"));
         assertThat(log, containsString("Build step 'BlockingBuilder' marked build as failure"));
         assertThat(log, containsString("Agent went offline during the build"));

--- a/test/src/test/java/hudson/model/FreestyleJobPublisherTest.java
+++ b/test/src/test/java/hudson/model/FreestyleJobPublisherTest.java
@@ -41,7 +41,7 @@ public class FreestyleJobPublisherTest {
         p.getPublishersList().add(artifactArchiver); // transfer file to build dir
 
         FreeStyleBuild b = p.scheduleBuild2(0).get();
-        assertEquals("Build must fail, because we used FalsePublisher", b.getResult(), Result.FAILURE);
+        assertEquals("Build must fail, because we used FalsePublisher", Result.FAILURE, b.getResult());
         File file = new File(b.getArtifactsDir(), "result.txt");
         assertTrue("ArtifactArchiver is executed even prior publisher fails", file.exists());
         assertEquals("Publisher, after publisher with return false status, must see FAILURE status", FileUtils.readFileToString(file), Result.FAILURE.toString());
@@ -64,7 +64,7 @@ public class FreestyleJobPublisherTest {
 
         FreeStyleBuild b = p.scheduleBuild2(0).get();
 
-        assertEquals("Build must fail, because we used AbortExceptionPublisher", b.getResult(), Result.FAILURE);
+        assertEquals("Build must fail, because we used AbortExceptionPublisher", Result.FAILURE, b.getResult());
         j.assertLogNotContains("\tat", b); // log must not contain stacktrace
         j.assertLogContains("Threw AbortException from publisher!", b); // log must contain exact error message
         File file = new File(b.getArtifactsDir(), "result.txt");
@@ -89,7 +89,7 @@ public class FreestyleJobPublisherTest {
 
         FreeStyleBuild b = p.scheduleBuild2(0).get();
 
-        assertEquals("Build must fail, because we used FalsePublisher", b.getResult(), Result.FAILURE);
+        assertEquals("Build must fail, because we used FalsePublisher", Result.FAILURE, b.getResult());
         j.assertLogContains("\tat hudson.model.utils.IOExceptionPublisher", b); // log must contain stacktrace
         j.assertLogContains("Threw IOException from publisher!", b); // log must contain exact error message
         File file = new File(b.getArtifactsDir(), "result.txt");

--- a/test/src/test/java/hudson/model/ListViewTest.java
+++ b/test/src/test/java/hudson/model/ListViewTest.java
@@ -294,7 +294,7 @@ public class ListViewTest {
             view.doRemoveJobFromView("job2");
             fail("Remove job2");
         } catch(Failure e) {
-            assertEquals(e.getMessage(), "Query parameter 'name' does not correspond to a known and readable item");
+            assertEquals("Query parameter 'name' does not correspond to a known and readable item", e.getMessage());
         }
     }
 

--- a/test/src/test/java/hudson/model/ParametersAction2Test.java
+++ b/test/src/test/java/hudson/model/ParametersAction2Test.java
@@ -306,8 +306,8 @@ public class ParametersAction2Test {
 
         assertEquals(1, p1.getLastBuild().getAction(ParametersAction.class).getParameters().size());
         assertEquals(1, p2.getLastBuild().getAction(ParametersAction.class).getParameters().size());
-        assertEquals(p1.getLastBuild().getAction(ParametersAction.class).getParameter("foo").getValue(), "for p1");
-        assertEquals(p2.getLastBuild().getAction(ParametersAction.class).getParameter("foo").getValue(), "for p2");
+        assertEquals("for p1", p1.getLastBuild().getAction(ParametersAction.class).getParameter("foo").getValue());
+        assertEquals("for p2", p2.getLastBuild().getAction(ParametersAction.class).getParameter("foo").getValue());
     }
 
     @Issue("JENKINS-49573")

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -234,7 +234,7 @@ public class ProjectTest {
         j.jenkins.setQuietPeriod(0);
         assertEquals("Quiet period is not set so it should be the same as global quiet period.", 0, p.getQuietPeriod());
         p.setQuietPeriod(10);
-        assertEquals("Quiet period was set.",p.getQuietPeriod(),10);
+        assertEquals("Quiet period was set.", 10, p.getQuietPeriod());
     }
     
     @Test
@@ -622,7 +622,7 @@ public class ProjectTest {
         wc.withBasicCredentials(user.getId(), "password");
         WebRequest request = new WebRequest(new URL(wc.getContextPath() + project.getUrl() + "doWipeOutWorkspace"), HttpMethod.POST);
         HtmlPage p = wc.getPage(request);
-        assertEquals(p.getWebResponse().getStatusCode(), 200);
+        assertEquals(200, p.getWebResponse().getStatusCode());
 
         Thread.sleep(500);
         assertFalse("Workspace should not exist.", project.getSomeWorkspace().exists());

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -1016,7 +1016,7 @@ public class QueueTest {
             if (element.getNodeName().equals("task")) {
                 for (DomNode child: ((DomElement) element).getChildNodes()) {
                     if (child.getNodeName().equals("name")) {
-                        assertEquals(child.asText(), "project");
+                        assertEquals("project", child.asText());
                     } else if (child.getNodeName().equals("url")) {
                         assertNotNull(child.asText());
                     }

--- a/test/src/test/java/hudson/model/ViewDescriptorTest.java
+++ b/test/src/test/java/hudson/model/ViewDescriptorTest.java
@@ -104,8 +104,13 @@ public class ViewDescriptorTest {
 
         r.jenkins.addView(myListView);
 
-        assertEquals(r.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class).getSomeProperty(),
-                     "You cannot see me.");
+        assertEquals(
+                "You cannot see me.",
+                r.jenkins
+                        .getView("Rock")
+                        .getProperties()
+                        .get(CustomInvisibleProperty.class)
+                        .getSomeProperty());
 
         //WHEN the users goes with "Edit View" on the configure page
         JenkinsRule.WebClient webClient = r.createWebClient();
@@ -129,8 +134,13 @@ public class ViewDescriptorTest {
         //AND THEN after View save, the invisible property is still persisted with the View.
         assertNotNull("The CustomInvisibleProperty should be persisted on the View.",
                       r.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class));
-        assertEquals(r.jenkins.getView("Rock").getProperties().get(CustomInvisibleProperty.class).getSomeProperty(),
-                     "You cannot see me.");
+        assertEquals(
+                "You cannot see me.",
+                r.jenkins
+                        .getView("Rock")
+                        .getProperties()
+                        .get(CustomInvisibleProperty.class)
+                        .getSomeProperty());
 
     }
 

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -196,7 +196,7 @@ public class ViewTest {
         j.submit(form);
 
         assertTrue(proxyView instanceof ProxyView);
-        assertEquals(((ProxyView) proxyView).getProxiedViewName(), "listView");
+        assertEquals("listView", ((ProxyView) proxyView).getProxiedViewName());
         assertEquals(((ProxyView) proxyView).getProxiedView(), listView);
     }
 

--- a/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
@@ -143,11 +143,11 @@ public class LabelExpressionTest {
     public void setLabelString() throws Exception {
         DumbSlave s = j.createSlave("foo", "", null);
 
-        assertSame(s.getLabelString(), "");
+        assertSame("", s.getLabelString());
 
         s.setLabelString("bar");
 
-        assertSame(s.getLabelString(), "bar");
+        assertSame("bar", s.getLabelString());
     }
 
     /**
@@ -188,8 +188,8 @@ public class LabelExpressionTest {
     public void laxParsing() {
         // this should parse as an atom
         LabelAtom l = (LabelAtom) j.jenkins.getLabel("lucene.zones.apache.org (Solaris 10)");
-        assertEquals(l.getName(),"lucene.zones.apache.org (Solaris 10)");
-        assertEquals(l.getExpression(),"\"lucene.zones.apache.org (Solaris 10)\"");
+        assertEquals("lucene.zones.apache.org (Solaris 10)", l.getName());
+        assertEquals("\"lucene.zones.apache.org (Solaris 10)\"", l.getExpression());
     }
 
     @Test

--- a/test/src/test/java/hudson/security/PermissionGroupTest.java
+++ b/test/src/test/java/hudson/security/PermissionGroupTest.java
@@ -41,7 +41,7 @@ public class PermissionGroupTest {
      */
     @Email("http://jenkins-ci.361315.n4.nabble.com/Master-slave-refactor-tp391495.html")
     @Test public void order() {
-        assertSame(PermissionGroup.getAll().get(0), Jenkins.PERMISSIONS);
+        assertSame(Jenkins.PERMISSIONS, PermissionGroup.getAll().get(0));
     }
 
     @SuppressWarnings("ResultOfObjectAllocationIgnored")

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -65,7 +65,7 @@ public class SecurityRealmTest {
         WebResponse response = j.createWebClient()
                 .goTo("securityRealm/captcha", "")
                 .getWebResponse();
-        assertEquals(response.getContentAsString(), "");
+        assertEquals("", response.getContentAsString());
 
         securityRealm.setCaptchaSupport(new DummyCaptcha());
 

--- a/test/src/test/java/hudson/tasks/FingerprinterTest.java
+++ b/test/src/test/java/hudson/tasks/FingerprinterTest.java
@@ -259,7 +259,7 @@ public class FingerprinterTest {
         Collection<Fingerprint> fingerprints = action.getFingerprints().values();
         for (Fingerprint f: fingerprints) {
             assertTrue(f.getOriginal().is(upstream));
-            assertEquals(f.getOriginal().getName(), renamedProject1);
+            assertEquals(renamedProject1, f.getOriginal().getName());
             assertNotEquals(f.getOriginal().getName(), oldUpstreamName);
         }
         
@@ -268,7 +268,7 @@ public class FingerprinterTest {
         fingerprints = action.getFingerprints().values();
         for (Fingerprint f: fingerprints) {
             assertTrue(f.getOriginal().is(upstream));
-            assertEquals(f.getOriginal().getName(), renamedProject1);
+            assertEquals(renamedProject1, f.getOriginal().getName());
             assertNotEquals(f.getOriginal().getName(), oldUpstreamName);
         }
          

--- a/test/src/test/java/hudson/tasks/UserAvatarResolverTest.java
+++ b/test/src/test/java/hudson/tasks/UserAvatarResolverTest.java
@@ -53,7 +53,7 @@ public class UserAvatarResolverTest {
     public void resolverIsUsed() {
         expUser = User.get("unique-user-not-used-in-anyother-test", true);
         String avatar = UserAvatarResolver.resolve(expUser, "20x20");
-        assertEquals(avatar, "http://myown.image");
+        assertEquals("http://myown.image", avatar);
     }
 
     @Test

--- a/test/src/test/java/hudson/tools/ToolLocationTest.java
+++ b/test/src/test/java/hudson/tools/ToolLocationTest.java
@@ -27,14 +27,14 @@ public class ToolLocationTest {
     @LocalData
     public void toolCompatibility() {
         Maven.MavenInstallation[] maven = j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).getInstallations();
-        assertEquals(maven.length, 1);
-        assertEquals(maven[0].getHome(), "bar");
-        assertEquals(maven[0].getName(), "Maven 1");
+        assertEquals(1, maven.length);
+        assertEquals("bar", maven[0].getHome());
+        assertEquals("Maven 1", maven[0].getName());
 
         Ant.AntInstallation[] ant = j.jenkins.getDescriptorByType(Ant.DescriptorImpl.class).getInstallations();
-        assertEquals(ant.length, 1);
-        assertEquals(ant[0].getHome(), "foo");
-        assertEquals(ant[0].getName(), "Ant 1");
+        assertEquals(1, ant.length);
+        assertEquals("foo", ant[0].getHome());
+        assertEquals("Ant 1", ant[0].getName());
 
         JDK[] jdk = j.jenkins.getDescriptorByType(JDK.DescriptorImpl.class).getInstallations();
         assertEquals(Arrays.asList(jdk), j.jenkins.getJDKs());

--- a/test/src/test/java/hudson/triggers/SCMTriggerTest.java
+++ b/test/src/test/java/hudson/triggers/SCMTriggerTest.java
@@ -23,6 +23,7 @@
  */
 package hudson.triggers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -170,7 +171,7 @@ public class SCMTriggerTest {
 
         List<BuildAction> ba = build.getActions(BuildAction.class);
 
-        assertFalse("There should only be one BuildAction.", ba.size()!=1);
+        assertEquals("There should only be one BuildAction.", 1, ba.size());
     }
 
     @TestExtension

--- a/test/src/test/java/hudson/util/FormFieldValidatorTest.java
+++ b/test/src/test/java/hudson/util/FormFieldValidatorTest.java
@@ -35,7 +35,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.recipes.WithPlugin;
 
 /**
  * @author Kohsuke Kawaguchi

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -694,7 +694,7 @@ public class JenkinsTest {
         j.jenkins.save();
         VersionNumber storedVersion = Jenkins.getStoredVersion();
         assertNotNull(storedVersion);
-        assertEquals(storedVersion.toString(), "1.0");
+        assertEquals("1.0", storedVersion.toString());
 
         Jenkins.VERSION = null;
         j.jenkins.save();

--- a/test/src/test/java/jenkins/security/FrameOptionsPageDecoratorTest.java
+++ b/test/src/test/java/jenkins/security/FrameOptionsPageDecoratorTest.java
@@ -21,7 +21,7 @@ public class FrameOptionsPageDecoratorTest {
     public void defaultHeaderPresent() throws IOException, SAXException {
         JenkinsRule.WebClient wc = j.createWebClient();
         HtmlPage page = wc.goTo("");
-        assertEquals("Expected different X-Frame-Options value", getFrameOptionsFromResponse(page.getWebResponse()), "sameorigin");
+        assertEquals("Expected different X-Frame-Options value", "sameorigin", getFrameOptionsFromResponse(page.getWebResponse()));
     }
 
     @Test

--- a/test/src/test/java/jenkins/security/Security177Test.java
+++ b/test/src/test/java/jenkins/security/Security177Test.java
@@ -31,6 +31,6 @@ public class Security177Test {
 
     private void verifyNoSniff(Page p) {
         String v = p.getWebResponse().getResponseHeaderValue("X-Content-Type-Options");
-        assertEquals(v,"nosniff");
+        assertEquals("nosniff", v);
     }
 }

--- a/test/src/test/java/jenkins/security/SpySecurityListener.java
+++ b/test/src/test/java/jenkins/security/SpySecurityListener.java
@@ -103,7 +103,7 @@ public abstract class SpySecurityListener extends SecurityListener {
         }
 
         public void assertNoNewEvents(){
-            assertEquals("list of event should be empty", eventList.size(), 0);
+            assertEquals("list of event should be empty", 0, eventList.size());
         }
 
         public void clear(){

--- a/test/src/test/java/jenkins/security/stapler/Security914Test.java
+++ b/test/src/test/java/jenkins/security/stapler/Security914Test.java
@@ -84,6 +84,6 @@ public class Security914Test {
         
         Page p = wc.getPage(request);
         assertEquals(HttpURLConnection.HTTP_NOT_FOUND, p.getWebResponse().getStatusCode());
-        assertEquals(p.getWebResponse().getContentType(), "text/html");
+        assertEquals("text/html", p.getWebResponse().getContentType());
     }
 }

--- a/test/src/test/java/lib/form/OptionTest.java
+++ b/test/src/test/java/lib/form/OptionTest.java
@@ -265,12 +265,12 @@ public class OptionTest {
 
             // first value shown as value
             int indexOfValue = responseContent.indexOf(valueContainsExpected);
-            assertTrue(indexOfValue != -1);
+            assertNotEquals(-1, indexOfValue);
 
             // second as body
             int indexOfBody = responseContent.indexOf(bodyContainsExpected, indexOfValue + 1);
 
-            assertTrue(indexOfBody != -1);
+            assertNotEquals(-1, indexOfBody);
 
             // also check there is no "<script>" present in the answer
             int indexOfScript = responseContent.indexOf("<script>");


### PR DESCRIPTION
Fixes a common mistake when using JUnit; namely, that `org.junit.Assert#assertEquals` takes the expected value as the first argument and the actual value as the second argument, but these are often mistakenly reversed.