### PR TITLE
Use versions from parent POM where possible

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -109,7 +109,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <!-- Version specified in grandparent POM -->
       </plugin>
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -170,6 +170,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
         <executions>
           <execution>
             <id>add-source</id>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -595,6 +595,7 @@ THE SOFTWARE.
         <plugin>
          <groupId>org.codehaus.mojo</groupId>
          <artifactId>build-helper-maven-plugin</artifactId>
+         <!-- Version specified in grandparent POM -->
          <executions>
              <execution>
                  <id>add-source</id>
@@ -615,6 +616,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
         <executions>
           <execution>
             <goals>
@@ -714,6 +716,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
         <executions>
           <execution>
             <id>winsw</id>
@@ -740,6 +743,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
         <configuration>
           <forkCount>0.5C</forkCount>
           <reuseForks>true</reuseForks>
@@ -767,7 +771,7 @@ THE SOFTWARE.
       <plugin><!-- generate Jelly tag lib documentation -->
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>maven-stapler-plugin</artifactId>
-        <version>${maven-stapler-plugin.version}</version>
+        <!-- Version specified in grandparent POM -->
         <configuration>
           <patterns>
             <pattern>/lib/.*</pattern>
@@ -776,7 +780,7 @@ THE SOFTWARE.
       </plugin>
       <plugin><!-- skip slow dependency analysis -->
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.1.1</version>
+        <!-- Version specified in grandparent POM -->
         <configuration>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -219,14 +219,17 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
+          <!-- Version specified in parent POM -->
           <configuration>
             <fork>true</fork>
             <compilerReuseStrategy>alwaysNew</compilerReuseStrategy>
@@ -241,14 +244,17 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
+          <!-- Version specified in parent POM -->
           <configuration>
             <quiet>true</quiet>
             <doclint>all,-missing</doclint>
@@ -257,14 +263,17 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
+          <!-- Version specified in parent POM -->
           <configuration>
             <argLine>-noverify</argLine> <!-- some versions of JDK7/8 causes VerifyError during mock tests: http://code.google.com/p/powermock/issues/detail?id=504 -->
             <systemPropertyVariables>
@@ -278,6 +287,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <artifactId>maven-jarsigner-plugin</artifactId>
@@ -297,6 +307,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <!--
@@ -313,7 +324,7 @@ THE SOFTWARE.
           -->
           <groupId>org.kohsuke.stapler</groupId>
           <artifactId>maven-stapler-plugin</artifactId>
-          <!-- version specified in grandparent pom -->
+          <!-- version specified in parent pom -->
           <extensions>true</extensions>
           <dependencies>
             <dependency>
@@ -331,6 +342,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>com.cloudbees</groupId>
           <artifactId>maven-license-plugin</artifactId>
+          <!-- Version specified in parent POM -->
           <executions>
             <execution>
               <goals>
@@ -347,6 +359,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.jvnet.localizer</groupId>
           <artifactId>localizer-maven-plugin</artifactId>
+          <!-- Version specified in parent POM -->
           <configuration>
             <outputEncoding>UTF-8</outputEncoding>
           </configuration>
@@ -369,6 +382,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
         <plugin>
           <groupId>org.jvnet.updatecenter2</groupId>
@@ -378,16 +392,18 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
+          <!-- Version specified in parent POM -->
         </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <!-- Version specified in parent POM -->
       </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>
         	<groupId>org.eclipse.m2e</groupId>
         	<artifactId>lifecycle-mapping</artifactId>
-        	<version>1.0.0</version>
+        	<!-- Version specified in parent POM -->
         	<configuration>
         		<lifecycleMappingMetadata>
         			<pluginExecutions>
@@ -395,6 +411,7 @@ THE SOFTWARE.
         					<pluginExecutionFilter>
         						<groupId>org.apache.maven.plugins</groupId>
         						<artifactId>maven-dependency-plugin</artifactId>
+        						<!-- Version specified in parent POM -->
         						<versionRange>[2.3,)</versionRange>
         						<goals>
         							<goal>list</goal>
@@ -416,6 +433,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
+          <!-- Version specified in parent POM -->
           <configuration>
             <maxHeap>768</maxHeap>
           </configuration>
@@ -423,6 +441,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
+          <!-- Version specified in parent POM -->
           <configuration>
              <consoleOutput>true</consoleOutput>
              <failsOnError>true</failsOnError>
@@ -454,6 +473,7 @@ THE SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
+        <!-- Version specified in parent POM -->
         <configuration>
           <!-- enable release profile during the release, create IPS package, and sign bits. -->
           <arguments>-P release,sign</arguments>
@@ -467,6 +487,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
+        <!-- Version specified in parent POM -->
         <executions>
           <execution>
             <goals>
@@ -501,6 +522,7 @@ THE SOFTWARE.
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <!-- Version specified in parent POM -->
         <configuration>
           <source>1.${java.level}</source>
           <target>1.${java.level}</target>
@@ -514,6 +536,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <!-- Version specified in parent POM -->
         <executions>
           <execution>
             <id>enforce-banned-dependencies</id>
@@ -539,6 +562,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <!-- Version specified in parent POM -->
       </plugin>
     </plugins>
 
@@ -559,6 +583,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
+            <!-- Version specified in parent POM -->
             <configuration>
               <threshold>High</threshold>
             </configuration>
@@ -610,6 +635,7 @@ THE SOFTWARE.
         <plugins>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
+            <!-- Version specified in parent POM -->
             <inherited>false</inherited>
             <executions>
               <execution>
@@ -628,6 +654,7 @@ THE SOFTWARE.
           </plugin>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
+            <!-- Version specified in parent POM -->
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -166,6 +166,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
         <extensions>true</extensions>
       </plugin>
       <plugin>
@@ -176,6 +177,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
         <executions>
           <execution>
             <id>old-remoting-for-test</id>
@@ -217,6 +219,7 @@ THE SOFTWARE.
       </plugin>
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -224,6 +227,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
         <configuration>
           <fork>true</fork>
         </configuration>
@@ -246,6 +250,7 @@ THE SOFTWARE.
         <plugins>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
+            <!-- Version specified in grandparent POM -->
             <configuration>
               <groups>org.jvnet.hudson.test.SmokeTest</groups>
             </configuration>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -574,6 +574,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
+            <!-- Version specified in grandparent POM -->
             <executions>
               <execution>
                 <id>enforce-versions</id>
@@ -682,6 +683,7 @@ THE SOFTWARE.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-clean-plugin</artifactId>
+            <!-- Version specified in grandparent POM -->
             <configuration>
               <filesets>
                 <fileset>


### PR DESCRIPTION
In most cases, we were using versions from the [Jenkins core parent POM](https://github.com/jenkinsci/pom) where possible, but there were a handful of places where we weren't. This leads to unnecessary Dependabot updates. I removed any `<version>` tags where the version was already defined upstream.

The POM files in this repository already had a number of helpful comments referring the reader to the parent or grandparent POM where a particular version was defined. However, these comments were not consistently written for all versions and one of them was incorrect. I fixed this by consistently adding the comments for all versions and ensuring they referred to the correct (parent or grandparent) POM.