### PR TITLE
Delete SSH-specific scenarios from CLITest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,9 +113,6 @@ THE SOFTWARE.
     <access-modifier-checker.version>1.21</access-modifier-checker.version>
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
     <powermock.version>2.0.9</powermock.version>
-
-    <!-- SSHD plugin version -->
-    <sshd.plugin.version>3.0.1</sshd.plugin.version>
   </properties>
 
   <!-- Note that the 'repositories' and 'pluginRepositories' blocks below are actually copy-pasted

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -138,12 +138,6 @@ THE SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.modules</groupId>
-      <artifactId>sshd</artifactId>
-      <version>${sshd.plugin.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>2.2</version>

--- a/test/src/test/java/hudson/cli/CLITest.java
+++ b/test/src/test/java/hudson/cli/CLITest.java
@@ -30,7 +30,6 @@ import hudson.Launcher;
 import hudson.Proc;
 import hudson.model.FreeStyleProject;
 import hudson.model.UnprotectedRootAction;
-import hudson.model.User;
 import hudson.security.csrf.CrumbExclusion;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
@@ -38,25 +37,18 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.TeeOutputStream;
-import org.apache.sshd.common.util.io.ModifiableFileWatcher;
 import static org.hamcrest.Matchers.*;
-import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl;
-import org.jenkinsci.main.modules.sshd.SSHD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assume.*;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -90,54 +82,7 @@ public class CLITest {
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
 
-    private File home;
     private File jar;
-
-    /** Sets up a fake {@code user.home} so that tests {@code -ssh} mode does not get confused by the developer’s real {@code ~/.ssh/known_hosts}. */
-    private File tempHome() throws IOException {
-        home = tmp.newFolder();
-        // Seems it gets created automatically but with inappropriate permissions:
-        File known_hosts = new File(new File(home, ".ssh"), "known_hosts");
-        assumeTrue(known_hosts.getParentFile().mkdir());
-        assumeTrue(known_hosts.createNewFile());
-        assumeTrue(known_hosts.setWritable(false, false));
-        assumeTrue(known_hosts.setWritable(true, true));
-        try {
-            Files.getOwner(known_hosts.toPath());
-        } catch (IOException x) {
-            assumeNoException("Sometimes on Windows KnownHostsServerKeyVerifier.acceptIncompleteHostKeys says WARNING: Failed (FileSystemException) to reload server keys from …\\\\.ssh\\\\known_hosts: … Incorrect function.", x);
-        }
-        assumeThat("or on Windows DefaultKnownHostsServerKeyVerifier.reloadKnownHosts says invalid file permissions: Owner violation (Administrators)",
-            ModifiableFileWatcher.validateStrictConfigFilePermissions(known_hosts.toPath()), nullValue());
-        return home;
-    }
-
-    @Issue("JENKINS-41745")
-    @Test
-    public void strictHostKey() throws Exception {
-        home = tempHome();
-        grabCliJar();
-
-        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
-        r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to("admin"));
-        SSHD.get().setPort(0);
-        File privkey = tmp.newFile("id_rsa");
-        FileUtils.copyURLToFile(CLITest.class.getResource("id_rsa"), privkey);
-        User.get("admin").addProperty(new UserPropertyImpl(IOUtils.toString(CLITest.class.getResource("id_rsa.pub"))));
-        assertNotEquals(0, new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
-            "java", "-Duser.home=" + home, "-jar", jar.getAbsolutePath(), "-s", r.getURL().toString(), "-ssh", "-user", "admin", "-i", privkey.getAbsolutePath(), "-strictHostKey", "who-am-i"
-        ).stdout(System.out).stderr(System.err).join());
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        assertEquals(0, new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
-            "java", "-Duser.home=" + home, "-jar", jar.getAbsolutePath(), "-s", r.getURL().toString(), "-ssh", "-user", "admin", "-i", privkey.getAbsolutePath(), "-logger", "FINEST",  "who-am-i"
-        ).stdout(baos).stderr(System.err).join());
-        assertThat(baos.toString(), containsString("Authenticated as: admin"));
-        baos = new ByteArrayOutputStream();
-        assertEquals(0, new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
-            "java", "-Duser.home=" + home, "-jar", jar.getAbsolutePath(), "-s", r.getURL().toString()./* just checking */replaceFirst("/$", ""), "-ssh", "-user", "admin", "-i", privkey.getAbsolutePath(), "-strictHostKey", "who-am-i"
-        ).stdout(baos).stderr(System.err).join());
-        assertThat(baos.toString(), containsString("Authenticated as: admin"));
-    }
 
     private void grabCliJar() throws IOException {
         jar = tmp.newFile("jenkins-cli.jar");
@@ -147,24 +92,18 @@ public class CLITest {
     @Issue("JENKINS-41745")
     @Test
     public void interrupt() throws Exception {
-        home = tempHome();
         grabCliJar();
 
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to("admin"));
-        SSHD.get().setPort(0);
-        File privkey = tmp.newFile("id_rsa");
-        FileUtils.copyURLToFile(CLITest.class.getResource("id_rsa"), privkey);
-        User.get("admin").addProperty(new UserPropertyImpl(IOUtils.toString(CLITest.class.getResource("id_rsa.pub"))));
         FreeStyleProject p = r.createFreeStyleProject("p");
         p.getBuildersList().add(new SleepBuilder(TimeUnit.MINUTES.toMillis(5)));
-        doInterrupt(p, "-ssh", "-user", "admin", "-i", privkey.getAbsolutePath());
         doInterrupt(p, "-http", "-auth", "admin:admin");
         doInterrupt(p, "-webSocket", "-auth", "admin:admin");
     }
     private void doInterrupt(FreeStyleProject p, String... modeArgs) throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        List<String> args = Lists.newArrayList("java", "-Duser.home=" + home, "-jar", jar.getAbsolutePath(), "-s", r.getURL().toString());
+        List<String> args = Lists.newArrayList("java", "-jar", jar.getAbsolutePath(), "-s", r.getURL().toString());
         args.addAll(Arrays.asList(modeArgs));
         args.addAll(Arrays.asList("build", "-s", "-v", "p"));
         Proc proc = new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(args).stdout(new TeeOutputStream(baos, System.out)).stderr(System.err).start();
@@ -181,20 +120,16 @@ public class CLITest {
 
     @Test @Issue("JENKINS-44361")
     public void reportNotJenkins() throws Exception {
-        home = tempHome();
         grabCliJar();
 
         String url = r.getURL().toExternalForm() + "not-jenkins/";
-        for (String transport : Arrays.asList("-http", "-ssh")) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int ret = new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
+                "java", "-jar", jar.getAbsolutePath(), "-s", url, "-http", "-user", "asdf", "who-am-i"
+        ).stdout(baos).stderr(baos).join();
 
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            int ret = new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
-                    "java", "-Duser.home=" + home, "-jar", jar.getAbsolutePath(), "-s", url, transport, "-user", "asdf", "who-am-i"
-            ).stdout(baos).stderr(baos).join();
-
-            assertThat(baos.toString(), containsString("There's no Jenkins running at"));
-            assertNotEquals(0, ret);
-        }
+        assertThat(baos.toString(), containsString("There's no Jenkins running at"));
+        assertNotEquals(0, ret);
         // TODO -webSocket currently produces a stack trace
     }
     @TestExtension("reportNotJenkins")
@@ -230,13 +165,7 @@ public class CLITest {
 
     @Test @Issue("JENKINS-44361")
     public void redirectToEndpointShouldBeFollowed() throws Exception {
-        home = tempHome();
         grabCliJar();
-
-        // Enable CLI over SSH
-        SSHD sshd = GlobalConfiguration.all().get(SSHD.class);
-        sshd.setPort(0); // random
-        sshd.start();
 
         // Sanity check
         JenkinsRule.WebClient wc = r.createWebClient()
@@ -247,14 +176,13 @@ public class CLITest {
         assertEquals(rsp.getContentAsString(), HttpURLConnection.HTTP_MOVED_TEMP, rsp.getStatusCode());
         assertNull(rsp.getContentAsString(), rsp.getResponseHeaderValue("X-Jenkins"));
         assertNull(rsp.getContentAsString(), rsp.getResponseHeaderValue("X-Jenkins-CLI-Port"));
-        assertNull(rsp.getContentAsString(), rsp.getResponseHeaderValue("X-SSH-Endpoint"));
 
-        for (String transport: Arrays.asList("-http", "-ssh", "-webSocket")) {
+        for (String transport: Arrays.asList("-http", "-webSocket")) {
 
             String url = r.getURL().toString() + "cli-proxy/";
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             int ret = new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
-                    "java", "-Duser.home=" + home, "-jar", jar.getAbsolutePath(), "-s", url, transport, "-user", "asdf", "who-am-i"
+                    "java", "-jar", jar.getAbsolutePath(), "-s", url, transport, "-user", "asdf", "who-am-i"
             ).stdout(baos).stderr(baos).join();
 
             //assertThat(baos.toString(), containsString("There's no Jenkins running at"));
@@ -267,14 +195,12 @@ public class CLITest {
     @Test
     @Issue("JENKINS-54310")
     public void readInputAtOnce() throws Exception {
-        home = tempHome();
         grabCliJar();
 
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             int ret = new Launcher.LocalLauncher(StreamTaskListener.fromStderr())
                     .launch()
                     .cmds("java",
-                            "-Duser.home=" + home,
                             "-jar", jar.getAbsolutePath(),
                             "-s", r.getURL().toString(),
                             "list-plugins") // This CLI Command needs -auth option, so when we omit it, the CLI stops before reading the input.

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -389,7 +389,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.modules</groupId>
                   <artifactId>sshd</artifactId>
-                  <version>${sshd.plugin.version}</version>
+                  <version>3.0.1</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
Complements https://github.com/jenkinsci/sshd-plugin/pull/44 so that every scenario is tested just once, and we do not need a test dep on the `sshd` plugin. Follows up #5049.

### Proposed changelog entries

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
