### PR TITLE
Fix styling of project naming strategy pattern field

### DIFF
--- a/core/src/main/resources/jenkins/model/ProjectNamingStrategy/PatternProjectNamingStrategy/config.groovy
+++ b/core/src/main/resources/jenkins/model/ProjectNamingStrategy/PatternProjectNamingStrategy/config.groovy
@@ -4,7 +4,7 @@ package jenkins.model.ProjectNamingStrategy.PatternProjectNamingStrategy
 def f=namespace(lib.FormTagLib)
 
 f.entry(title:_("namePattern"), field:"namePattern") {
-    f.textbox(value:h.defaulted(instance?.namePattern, descriptor.DEFAULT_PATTERN),class:"fixed-width")
+    f.textbox(value: h.defaulted(instance?.namePattern, descriptor.DEFAULT_PATTERN), clazz: "fixed-width")
 }
 
 f.entry(title:_("description"), field:"description") {


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/blob/e681b4ff928435a500dcfb372cc9fc15b1c94413/core/src/main/resources/lib/form/textbox.jelly#L54-L57 and https://github.com/jenkinsci/jenkins/blob/e681b4ff928435a500dcfb372cc9fc15b1c94413/core/src/main/resources/lib/form/textbox.jelly#L90

Noticed this while debugging Stapler for #5324. (`f:textarea` OTOH has `class` 🤦 )

This seems to be the only `f:textbox` in core using this class, so an argument could be made to just remove it.

#### Before

> <img width="1070" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/109819222-1d7ff200-7c34-11eb-8bd0-553bc348c3d5.png">

#### After

> <img width="1084" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/109819227-1fe24c00-7c34-11eb-9d54-0c4eb38216c0.png">

### Proposed changelog entries

(too minor)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
