### PR TITLE
[JENKINS-64972] Help-buttons are not working when they are at the top of draggable div

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -84,8 +84,8 @@ THE SOFTWARE.
         <j:set var="help" value="${descriptor.helpFile}" />
         <j:if test="${hasHeader}">
           <div class="tr help-sibling">
-            <div colspan="3" style="display: flex;">
-              <div class="${attrs.disableDragAndDrop or readOnlyMode ? '' : 'dd-handle'}" style="flex: 1;">
+            <div colspan="3">
+              <div class="${attrs.disableDragAndDrop or readOnlyMode ? '' : 'dd-handle'}">
                 <b>${descriptor.displayName}</b>
               </div>
               <f:helpLink url="${help}"/>

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -84,11 +84,11 @@ THE SOFTWARE.
         <j:set var="help" value="${descriptor.helpFile}" />
         <j:if test="${hasHeader}">
           <div class="tr help-sibling">
-            <div colspan="3">
-              <div class="${attrs.disableDragAndDrop or readOnlyMode ? '' : 'dd-handle'}">
+            <div colspan="3" style="display: flex;">
+              <div class="${attrs.disableDragAndDrop or readOnlyMode ? '' : 'dd-handle'}" style="flex: 1;">
                 <b>${descriptor.displayName}</b>
-                <f:helpLink url="${help}"/>
               </div>
+              <f:helpLink url="${help}"/>
             </div>
           </div>
           <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1280,6 +1280,14 @@ textarea.rich-editor {
 
 /* ========================= D&D support in heterogenous/repeatable lists = */
 
+.hetero-list-container .has-help {
+    display: flex;
+}
+
+.hetero-list-container .has-help .dd-handle {
+    flex: 1;
+}
+
 .hetero-list-container .dd-handle,
 .repeated-container .dd-handle {
     cursor: move;


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-64972](https://issues.jenkins-ci.org/browse/JENKINS-64972).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

The 'dd-handle' div will make all events in that div (e.g. click event of a button) not triggered, so I move the help-button out of the 'dd-handle' div.
In order to make the button still at the right of the same line, I use "flex" to realize.

See demo:
![After](https://user-images.githubusercontent.com/20413055/109334925-4dc63a00-789c-11eb-8ae3-9e6def25b7cb.gif)

### Proposed changelog entries

* Fix help-buttons in the draggable section (regression in 2.264)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [X] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
