### PR TITLE
JENKINS-65033 Run / Project summary - tables to divs

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -304,6 +304,7 @@ public class Functions {
         context.setVariable("resURL",rootURL+getResourcePath());
         context.setVariable("imagesURL",rootURL+getResourcePath()+"/images");
         context.setVariable("divBasedFormLayout", true);
+        context.setVariable("divBasedRunLayout", true);
         context.setVariable("userAgent", currentRequest.getHeader("User-Agent"));
         IconSet.initPageVariables(context);
     }

--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -56,7 +56,7 @@ THE SOFTWARE.
         <t:editableDescription permission="${it.UPDATE}" />
       </div>
 
-      <table style="margin-top: 1em; margin-left:1em;">
+      <div>
         <t:artifactList build="${it}" caption="${%Build Artifacts}"
           permission="${it.ARTIFACTS}" />
 
@@ -107,9 +107,11 @@ THE SOFTWARE.
 
         <!-- give actions a chance to contribute summary item -->
         <j:forEach var="a" items="${it.allActions}">
-          <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
+          <div style="margin-top: 1em;">
+            <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
+          </div>
         </j:forEach>
-      </table>
+      </div>
 
       <st:include page="main.jelly" optional="true" />
 

--- a/core/src/main/resources/hudson/model/AbstractProject/main.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/main.jelly
@@ -30,17 +30,21 @@ THE SOFTWARE.
 
   <p:projectActionFloatingBox />
 
-  <table style="margin-top: 1em; margin-left:1em;">
+  <div style="margin-top: 1em; margin-left:1em;">
 
     <j:forEach var="act" items="${it.prominentActions}">
       <j:set var="icon" value="${act.iconClassName != null ? act.iconClassName : act.iconFileName}"/>
-      <t:summary icon="${icon}" href="${act.urlName}">
-        ${act.displayName}
-      </t:summary>
+      <div>
+        <t:summary icon="${icon}" href="${act.urlName}">
+          ${act.displayName}
+        </t:summary>
+      </div>
     </j:forEach>
-    <t:summary icon="folder.png" href="ws/" permission="${it.WORKSPACE}">
-      ${%Workspace}
-    </t:summary>
+    <div>
+      <t:summary icon="folder.png" href="ws/" permission="${it.WORKSPACE}">
+        ${%Workspace}
+      </t:summary>
+    </div>
 
     <t:artifactList caption="${%Last Successful Artifacts}"
         build="${it.lastSuccessfulBuild}" baseURL="lastSuccessfulBuild/"
@@ -50,11 +54,13 @@ THE SOFTWARE.
       ${%Recent Changes}
     </t:summary>
 
-  </table>
+  </div>
 
   <!-- merge fragments from the actions -->
   <j:forEach var="a" items="${it.allActions}">
-    <st:include page="jobMain.jelly" it="${a}" optional="true" />
+    <div>
+      <st:include page="jobMain.jelly" it="${a}" optional="true" />
+    </div>
   </j:forEach>
 
   <p:upstream-downstream />

--- a/core/src/main/resources/hudson/model/CauseAction/summary.jelly
+++ b/core/src/main/resources/hudson/model/CauseAction/summary.jelly
@@ -26,12 +26,10 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <t:summary icon="orange-square.png">
     <j:forEach var="entry" items="${it.causeCounts.entrySet()}">
-      <p>
         <st:include page="description.jelly" it="${entry.key}"/>
         <j:if test="${entry.value > 1}">
           <st:nbsp/>${%Ntimes(entry.value)}
         </j:if>
-      </p>
     </j:forEach>
   </t:summary>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/CauseAction/summary.jelly
+++ b/core/src/main/resources/hudson/model/CauseAction/summary.jelly
@@ -25,11 +25,16 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <t:summary icon="orange-square.png">
+      ${%Caused by}
+      <ul>
     <j:forEach var="entry" items="${it.causeCounts.entrySet()}">
-        <st:include page="description.jelly" it="${entry.key}"/>
-        <j:if test="${entry.value > 1}">
-          <st:nbsp/>${%Ntimes(entry.value)}
-        </j:if>
+        <li>
+            <st:include page="description.jelly" it="${entry.key}"/>
+            <j:if test="${entry.value > 1}">
+              <st:nbsp/>${%Ntimes(entry.value)}
+            </j:if>
+        </li>
     </j:forEach>
+      </ul>
   </t:summary>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/summary.jelly
+++ b/core/src/main/resources/lib/hudson/summary.jelly
@@ -46,8 +46,6 @@ THE SOFTWARE.
   </st:documentation>
   <j:if test="${h.hasPermission(it,attrs.permission)}">
     <j:if test="${attrs.icon!=null}">
-      <tr>
-        <td>
           <!--
             Backward compatibility.  Ugly but needed for now.
 
@@ -93,8 +91,6 @@ THE SOFTWARE.
               </j:choose>
             </j:otherwise>
           </j:choose>
-        </td>
-        <td style="vertical-align:middle">
           <j:choose>
             <j:when test="${attrs.href!=null &amp;&amp; !attrs.iconOnly}">
               <a href="${attrs.href}">
@@ -105,8 +101,6 @@ THE SOFTWARE.
               <d:invokeBody />
             </j:otherwise>
           </j:choose>
-        </td>
-      </tr>
     </j:if>
   </j:if>
 </j:jelly>


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-65033](https://issues.jenkins.io/browse/JENKINS-65033).

This required some minor adaption in a few plugins that had a block layout (should have been inline) next to the icon, see https://github.com/jenkinsci/warnings-ng-plugin/pull/841, https://github.com/jenkinsci/code-coverage-api-plugin/pull/185

This is a lot safer than forms as it won't break anything, possibly minor changes in some plugins, I've tested all the ones we use on ci.jenkins.io and https://plugins.jenkins.io/sauce-ondemand which was broken without this change due to tables nesting

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: JENKINS-65033, Run summary page now uses div for layout
* Entry 2: Developer: `divBasedRunLayout` jelly variable available for detecting if Jenkins uses divs for run summary page
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
