### PR TITLE
Add missing @Override annotations

### DIFF
--- a/cli/src/main/java/hudson/cli/FlightRecorderInputStream.java
+++ b/cli/src/main/java/hudson/cli/FlightRecorderInputStream.java
@@ -54,6 +54,7 @@ class FlightRecorderInputStream extends InputStream {
         final IOException[] error = new IOException[1];
 
         Thread diagnosisThread = new Thread(diagnosisName+" stream corruption diagnosis thread") {
+            @Override
             public void run() {
                 int b;
                 try {

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -529,6 +529,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
                  * Forces the fixed timestamp for directories to make sure
                  * classes.jar always get a consistent checksum.
                  */
+                @Override
                 protected void zipDir(Resource dir, ZipOutputStream zOut, String vPath,
                                       int mode, ZipExtraField[] extra)
                     throws IOException {

--- a/core/src/main/java/hudson/PluginFirstClassLoader.java
+++ b/core/src/main/java/hudson/PluginFirstClassLoader.java
@@ -52,6 +52,7 @@ public class PluginFirstClassLoader
 
     private List<URL> urls = new ArrayList<>();
 
+    @Override
     public void addPathFiles( Collection<File> paths )
         throws IOException
     {

--- a/core/src/main/java/hudson/console/ExpandableDetailsNote.java
+++ b/core/src/main/java/hudson/console/ExpandableDetailsNote.java
@@ -67,6 +67,7 @@ public class ExpandableDetailsNote extends ConsoleNote {
 
     @Extension
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @Override
         public String getDisplayName() {
             return "Expandable details";
         }

--- a/core/src/main/java/hudson/console/HyperlinkNote.java
+++ b/core/src/main/java/hudson/console/HyperlinkNote.java
@@ -102,6 +102,7 @@ public class HyperlinkNote extends ConsoleNote {
 
     @Extension @Symbol("hyperlink")
     public static class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @Override
         public String getDisplayName() {
             return "Hyperlinks";
         }

--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -67,6 +67,7 @@ public class ModelHyperlinkNote extends HyperlinkNote {
 
     @Extension @Symbol("hyperlinkToModels")
     public static class DescriptorImpl extends HyperlinkNote.DescriptorImpl {
+        @Override
         public String getDisplayName() {
             return "Hyperlinks to models";
         }

--- a/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
@@ -90,6 +90,7 @@ public class WindowsInstallerLink extends ManagementLink {
         return Messages.WindowsInstallerLink_DisplayName();
     }
 
+    @Override
     public String getDescription() {
         return Messages.WindowsInstallerLink_Description();
     }
@@ -192,12 +193,14 @@ public class WindowsInstallerLink extends ManagementLink {
         // initiate an orderly shutdown after we finished serving this request
         new Thread("terminator") {
             @SuppressFBWarnings(value = "DM_EXIT", justification = "Exit is really intended.")
+            @Override
             public void run() {
                 try {
                     Thread.sleep(1000);
 
                     // let the service start after we close our sockets, to avoid conflicts
                     Runtime.getRuntime().addShutdownHook(new Thread("service starter") {
+                        @Override
                         public void run() {
                             try {
                                 if(!oldRoot.equals(installationDir)) {

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -364,6 +364,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * @since 1.319
      */
     @Exported
+    @Override
     public boolean isConcurrentBuild() {
         return concurrentBuild;
     }
@@ -377,6 +378,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * If this project is configured to be always built on this node,
      * return that {@link Node}. Otherwise null.
      */
+    @Override
     public @CheckForNull Label getAssignedLabel() {
         if(canRoam)
             return null;
@@ -452,6 +454,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      *
      * @since 1.401
      */
+    @Override
     public String getBuildNowText() {
         // For compatibility, still use the deprecated replacer if specified.
         return AlternativeUiTextProvider.get(BUILD_NOW_TEXT, this, ParameterizedJobMixIn.ParameterizedJob.super.getBuildNowText());
@@ -595,6 +598,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return b != null ? b.getModuleRoots() : null;
     }
 
+    @Override
     public int getQuietPeriod() {
         return quietPeriod!=null ? quietPeriod : Jenkins.get().getQuietPeriod();
     }
@@ -998,6 +1002,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      *      null if no information is available (for example,
      *      if no build was done yet.)
      */
+    @Override
     public Node getLastBuiltOn() {
         // where was it built on?
         AbstractBuild b = getLastBuild();
@@ -1007,6 +1012,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
             return b.getBuiltOn();
     }
 
+    @Override
     public Object getSameNodeConstraint() {
         return this; // in this way, any member that wants to run with the main guy can nominate the project itself
     }
@@ -1122,6 +1128,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
         return null;
     }
 
+    @Override
     public List<SubTask> getSubTasks() {
         List<SubTask> r = new ArrayList<>();
         r.add(this);
@@ -1167,6 +1174,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     /**
      * List of necessary resources to perform the build of this project.
      */
+    @Override
     public ResourceList getResourceList() {
         final Set<ResourceActivity> resourceActivities = getResourceActivities();
         final List<ResourceList> resourceLists = new ArrayList<>(1 + resourceActivities.size());

--- a/core/src/main/java/hudson/model/AllView.java
+++ b/core/src/main/java/hudson/model/AllView.java
@@ -185,6 +185,7 @@ public class AllView extends View {
             return true;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.Hudson_ViewName();
         }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -262,6 +262,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * Returns the transient {@link Action}s associated with the computer.
      */
     @SuppressWarnings("deprecation")
+    @Override
     public List<Action> getActions() {
         List<Action> result = new ArrayList<>(super.getActions());
         synchronized (this) {

--- a/core/src/main/java/hudson/model/FreeStyleProject.java
+++ b/core/src/main/java/hudson/model/FreeStyleProject.java
@@ -77,6 +77,7 @@ public class FreeStyleProject extends Project<FreeStyleProject,FreeStyleBuild> i
             DESCRIPTOR = this;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.FreeStyleProject_DisplayName();
         }

--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -172,6 +172,7 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
     @Extension @Symbol("jdk")
     public static class DescriptorImpl extends ToolDescriptor<JDK> {
 
+        @Override
         public String getDisplayName() {
             return "JDK"; // TODO I18N
         }

--- a/core/src/main/java/hudson/model/JobProperty.java
+++ b/core/src/main/java/hudson/model/JobProperty.java
@@ -162,6 +162,7 @@ public abstract class JobProperty<J extends Job<?,?>> implements ReconfigurableD
      * Returns {@link BuildStepMonitor#NONE} by default, as {@link JobProperty}s normally don't depend
      * on its previous result.
      */
+    @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }

--- a/core/src/main/java/hudson/model/LargeText.java
+++ b/core/src/main/java/hudson/model/LargeText.java
@@ -120,10 +120,12 @@ public class LargeText {
                 else        return -1; // EOF
             }
 
+            @Override
             public int read(byte[] buf, int off, int len) throws IOException {
                 return session.read(buf,off,len);
             }
 
+            @Override
             public void close() throws IOException {
                 session.close();
             }

--- a/core/src/main/java/hudson/model/MyView.java
+++ b/core/src/main/java/hudson/model/MyView.java
@@ -100,6 +100,7 @@ public class MyView extends View {
             return Jenkins.get().isUseSecurity();
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.MyView_DisplayName();
         }

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -163,6 +163,7 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
         viewGroupMixIn.addView(view);
     }
 
+    @Override
     public View getPrimaryView() {
         return viewGroupMixIn.getPrimaryView();
     }
@@ -240,6 +241,7 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
         return Jenkins.get().getViewsTabBar();
     }
 
+    @Override
     public List<Action> getViewActions() {
         // Jenkins.get().getViewActions() are tempting but they are in a wrong scope
         return Collections.emptyList();

--- a/core/src/main/java/hudson/model/PasswordParameterValue.java
+++ b/core/src/main/java/hudson/model/PasswordParameterValue.java
@@ -78,6 +78,7 @@ public class PasswordParameterValue extends ParameterValue {
     }
 
     @NonNull
+    @Override
     public Secret getValue() {
         return value;
     }

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1377,6 +1377,7 @@ public class Queue extends ResourceController implements Saveable {
      * @param runnable the operation to perform.
      * @since 1.592
      */
+    @Override
     protected void _withLock(Runnable runnable) {
         lock.lock();
         try {
@@ -1417,6 +1418,7 @@ public class Queue extends ResourceController implements Saveable {
      * @throws T the exception of the callable
      * @since 1.592
      */
+    @Override
     protected <V, T extends Throwable> V _withLock(hudson.remoting.Callable<V, T> callable) throws T {
         lock.lock();
         try {
@@ -1436,6 +1438,7 @@ public class Queue extends ResourceController implements Saveable {
      * @throws Exception if the callable throws an exception.
      * @since 1.592
      */
+    @Override
     protected <V> V _withLock(java.util.concurrent.Callable<V> callable) throws Exception {
         lock.lock();
         try {

--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -113,6 +113,7 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
                 return last;
             }
 
+            @Override
             public void remove() {
                 if (last==null)
                     throw new UnsupportedOperationException();

--- a/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
+++ b/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
@@ -255,6 +255,7 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> im
      *      This is not a valid operation for {@link Item}s.
      */
     @Deprecated
+    @Override
     public TopLevelItem newInstance(StaplerRequest req) throws FormException {
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/hudson/model/TreeView.java
+++ b/core/src/main/java/hudson/model/TreeView.java
@@ -179,6 +179,7 @@ public class TreeView extends View implements ViewGroup {
     }
 
     public static final class DescriptorImpl extends ViewDescriptor {
+        @Override
         public String getDisplayName() {
             return "Tree View";
         }
@@ -188,10 +189,12 @@ public class TreeView extends View implements ViewGroup {
         return Jenkins.get().getViewsTabBar();
     }
 
+    @Override
     public ItemGroup<? extends TopLevelItem> getItemGroup() {
         return getOwner().getItemGroup();
     }
 
+    @Override
     public List<Action> getViewActions() {
         return owner.getViewActions();
     }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1937,6 +1937,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 this.message = message;
             }
 
+            @Override
             public String getMessage() {
                 return message.toString();
             }

--- a/core/src/main/java/hudson/model/labels/LabelAtom.java
+++ b/core/src/main/java/hudson/model/labels/LabelAtom.java
@@ -132,6 +132,7 @@ public class LabelAtom extends Label implements Saveable {
     /**
      * @since 1.580
      */
+    @Override
     public String getDescription() {
         return description;
     }
@@ -304,10 +305,12 @@ public class LabelAtom extends Label implements Saveable {
             super(XSTREAM);
         }
 
+        @Override
         public boolean canConvert(Class type) {
             return LabelAtom.class.isAssignableFrom(type);
         }
 
+        @Override
         public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context) {
             if (context.get(IN_NESTED)==null) {
                 context.put(IN_NESTED,true);
@@ -320,6 +323,7 @@ public class LabelAtom extends Label implements Saveable {
                 leafLabelConverter.marshal(source,writer,context);
         }
 
+        @Override
         public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
             if (context.get(IN_NESTED)==null) {
                 context.put(IN_NESTED,true);

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -48,24 +48,29 @@ public abstract class QueueTaskFilter implements Queue.Task {
         this.base = base;
     }
 
+    @Override
     public Label getAssignedLabel() {
         return base.getAssignedLabel();
     }
 
+    @Override
     public Node getLastBuiltOn() {
         return base.getLastBuiltOn();
     }
 
     @Deprecated
+    @Override
     public boolean isBuildBlocked() {
         return base.isBuildBlocked();
     }
 
     @Deprecated
+    @Override
     public String getWhyBlocked() {
         return base.getWhyBlocked();
     }
 
+    @Override
     public CauseOfBlockage getCauseOfBlockage() {
         return base.getCauseOfBlockage();
     }
@@ -78,6 +83,7 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getFullDisplayName();
     }
 
+    @Override
     public long getEstimatedDuration() {
         return base.getEstimatedDuration();
     }
@@ -98,6 +104,7 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getUrl();
     }
 
+    @Override
     public boolean isConcurrentBuild() {
         return base.isConcurrentBuild();
     }
@@ -106,14 +113,17 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getDisplayName();
     }
 
+    @Override
     public ResourceList getResourceList() {
         return base.getResourceList();
     }
 
+    @Override
     public Collection<? extends SubTask> getSubTasks() {
         return base.getSubTasks();
     }
 
+    @Override
     public Object getSameNodeConstraint() {
         return base.getSameNodeConstraint();
     }

--- a/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
@@ -46,10 +46,12 @@ public class ArchitectureMonitor extends NodeMonitor {
             return new GetArchTask();
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.ArchitectureMonitor_DisplayName();
         }
 
+        @Override
         public NodeMonitor newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             return new ArchitectureMonitor();
         }

--- a/core/src/main/java/hudson/node_monitors/ClockMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ClockMonitor.java
@@ -70,6 +70,7 @@ public class ClockMonitor extends NodeMonitor {
             return n.getClockDifferenceCallable();
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.ClockMonitor_DisplayName();
         }

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -61,6 +61,7 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
     }
 
     public static final DiskSpaceMonitorDescriptor DESCRIPTOR = new DiskSpaceMonitorDescriptor() {
+        @Override
         public String getDisplayName() {
             return Messages.DiskSpaceMonitor_DisplayName();
         }

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -81,6 +81,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
             return monitoringData;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.ResponseTimeMonitor_DisplayName();
         }

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -99,6 +99,7 @@ public class SwapSpaceMonitor extends NodeMonitor {
             return new MonitorTask();
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.SwapSpaceMonitor_DisplayName();
         }

--- a/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
@@ -75,6 +75,7 @@ public class TemporarySpaceMonitor extends AbstractDiskSpaceMonitor {
             DESCRIPTOR = this;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.TemporarySpaceMonitor_DisplayName();
         }

--- a/core/src/main/java/hudson/org/apache/tools/tar/TarInputStream.java
+++ b/core/src/main/java/hudson/org/apache/tools/tar/TarInputStream.java
@@ -112,6 +112,7 @@ public class TarInputStream extends FilterInputStream {
      * Closes this stream. Calls the TarBuffer's close() method.
      * @throws IOException on error
      */
+    @Override
     public void close() throws IOException {
         this.buffer.close();
     }
@@ -137,6 +138,7 @@ public class TarInputStream extends FilterInputStream {
      * @return The number of available bytes for the current entry.
      * @throws IOException for signature
      */
+    @Override
     public int available() throws IOException {
         if (this.entrySize - this.entryOffset > Integer.MAX_VALUE) {
             return Integer.MAX_VALUE;
@@ -154,6 +156,7 @@ public class TarInputStream extends FilterInputStream {
      * @return the number actually skipped
      * @throws IOException on error
      */
+    @Override
     public long skip(long numToSkip) throws IOException {
         // REVIEW
         // This is horribly inefficient, but it ensures that we
@@ -177,6 +180,7 @@ public class TarInputStream extends FilterInputStream {
      *
      * @return False.
      */
+    @Override
     public boolean markSupported() {
         return false;
     }
@@ -186,12 +190,14 @@ public class TarInputStream extends FilterInputStream {
      *
      * @param markLimit The limit to mark.
      */
+    @Override
     public void mark(int markLimit) {
     }
 
     /**
      * Since we do not support marking just yet, we do nothing.
      */
+    @Override
     public void reset() {
     }
 
@@ -296,6 +302,7 @@ public class TarInputStream extends FilterInputStream {
      * @return The byte read, or -1 at EOF.
      * @throws IOException on error
      */
+    @Override
     public int read() throws IOException {
         int num = this.read(this.oneBuf, 0, 1);
         return num == -1 ? -1 : ((int) this.oneBuf[0]) & 0xFF;
@@ -314,6 +321,7 @@ public class TarInputStream extends FilterInputStream {
      * @return The number of bytes read, or -1 at EOF.
      * @throws IOException on error
      */
+    @Override
     public int read(byte[] buf, int offset, int numToRead) throws IOException {
         int totalRead = 0;
 

--- a/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
+++ b/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
@@ -154,6 +154,7 @@ public class TarOutputStream extends FilterOutputStream {
      * TarBuffer's close().
      * @throws IOException on error
      */
+    @Override
     public void close() throws IOException {
         if (!closed) {
             this.finish();
@@ -257,6 +258,7 @@ public class TarOutputStream extends FilterOutputStream {
      * @param b The byte written.
      * @throws IOException on error
      */
+    @Override
     public void write(int b) throws IOException {
         this.oneBuf[0] = (byte) b;
 
@@ -271,6 +273,7 @@ public class TarOutputStream extends FilterOutputStream {
      * @param wBuf The buffer to write to the archive.
      * @throws IOException on error
      */
+    @Override
     public void write(byte[] wBuf) throws IOException {
         this.write(wBuf, 0, wBuf.length);
     }
@@ -289,6 +292,7 @@ public class TarOutputStream extends FilterOutputStream {
      * @param numToWrite The number of bytes to write.
      * @throws IOException on error
      */
+    @Override
     public void write(byte[] wBuf, int wOffset, int numToWrite) throws IOException {
         if ((this.currBytes + numToWrite) > this.currSize) {
             throw new IOException("request to write '" + numToWrite

--- a/core/src/main/java/hudson/search/UserSearchProperty.java
+++ b/core/src/main/java/hudson/search/UserSearchProperty.java
@@ -38,6 +38,7 @@ public class UserSearchProperty extends hudson.model.UserProperty {
 
     @Extension @Symbol("search")
     public static final class DescriptorImpl extends UserPropertyDescriptor {
+        @Override
         public String getDisplayName() {
             return Messages.UserSearchProperty_DisplayName();
         }

--- a/core/src/main/java/hudson/security/FullControlOnceLoggedInAuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/FullControlOnceLoggedInAuthorizationStrategy.java
@@ -100,6 +100,7 @@ public class FullControlOnceLoggedInAuthorizationStrategy extends AuthorizationS
             DESCRIPTOR = this;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.FullControlOnceLoggedInAuthorizationStrategy_DisplayName();
         }

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -539,10 +539,12 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         return Jenkins.get().getACL();
     }
 
+    @Override
     public void checkPermission(Permission permission) {
         Jenkins.get().checkPermission(permission);
     }
 
+    @Override
     public boolean hasPermission(Permission permission) {
         return Jenkins.get().hasPermission(permission);
     }
@@ -951,6 +953,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
     @Extension @Symbol("local")
     public static final class DescriptorImpl extends Descriptor<SecurityRealm> {
+        @Override
         public String getDisplayName() {
             return Messages.HudsonPrivateSecurityRealm_DisplayName();
         }

--- a/core/src/main/java/hudson/security/LegacyAuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/LegacyAuthorizationStrategy.java
@@ -57,6 +57,7 @@ public final class LegacyAuthorizationStrategy extends AuthorizationStrategy {
 
     @Extension @Symbol("legacy")
     public static final class DescriptorImpl extends Descriptor<AuthorizationStrategy> {
+        @Override
         public String getDisplayName() {
             return Messages.LegacyAuthorizationStrategy_DisplayName();
         }

--- a/core/src/main/java/hudson/security/LegacySecurityRealm.java
+++ b/core/src/main/java/hudson/security/LegacySecurityRealm.java
@@ -101,6 +101,7 @@ public final class LegacySecurityRealm extends SecurityRealm implements Authenti
             DESCRIPTOR = this;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.LegacySecurityRealm_Displayname();
         }

--- a/core/src/main/java/hudson/security/captcha/CaptchaSupport.java
+++ b/core/src/main/java/hudson/security/captcha/CaptchaSupport.java
@@ -59,6 +59,7 @@ public abstract class CaptchaSupport extends AbstractDescribableImpl<CaptchaSupp
     
     abstract public void generateImage(String id, OutputStream ios) throws IOException;
 
+    @Override
     public CaptchaSupportDescriptor getDescriptor() {
         return (CaptchaSupportDescriptor)super.getDescriptor();
     }

--- a/core/src/main/java/hudson/slaves/DumbSlave.java
+++ b/core/src/main/java/hudson/slaves/DumbSlave.java
@@ -69,6 +69,7 @@ public final class DumbSlave extends Slave {
     @Extension @Symbol({"permanent" /*because this is in effect the canonical agent type*/,
             "dumb", "slave"})
     public static final class DescriptorImpl extends SlaveDescriptor {
+        @Override
         public String getDisplayName() {
             return Messages.DumbSlave_displayName();
         }

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -204,6 +204,7 @@ public class JNLPLauncher extends ComputerLauncher {
             DESCRIPTOR = this;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.JNLPLauncher_displayName();
         }

--- a/core/src/main/java/hudson/slaves/RetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/RetentionStrategy.java
@@ -165,6 +165,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
 
         @Extension(ordinal=100) @Symbol("always")
         public static class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
+            @Override
             public String getDisplayName() {
                 return Messages.RetentionStrategy_Always_displayName();
             }

--- a/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
@@ -245,6 +245,7 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
 
     @Extension @Symbol("schedule")
     public static class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
+        @Override
         public String getDisplayName() {
             return Messages.SimpleScheduledRetentionStrategy_displayName();
         }

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -323,6 +323,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
         }
     }
 
+    @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
@@ -341,6 +342,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
             DESCRIPTOR = this; // backward compatibility
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.ArtifactArchiver_DisplayName();
         }

--- a/core/src/main/java/hudson/tasks/BatchFile.java
+++ b/core/src/main/java/hudson/tasks/BatchFile.java
@@ -111,6 +111,7 @@ public class BatchFile extends CommandInterpreter {
             return "/help/project-config/batch.html";
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.BatchFile_DisplayName();
         }

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -165,6 +165,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
         return Items.fromNameList(owner.getParent(), childProjects, (Class<Job<?, ?>>) (Class) Job.class);
     }
 
+    @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
@@ -355,6 +356,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
 
     @Extension @Symbol("downstream")
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        @Override
         public String getDisplayName() {
             return Messages.BuildTrigger_DisplayName();
         }

--- a/core/src/main/java/hudson/tasks/BuildWrapper.java
+++ b/core/src/main/java/hudson/tasks/BuildWrapper.java
@@ -101,6 +101,7 @@ public abstract class BuildWrapper extends AbstractDescribableImpl<BuildWrapper>
          *      and reports a nice error message.
          * @since 1.150
          */
+        @Override
         public boolean tearDown( AbstractBuild build, BuildListener listener ) throws IOException, InterruptedException {
             if (build instanceof Build)
                 return tearDown((Build)build, listener);

--- a/core/src/main/java/hudson/tasks/Builder.java
+++ b/core/src/main/java/hudson/tasks/Builder.java
@@ -51,6 +51,7 @@ public abstract class Builder extends BuildStepCompatibilityLayer implements Des
     /**
      * Default implementation that does nothing.
      */
+    @Override
     public boolean prebuild(Build build, BuildListener listener) {
         return true;
     }
@@ -59,6 +60,7 @@ public abstract class Builder extends BuildStepCompatibilityLayer implements Des
      * Returns {@link BuildStepMonitor#NONE} by default, as {@link Builder}s normally don't depend
      * on its previous result.
      */
+    @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }

--- a/core/src/main/java/hudson/tasks/CommandInterpreter.java
+++ b/core/src/main/java/hudson/tasks/CommandInterpreter.java
@@ -76,6 +76,7 @@ public abstract class CommandInterpreter extends Builder implements EnvVarsFilte
         return command;
     }
 
+    @Override
     public @NonNull List<EnvVarsFilterLocalRule> buildEnvVarsFilterRules() {
         return configuredLocalRules == null ? Collections.emptyList() : new ArrayList<>(configuredLocalRules);
     }

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -200,6 +200,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
         // failing to record fingerprints is an error but not fatal
     }
 
+    @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
@@ -326,6 +327,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
 
     @Extension @Symbol("fingerprint")
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        @Override
         public String getDisplayName() {
             return Messages.Fingerprinter_DisplayName();
         }

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -295,6 +295,7 @@ public class LogRotator extends BuildDiscarder {
 
     @Extension @Symbol("logRotator")
     public static final class LRDescriptor extends BuildDiscarderDescriptor {
+        @Override
         public String getDisplayName() {
             return "Log Rotation";
         }

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -443,6 +443,7 @@ public class Maven extends Builder {
             return super.getHelpFile(fieldName);
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.Maven_DisplayName();
         }
@@ -751,6 +752,7 @@ public class Maven extends Builder {
 
         @Extension @Symbol("maven")
         public static final class DescriptorImpl extends DownloadFromUrlInstaller.DescriptorImpl<MavenInstaller> {
+            @Override
             public String getDisplayName() {
                 return Messages.InstallFromApache();
             }

--- a/core/src/main/java/hudson/tasks/Notifier.java
+++ b/core/src/main/java/hudson/tasks/Notifier.java
@@ -47,6 +47,7 @@ import hudson.ExtensionPoint;
 public abstract class Notifier extends Publisher implements ExtensionPoint {
     @SuppressWarnings("deprecation") // super only @Deprecated to discourage other subclasses
     protected Notifier() {}
+    @Override
     public BuildStepDescriptor getDescriptor() {
         return (BuildStepDescriptor)super.getDescriptor();
     }

--- a/core/src/main/java/hudson/tasks/Recorder.java
+++ b/core/src/main/java/hudson/tasks/Recorder.java
@@ -47,6 +47,7 @@ import hudson.ExtensionPoint;
 public abstract class Recorder extends Publisher implements ExtensionPoint {
     @SuppressWarnings("deprecation") // super only @Deprecated to discourage other subclasses
     protected Recorder() {}
+    @Override
     public BuildStepDescriptor getDescriptor() {
         return (BuildStepDescriptor)super.getDescriptor();
     }

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -200,6 +200,7 @@ public class Shell extends CommandInterpreter {
             save();
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.Shell_DisplayName();
         }

--- a/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
@@ -60,6 +60,7 @@ public class Maven3MojoNote extends ConsoleNote {
 
     @Extension @Symbol("maven3Mojos")
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @Override
         public String getDisplayName() {
             return "Maven 3 Mojos";
         }

--- a/core/src/main/java/hudson/tasks/_maven/MavenErrorNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenErrorNote.java
@@ -47,6 +47,7 @@ public class MavenErrorNote extends ConsoleNote {
 
     @Extension @Symbol("mavenErrors")
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @Override
         public String getDisplayName() {
             return "Maven Errors";
         }

--- a/core/src/main/java/hudson/tasks/_maven/MavenMojoNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenMojoNote.java
@@ -52,6 +52,7 @@ public class MavenMojoNote extends ConsoleNote {
 
     @Extension @Symbol("mavenMojos")
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @Override
         public String getDisplayName() {
             return "Maven Mojos";
         }

--- a/core/src/main/java/hudson/tasks/_maven/MavenWarningNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenWarningNote.java
@@ -49,6 +49,7 @@ public class MavenWarningNote extends ConsoleNote {
 
     @Extension @Symbol("mavenWarnings")
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @Override
         public String getDisplayName() {
             return "Maven Warnings";
         }

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -135,6 +135,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
         public Downloadable createDownloadable() {
             final DescriptorImpl delegate = this;
             return new Downloadable(getId()) {
+                @Override
                 public JSONObject reduce(List<JSONObject> jsonList) {
                     if (isDefaultSchema(jsonList)) {
                         return delegate.reduce(jsonList);
@@ -200,6 +201,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
          * <p>
          * By default we use the fully-qualified class name of the {@link DownloadFromUrlInstaller} subtype.
          */
+        @Override
         public String getId() {
             return clazz.getName().replace('$','.');
         }

--- a/core/src/main/java/hudson/tools/InstallSourceProperty.java
+++ b/core/src/main/java/hudson/tools/InstallSourceProperty.java
@@ -64,6 +64,7 @@ public class InstallSourceProperty extends ToolProperty<ToolInstallation> {
 
     @Extension @Symbol("installSource")
     public static class DescriptorImpl extends ToolPropertyDescriptor {
+        @Override
         public String getDisplayName() {
             return Messages.InstallSourceProperty_DescriptorImpl_displayName();
         }

--- a/core/src/main/java/hudson/tools/ToolLocationNodeProperty.java
+++ b/core/src/main/java/hudson/tools/ToolLocationNodeProperty.java
@@ -119,6 +119,7 @@ public class ToolLocationNodeProperty extends NodeProperty<Node> {
     @Extension @Symbol("toolLocation")
     public static class DescriptorImpl extends NodePropertyDescriptor {
 
+        @Override
         public String getDisplayName() {
             return Messages.ToolLocationNodeProperty_displayName();
         }

--- a/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
+++ b/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
@@ -93,6 +93,7 @@ public class ZipExtractionInstaller extends ToolInstaller {
     @Extension @Symbol("zip")
     public static class DescriptorImpl extends ToolInstallerDescriptor<ZipExtractionInstaller> {
 
+        @Override
         public String getDisplayName() {
             return Messages.ZipExtractionInstaller_DescriptorImpl_displayName();
         }

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -294,6 +294,7 @@ public class SCMTrigger extends Trigger<Item> {
             return r;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.SCMTrigger_DisplayName();
         }

--- a/core/src/main/java/hudson/triggers/TimerTrigger.java
+++ b/core/src/main/java/hudson/triggers/TimerTrigger.java
@@ -73,6 +73,7 @@ public class TimerTrigger extends Trigger<BuildableItem> {
             return item instanceof BuildableItem;
         }
 
+        @Override
         public String getDisplayName() {
             return Messages.TimerTrigger_DisplayName();
         }

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -215,6 +215,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
             return MIN;
         }
 
+        @Override
         public long getInitialDelay() {
             return MIN - TimeUnit.SECONDS.toMillis(Calendar.getInstance().get(Calendar.SECOND));
         }

--- a/core/src/main/java/hudson/util/AdaptedIterator.java
+++ b/core/src/main/java/hudson/util/AdaptedIterator.java
@@ -56,6 +56,7 @@ public abstract class AdaptedIterator<T,U> implements Iterator<U> {
 
     protected abstract U adapt(T item);
 
+    @Override
     public void remove() {
         core.remove();
     }

--- a/core/src/main/java/hudson/util/ByteBuffer.java
+++ b/core/src/main/java/hudson/util/ByteBuffer.java
@@ -46,6 +46,7 @@ public class ByteBuffer extends OutputStream {
     private int size = 0;
 
 
+    @Override
     public synchronized void write(byte[] b, int off, int len) throws IOException {
         ensureCapacity(len);
         System.arraycopy(b,off,buf,size,len);
@@ -94,6 +95,7 @@ public class ByteBuffer extends OutputStream {
                 }
             }
 
+            @Override
             public int read(byte[] b, int off, int len) throws IOException {
                 synchronized(ByteBuffer.this) {
                     if(size==pos)
@@ -107,12 +109,14 @@ public class ByteBuffer extends OutputStream {
             }
 
 
+            @Override
             public int available() throws IOException {
                 synchronized(ByteBuffer.this) {
                     return size-pos;
                 }
             }
 
+            @Override
             public long skip(long n) throws IOException {
                 synchronized(ByteBuffer.this) {
                     int diff = (int) Math.min(n,size-pos);

--- a/core/src/main/java/hudson/util/CharSpool.java
+++ b/core/src/main/java/hudson/util/CharSpool.java
@@ -63,6 +63,7 @@ public final class CharSpool extends Writer {
         pos = 0;
     }
 
+    @Override
     public void write(int c) {
         renew();
         last[pos++] = (char)c;

--- a/core/src/main/java/hudson/util/ConsistentHash.java
+++ b/core/src/main/java/hudson/util/ConsistentHash.java
@@ -158,6 +158,7 @@ public class ConsistentHash<T> {
                     return (T) owner[(start + (pos++)) % owner.length];
                 }
 
+                @Override
                 public void remove() {
                     throw new UnsupportedOperationException();
                 }

--- a/core/src/main/java/hudson/util/CopyOnWriteList.java
+++ b/core/src/main/java/hudson/util/CopyOnWriteList.java
@@ -107,6 +107,7 @@ public class CopyOnWriteList<E> implements Iterable<E> {
                 return last=itr.next();
             }
 
+            @Override
             public void remove() {
                 CopyOnWriteList.this.remove(last);
             }

--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -85,6 +85,7 @@ public class Iterators {
             return cur.next();
         }
 
+        @Override
         public void remove() {
             throw new UnsupportedOperationException();
         }
@@ -139,6 +140,7 @@ public class Iterators {
             return next;
         }
 
+        @Override
         public void remove() {
             core.remove();
         }
@@ -180,6 +182,7 @@ public class Iterators {
                     return itr.previous();
                 }
 
+                @Override
                 public void remove() {
                     itr.remove();
                 }
@@ -205,6 +208,7 @@ public class Iterators {
                     return itr.next();
                 }
 
+                @Override
                 public void remove() {
                     itr.remove();
                 }
@@ -295,6 +299,7 @@ public class Iterators {
                 return itr.next();
             }
 
+            @Override
             public void remove() {
                 throw new UnsupportedOperationException();
             }
@@ -385,6 +390,7 @@ public class Iterators {
                 }
             }
 
+            @Override
             public void remove() {
                 throw new UnsupportedOperationException();
             }

--- a/core/src/main/java/hudson/util/LineEndNormalizingWriter.java
+++ b/core/src/main/java/hudson/util/LineEndNormalizingWriter.java
@@ -48,14 +48,17 @@ public class LineEndNormalizingWriter extends FilterWriter {
         super(out);
     }
 
+    @Override
     public void write(char[] cbuf) throws IOException {
         write(cbuf, 0, cbuf.length);
     }
 
+    @Override
     public void write(String str) throws IOException {
         write(str,0,str.length());
     }
 
+    @Override
     public void write(int c) throws IOException {
         if(!seenCR && c==LF)
             super.write("\r\n");
@@ -64,6 +67,7 @@ public class LineEndNormalizingWriter extends FilterWriter {
         seenCR = (c==CR);
     }
 
+    @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
         int end = off+len;
         int writeBegin = off;
@@ -82,6 +86,7 @@ public class LineEndNormalizingWriter extends FilterWriter {
         super.write(cbuf,writeBegin,end-writeBegin);
     }
 
+    @Override
     public void write(String str, int off, int len) throws IOException {
         int end = off+len;
         int writeBegin = off;

--- a/core/src/main/java/hudson/util/PackedMap.java
+++ b/core/src/main/java/hudson/util/PackedMap.java
@@ -104,6 +104,7 @@ public final class PackedMap<K,V> extends AbstractMap<K,V> {
                     };
                 }
 
+                @Override
                 public void remove() {
                     throw new UnsupportedOperationException();
                 }

--- a/core/src/main/java/hudson/util/PersistedList.java
+++ b/core/src/main/java/hudson/util/PersistedList.java
@@ -166,10 +166,12 @@ public class PersistedList<T> extends AbstractList<T> {
     }
 
 
+    @Override
     public void clear() {
         data.clear();
     }
 
+    @Override
     public Iterator<T> iterator() {
         return data.iterator();
     }

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -1926,6 +1926,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 return this; // cancel out super.writeReplace()
             }
 
+            @Override
             public <T> T act(ProcessCallable<T> callable) throws IOException, InterruptedException {
                 return proxy.act(callable);
             }

--- a/core/src/main/java/hudson/util/WriterOutputStream.java
+++ b/core/src/main/java/hudson/util/WriterOutputStream.java
@@ -63,6 +63,7 @@ public class WriterOutputStream extends OutputStream {
         buf.put((byte)b);
     }
 
+    @Override
     public void write(byte[] b, int off, int len) throws IOException {
         while(len>0) {
             if(buf.remaining()==0)
@@ -74,6 +75,7 @@ public class WriterOutputStream extends OutputStream {
         }
     }
 
+    @Override
     public void flush() throws IOException {
         decode(false);
         flushOutput();
@@ -85,6 +87,7 @@ public class WriterOutputStream extends OutputStream {
         out.clear();
     }
 
+    @Override
     public void close() throws IOException {
         decode(true);
         flushOutput();

--- a/core/src/main/java/hudson/util/xstream/MapperDelegate.java
+++ b/core/src/main/java/hudson/util/xstream/MapperDelegate.java
@@ -35,54 +35,67 @@ public class MapperDelegate extends MapperWrapper {
         this.delegate = delegate;
     }
 
+    @Override
     public String serializedClass(Class type) {
         return delegate.serializedClass(type);
     }
 
+    @Override
     public Class realClass(String elementName) {
         return delegate.realClass(elementName);
     }
 
+    @Override
     public String serializedMember(Class type, String memberName) {
         return delegate.serializedMember(type, memberName);
     }
 
+    @Override
     public String realMember(Class type, String serialized) {
         return delegate.realMember(type, serialized);
     }
 
+    @Override
     public boolean isImmutableValueType(Class type) {
         return delegate.isImmutableValueType(type);
     }
 
+    @Override
     public Class defaultImplementationOf(Class type) {
         return delegate.defaultImplementationOf(type);
     }
 
+    @Override
     public String aliasForAttribute(String attribute) {
         return delegate.aliasForAttribute(attribute);
     }
 
+    @Override
     public String attributeForAlias(String alias) {
         return delegate.attributeForAlias(alias);
     }
 
+    @Override
     public String aliasForSystemAttribute(String attribute) {
         return delegate.aliasForSystemAttribute(attribute);
     }
 
+    @Override
     public String getFieldNameForItemTypeAndName(Class definedIn, Class itemType, String itemFieldName) {
         return delegate.getFieldNameForItemTypeAndName(definedIn, itemType, itemFieldName);
     }
 
+    @Override
     public Class getItemTypeForItemFieldName(Class definedIn, String itemFieldName) {
         return delegate.getItemTypeForItemFieldName(definedIn, itemFieldName);
     }
 
+    @Override
     public ImplicitCollectionMapping getImplicitCollectionDefForFieldName(Class itemType, String fieldName) {
         return delegate.getImplicitCollectionDefForFieldName(itemType, fieldName);
     }
 
+    @Override
     public boolean shouldSerializeMember(Class definedIn, String fieldName) {
         return delegate.shouldSerializeMember(definedIn, fieldName);
     }
@@ -91,6 +104,7 @@ public class MapperDelegate extends MapperWrapper {
      * @deprecated since 1.3, use {@link #getConverterFromItemType(String, Class, Class)}
      */
     @Deprecated
+    @Override
     public SingleValueConverter getConverterFromItemType(String fieldName, Class type) {
         return delegate.getConverterFromItemType(fieldName, type);
     }
@@ -99,6 +113,7 @@ public class MapperDelegate extends MapperWrapper {
      * @deprecated since 1.3, use {@link #getConverterFromItemType(String, Class, Class)}
      */
     @Deprecated
+    @Override
     public SingleValueConverter getConverterFromItemType(Class type) {
         return delegate.getConverterFromItemType(type);
     }
@@ -107,18 +122,22 @@ public class MapperDelegate extends MapperWrapper {
      * @deprecated since 1.3, use {@link #getConverterFromAttribute(Class, String, Class)}
      */
     @Deprecated
+    @Override
     public SingleValueConverter getConverterFromAttribute(String name) {
         return delegate.getConverterFromAttribute(name);
     }
 
+    @Override
     public Converter getLocalConverter(Class definedIn, String fieldName) {
         return delegate.getLocalConverter(definedIn, fieldName);
     }
 
+    @Override
     public Mapper lookupMapperOfType(Class type) {
         return type.isAssignableFrom(getClass()) ? this : delegate.lookupMapperOfType(type);
     }
 
+    @Override
     public SingleValueConverter getConverterFromItemType(String fieldName, Class type, Class definedIn) {
     	return delegate.getConverterFromItemType(fieldName, type, definedIn);
     }
@@ -127,6 +146,7 @@ public class MapperDelegate extends MapperWrapper {
      * @deprecated since 1.3, use combination of {@link #serializedMember(Class, String)} and {@link #getConverterFromItemType(String, Class, Class)}
      */
     @Deprecated
+    @Override
     public String aliasForAttribute(Class definedIn, String fieldName) {
     	return delegate.aliasForAttribute(definedIn, fieldName);
     }
@@ -135,6 +155,7 @@ public class MapperDelegate extends MapperWrapper {
      * @deprecated since 1.3, use combination of {@link #realMember(Class, String)} and {@link #getConverterFromItemType(String, Class, Class)}
      */
     @Deprecated
+    @Override
     public String attributeForAlias(Class definedIn, String alias) {
     	return delegate.attributeForAlias(definedIn, alias);
     }
@@ -143,10 +164,12 @@ public class MapperDelegate extends MapperWrapper {
      * @deprecated since 1.3.1, use {@link #getConverterFromAttribute(Class, String, Class)}
      */
     @Deprecated
+    @Override
     public SingleValueConverter getConverterFromAttribute(Class type, String attribute) {
     	return delegate.getConverterFromAttribute(type, attribute);
     }
 
+    @Override
     public SingleValueConverter getConverterFromAttribute(Class definedIn, String attribute, Class type) {
         return delegate.getConverterFromAttribute(definedIn, attribute, type);
     }

--- a/core/src/main/java/hudson/views/MyViewsTabBar.java
+++ b/core/src/main/java/hudson/views/MyViewsTabBar.java
@@ -66,6 +66,7 @@ public abstract class MyViewsTabBar extends AbstractDescribableImpl<MyViewsTabBa
         return Jenkins.get().getDescriptorList(MyViewsTabBar.class);
     }
 
+    @Override
     public MyViewsTabBarDescriptor getDescriptor() {
         return (MyViewsTabBarDescriptor)super.getDescriptor();
     }

--- a/core/src/main/java/jenkins/InitReactorRunner.java
+++ b/core/src/main/java/jenkins/InitReactorRunner.java
@@ -64,18 +64,22 @@ public class InitReactorRunner {
         List<ReactorListener> r = Lists.newArrayList(ServiceLoader.load(InitReactorListener.class, Thread.currentThread().getContextClassLoader()));
         r.add(new ReactorListener() {
             final Level level = Level.parse( SystemProperties.getString(Jenkins.class.getName() + "." + "initLogLevel", "FINE") );
+            @Override
             public void onTaskStarted(Task t) {
                 LOGGER.log(level, "Started {0}", getDisplayName(t));
             }
 
+            @Override
             public void onTaskCompleted(Task t) {
                 LOGGER.log(level, "Completed {0}", getDisplayName(t));
             }
 
+            @Override
             public void onTaskFailed(Task t, Throwable err, boolean fatal) {
                 LOGGER.log(SEVERE, "Failed " + getDisplayName(t), err);
             }
 
+            @Override
             public void onAttained(Milestone milestone) {
                 Level lv = level;
                 String s = "Attained "+milestone.toString();

--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -102,6 +102,7 @@ public class InstallState implements ExtensionPoint {
         InitialSetupCompleted() {
             super("INITIAL_SETUP_COMPLETED", true);
         }
+        @Override
         public void initializeState() {
             Jenkins j = Jenkins.get();
             try {
@@ -122,6 +123,7 @@ public class InstallState implements ExtensionPoint {
         CreateAdminUser() {
             super("CREATE_ADMIN_USER", false);
         }
+        @Override
         public void initializeState() {
             Jenkins j = Jenkins.get();
             // Skip this state if not using the security defaults
@@ -138,6 +140,7 @@ public class InstallState implements ExtensionPoint {
         ConfigureInstance() {
             super("CONFIGURE_INSTANCE", false);
         }
+        @Override
         public void initializeState() {
             // Skip this state if a boot script already configured the root URL
             // in case we add more fields in this page, this should be adapted
@@ -163,6 +166,7 @@ public class InstallState implements ExtensionPoint {
         InitialSecuritySetup() {
             super("INITIAL_SECURITY_SETUP", false);
         }
+        @Override
         public void initializeState() {
             try {
                 Jenkins.get().getSetupWizard().init(true);
@@ -189,6 +193,7 @@ public class InstallState implements ExtensionPoint {
         Restart() {
             super("RESTART", true);
         }
+        @Override
         public void initializeState() {
             InstallUtil.saveLastExecVersion();
         }
@@ -245,6 +250,7 @@ public class InstallState implements ExtensionPoint {
         Downgrade() {
             super("DOWNGRADE", true);
         }
+        @Override
         public void initializeState() {
             // Schedule an update of the update center after a Jenkins downgrade
             reloadUpdateSiteData();

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -733,6 +733,7 @@ public class SetupWizard extends PageDecorator {
                 } else if (req.getRequestURI().equals(req.getContextPath() + "/")) {
                     Jenkins.get().checkPermission(Jenkins.ADMINISTER);
                     chain.doFilter(new HttpServletRequestWrapper(req) {
+                        @Override
                         public String getRequestURI() {
                             return getContextPath() + "/setupWizard/";
                         }

--- a/core/src/main/java/jenkins/model/DefaultUserCanonicalIdResolver.java
+++ b/core/src/main/java/jenkins/model/DefaultUserCanonicalIdResolver.java
@@ -59,6 +59,7 @@ public class DefaultUserCanonicalIdResolver extends User.CanonicalIdResolver {
     }
 
     public static final Descriptor<User.CanonicalIdResolver> DESCRIPTOR = new Descriptor<User.CanonicalIdResolver>() {
+        @Override
         public String getDisplayName() {
             return "compute default user ID";
         }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1566,6 +1566,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Alias for {@link #getDescriptor(String)}.
      */
+    @Override
     public Descriptor getDescriptorByName(String id) {
         return getDescriptor(id);
     }
@@ -1790,6 +1791,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @see #getAllItems(Class)
      * @since 2.221
      */
+    @Override
     public List<TopLevelItem> getItems(Predicate<TopLevelItem> pred) {
         List<TopLevelItem> viewableItems = new ArrayList<>();
         for (TopLevelItem item : items.values()) {
@@ -1846,6 +1848,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return names;
     }
 
+    @Override
     public List<Action> getViewActions() {
         return getActions();
     }
@@ -1920,6 +1923,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Returns the primary {@link View} that renders the top-page of Jenkins.
      */
     @Exported
+    @Override
     public View getPrimaryView() {
         return viewGroupMixIn.getPrimaryView();
      }
@@ -1936,6 +1940,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         this.viewsTabBar = viewsTabBar;
     }
 
+    @Override
     public Jenkins getItemGroup() {
         return this;
    }
@@ -2531,6 +2536,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return new FilePath((VirtualChannel)null,absolutePath);
     }
 
+    @Override
     public ClockDifference getClockDifference() {
         return ClockDifference.ZERO;
     }
@@ -3044,6 +3050,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Called by {@link Job#renameTo(String)} to update relevant data structure.
      * assumed to be synchronized on Jenkins by the caller.
      */
+    @Override
     public void onRenamed(TopLevelItem job, String oldName, String newName) throws IOException {
         items.remove(oldName);
         items.put(newName,job);
@@ -3499,18 +3506,22 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             new Reactor(tf).execute(Runnable::run, new ReactorListener() {
                 final Level level = Level.parse(SystemProperties.getString(Jenkins.class.getName() + "." +"termLogLevel", "FINE"));
 
+                @Override
                 public void onTaskStarted(Task t) {
                     LOGGER.log(level, "Started {0}", InitReactorRunner.getDisplayName(t));
                 }
 
+                @Override
                 public void onTaskCompleted(Task t) {
                     LOGGER.log(level, "Completed {0}", InitReactorRunner.getDisplayName(t));
                 }
 
+                @Override
                 public void onTaskFailed(Task t, Throwable err, boolean fatal) {
                     LOGGER.log(SEVERE, err, () -> "Failed " + InitReactorRunner.getDisplayName(t));
                 }
 
+                @Override
                 public void onAttained(Milestone milestone) {
                     Level lv = level;
                     String s = "Attained " + milestone.toString();

--- a/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
+++ b/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
@@ -171,6 +171,7 @@ public abstract class ProjectNamingStrategy implements Describable<ProjectNaming
             return description;
         }
 
+        @Override
         public boolean isForceExistingJobs() {
             return forceExistingJobs;
         }

--- a/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java
+++ b/core/src/main/java/jenkins/model/UnlabeledLoadStatistics.java
@@ -110,6 +110,7 @@ public class UnlabeledLoadStatistics extends LoadStatistics {
             return n != null && n.getMode() == Mode.NORMAL;
         }
 
+        @Override
         public void remove() {
             // why does Iterators.FilterIterator do the stupid thing and allow remove?
             // (remove should remove the object last returned by next(), but it won't if hasNext() is called

--- a/core/src/main/java/jenkins/model/lazy/LazyLoadRunMapEntrySet.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyLoadRunMapEntrySet.java
@@ -81,6 +81,7 @@ class LazyLoadRunMapEntrySet<R> extends AbstractSet<Entry<Integer,R>> {
                 return new SimpleImmutableEntry<>(owner.getNumberOf(r), r);
             }
 
+            @Override
             public void remove() {
                 if (last==null)
                     throw new UnsupportedOperationException();

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -700,6 +700,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      * @return a stream to the required resource or {@code null} if the
      *         resource cannot be found on the loader's classpath.
      */
+    @Override
     public InputStream getResourceAsStream(String name) {
         InputStream resourceStream = null;
         if (isParentFirst(name)) {
@@ -885,6 +886,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      *         resource could not be found or the caller doesn't have
      *         adequate privileges to get the resource.
      */
+    @Override
     public URL getResource(String name) {
         // we need to search the components of the path to see if
         // we can find the class we want.
@@ -960,6 +962,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      * @return an enumeration of URLs for the resources
      * @exception IOException if I/O errors occurs (can't happen)
      */
+    @Override
     public Enumeration/*<URL>*/ findResources(String name) throws IOException {
         return findResources(name, true);
     }
@@ -1067,6 +1070,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      * on the system classpath (when not in isolated mode) or this loader's
      * classpath.
      */
+    @Override
     protected synchronized Class loadClass(String classname, boolean resolve)
             throws ClassNotFoundException {
         // 'sync' is needed - otherwise 2 threads can load the same class
@@ -1337,6 +1341,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener {
      * @exception ClassNotFoundException if the requested class does not exist
      *                                   on this loader's classpath.
      */
+    @Override
     public Class findClass(String name) throws ClassNotFoundException {
         log("Finding class " + name, Project.MSG_DEBUG);
         return findClassInComponents(name);

--- a/core/src/main/java/jenkins/util/MarkFindingOutputStream.java
+++ b/core/src/main/java/jenkins/util/MarkFindingOutputStream.java
@@ -46,6 +46,7 @@ public abstract class MarkFindingOutputStream extends OutputStream {
         }
     }
 
+    @Override
     public void write(byte[] b, int off, int len) throws IOException {
         final int start = off; 
         final int end = off + len;
@@ -85,11 +86,13 @@ public abstract class MarkFindingOutputStream extends OutputStream {
             base.write(b, off, len-match);
     }
 
+    @Override
     public void flush() throws IOException {
         flushPartialMatch();
         base.flush();
     }
 
+    @Override
     public void close() throws IOException {
         flushPartialMatch();
         base.close();

--- a/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
+++ b/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
@@ -373,6 +373,7 @@ public class XStreamDOM {
         public void close() {
         }
 
+        @Override
         public String peekNextChild() {
             return current().peekNextChild();
         }
@@ -457,6 +458,7 @@ public class XStreamDOM {
         public void close() {
         }
 
+        @Override
         public HierarchicalStreamWriter underlyingWriter() {
             return this;
         }


### PR DESCRIPTION
Using the`@Override` annotation consistently is desirable for two reasons:

- It produces a compiler warning if the annotated method doesn't actually override anything (e.g., if there is a misspelling).
- It improves readability by making it explicitly clear that methods are overridden.