### PR TITLE
Declare modifiers in JLS order

### DIFF
--- a/cli/src/main/java/hudson/cli/PlainCLIProtocol.java
+++ b/cli/src/main/java/hudson/cli/PlainCLIProtocol.java
@@ -174,7 +174,7 @@ class PlainCLIProtocol {
         }
     }
 
-    static abstract class EitherSide implements Closeable {
+    abstract static class EitherSide implements Closeable {
 
         private final Output out;
 
@@ -252,7 +252,7 @@ class PlainCLIProtocol {
 
     }
 
-    static abstract class ServerSide extends EitherSide {
+    abstract static class ServerSide extends EitherSide {
 
         ServerSide(Output out) {
             super(out);
@@ -311,7 +311,7 @@ class PlainCLIProtocol {
 
     }
 
-    static abstract class ClientSide extends EitherSide {
+    abstract static class ClientSide extends EitherSide {
 
         ClientSide(Output out) {
             super(out);

--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -55,7 +55,7 @@ import java.util.ArrayList;
 public class QuotedStringTokenizer
     extends StringTokenizer
 {
-    private final static String __delim=" \t\n\r";
+    private static final String __delim=" \t\n\r";
     private String _string;
     private String _delim = __delim;
     private boolean _returnQuotes=false;

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -214,7 +214,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
     /**
      * Captures information about the annotation that we use to mark Guice-instantiated components.
      */
-    public static abstract class GuiceExtensionAnnotation<T extends Annotation> {
+    public abstract static class GuiceExtensionAnnotation<T extends Annotation> {
         public final Class<T> annotationType;
 
         protected GuiceExtensionAnnotation(Class<T> annotationType) {

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1136,7 +1136,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * The code is the same as {@link SlaveToMasterFileCallable}, but used as a marker to
      * designate those impls that use {@link FilePathFilter}.
      */
-    /*package*/ static abstract class SecureFileCallable<T> extends SlaveToMasterFileCallable<T> {
+    /*package*/ abstract static class SecureFileCallable<T> extends SlaveToMasterFileCallable<T> {
     }
 
     /**
@@ -1174,7 +1174,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * @since 1.482
      * @see AbstractInterceptorCallableWrapper
      */
-    public static abstract class FileCallableWrapperFactory implements ExtensionPoint {
+    public abstract static class FileCallableWrapperFactory implements ExtensionPoint {
 
         public abstract <T> DelegatingCallable<T,IOException> wrap(DelegatingCallable<T,IOException> callable);
 
@@ -1185,7 +1185,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * {@link hudson.FilePath.FileCallableWrapperFactory} that want to implement AOP-style interceptors
      * @since 1.482
      */
-    public static abstract class AbstractInterceptorCallableWrapper<T> implements DelegatingCallable<T, IOException> {
+    public abstract static class AbstractInterceptorCallableWrapper<T> implements DelegatingCallable<T, IOException> {
         private static final long serialVersionUID = 1L;
 
         private final DelegatingCallable<T, IOException> callable;

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -1122,7 +1122,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     }
 
     @Extension
-    public final static PluginWrapperAdministrativeMonitor NOTICE = new PluginWrapperAdministrativeMonitor();
+    public static final PluginWrapperAdministrativeMonitor NOTICE = new PluginWrapperAdministrativeMonitor();
 
     /**
      * Administrative Monitor for failed plugins

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -356,7 +356,7 @@ public final class TcpSlaveAgentListener extends Thread {
     }
 
     // This is essentially just to be able to pass the parent thread into the callback, as it can't access it otherwise
-    private static abstract class ConnectionHandlerFailureCallback {
+    private abstract static class ConnectionHandlerFailureCallback {
         private Thread parentThread;
 
         public ConnectionHandlerFailureCallback(Thread parentThread) {

--- a/core/src/main/java/hudson/cli/CLIAction.java
+++ b/core/src/main/java/hudson/cli/CLIAction.java
@@ -76,7 +76,7 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
 
     private static final Logger LOGGER = Logger.getLogger(CLIAction.class.getName());
 
-    private transient final Map<UUID, FullDuplexHttpService> duplexServices = new HashMap<>();
+    private final transient Map<UUID, FullDuplexHttpService> duplexServices = new HashMap<>();
 
     public String getIconFileName() {
         return null;

--- a/core/src/main/java/hudson/console/LineTransformationOutputStream.java
+++ b/core/src/main/java/hudson/console/LineTransformationOutputStream.java
@@ -117,7 +117,7 @@ public abstract class LineTransformationOutputStream extends OutputStream {
      * Flushing or closing the decorated stream will behave properly.
      * @since 2.173
      */
-    public static abstract class Delegating extends LineTransformationOutputStream {
+    public abstract static class Delegating extends LineTransformationOutputStream {
 
         protected final OutputStream out;
 

--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageMonitor.java
@@ -107,7 +107,7 @@ public final class HudsonHomeDiskUsageMonitor extends AdministrativeMonitor {
      * </dd>
      * </dl>
      */
-    public static abstract class Solution extends AbstractModelObject implements ExtensionPoint {
+    public abstract static class Solution extends AbstractModelObject implements ExtensionPoint {
         /**
          * Human-readable ID of this monitor, which needs to be unique within the system.
          *

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -242,7 +242,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
         final VersionNumber min;
         final VersionNumber max;
         final boolean single;
-        final public String extra;
+        public final String extra;
 
         public VersionRange(VersionRange previous, String version, String extra) {
             if (previous == null) {

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -55,7 +55,7 @@ public abstract class Lifecycle implements ExtensionPoint {
      *
      * @return never null
      */
-    public synchronized static Lifecycle get() {
+    public static synchronized Lifecycle get() {
         if(INSTANCE==null) {
             Lifecycle instance;
             String p = SystemProperties.getString("hudson.lifecycle");

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -78,7 +78,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
     private volatile String name;
 
     public final CopyOnWriteList<Target> targets = new CopyOnWriteList<>();
-    private final static TargetComparator TARGET_COMPARATOR = new TargetComparator();
+    private static final TargetComparator TARGET_COMPARATOR = new TargetComparator();
     
     @Restricted(NoExternalUse.class)
     Target[] orderedTargets() {

--- a/core/src/main/java/hudson/logging/LogRecorderManager.java
+++ b/core/src/main/java/hudson/logging/LogRecorderManager.java
@@ -68,7 +68,7 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
     /**
      * {@link LogRecorder}s keyed by their {@linkplain LogRecorder#name name}.
      */
-    public transient final Map<String,LogRecorder> logRecorders = new CopyOnWriteMap.Tree<>();
+    public final transient Map<String,LogRecorder> logRecorders = new CopyOnWriteMap.Tree<>();
 
     public String getDisplayName() {
         return Messages.LogRecorderManager_DisplayName();

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -133,7 +133,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     /**
      * Changes in this build.
      */
-    private volatile transient WeakReference<ChangeLogSet<? extends Entry>> changeSet;
+    private transient volatile WeakReference<ChangeLogSet<? extends Entry>> changeSet;
 
     /**
      * Cumulative list of people who contributed to the build problem.
@@ -156,7 +156,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
      */
     protected transient List<Environment> buildEnvironments;
 
-    private transient final LazyBuildMixIn.RunMixIn<P,R> runMixIn = new LazyBuildMixIn.RunMixIn<P,R>() {
+    private final transient LazyBuildMixIn.RunMixIn<P,R> runMixIn = new LazyBuildMixIn.RunMixIn<P,R>() {
         @Override protected R asRun() {
             return _this();
         }

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -152,7 +152,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     /**
      * State returned from {@link SCM#poll(AbstractProject, Launcher, FilePath, TaskListener, SCMRevisionState)}.
      */
-    private volatile transient SCMRevisionState pollingBaseline = null;
+    private transient volatile SCMRevisionState pollingBaseline = null;
 
     private transient LazyBuildMixIn<P,R> buildMixIn;
 
@@ -1877,7 +1877,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      *
      * @since 1.294
      */
-    public static abstract class AbstractProjectDescriptor extends TopLevelItemDescriptor {
+    public abstract static class AbstractProjectDescriptor extends TopLevelItemDescriptor {
         /**
          * {@link AbstractProject} subtypes can override this method to veto some {@link Descriptor}s
          * from showing up on their configuration screen. This is often useful when you are building
@@ -2048,7 +2048,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      * @deprecated Use {@link jenkins.model.labels.LabelValidator} instead.
      */
     @Deprecated
-    public static abstract class LabelValidator implements ExtensionPoint {
+    public abstract static class LabelValidator implements ExtensionPoint {
 
         /**
          * Check the use of the label within the specified context.

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -202,7 +202,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * @since 1.607
      * @see Executor#resetWorkUnit(String)
      */
-    private transient final List<TerminationRequest> terminatedBy = Collections.synchronizedList(new ArrayList<>());
+    private final transient List<TerminationRequest> terminatedBy = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * This method captures the information of a request to terminate a computer instance. Method is public as

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -137,9 +137,9 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
     /**
      * The class being described by this descriptor.
      */
-    public transient final Class<? extends T> clazz;
+    public final transient Class<? extends T> clazz;
 
-    private transient final Map<String,CheckMethod> checkMethods = new ConcurrentHashMap<>(2);
+    private final transient Map<String,CheckMethod> checkMethods = new ConcurrentHashMap<>(2);
 
     /**
      * Lazily computed list of properties on {@link #clazz} and on the descriptor itself.
@@ -235,7 +235,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      *
      * @see #getHelpFile(String) 
      */
-    private transient final Map<String,HelpRedirect> helpRedirect = new HashMap<>(2);
+    private final transient Map<String,HelpRedirect> helpRedirect = new HashMap<>(2);
 
     private static class HelpRedirect {
         private final Class<? extends Describable> owner;

--- a/core/src/main/java/hudson/model/DisplayNameListener.java
+++ b/core/src/main/java/hudson/model/DisplayNameListener.java
@@ -39,7 +39,7 @@ import hudson.model.listeners.ItemListener;
 @Extension
 public class DisplayNameListener extends ItemListener {
 
-    private final static Logger LOGGER = Logger.getLogger(DisplayNameListener.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(DisplayNameListener.class.getName());
 
     /**
      * Called after the user has clicked OK in the New Job page when 

--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -75,7 +75,7 @@ public class FileParameterValue extends ParameterValue {
     public static /* Script Console modifiable */ boolean ALLOW_FOLDER_TRAVERSAL_OUTSIDE_WORKSPACE = 
             Boolean.getBoolean(FileParameterValue.class.getName() + ".allowFolderTraversalOutsideWorkspace");
 
-    private transient final FileItem file;
+    private final transient FileItem file;
 
     /**
      * The name of the originally uploaded file.

--- a/core/src/main/java/hudson/model/FullDuplexHttpChannel.java
+++ b/core/src/main/java/hudson/model/FullDuplexHttpChannel.java
@@ -41,7 +41,7 @@ import jenkins.util.FullDuplexHttpService;
  * @deprecated Unused.
  */
 @Deprecated
-abstract public class FullDuplexHttpChannel extends FullDuplexHttpService {
+public abstract class FullDuplexHttpChannel extends FullDuplexHttpService {
     private Channel channel;
     private final boolean restricted;
 

--- a/core/src/main/java/hudson/model/Hudson.java
+++ b/core/src/main/java/hudson/model/Hudson.java
@@ -60,14 +60,14 @@ public class Hudson extends Jenkins {
      * @deprecated as of 1.286
      */
     @Deprecated
-    private transient final CopyOnWriteList<ItemListener> itemListeners = ExtensionListView.createCopyOnWriteList(ItemListener.class);
+    private final transient CopyOnWriteList<ItemListener> itemListeners = ExtensionListView.createCopyOnWriteList(ItemListener.class);
 
     /**
     * List of registered {@link hudson.slaves.ComputerListener}s.
      * @deprecated as of 1.286
      */
     @Deprecated
-    private transient final CopyOnWriteList<ComputerListener> computerListeners = ExtensionListView.createCopyOnWriteList(ComputerListener.class);
+    private final transient CopyOnWriteList<ComputerListener> computerListeners = ExtensionListView.createCopyOnWriteList(ComputerListener.class);
 
     /** @deprecated Here only for compatibility. Use {@link Jenkins#get} instead. */
     @Deprecated

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1587,5 +1587,5 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         return new BuildTimelineWidget(getBuilds());
     }
 
-    private final static HexStringConfidentialKey SERVER_COOKIE = new HexStringConfidentialKey(Job.class,"serverCookie",16);
+    private static final HexStringConfidentialKey SERVER_COOKIE = new HexStringConfidentialKey(Job.class,"serverCookie",16);
 }

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -88,16 +88,16 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
      * Display name of this label.
      */
     @NonNull
-    protected transient final String name;
+    protected final transient String name;
     private transient volatile Set<Node> nodes;
     private transient volatile Set<Cloud> clouds;
     private transient volatile int tiedJobsCount;
 
     @Exported
     @NonNull
-    public transient final LoadStatistics loadStatistics;
+    public final transient LoadStatistics loadStatistics;
     @NonNull
-    public transient final NodeProvisioner nodeProvisioner;
+    public final transient NodeProvisioner nodeProvisioner;
 
     public Label(@NonNull String name) {
         this.name = name;

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -105,7 +105,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
      * Newly copied agents get this flag set, so that Jenkins doesn't try to start/remove this node until its configuration
      * is saved once.
      */
-    protected volatile transient boolean holdOffLaunchUntilSave;
+    protected transient volatile boolean holdOffLaunchUntilSave;
 
     public String getDisplayName() {
         return getNodeName(); // default implementation

--- a/core/src/main/java/hudson/model/PaneStatusProperties.java
+++ b/core/src/main/java/hudson/model/PaneStatusProperties.java
@@ -61,7 +61,7 @@ public class PaneStatusProperties extends UserProperty implements Saveable {
 	
 	private static class PaneStatusPropertiesSessionFallback extends PaneStatusProperties {
 		
-		private final static String attribute = "jenkins_pane_%s_collapsed";
+		private static final String attribute = "jenkins_pane_%s_collapsed";
 		
 		@Override
 		public boolean isCollapsed(String paneId) {

--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -132,7 +132,7 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Extension @Symbol({"password"})
-    public final static class ParameterDescriptorImpl extends ParameterDescriptor {
+    public static final class ParameterDescriptorImpl extends ParameterDescriptor {
         @Override
         public String getDisplayName() {
             return Messages.PasswordParameterDefinition_DisplayName();

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -326,11 +326,11 @@ public class Queue extends ResourceController implements Saveable {
         }
     }
 
-    private volatile transient LoadBalancer loadBalancer;
+    private transient volatile LoadBalancer loadBalancer;
 
-    private volatile transient QueueSorter sorter;
+    private transient volatile QueueSorter sorter;
 
-    private transient final AtmostOneTaskExecutor<Void> maintainerThread = new AtmostOneTaskExecutor<>(new Callable<Void>() {
+    private final transient AtmostOneTaskExecutor<Void> maintainerThread = new AtmostOneTaskExecutor<>(new Callable<Void>() {
         @Override
         public Void call() throws Exception {
             maintain();
@@ -343,9 +343,9 @@ public class Queue extends ResourceController implements Saveable {
         }
     });
 
-    private transient final ReentrantLock lock = new ReentrantLock();
+    private final transient ReentrantLock lock = new ReentrantLock();
 
-    private transient final Condition condition = lock.newCondition();
+    private final transient Condition condition = lock.newCondition();
 
     public Queue(@NonNull LoadBalancer loadBalancer) {
         this.loadBalancer =  loadBalancer.sanitize();
@@ -1780,7 +1780,7 @@ public class Queue extends ResourceController implements Saveable {
         };
     }
 
-    private final static Hash<Node> NODE_HASH = Node::getNodeName;
+    private static final Hash<Node> NODE_HASH = Node::getNodeName;
 
     private boolean makePending(BuildableItem p) {
         // LOGGER.info("Making "+p.task+" pending"); // REMOVE
@@ -2092,7 +2092,7 @@ public class Queue extends ResourceController implements Saveable {
      * Item in a queue.
      */
     @ExportedBean(defaultVisibility = 999)
-    public static abstract class Item extends Actionable {
+    public abstract static class Item extends Actionable {
 
         private final long id;
 
@@ -2474,7 +2474,7 @@ public class Queue extends ResourceController implements Saveable {
      *
      * @since 1.316
      */
-    public static abstract class QueueDecisionHandler implements ExtensionPoint {
+    public abstract static class QueueDecisionHandler implements ExtensionPoint {
         /**
          * Returns whether the new item should be scheduled.
          *
@@ -2564,7 +2564,7 @@ public class Queue extends ResourceController implements Saveable {
     /**
      * Common part between {@link BlockedItem} and {@link BuildableItem}.
      */
-    public static abstract class NotWaitingItem extends Item {
+    public abstract static class NotWaitingItem extends Item {
         /**
          * When did this job exit the {@link Queue#waitingList} phase?
          */
@@ -2652,7 +2652,7 @@ public class Queue extends ResourceController implements Saveable {
     /**
      * {@link Item} in the {@link Queue#buildables} stage.
      */
-    public final static class BuildableItem extends NotWaitingItem {
+    public static final class BuildableItem extends NotWaitingItem {
         /**
          * Set to true when this is added to the {@link Queue#pendings} list.
          */
@@ -2763,7 +2763,7 @@ public class Queue extends ResourceController implements Saveable {
      *
      * @since 1.519
      */
-    public final static class LeftItem extends Item {
+    public static final class LeftItem extends Item {
         public final WorkUnitContext outcome;
 
         /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -167,7 +167,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */
     private static /* non-final for Groovy */ int TRUNCATED_DESCRIPTION_LIMIT = SystemProperties.getInteger("historyWidget.descriptionLimit", 100);
 
-    protected transient final @NonNull JobT project;
+    protected final transient @NonNull JobT project;
 
     /**
      * Build number.
@@ -190,7 +190,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * External code should use {@link #getPreviousBuild()}
      */
     @Restricted(NoExternalUse.class)
-    protected volatile transient RunT previousBuild;
+    protected transient volatile RunT previousBuild;
 
     /**
      * Next build. Can be null.
@@ -198,14 +198,14 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * External code should use {@link #getNextBuild()}
      */
     @Restricted(NoExternalUse.class)
-    protected volatile transient RunT nextBuild;
+    protected transient volatile RunT nextBuild;
 
     /**
      * Pointer to the next younger build in progress. This data structure is lazily updated,
      * so it may point to the build that's already completed. This pointer is set to 'this'
      * if the computation determines that everything earlier than this build is already completed.
      */
-    /* does not compile on JDK 7: private*/ volatile transient RunT previousBuildInProgress;
+    /* does not compile on JDK 7: private*/ transient volatile RunT previousBuildInProgress;
 
     /** ID as used for historical build records; otherwise null. */
     private @CheckForNull String id;
@@ -249,7 +249,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     /**
      * The current build state.
      */
-    private volatile transient State state;
+    private transient volatile State state;
 
     private enum State {
         /**
@@ -300,7 +300,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * If the build is in progress, remember {@link RunExecution} that's running it.
      * This field is not persisted.
      */
-    private volatile transient RunExecution runner;
+    private transient volatile RunExecution runner;
 
     /**
      * Artifact manager associated with this build, if any.
@@ -2196,7 +2196,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      * Used to implement {@link #getBuildStatusSummary}.
      * @since 1.575
      */
-    public static abstract class StatusSummarizer implements ExtensionPoint {
+    public abstract static class StatusSummarizer implements ExtensionPoint {
         /**
          * Possibly summarizes the reasons for a build’s status.
          * @param run a completed build

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -574,7 +574,7 @@ public abstract class Slave extends Node implements Serializable {
         throw new IllegalStateException(d.getClass()+" needs to extend from SlaveDescriptor");
     }
 
-    public static abstract class SlaveDescriptor extends NodeDescriptor {
+    public abstract static class SlaveDescriptor extends NodeDescriptor {
         public FormValidation doCheckNumExecutors(@QueryParameter String value) {
             return FormValidation.validatePositiveInteger(value);
         }

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -75,12 +75,12 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
     /**
      * Lazily computed {@link PublicKey} representation of {@link #keyImage}.
      */
-    private volatile transient RSAPublicKey key;
+    private transient volatile RSAPublicKey key;
 
     /**
      * When was the last time we asked a browser to send the usage stats for us?
      */
-    private volatile transient long lastAttempt = -1;
+    private transient volatile long lastAttempt = -1;
 
     public UsageStatistics() {
         this(DEFAULT_KEY_BYTES);

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -1120,7 +1120,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      * @see FullNameIdResolver
      * @since 1.479
      */
-    public static abstract class CanonicalIdResolver extends AbstractDescribableImpl<CanonicalIdResolver> implements ExtensionPoint, Comparable<CanonicalIdResolver> {
+    public abstract static class CanonicalIdResolver extends AbstractDescribableImpl<CanonicalIdResolver> implements ExtensionPoint, Comparable<CanonicalIdResolver> {
 
         /**
          * context key for realm (domain) where idOrFullName has been retrieved from.

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -475,7 +475,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
         return false;
     }
 
-    private final static int FILTER_LOOP_MAX_COUNT = 10;
+    private static final int FILTER_LOOP_MAX_COUNT = 10;
 
     private List<Queue.Item> filterQueue(List<Queue.Item> base) {
         if (!isFilterQueue()) {
@@ -1426,5 +1426,5 @@ public abstract class View extends AbstractModelObject implements AccessControll
      */
     public static final Message<View> NEW_PRONOUN = new Message<>();
 
-    private final static Logger LOGGER = Logger.getLogger(View.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(View.class.getName());
 }

--- a/core/src/main/java/hudson/model/labels/LabelExpression.java
+++ b/core/src/main/java/hudson/model/labels/LabelExpression.java
@@ -118,7 +118,7 @@ public abstract class LabelExpression extends Label {
         return l.getExpression();
     }
 
-    public static abstract class Binary extends LabelExpression {
+    public abstract static class Binary extends LabelExpression {
         public final Label lhs,rhs;
 
         public Binary(Label lhs, Label rhs, LabelOperatorPrecedence op) {

--- a/core/src/main/java/hudson/model/queue/MappingWorksheet.java
+++ b/core/src/main/java/hudson/model/queue/MappingWorksheet.java
@@ -396,7 +396,7 @@ public class MappingWorksheet {
         return executors.get(index);
     }
 
-    public static abstract class ExecutorSlot {
+    public abstract static class ExecutorSlot {
         public abstract Executor getExecutor();
 
         public abstract boolean isAvailable();

--- a/core/src/main/java/hudson/os/SU.java
+++ b/core/src/main/java/hudson/os/SU.java
@@ -134,7 +134,7 @@ public abstract class SU {
         }
     }
 
-    private static abstract class UnixSu {
+    private abstract static class UnixSu {
 
         protected abstract String sudoExe();
 

--- a/core/src/main/java/hudson/scheduler/CronTab.java
+++ b/core/src/main/java/hudson/scheduler/CronTab.java
@@ -150,7 +150,7 @@ public final class CronTab {
         return true;
     }
 
-    private static abstract class CalendarField {
+    private abstract static class CalendarField {
         /**
          * {@link Calendar} field ID.
          */

--- a/core/src/main/java/hudson/scm/ChangeLogSet.java
+++ b/core/src/main/java/hudson/scm/ChangeLogSet.java
@@ -137,7 +137,7 @@ public abstract class ChangeLogSet<T extends ChangeLogSet.Entry> implements Iter
     }
 
     @ExportedBean(defaultVisibility=999)
-    public static abstract class Entry {
+    public abstract static class Entry {
         private ChangeLogSet parent;
 
         public ChangeLogSet getParent() {

--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -52,9 +52,9 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
      * If this SCM has corresponding {@link RepositoryBrowser},
      * that type. Otherwise this SCM will not have any repository browser.
      */
-    public transient final Class<? extends RepositoryBrowser> repositoryBrowser;
+    public final transient Class<? extends RepositoryBrowser> repositoryBrowser;
     
-    private transient final AtomicInteger atomicGeneration = new AtomicInteger(1);
+    private final transient AtomicInteger atomicGeneration = new AtomicInteger(1);
 
     protected SCMDescriptor(Class<T> clazz, Class<? extends RepositoryBrowser> repositoryBrowser) {
         super(clazz);

--- a/core/src/main/java/hudson/search/ParsedQuickSilver.java
+++ b/core/src/main/java/hudson/search/ParsedQuickSilver.java
@@ -41,7 +41,7 @@ import java.beans.Introspector;
 final class ParsedQuickSilver {
     private static final Map<Class,ParsedQuickSilver> TABLE = new HashMap<>();
 
-    synchronized static ParsedQuickSilver get(Class<? extends SearchableModelObject> clazz) {
+    static synchronized ParsedQuickSilver get(Class<? extends SearchableModelObject> clazz) {
         ParsedQuickSilver pqs = TABLE.get(clazz);
         if(pqs==null)
             TABLE.put(clazz,pqs = new ParsedQuickSilver(clazz));
@@ -98,7 +98,7 @@ final class ParsedQuickSilver {
     }
 
 
-    static abstract class Getter {
+    abstract static class Getter {
         final String url;
         final String searchName;
 

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -418,5 +418,5 @@ public class Search implements StaplerProxy {
     @Restricted(NoExternalUse.class)
     public static /* Script Console modifiable */ boolean SKIP_PERMISSION_CHECK = Boolean.getBoolean(Search.class.getName() + ".skipPermissionCheck");
 
-    private final static Logger LOGGER = Logger.getLogger(Search.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(Search.class.getName());
 }

--- a/core/src/main/java/hudson/security/captcha/CaptchaSupport.java
+++ b/core/src/main/java/hudson/security/captcha/CaptchaSupport.java
@@ -55,9 +55,9 @@ public abstract class CaptchaSupport extends AbstractDescribableImpl<CaptchaSupp
         return Jenkins.get().getDescriptorList(CaptchaSupport.class);
     }
     
-    abstract public  boolean validateCaptcha(String id, String text); 
+    public abstract boolean validateCaptcha(String id, String text);
     
-    abstract public void generateImage(String id, OutputStream ios) throws IOException;
+    public abstract void generateImage(String id, OutputStream ios) throws IOException;
 
     @Override
     public CaptchaSupportDescriptor getDescriptor() {

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -123,7 +123,7 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
     @Extension @Symbol("standard")
     public static final class DescriptorImpl extends CrumbIssuerDescriptor<DefaultCrumbIssuer> implements ModelObject, PersistentDescriptor {
 
-        private final static HexStringConfidentialKey CRUMB_SALT = new HexStringConfidentialKey(Jenkins.class,"crumbSalt",16);
+        private static final HexStringConfidentialKey CRUMB_SALT = new HexStringConfidentialKey(Jenkins.class,"crumbSalt",16);
         
         public DescriptorImpl() {
             super(CRUMB_SALT.get(), SystemProperties.getString("hudson.security.csrf.requestfield", CrumbIssuer.DEFAULT_CRUMB_NAME));

--- a/core/src/main/java/hudson/slaves/DelegatingComputerLauncher.java
+++ b/core/src/main/java/hudson/slaves/DelegatingComputerLauncher.java
@@ -74,7 +74,7 @@ public abstract class DelegatingComputerLauncher extends ComputerLauncher {
         getLauncher().beforeDisconnect(computer, listener);
     }
 
-    public static abstract class DescriptorImpl extends Descriptor<ComputerLauncher> {
+    public abstract static class DescriptorImpl extends Descriptor<ComputerLauncher> {
         /**
          * Returns the applicable nested computer launcher types.
          * The default implementation avoids all delegating descriptors, as that creates infinite recursion.

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -372,7 +372,7 @@ public class NodeProvisioner {
      * Extension point for node provisioning strategies.
      * @since 1.588
      */
-    public static abstract class Strategy implements ExtensionPoint {
+    public abstract static class Strategy implements ExtensionPoint {
 
         /**
          * Called by {@link NodeProvisioner#update()} to apply this strategy against the specified state.

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -109,7 +109,7 @@ import org.jenkinsci.remoting.util.LoggingChannelListener;
  */
 public class SlaveComputer extends Computer {
     private volatile Channel channel;
-    private volatile transient boolean acceptingTasks = true;
+    private transient volatile boolean acceptingTasks = true;
     private Charset defaultCharset;
     private Boolean isUnix;
     /**

--- a/core/src/main/java/hudson/slaves/WorkspaceList.java
+++ b/core/src/main/java/hudson/slaves/WorkspaceList.java
@@ -109,7 +109,7 @@ public final class WorkspaceList {
     /**
      * Represents a leased workspace that needs to be returned later.
      */
-    public static abstract class Lease implements /*Auto*/Closeable {
+    public abstract static class Lease implements /*Auto*/Closeable {
         public final @NonNull FilePath path;
 
         protected Lease(@NonNull FilePath path) {

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -152,8 +152,8 @@ public class Maven extends Builder {
      */
     private @NonNull Boolean injectBuildVariables;
 
-    private final static String MAVEN_1_INSTALLATION_COMMON_FILE = "bin/maven";
-    private final static String MAVEN_2_INSTALLATION_COMMON_FILE = "bin/mvn";
+    private static final String MAVEN_1_INSTALLATION_COMMON_FILE = "bin/maven";
+    private static final String MAVEN_2_INSTALLATION_COMMON_FILE = "bin/mvn";
     
     private static final Pattern S_PATTERN = Pattern.compile("(^| )-s ");
     private static final Pattern GS_PATTERN = Pattern.compile("(^| )-gs ");

--- a/core/src/main/java/hudson/tools/AbstractCommandInstaller.java
+++ b/core/src/main/java/hudson/tools/AbstractCommandInstaller.java
@@ -85,7 +85,7 @@ public abstract class AbstractCommandInstaller extends ToolInstaller {
         return dir.child(getToolHome());
     }
 
-    public static abstract class Descriptor<TInstallerClass extends AbstractCommandInstaller>
+    public abstract static class Descriptor<TInstallerClass extends AbstractCommandInstaller>
             extends ToolInstallerDescriptor<TInstallerClass> {
 
         public FormValidation doCheckCommand(@QueryParameter String value) {

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -121,7 +121,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
         return null;
     }
 
-    public static abstract class DescriptorImpl<T extends DownloadFromUrlInstaller> extends ToolInstallerDescriptor<T> {
+    public abstract static class DescriptorImpl<T extends DownloadFromUrlInstaller> extends ToolInstallerDescriptor<T> {
         
         @SuppressWarnings("deprecation") // intentionally adding dynamic item here
         protected DescriptorImpl() {

--- a/core/src/main/java/hudson/tools/ToolInstallation.java
+++ b/core/src/main/java/hudson/tools/ToolInstallation.java
@@ -254,7 +254,7 @@ public abstract class ToolInstallation extends AbstractDescribableImpl<ToolInsta
     /**
      * Subclasses can extend this for data migration from old field storing home directory.
      */
-    protected static abstract class ToolConverter extends XStream2.PassthruConverter<ToolInstallation> {
+    protected abstract static class ToolConverter extends XStream2.PassthruConverter<ToolInstallation> {
         public ToolConverter(XStream2 xstream) { super(xstream); }
         protected void callback(ToolInstallation obj, UnmarshallingContext context) {
             String s;

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -231,7 +231,7 @@ public class SCMTrigger extends Trigger<Item> {
          * of a potential workspace lock between a build and a polling, we may end up using executor threads unwisely --- they
          * may block.
          */
-        private transient final SequentialExecutionQueue queue = new SequentialExecutionQueue(Executors.newSingleThreadExecutor(threadFactory()));
+        private final transient SequentialExecutionQueue queue = new SequentialExecutionQueue(Executors.newSingleThreadExecutor(threadFactory()));
 
         /**
          * Whether the projects should be polled all in one go in the order of dependencies. The default behavior is

--- a/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
+++ b/core/src/main/java/hudson/util/DOSToUnixPathHelper.java
@@ -17,7 +17,7 @@ class DOSToUnixPathHelper {
         void error(String string);
         void validate(File fexe);
     }
-    static private boolean checkPrefix(String prefix, Helper helper) {
+    private static boolean checkPrefix(String prefix, Helper helper) {
         File f = constructFile(prefix);
         if(f.exists()) {
             helper.checkExecutable(f);

--- a/core/src/main/java/hudson/util/DescribableList.java
+++ b/core/src/main/java/hudson/util/DescribableList.java
@@ -287,5 +287,5 @@ public class DescribableList<T extends Describable<T>, D extends Descriptor<T>> 
         }
     }
 
-    private final static Logger LOGGER = Logger.getLogger(DescribableList.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(DescribableList.class.getName());
 }

--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -251,7 +251,7 @@ public abstract class FormFieldValidator {
      *      Use {@link FormValidation.URLCheck}
      */
     @Deprecated
-    public static abstract class URLCheck extends FormFieldValidator {
+    public abstract static class URLCheck extends FormFieldValidator {
 
         public URLCheck(StaplerRequest request, StaplerResponse response) {
             // can be used to check the existence of any file in file system

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -303,7 +303,7 @@ public abstract class FormValidation extends IOException implements HttpResponse
      * <p>
      * This is used as a piece in a bigger validation effort.
      */
-    public static abstract class FileValidator {
+    public abstract static class FileValidator {
         public abstract FormValidation validate(File f);
 
         /**
@@ -458,7 +458,7 @@ public abstract class FormValidation extends IOException implements HttpResponse
      * <p>
      * This allows the check method to call various utility methods in a concise syntax.
      */
-    public static abstract class URLCheck {
+    public abstract static class URLCheck {
         /**
          * Opens the given URL and reads text content from it.
          * This method honors Content-type header.

--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -56,7 +56,7 @@ public class Iterators {
     /**
      * Produces {A,B,C,D,E,F} from {{A,B},{C},{},{D,E,F}}.
      */
-    public static abstract class FlattenIterator<U,T> implements Iterator<U> {
+    public abstract static class FlattenIterator<U,T> implements Iterator<U> {
         private final Iterator<? extends T> core;
         private Iterator<U> cur;
 
@@ -96,7 +96,7 @@ public class Iterators {
      *
      * @since 1.150
      */
-    public static abstract class FilterIterator<T> implements Iterator<T> {
+    public abstract static class FilterIterator<T> implements Iterator<T> {
         private final Iterator<? extends T> core;
         private T next;
         private boolean fetched;

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -723,7 +723,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         }
     }
 
-    static abstract class Unix extends Local {
+    abstract static class Unix extends Local {
         public Unix(boolean vetoersExist) {
             super(vetoersExist);
         }
@@ -743,7 +743,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     /**
      * {@link ProcessTree} based on /proc.
      */
-    static abstract class ProcfsUnix extends Unix {
+    abstract static class ProcfsUnix extends Unix {
         ProcfsUnix(boolean vetoersExist) {
             super(vetoersExist);
             
@@ -1841,7 +1841,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
      * Represents a local process tree, where this JVM and the process tree run on the same system.
      * (The opposite of {@link Remote}.)
      */
-    public static abstract class Local extends ProcessTree {
+    public abstract static class Local extends ProcessTree {
         @Deprecated
         Local() {
         }

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -326,7 +326,7 @@ public class XStream2 extends XStream {
         mapperInjectionPoint.setDelegate(m);
     }
 
-    final static class MapperInjectionPoint extends MapperDelegate {
+    static final class MapperInjectionPoint extends MapperDelegate {
         public MapperInjectionPoint(Mapper wrapped) {
             super(wrapped);
         }
@@ -473,7 +473,7 @@ public class XStream2 extends XStream {
      *     ...
      * </pre>
      */
-    public static abstract class PassthruConverter<T> implements Converter {
+    public abstract static class PassthruConverter<T> implements Converter {
         private Converter converter;
 
         public PassthruConverter(XStream2 xstream) {

--- a/core/src/main/java/hudson/views/ViewJobFilter.java
+++ b/core/src/main/java/hudson/views/ViewJobFilter.java
@@ -59,5 +59,5 @@ public abstract class ViewJobFilter implements ExtensionPoint, Describable<ViewJ
      * @param filteringView The view that we are filtering jobs for.
      * @return a new list based off of the jobs added so far, and all jobs available.
      */
-    abstract public List<TopLevelItem> filter(List<TopLevelItem> added, List<TopLevelItem> all, View filteringView);
+    public abstract List<TopLevelItem> filter(List<TopLevelItem> added, List<TopLevelItem> all, View filteringView);
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -314,7 +314,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLevelItemGroup, StaplerProxy, StaplerFallback,
         ModifiableViewGroup, AccessControlled, DescriptorByNameOwner,
         ModelObjectWithContextMenu, ModelObjectWithChildren, OnMaster {
-    private transient final Queue queue;
+    private final transient Queue queue;
 
     // flag indicating if we have loaded the jenkins configuration or not yet.
     private transient volatile boolean configLoaded = false;
@@ -322,7 +322,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Stores various objects scoped to {@link Jenkins}.
      */
-    public transient final Lookup lookup = new Lookup();
+    public final transient Lookup lookup = new Lookup();
 
     /**
      * We update this field to the current version of Jenkins whenever we save {@code config.xml}.
@@ -435,7 +435,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Root directory of the system.
      */
-    public transient final File root;
+    public final transient File root;
 
     /**
      * Where are we in the initialization?
@@ -445,7 +445,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * All {@link Item}s keyed by their {@link Item#getName() name}s.
      */
-    /*package*/ transient final Map<String,TopLevelItem> items = new CopyOnWriteMap.Tree<>(CaseInsensitiveComparator.INSTANCE);
+    /*package*/ final transient Map<String,TopLevelItem> items = new CopyOnWriteMap.Tree<>(CaseInsensitiveComparator.INSTANCE);
 
     /**
      * The sole instance.
@@ -467,7 +467,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *     STARTUP_MARKER_FILE.get(); // returns false if we are on a fresh startup. True for next startups.
      * }
      */
-    private transient static FileBoolean STARTUP_MARKER_FILE;
+    private static transient FileBoolean STARTUP_MARKER_FILE;
 
     private volatile List<JDK> jdks = new ArrayList<>();
 
@@ -488,18 +488,18 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * All {@link ExtensionList} keyed by their {@link ExtensionList#extensionType}.
      */
     @SuppressWarnings("rawtypes")
-    private transient final Map<Class, ExtensionList> extensionLists = new ConcurrentHashMap<>();
+    private final transient Map<Class, ExtensionList> extensionLists = new ConcurrentHashMap<>();
 
     /**
      * All {@link DescriptorExtensionList} keyed by their {@link DescriptorExtensionList#describableType}.
      */
     @SuppressWarnings("rawtypes")
-    private transient final Map<Class, DescriptorExtensionList> descriptorLists = new ConcurrentHashMap<>();
+    private final transient Map<Class, DescriptorExtensionList> descriptorLists = new ConcurrentHashMap<>();
 
     /**
      * {@link Computer}s in this Jenkins system. Read-only.
      */
-    protected transient final Map<Node,Computer> computers = new CopyOnWriteMap.Hash<>();
+    protected final transient Map<Node,Computer> computers = new CopyOnWriteMap.Hash<>();
 
     /**
      * Active {@link Cloud}s.
@@ -540,7 +540,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * @since 1.607
      */
-    private transient final Nodes nodes = new Nodes(this);
+    private final transient Nodes nodes = new Nodes(this);
 
     /**
      * Quiet period.
@@ -567,28 +567,28 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     private volatile String primaryView;
 
-    private transient final ViewGroupMixIn viewGroupMixIn = new ViewGroupMixIn(this) {
+    private final transient ViewGroupMixIn viewGroupMixIn = new ViewGroupMixIn(this) {
         protected List<View> views() { return views; }
         protected String primaryView() { return primaryView; }
         protected void primaryView(String name) { primaryView=name; }
     };
 
 
-    private transient final FingerprintMap fingerprintMap = new FingerprintMap();
+    private final transient FingerprintMap fingerprintMap = new FingerprintMap();
 
     /**
      * Loaded plugins.
      */
-    public transient final PluginManager pluginManager;
+    public final transient PluginManager pluginManager;
 
     public transient volatile TcpSlaveAgentListener tcpSlaveAgentListener;
 
-    private transient final Object tcpSlaveAgentListenerLock = new Object();
+    private final transient Object tcpSlaveAgentListenerLock = new Object();
 
     /**
      * List of registered {@link SCMListener}s.
      */
-    private transient final CopyOnWriteList<SCMListener> scmListeners = new CopyOnWriteList<>();
+    private final transient CopyOnWriteList<SCMListener> scmListeners = new CopyOnWriteList<>();
 
     /**
      * TCP agent port.
@@ -657,7 +657,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * All labels known to Jenkins. This allows us to reuse the same label instances
      * as much as possible, even though that's not a strict requirement.
      */
-    private transient final ConcurrentHashMap<String,Label> labels = new ConcurrentHashMap<>();
+    private final transient ConcurrentHashMap<String,Label> labels = new ConcurrentHashMap<>();
 
     /**
      * Load statistics of the entire system.
@@ -665,7 +665,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * This includes every executor and every job in the system.
      */
     @Exported
-    public transient final OverallLoadStatistics overallLoad = new OverallLoadStatistics();
+    public final transient OverallLoadStatistics overallLoad = new OverallLoadStatistics();
 
     /**
      * Load statistics of the free roaming jobs and agents.
@@ -675,13 +675,13 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 1.467
      */
     @Exported
-    public transient final LoadStatistics unlabeledLoad = new UnlabeledLoadStatistics();
+    public final transient LoadStatistics unlabeledLoad = new UnlabeledLoadStatistics();
 
     /**
      * {@link NodeProvisioner} that reacts to {@link #unlabeledLoad}.
      * @since 1.467
      */
-    public transient final NodeProvisioner unlabeledNodeProvisioner = new NodeProvisioner(null,unlabeledLoad);
+    public final transient NodeProvisioner unlabeledNodeProvisioner = new NodeProvisioner(null,unlabeledLoad);
 
     /**
      * @deprecated as of 1.467
@@ -692,16 +692,16 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @Restricted(NoExternalUse.class)
     @Deprecated
-    public transient final NodeProvisioner overallNodeProvisioner = unlabeledNodeProvisioner;
+    public final transient NodeProvisioner overallNodeProvisioner = unlabeledNodeProvisioner;
 
 
-    public transient final ServletContext servletContext;
+    public final transient ServletContext servletContext;
 
     /**
      * Transient action list. Useful for adding navigation items to the navigation bar
      * on the left.
      */
-    private transient final List<Action> actions = new CopyOnWriteArrayList<>();
+    private final transient List<Action> actions = new CopyOnWriteArrayList<>();
 
     /**
      * List of master node properties
@@ -718,22 +718,22 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * @see AdministrativeMonitor
      */
-    public transient final List<AdministrativeMonitor> administrativeMonitors = getExtensionList(AdministrativeMonitor.class);
+    public final transient List<AdministrativeMonitor> administrativeMonitors = getExtensionList(AdministrativeMonitor.class);
 
     /**
      * Widgets on Jenkins.
      */
-    private transient final List<Widget> widgets = getExtensionList(Widget.class);
+    private final transient List<Widget> widgets = getExtensionList(Widget.class);
 
     /**
      * {@link AdjunctManager}
      */
-    private transient final AdjunctManager adjuncts;
+    private final transient AdjunctManager adjuncts;
 
     /**
      * Code that handles {@link ItemGroup} work.
      */
-    private transient final ItemGroupMixIn itemGroupMixIn = new ItemGroupMixIn(this,this) {
+    private final transient ItemGroupMixIn itemGroupMixIn = new ItemGroupMixIn(this,this) {
         @Override
         protected void add(TopLevelItem item) {
             items.put(item.getName(),item);
@@ -821,9 +821,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * container start/stop. Persisted outside {@code config.xml} to avoid
      * accidental exposure.
      */
-    private transient final String secretKey;
+    private final transient String secretKey;
 
-    private transient final UpdateCenter updateCenter = UpdateCenter.createUpdateCenter(null);
+    private final transient UpdateCenter updateCenter = UpdateCenter.createUpdateCenter(null);
 
     /**
      * True if the user opted out from the statistics tracking. We'll never send anything if this is true.
@@ -838,9 +838,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Bound to "/log".
      */
-    private transient final LogRecorderManager log = new LogRecorderManager();
+    private final transient LogRecorderManager log = new LogRecorderManager();
 
-    private transient final boolean oldJenkinsJVM;
+    private final transient boolean oldJenkinsJVM;
 
     protected Jenkins(File root, ServletContext context) throws IOException, InterruptedException, ReactorException {
         this(root, context, null);
@@ -5122,7 +5122,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * <p>
      * The idea here is to overlap the CPU and I/O, so we want more threads than CPU numbers.
      */
-    /*package*/ transient final ExecutorService threadPoolForLoad = new ThreadPoolExecutor(
+    /*package*/ final transient ExecutorService threadPoolForLoad = new ThreadPoolExecutor(
         TWICE_CPU_NUM, TWICE_CPU_NUM,
         5L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new NamingThreadFactory(new DaemonThreadFactory(), "Jenkins load"));
 

--- a/core/src/main/java/jenkins/model/OptionalJobProperty.java
+++ b/core/src/main/java/jenkins/model/OptionalJobProperty.java
@@ -43,7 +43,7 @@ public abstract class OptionalJobProperty<J extends Job<?,?>> extends JobPropert
         return (OptionalJobPropertyDescriptor) super.getDescriptor();
     }
 
-    public static abstract class OptionalJobPropertyDescriptor extends JobPropertyDescriptor {
+    public abstract static class OptionalJobPropertyDescriptor extends JobPropertyDescriptor {
 
         protected OptionalJobPropertyDescriptor(Class<? extends JobProperty<?>> clazz) {
             super(clazz);

--- a/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
+++ b/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
@@ -207,7 +207,7 @@ public abstract class ProjectNamingStrategy implements Describable<ProjectNaming
         }
     }
 
-    public static abstract class ProjectNamingStrategyDescriptor extends Descriptor<ProjectNamingStrategy> {
+    public abstract static class ProjectNamingStrategyDescriptor extends Descriptor<ProjectNamingStrategy> {
     }
 
 }

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -285,9 +285,9 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT,RunT> & Queue.Task & 
 
     /**
      * Accompanying helper for the run type.
-     * Stateful but should be held in a {@code transient final} field.
+     * Stateful but should be held in a {@code final transient} field.
      */
-    public static abstract class RunMixIn<JobT extends Job<JobT,RunT> & Queue.Task & LazyBuildMixIn.LazyLoadingJob<JobT,RunT>, RunT extends Run<JobT,RunT> & LazyLoadingRun<JobT,RunT>> {
+    public abstract static class RunMixIn<JobT extends Job<JobT,RunT> & Queue.Task & LazyBuildMixIn.LazyLoadingJob<JobT,RunT>, RunT extends Run<JobT,RunT> & LazyLoadingRun<JobT,RunT>> {
 
         /**
          * Pointers to form bi-directional link between adjacent runs using

--- a/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
+++ b/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
@@ -102,7 +102,7 @@ public abstract class AsynchronousExecution extends RuntimeException {
      * has not been called yet.
      */
     @CheckForNull
-    public synchronized final Executor getExecutor() {
+    public final synchronized Executor getExecutor() {
         return executor;
     }
 
@@ -112,7 +112,7 @@ public abstract class AsynchronousExecution extends RuntimeException {
      * after releasing any problematic locks.
      */
     @Restricted(NoExternalUse.class)
-    public synchronized final void setExecutorWithoutCompleting(@NonNull Executor executor) {
+    public final synchronized void setExecutorWithoutCompleting(@NonNull Executor executor) {
         assert this.executor == null;
         this.executor = executor;
     }
@@ -122,7 +122,7 @@ public abstract class AsynchronousExecution extends RuntimeException {
      * Must be called after {@link #setExecutorWithoutCompleting(Executor)}.
      */
     @Restricted(NoExternalUse.class)
-    public synchronized final void maybeComplete() {
+    public final synchronized void maybeComplete() {
         assert this.executor != null;
         if (result != null) {
             executor.completedAsynchronous(result != NULL ? result : null);
@@ -134,7 +134,7 @@ public abstract class AsynchronousExecution extends RuntimeException {
      * To be called when the task is actually complete.
      * @param error normally null (preferable to handle errors yourself), but may be specified to simulate an exception from {@link Executable#run}, as per {@link ExecutorListener#taskCompletedWithProblems}
      */
-    public synchronized final void completed(@CheckForNull Throwable error) {
+    public final synchronized void completed(@CheckForNull Throwable error) {
         if (executor!=null) {
             executor.completedAsynchronous(error);
         } else {

--- a/core/src/main/java/jenkins/tasks/SimpleBuildWrapper.java
+++ b/core/src/main/java/jenkins/tasks/SimpleBuildWrapper.java
@@ -208,7 +208,7 @@ public abstract class SimpleBuildWrapper extends BuildWrapper {
      * An optional callback to run at the end of the wrapped block.
      * Must be safely serializable, so it receives runtime context comparable to that of the original setup.
      */
-    public static abstract class Disposer implements Serializable {
+    public abstract static class Disposer implements Serializable {
 
         @CheckForNull
         private Boolean wrapperRequiresWorkspace;

--- a/core/src/main/java/jenkins/telemetry/impl/java11/MissingClassTelemetry.java
+++ b/core/src/main/java/jenkins/telemetry/impl/java11/MissingClassTelemetry.java
@@ -67,9 +67,9 @@ public class MissingClassTelemetry extends Telemetry {
     private static MissingClassEvents events = new MissingClassEvents();
 
     // When we begin to gather these data
-    private final static LocalDate START = LocalDate.of(2019, 4, 1);
+    private static final LocalDate START = LocalDate.of(2019, 4, 1);
     // Gather for 2 years (who knows how long people will need to migrate to Java 11)
-    private final static LocalDate END = START.plusMonths(24);
+    private static final LocalDate END = START.plusMonths(24);
 
     // The types of exceptions which can be reported
     private static final Set reportableExceptions =
@@ -82,7 +82,7 @@ public class MissingClassTelemetry extends Telemetry {
      * Packages removed from java8 up to java11
      * https://blog.codefx.org/java/java-11-migration-guide/
      */
-    private final static String[] MOVED_PACKAGES = new String[] {"javax.activation", "javax.annotation", "javax.jws",
+    private static final String[] MOVED_PACKAGES = new String[] {"javax.activation", "javax.annotation", "javax.jws",
             "javax.rmi", "javax.transaction", "javax.xml.bind", "javax.xml.soap", "javax.xml.ws", "org.omg",
             "javax.activity", "com.sun", "sun"};
 

--- a/core/src/main/java/jenkins/util/FullDuplexHttpService.java
+++ b/core/src/main/java/jenkins/util/FullDuplexHttpService.java
@@ -146,7 +146,7 @@ public abstract class FullDuplexHttpService {
     /**
      * HTTP response that allows a client to use this service.
      */
-    public static abstract class Response extends HttpResponses.HttpResponseException {
+    public abstract static class Response extends HttpResponses.HttpResponseException {
 
         private final Map<UUID, FullDuplexHttpService> services;
 

--- a/core/src/main/java/jenkins/util/xml/RestrictiveEntityResolver.java
+++ b/core/src/main/java/jenkins/util/xml/RestrictiveEntityResolver.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 @Restricted(NoExternalUse.class)
 public final class RestrictiveEntityResolver implements EntityResolver {
 
-    public final static RestrictiveEntityResolver INSTANCE = new RestrictiveEntityResolver();
+    public static final RestrictiveEntityResolver INSTANCE = new RestrictiveEntityResolver();
 
     private RestrictiveEntityResolver() {
         // prevent multiple instantiation.

--- a/core/src/main/java/jenkins/util/xml/XMLUtils.java
+++ b/core/src/main/java/jenkins/util/xml/XMLUtils.java
@@ -41,8 +41,8 @@ import javax.xml.xpath.XPathFactory;
  */
 public final class XMLUtils {
 
-    private final static Logger LOGGER = LogManager.getLogManager().getLogger(XMLUtils.class.getName());
-    private final static String DISABLED_PROPERTY_NAME = XMLUtils.class.getName() + ".disableXXEPrevention";
+    private static final Logger LOGGER = LogManager.getLogManager().getLogger(XMLUtils.class.getName());
+    private static final String DISABLED_PROPERTY_NAME = XMLUtils.class.getName() + ".disableXXEPrevention";
 
     private static final String FEATURE_HTTP_XML_ORG_SAX_FEATURES_EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
     private static final String FEATURE_HTTP_XML_ORG_SAX_FEATURES_EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";

--- a/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
+++ b/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
@@ -275,7 +275,7 @@ public class ViewOptionHandlerTest {
         });
     }
 
-    private static abstract class CompositeView extends View implements ViewGroup {
+    private abstract static class CompositeView extends View implements ViewGroup {
         protected CompositeView(String name) {
             super(name);
         }

--- a/core/src/test/java/hudson/model/StubJob.java
+++ b/core/src/test/java/hudson/model/StubJob.java
@@ -34,7 +34,7 @@ import java.util.SortedMap;
 @SuppressWarnings({ "rawtypes" })
 class StubJob extends Job {
 
-    public final static String DEFAULT_STUB_JOB_NAME = "StubJob";
+    public static final String DEFAULT_STUB_JOB_NAME = "StubJob";
     
     public StubJob() {
         super(null, DEFAULT_STUB_JOB_NAME);

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -78,7 +78,7 @@ public class IsOverriddenTest {
         Util.isOverridden(Base.class, Intermediate.class, "aPrivateMethod");
     }
 
-    public static abstract class Base<T> {
+    public abstract static class Base<T> {
         protected abstract void method();
         private void aPrivateMethod() {}
         public void setX(T t) {}
@@ -150,12 +150,12 @@ public class IsOverriddenTest {
     private interface I2 extends I1 {
         default String bar() { return "default"; }
     }
-    private static abstract class C1 implements I1 {
+    private abstract static class C1 implements I1 {
     }
-    private static abstract class C2 extends C1 implements I2 {
+    private abstract static class C2 extends C1 implements I2 {
         @Override public abstract String foo();
     }
-    private static abstract class C3 extends C2 {
+    private abstract static class C3 extends C2 {
         @Override public String foo() { return "foo"; }
     }
     private static class C4 extends C3 implements I1 {

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -113,7 +113,7 @@ public class RobustReflectionConverterTest {
     public static class Bild {
         Steppe[] steppes;
     }
-    public static abstract class Steppe {
+    public abstract static class Steppe {
         int number;
     }
     @Owner("p1")
@@ -130,7 +130,7 @@ public class RobustReflectionConverterTest {
     public static class Boot {}
     public static class Jacket {}
     @Owner("p2")
-    public static abstract class Lover {}
+    public abstract static class Lover {}
     @Owner("p3")
     public static class Billy extends Lover {}
     @Owner("p4")

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -92,9 +92,9 @@ public class ExtensionListTest {
 //
 //
 
-    public static abstract class FishDescriptor extends Descriptor<Fish> {}
+    public abstract static class FishDescriptor extends Descriptor<Fish> {}
 
-    public static abstract class Fish implements Describable<Fish> {
+    public abstract static class Fish implements Describable<Fish> {
         public Descriptor<Fish> getDescriptor() {
             return Jenkins.get().getDescriptor(getClass());
         }

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -60,9 +60,9 @@ import static org.junit.Assert.fail;
 public class QuietDownCommandTest {
 
     private CLICommandInvoker command;
-    private final static QueueTest.TestFlyweightTask task
+    private static final QueueTest.TestFlyweightTask task
             = new QueueTest.TestFlyweightTask(new AtomicInteger(), null);
-    private final static String TEST_REASON = "test reason";
+    private static final String TEST_REASON = "test reason";
 
     @Rule
     public final JenkinsRule j = new JenkinsRule();

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -131,7 +131,7 @@ public class DescriptorTest {
         rule.configRoundtrip(p);
         rule.assertLogContains("[D1, D2]", rule.buildAndAssertSuccess(p));
     }
-    public static abstract class D extends AbstractDescribableImpl<D> {
+    public abstract static class D extends AbstractDescribableImpl<D> {
         @Override public String toString() {return getDescriptor().getDisplayName();}
     }
     public static class D1 extends D {

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -997,7 +997,7 @@ public class ViewTest {
         private List<TopLevelItem> jobs;
         private String primaryView;
 
-        private transient final ViewGroupMixIn viewGroupMixIn = new ViewGroupMixIn(this) {
+        private final transient ViewGroupMixIn viewGroupMixIn = new ViewGroupMixIn(this) {
             protected List<View> views() { return views; }
             protected String primaryView() { return primaryView; }
             protected void primaryView(String name) { primaryView = name; }

--- a/test/src/test/java/jenkins/security/SecurityContextExecutorServiceTest.java
+++ b/test/src/test/java/jenkins/security/SecurityContextExecutorServiceTest.java
@@ -47,7 +47,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
  */
 public class SecurityContextExecutorServiceTest {
 
-    final private int NUM_THREADS = 10;
+    private final int NUM_THREADS = 10;
     private ExecutorService wrappedService = null;
     private SecurityContext systemContext = null;
     private SecurityContext userContext = null;

--- a/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
+++ b/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
@@ -216,7 +216,7 @@ public class DoActionFilterTest extends StaplerAbstractTest {
         }
     }
     
-    public static abstract class HttpResponseExceptionChild extends HttpResponses.HttpResponseException {
+    public abstract static class HttpResponseExceptionChild extends HttpResponses.HttpResponseException {
     }
     
     public static class ExceptionImplementingOnlyHttpResponse extends RuntimeException implements HttpResponse {
@@ -524,7 +524,7 @@ public class DoActionFilterTest extends StaplerAbstractTest {
 //        public void doAnnotatedJsonOutputFilter() { replyOk(); }
     }
     
-    public static abstract class RequestAndResponse implements StaplerRequest, StaplerResponse {
+    public abstract static class RequestAndResponse implements StaplerRequest, StaplerResponse {
         @Override
         public CollectionAndEnumeration getHeaderNames() {
             return null;
@@ -535,7 +535,7 @@ public class DoActionFilterTest extends StaplerAbstractTest {
             return null;
         }
         
-        public static abstract class CollectionAndEnumeration implements Collection, Enumeration {
+        public abstract static class CollectionAndEnumeration implements Collection, Enumeration {
         }
     }
     

--- a/test/src/test/java/jenkins/util/FullDuplexHttpServiceTest.java
+++ b/test/src/test/java/jenkins/util/FullDuplexHttpServiceTest.java
@@ -70,7 +70,7 @@ public class FullDuplexHttpServiceTest {
     }
     @TestExtension("smokes")
     public static class Endpoint extends InvisibleAction implements RootAction {
-        private transient final Map<UUID, FullDuplexHttpService> duplexServices = new HashMap<>();
+        private final transient Map<UUID, FullDuplexHttpService> duplexServices = new HashMap<>();
         @Override
         public String getUrlName() {
             return "test";

--- a/test/src/test/java/lib/form/RowVisibilityGroupTest.java
+++ b/test/src/test/java/lib/form/RowVisibilityGroupTest.java
@@ -126,7 +126,7 @@ public class RowVisibilityGroupTest extends HudsonTestCase implements Describabl
         }
     }
 
-    public static abstract class Drink extends AbstractDescribableImpl<Drink> {
+    public abstract static class Drink extends AbstractDescribableImpl<Drink> {
         public String textbox1;
         public Nested inner;
 


### PR DESCRIPTION
Code is easier to read if everybody follows the same conventions. This PR ensures that modifier order conforms to the suggestions in the [Java Language specification, § 8.1.1, 8.3.1, 8.4.3](https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html) and [9.4](https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html). The correct order is:

- `public`
- `protected`
- `private`
- `abstract`
- `default`
- `static`
- `final`
- `transient`
- `volatile`
- `synchronized`
- `native`
- `strictfp`

Note that I have not made an effort to ensure that annotations are declared before all other modifiers, which is also recommended by the JLS. That would be a more disruptive PR. I kept this PR simple and easy to review by explicitly not changing annotation order.