### PR TITLE
Update Commons BeanUtils from 1.9.3 to 1.9.4, adapt Stapler, migrate legacy Jelly callers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
       - dependency-name: "org.codehaus.groovy:groovy-all"
       # see https://github.com/jenkinsci/jenkins/pull/5184 should be updated with groovy-all
       - dependency-name: "org.fusesource.jansi:jansi"
-      # see https://github.com/jenkinsci/jenkins/pull/4328 and https://github.com/jenkinsci/jenkins/pull/4928#issuecomment-730224123
-      # fix requires investigation, for now we don't want dependabot updating it
-      - dependency-name: "commons-beanutils:commons-beanutils"
       # see https://github.com/jenkinsci/jenkins/pull/5144#pullrequestreview-559661934
       # will require source code changes to replace javax.mail with jakarta.mail 
       # and some handling for plugins that depend on javax.mail being provided by Jenkins core.

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
   <properties>
     <guavaVersion>11.0.1</guavaVersion>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <stapler.version>1.262</stapler.version>
+    <stapler.version>1.263-rc1494.794720f3af4f</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/211 -->
     <groovy.version>2.4.12</groovy.version>
   </properties>
 
@@ -247,7 +247,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.3</version>
+        <version>1.9.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/core/src/main/resources/hudson/model/ComputerSet/_new.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/_new.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
 
         <!-- main body of the configuration -->
         <j:set var="it" value="${null}" />
-        <st:include class="${requestScope.descriptor.clazz}" page="configure-entries.jelly" />
+        <st:include clazz="${requestScope.descriptor.clazz}" page="configure-entries.jelly" />
         
         <f:block>
           <input type="hidden" name="type" value="${request.getParameter('mode')}"/>

--- a/core/src/main/resources/hudson/model/Descriptor/newInstanceDetail.jelly
+++ b/core/src/main/resources/hudson/model/Descriptor/newInstanceDetail.jelly
@@ -29,5 +29,5 @@ THE SOFTWARE.
     By default we further delegate it to clazz, but this hook allows Descriptors to
     do something more sophisticated if needed.
   -->
-  <st:include page="newInstanceDetail.jelly" class="${it.clazz}" optional="true"/>
+  <st:include page="newInstanceDetail.jelly" clazz="${it.clazz}" optional="true"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Job/newInstanceDetail.jelly
+++ b/core/src/main/resources/hudson/model/Job/newInstanceDetail.jelly
@@ -29,5 +29,5 @@ THE SOFTWARE.
 
     "it" is a descriptor when this file is called.
   -->
-  <st:include page="newJobDetail.jelly" class="${it.clazz}" optional="true"/>
+  <st:include page="newJobDetail.jelly" clazz="${it.clazz}" optional="true"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Slave/help-launcher.jelly
+++ b/core/src/main/resources/hudson/model/Slave/help-launcher.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
         <j:forEach var="d" items="${h.getComputerLauncherDescriptors()}">
           <dt><b>${d.displayName}</b></dt>
           <dd>
-            <st:include class="${d.clazz}" page="help.jelly" optional="true"/>
+            <st:include clazz="${d.clazz}" page="help.jelly" optional="true"/>
           </dd>
         </j:forEach>
       </dl>

--- a/core/src/main/resources/hudson/model/ViewDescriptor/newInstanceDetail.jelly
+++ b/core/src/main/resources/hudson/model/ViewDescriptor/newInstanceDetail.jelly
@@ -3,4 +3,4 @@
   load it from there
 -->
 <?jelly escape-by-default='true'?>
-<st:include page="newViewDetail.jelly" class="${it.clazz}" xmlns:st="jelly:stapler"/>
+<st:include page="newViewDetail.jelly" clazz="${it.clazz}" xmlns:st="jelly:stapler"/>

--- a/core/src/main/resources/hudson/tools/ToolInstallation/global.jelly
+++ b/core/src/main/resources/hudson/tools/ToolInstallation/global.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
           >
             <j:set var="toolDescriptor" value="${descriptor}" /><!-- to make this descriptor accessible from properties -->
             <div>
-              <st:include page="config.jelly" from="${descriptor}" class="${descriptor.clazz}"/>
+              <st:include page="config.jelly" from="${descriptor}" clazz="${descriptor.clazz}"/>
               <f:descriptorList descriptors="${descriptor.propertyDescriptors}" field="properties"/>
               <l:isAdmin>
                 <f:entry title="">

--- a/core/src/main/resources/jenkins/model/OptionalJobProperty/config.jelly
+++ b/core/src/main/resources/jenkins/model/OptionalJobProperty/config.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
     <f:block>
         <f:optionalBlock title="${descriptor.displayName}" name="specified" checked="${instance != null}" inline="true" help="${descriptor.helpFile}">
-            <st:include page="config-details" from="${descriptor}" class="${descriptor.clazz}"/>
+            <st:include page="config-details" from="${descriptor}" clazz="${descriptor.clazz}"/>
         </f:optionalBlock>
     </f:block>
 </j:jelly>

--- a/core/src/main/resources/lib/form/repeatableProperty.jelly
+++ b/core/src/main/resources/lib/form/repeatableProperty.jelly
@@ -75,7 +75,7 @@ THE SOFTWARE.
 
   <f:repeatable field="${attrs.field}" default="${attrs.default}" noAddButton="${attrs.noAddButton}" header="${attrs.header}" add="${attrs.add}" minimum="${attrs.minimum ?: 0}" enableTopButton="${attrs.enableTopButton}">
     <div style="width:100%">
-      <st:include page="config.jelly" class="${descriptor.clazz}" />
+      <st:include page="config.jelly" clazz="${descriptor.clazz}" />
       <d:invokeBody/>
     </div>
   </f:repeatable>


### PR DESCRIPTION
Builds on the work started in #5324 by:

- Using the latest incremental from stapler/stapler#211 (wherein `class` is renamed to `clazz` rather than `className`)
- Migrating legacy Jelly files from the old convention to the new using a quick and dirty program I wrote at: https://github.com/basil/jelly-migrator/

As of this change we have validated stapler/stapler#211 in both the old convention and the new:

- The old convention still works because the test suite still passes in #5324.
- This PR's CI run should validate that the test suite passes with the new convention.
- In addition, I have tested this in a realistic classloader configuration by running `java -jar jenkins.war` and going to `/computer/createItem` (which corresponds to the file `core/src/main/resources/hudson/model/ComputerSet/_new.jelly` in this PR). I verified that the page was rendered correctly with the changes in this PR.