### PR TITLE
Be quiet if Queue.save gets ClosedByInterruptException

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -84,6 +84,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.nio.charset.Charset;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -476,7 +477,7 @@ public class Queue extends ResourceController implements Saveable {
             try {
                 queueFile.write(state);
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Failed to write out the queue file " + getXMLQueueFile(), e);
+                LOGGER.log(e instanceof ClosedByInterruptException ? Level.FINE : Level.WARNING, "Failed to write out the queue file " + getXMLQueueFile(), e);
             }
         } finally {
             lock.unlock();


### PR DESCRIPTION
In https://github.com/jenkinsci/jenkins-test-harness/pull/280 Jenkins shutdown always prints a rather noisy stack trace:

```
WARNING	hudson.model.Queue#save: Failed to write out the queue file /tmp/j h8077499820524049102/queue.xml
java.nio.channels.ClosedByInterruptException
	at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
	at sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:216)
	at hudson.util.FileChannelWriter.write(FileChannelWriter.java:73)
	at java.io.Writer.write(Writer.java:192)
	at hudson.util.AtomicFileWriter.write(AtomicFileWriter.java:163)
	at java.io.Writer.write(Writer.java:157)
	at hudson.XmlFile.write(XmlFile.java:191)
	at hudson.model.Queue.save(Queue.java:477)
	at jenkins.model.Jenkins._cleanUpPersistQueue(Jenkins.java:3681)
	at jenkins.model.Jenkins.cleanUp(Jenkins.java:3440)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jvnet.hudson.test.RealJenkinsRule$Body.run(RealJenkinsRule.java:231)
	at …
```

I have no idea what causes this (there is no record of what is “interrupting” the write) but it seems harmless enough, and the stack trace is irritating.

### Proposed changelog entries

* Lowered verbosity of an error message.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
