### PR TITLE
Test cleanup

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -60,6 +60,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
@@ -1067,12 +1068,12 @@ public class FilePathTest {
         assertThat(nonexistent.isDescendant("."), is(false));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     @Issue("SECURITY-904")
     public void isDescendant_throwIfAbsolutePathGiven() throws Exception {
         FilePath rootFolder = new FilePath(temp.newFolder("root"));
         rootFolder.mkdirs();
-        rootFolder.isDescendant(temp.newFile().getAbsolutePath());
+        assertThrows(IllegalArgumentException.class, () -> rootFolder.isDescendant(temp.newFile().getAbsolutePath()));
     }
 
     @Test

--- a/core/src/test/java/hudson/XmlFileTest.java
+++ b/core/src/test/java/hudson/XmlFileTest.java
@@ -13,6 +13,7 @@ import org.xml.sax.SAXParseException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class XmlFileTest {
 
@@ -33,7 +34,7 @@ public class XmlFileTest {
     // KXml2Driver is able to parse XML 1.0 even if it has control characters which
     // should be illegal.  Ignoring this test until we switch to a more compliant driver
     @Ignore
-    @Test(expected = SAXParseException.class)
+    @Test
     public void xml1_0_withSpecialCharsShouldFail() throws IOException {
         URL configUrl = getClass().getResource("/hudson/config_1_0_with_special_chars.xml");
         XStream2  xs = new XStream2();
@@ -41,9 +42,7 @@ public class XmlFileTest {
 
         XmlFile xmlFile =  new XmlFile(xs, new File(configUrl.getFile()));
         if (xmlFile.exists()) {
-            Node n = (Node) xmlFile.read();
-            assertThat(n.getNumExecutors(), is(2));
-            assertThat(n.getMode().toString(), is("NORMAL"));
+            assertThrows(SAXParseException.class, () -> xmlFile.read());
         }
     }
 

--- a/core/src/test/java/hudson/model/ActionableTest.java
+++ b/core/src/test/java/hudson/model/ActionableTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
@@ -182,29 +183,29 @@ public class ActionableTest {
         assertEquals(Arrays.asList(a1, a2), thing.getActions());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void addAction_null() {
-        thing.addAction(null);
+        assertThrows(IllegalArgumentException.class, () -> thing.addAction(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void replaceAction_null() {
-        thing.replaceAction(null);
+        assertThrows(IllegalArgumentException.class, () -> thing.replaceAction(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void replaceActions_null() {
-        thing.replaceActions(CauseAction.class, null);
+        assertThrows(IllegalArgumentException.class, () -> thing.replaceActions(CauseAction.class, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void replaceActions_null_null() {
-        thing.replaceActions(null, null);
+        assertThrows(IllegalArgumentException.class, () -> thing.replaceActions(null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void addOrReplaceAction_null() {
-        thing.addOrReplaceAction(null);
+        assertThrows(IllegalArgumentException.class, () -> thing.addOrReplaceAction(null));
     }
 
     @Test
@@ -212,9 +213,9 @@ public class ActionableTest {
         assertFalse(thing.removeAction(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void removeActions_null() {
-        thing.removeActions(null);
+        assertThrows(IllegalArgumentException.class, () -> thing.removeActions(null));
     }
 
     private static class ActionableImpl extends Actionable {

--- a/core/src/test/java/hudson/model/ChoiceParameterDefinitionTest.java
+++ b/core/src/test/java/hudson/model/ChoiceParameterDefinitionTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ChoiceParameterDefinitionTest {
@@ -110,23 +111,23 @@ public class ChoiceParameterDefinitionTest {
         assertFalse(parameterDefinition.isValid(parameterValue));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     @Issue("JENKINS-62889")
     public void checkValue_WrongValueType() {
         String stringValue = "single";
         String[] choices = new String[]{stringValue};
         ChoiceParameterDefinition parameterDefinition = new ChoiceParameterDefinition("name", choices, "description");
         BooleanParameterValue parameterValue = new BooleanParameterValue("choice", false);
-        parameterDefinition.isValid(parameterValue);
+        assertThrows(ClassCastException.class, () -> parameterDefinition.isValid(parameterValue));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     @Issue("JENKINS-62889")
     public void createValue_Invalid() {
         String stringValue = "single";
         String[] choices = new String[]{stringValue};
         ChoiceParameterDefinition parameterDefinition = new ChoiceParameterDefinition("name", choices, "description");
-        parameterDefinition.createValue("invalid");
+        assertThrows(IllegalArgumentException.class, () -> parameterDefinition.createValue("invalid"));
     }
 
     private void assertCreation(String stringValue, String[] choices, boolean valid) {

--- a/core/src/test/java/hudson/model/ComputerTest.java
+++ b/core/src/test/java/hudson/model/ComputerTest.java
@@ -1,5 +1,8 @@
 package hudson.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import hudson.FilePath;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
@@ -30,9 +33,9 @@ public class ComputerTest {
 
             Computer.relocateOldLogs(d);
 
-            assert dir.list().size()==1; // asserting later that this one child is the logs/ directory
-            assert dir.child("logs/slaves/abc/slave.log").exists();
-            assert dir.child("logs/slaves/def/slave.log.5").exists();
+            assertEquals(1, dir.list().size()); // asserting later that this one child is the logs/ directory
+            assertTrue(dir.child("logs/slaves/abc/slave.log").exists());
+            assertTrue(dir.child("logs/slaves/def/slave.log.5").exists());
         } finally {
             dir.deleteRecursive();
         }

--- a/core/src/test/java/hudson/model/UserIdMapperTest.java
+++ b/core/src/test/java/hudson/model/UserIdMapperTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
 
 public class UserIdMapperTest {
 
@@ -287,9 +288,9 @@ public class UserIdMapperTest {
         assertThat(directory1.getName(), startsWith("abcdef_"));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testXmlFileCorrupted() throws IOException {
-        UserIdMapper mapper = createUserIdMapper(IdStrategy.CASE_INSENSITIVE);
+        assertThrows(IOException.class, () -> createUserIdMapper(IdStrategy.CASE_INSENSITIVE));
     }
 
     @Test

--- a/core/src/test/java/hudson/tasks/BuildStepCompatibilityLayerTest.java
+++ b/core/src/test/java/hudson/tasks/BuildStepCompatibilityLayerTest.java
@@ -1,5 +1,6 @@
 package hudson.tasks;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -15,13 +16,13 @@ import org.mockito.Mockito;
 public class BuildStepCompatibilityLayerTest {
 
     @Issue("JENKINS-18734")
-    @Test(expected = AbstractMethodError.class)
+    @Test
     @SuppressWarnings("deprecation") /* testing deprecated variant */
     public void testPerformExpectAbstractMethodError() throws InterruptedException, IOException {
 
         FreeStyleBuild mock = Mockito.mock(FreeStyleBuild.class, Mockito.CALLS_REAL_METHODS);
         BuildStepCompatibilityLayer bscl = new BuildStepCompatibilityLayer() {};
-        bscl.perform(mock, null, null);
+        assertThrows(AbstractMethodError.class, () -> bscl.perform(mock, null, null));
 
     }
 

--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -14,6 +14,7 @@ import java.nio.file.StandardOpenOption;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class FileChannelWriterTest {
@@ -46,13 +47,12 @@ public class FileChannelWriterTest {
         assertContent("hello é è à");
     }
 
-    @Test(expected = ClosedChannelException.class)
+    @Test
     public void close() throws Exception {
         writer.write("helloooo");
         writer.close();
 
-        writer.write("helloooo");
-        fail("Should have failed the line above");
+        assertThrows(ClosedChannelException.class, () -> writer.write("helloooo"));
     }
 
 

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -25,6 +25,7 @@ package hudson.util;
 
 import org.junit.Test;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import hudson.Util;
@@ -59,23 +60,23 @@ public class IsOverriddenTest {
      * Negative test.
      * Trying to check for a method which does not exist in the hierarchy.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isOverriddenNegativeTest() {
-        Util.isOverridden(Base.class, Derived.class, "method2");
+        assertThrows(IllegalArgumentException.class, () -> Util.isOverridden(Base.class, Derived.class, "method2"));
     }
 
     /** Specifying a base class that is not a base class should result in an error. */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void badHierarchyIsReported() {
-        Util.isOverridden(Derived.class, Base.class, "method");
+        assertThrows(IllegalArgumentException.class, () -> Util.isOverridden(Derived.class, Base.class, "method"));
     }
 
     /**
      * Do not inspect private methods.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void avoidPrivateMethodsInspection() {
-        Util.isOverridden(Base.class, Intermediate.class, "aPrivateMethod");
+        assertThrows(IllegalArgumentException.class, () -> Util.isOverridden(Base.class, Intermediate.class, "aPrivateMethod"));
     }
 
     public abstract static class Base<T> {

--- a/core/src/test/java/hudson/util/SecretTest.java
+++ b/core/src/test/java/hudson/util/SecretTest.java
@@ -35,6 +35,7 @@ import jenkins.security.ConfidentialStoreRule;
 import org.apache.commons.lang.RandomStringUtils;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -72,16 +73,16 @@ public class SecretTest {
             String plaintext = RandomStringUtils.random(random.nextInt(i));
             String ciphertext = Secret.fromString(plaintext).getEncryptedValue();
             //println "${plaintext} → ${ciphertext}"
-            assert ENCRYPTED_VALUE_PATTERN.matcher(ciphertext).matches();
+            assertTrue(ENCRYPTED_VALUE_PATTERN.matcher(ciphertext).matches());
         }
         //Not "plain" text
-        assert !ENCRYPTED_VALUE_PATTERN.matcher("hello world").matches();
+        assertFalse(ENCRYPTED_VALUE_PATTERN.matcher("hello world").matches());
         //Not "plain" text
-        assert !ENCRYPTED_VALUE_PATTERN.matcher("helloworld!").matches();
+        assertFalse(ENCRYPTED_VALUE_PATTERN.matcher("helloworld!").matches());
         //legacy key
-        assert ENCRYPTED_VALUE_PATTERN.matcher("abcdefghijklmnopqr0123456789").matches();
+        assertTrue(ENCRYPTED_VALUE_PATTERN.matcher("abcdefghijklmnopqr0123456789").matches());
         //legacy key
-        assert ENCRYPTED_VALUE_PATTERN.matcher("abcdefghijklmnopqr012345678==").matches();
+        assertTrue(ENCRYPTED_VALUE_PATTERN.matcher("abcdefghijklmnopqr012345678==").matches());
     }
 
     @Test

--- a/core/src/test/java/jenkins/ResilientJsonObjectTest.java
+++ b/core/src/test/java/jenkins/ResilientJsonObjectTest.java
@@ -1,5 +1,7 @@
 package jenkins;
 
+import static org.junit.Assert.assertEquals;
+
 import net.sf.json.JSONObject;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -18,6 +20,6 @@ public class ResilientJsonObjectTest {
     public void databindingShouldIgnoreUnrecognizedJsonProperty() {
         JSONObject o = JSONObject.fromObject("{a:1,b:2}");
         Foo f = (Foo)JSONObject.toBean(o,Foo.class);
-        assert f.a == 1;
+        assertEquals(1, f.a);
     }
 }

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -285,7 +285,7 @@ public class AbstractLazyLoadRunMapTest {
         FakeMap map = f.make();
 
         Build x = map.search(Integer.MAX_VALUE, Direction.DESC);
-        assert x.n==201;
+        assertEquals(201, x.n);
     }
 
     @Issue("JENKINS-18065")

--- a/core/src/test/java/jenkins/util/JenkinsJVMTest.java
+++ b/core/src/test/java/jenkins/util/JenkinsJVMTest.java
@@ -2,6 +2,8 @@ package jenkins.util;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 public class JenkinsJVMTest {
 
     @Test
@@ -9,16 +11,16 @@ public class JenkinsJVMTest {
         JenkinsJVM.checkNotJenkinsJVM();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void checkJenkinsJVM_WhenNotInAJenkinsJVM() {
-        JenkinsJVM.checkJenkinsJVM();
+        assertThrows(IllegalStateException.class, () -> JenkinsJVM.checkJenkinsJVM());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void checkNotJenkinsJVM_WhenInAJenkinsJVM() {
         JenkinsJVM.setJenkinsJVM(true);
         try {
-            JenkinsJVM.checkNotJenkinsJVM();
+            assertThrows(IllegalStateException.class, () -> JenkinsJVM.checkNotJenkinsJVM());
         } finally {
             JenkinsJVM.setJenkinsJVM(false);
         }

--- a/core/src/test/java/jenkins/util/ResourceBundleUtilTest.java
+++ b/core/src/test/java/jenkins/util/ResourceBundleUtilTest.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 import java.util.Locale;
 import java.util.MissingResourceException;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
@@ -69,8 +71,8 @@ public class ResourceBundleUtilTest {
     /**
      * Test unknown bundle.
      */
-    @Test(expected = MissingResourceException.class)
+    @Test
     public void test_unknown_bundle() {
-        ResourceBundleUtil.getBundle("hudson.blah.Whatever");
+        assertThrows(MissingResourceException.class, () -> ResourceBundleUtil.getBundle("hudson.blah.Whatever"));
     }
 }

--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -29,7 +29,6 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
 import jenkins.model.Jenkins;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -263,42 +262,5 @@ public class DisconnectNodeCommandTest {
         assertThat(slave2.toComputer().isOffline(), equalTo(true));
         assertThat(slave2.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
         assertThat(((OfflineCause.ByCLI) slave2.toComputer().getOfflineCause()).message, equalTo("aCause"));
-    }
-
-    @Ignore("TODO currently failing")
-    @Test
-    public void disconnectNodeShouldSucceedOnMaster() throws Exception {
-        final Computer masterComputer = j.jenkins.getComputer("");
-        assertThat(masterComputer.isOnline(), equalTo(true));
-        assertThat(masterComputer.getOfflineCause(), equalTo(null));
-
-        CLICommandInvoker.Result result = command
-                .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
-                .invokeWithArgs("");
-        assertThat(result, succeededSilently());
-        assertThat(masterComputer.isOffline(), equalTo(true));
-        assertThat(masterComputer.getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) masterComputer.getOfflineCause()).message, equalTo(null));
-
-        masterComputer.connect(true);
-        masterComputer.waitUntilOnline();
-        assertThat(masterComputer.isOnline(), equalTo(true));
-        assertThat(masterComputer.getOfflineCause(), equalTo(null));
-
-        result = command
-                .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
-                .invokeWithArgs("");
-        assertThat(result, succeededSilently());
-        assertThat(masterComputer.isOffline(), equalTo(true));
-        assertThat(masterComputer.getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) masterComputer.getOfflineCause()).message, equalTo(null));
-
-        result = command
-                .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
-                .invokeWithArgs("");
-        assertThat(result, succeededSilently());
-        assertThat(masterComputer.isOffline(), equalTo(true));
-        assertThat(masterComputer.getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) masterComputer.getOfflineCause()).message, equalTo(null));
     }
 }

--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -29,6 +29,7 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.OfflineCause;
 import jenkins.model.Jenkins;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -264,6 +265,8 @@ public class DisconnectNodeCommandTest {
         assertThat(((OfflineCause.ByCLI) slave2.toComputer().getOfflineCause()).message, equalTo("aCause"));
     }
 
+    @Ignore("TODO currently failing")
+    @Test
     public void disconnectNodeShouldSucceedOnMaster() throws Exception {
         final Computer masterComputer = j.jenkins.getComputer("");
         assertThat(masterComputer.isOnline(), equalTo(true));

--- a/test/src/test/java/hudson/console/ConsoleLogFilterTest.java
+++ b/test/src/test/java/hudson/console/ConsoleLogFilterTest.java
@@ -1,9 +1,10 @@
 package hudson.console;
 
+import static org.junit.Assert.assertTrue;
+
 import hudson.model.Computer;
 import hudson.model.Run;
 import hudson.slaves.SlaveComputer;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -16,7 +17,7 @@ import java.io.OutputStream;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class ConsoleLogFilterTest extends Assert {
+public class ConsoleLogFilterTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 

--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -196,7 +196,7 @@ public class AbstractProjectTest {
 
         form = j.createWebClient().getPage(p, "configure").getFormByName("config");
         input = form.getInputByName("blockBuildWhenUpstreamBuilding");
-        assert input.isChecked() : "blockBuildWhenUpstreamBuilding check box is not checked.";
+        assertTrue("blockBuildWhenUpstreamBuilding check box is not checked.", input.isChecked());
     }
 
     /**

--- a/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
+++ b/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
@@ -96,24 +97,24 @@ public class ComputerConfigDotXmlTest {
         SecurityContextHolder.setContext(oldSecurityContext);
     }
 
-    @Test(expected = AccessDeniedException3.class)
+    @Test
     public void configXmlGetShouldFailForUnauthorized() throws Exception {
 
         when(req.getMethod()).thenReturn("GET");
 
         rule.jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
 
-        computer.doConfigDotXml(req, rsp);
+        assertThrows(AccessDeniedException3.class, () -> computer.doConfigDotXml(req, rsp));
     }
 
-    @Test(expected = AccessDeniedException3.class)
+    @Test
     public void configXmlPostShouldFailForUnauthorized() throws Exception {
 
         when(req.getMethod()).thenReturn("POST");
 
         rule.jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
 
-        computer.doConfigDotXml(req, rsp);
+        assertThrows(AccessDeniedException3.class, () -> computer.doConfigDotXml(req, rsp));
     }
 
     @Test

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -41,6 +41,7 @@ import net.sf.json.JSONObject;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -64,13 +65,9 @@ public class DescriptorTest {
         Describable<?> instance = new Shell("echo hello");
         Descriptor<?> descriptor = instance.getDescriptor();
         PropertyType propertyType = descriptor.getPropertyType(instance, "command");
-        try {
-            propertyType.getItemTypeDescriptorOrDie();
-            fail("not supposed to succeed");
-        } catch (AssertionError x) {
-            for (String text : new String[] {"hudson.tasks.CommandInterpreter", "getCommand", "java.lang.String", "collection"}) {
-                assertTrue(text + " mentioned in " + x, x.toString().contains(text));
-            }
+        AssertionError x = assertThrows(AssertionError.class, () -> propertyType.getItemTypeDescriptorOrDie());
+        for (String text : new String[]{"hudson.tasks.CommandInterpreter", "getCommand", "java.lang.String", "collection"}) {
+            assertTrue(text + " mentioned in " + x, x.toString().contains(text));
         }
     }
 

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -147,6 +147,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Ignore;
@@ -468,7 +469,8 @@ public class QueueTest {
         assertFalse(Queue.isBlockedByShutdown(task));
         r.waitUntilNoActivity();
         assertEquals(1, cnt.get());
-        assert task.exec instanceof OneOffExecutor : task.exec;
+        assertNotNull(task.exec);
+        assertThat(task.exec, instanceOf(OneOffExecutor.class));
     }
 
     @Issue("JENKINS-24519")
@@ -481,7 +483,8 @@ public class QueueTest {
         r.createSlave(label);
         r.waitUntilNoActivity();
         assertEquals(1, cnt.get());
-        assert task.exec instanceof OneOffExecutor : task.exec;
+        assertNotNull(task.exec);
+        assertThat(task.exec, instanceOf(OneOffExecutor.class));
     }
 
     @Issue("JENKINS-41127")

--- a/test/src/test/java/hudson/model/labels/LabelAtomSecurity1986Test.java
+++ b/test/src/test/java/hudson/model/labels/LabelAtomSecurity1986Test.java
@@ -37,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -173,11 +174,11 @@ public class LabelAtomSecurity1986Test {
         }
     }
 
-    @Test(expected = Exception.class)
+    @Test
     @Issue("SECURITY-1986")
-    public void programmaticCreationInvalidName() throws IOException {
+    public void programmaticCreationInvalidName() {
         LabelAtom label = new LabelAtom("foo/../goo");
-        label.save();
+        assertThrows(IOException.class, () -> label.save());
     }
 
     @Test

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -57,6 +57,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.lang.StringUtils;
@@ -514,12 +515,11 @@ public class HudsonPrivateSecurityRealmTest {
         assertThat(w2, hasXPath("//name", is("user_hashed")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createAccountWithHashedPasswordRequiresPrefix() throws Exception {
         HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
         j.jenkins.setSecurityRealm(securityRealm);
-
-        securityRealm.createAccountWithHashedPassword("user_hashed", BCrypt.hashpw("password", BCrypt.gensalt()));
+        assertThrows(IllegalArgumentException.class, () -> securityRealm.createAccountWithHashedPassword("user_hashed", BCrypt.hashpw("password", BCrypt.gensalt())));
     }
 
     @Test
@@ -551,14 +551,14 @@ public class HudsonPrivateSecurityRealmTest {
         assertTrue("version 2a is supported", BCrypt.checkpw("a", "$2a$06$m0CrhHm10qJ3lXRY.5zDGO3rS2KdeeWLuGmsfGlMfOxih58VYVfxe"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ensureHashingVersion_2x_isNotSupported() {
-        BCrypt.checkpw("abc", "$2x$08$Ro0CUfOqk6cXEKf3dyaM7OhSCvnwM9s4wIX9JeLapehKK5YdLxKcm");
+        assertThrows(IllegalArgumentException.class, () -> BCrypt.checkpw("abc", "$2x$08$Ro0CUfOqk6cXEKf3dyaM7OhSCvnwM9s4wIX9JeLapehKK5YdLxKcm"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ensureHashingVersion_2y_isNotSupported() {
-        BCrypt.checkpw("a", "$2y$08$cfcvVd2aQ8CMvoMpP2EBfeodLEkkFJ9umNEfPD18.hUF62qqlC/V.");
+        assertThrows(IllegalArgumentException.class, () -> BCrypt.checkpw("a", "$2y$08$cfcvVd2aQ8CMvoMpP2EBfeodLEkkFJ9umNEfPD18.hUF62qqlC/V."));
     }
     
     private void checkUserCanBeCreatedWith(HudsonPrivateSecurityRealm securityRealm, String id, String password, String fullName, String email) throws Exception {

--- a/test/src/test/java/hudson/security/PermissionGroupTest.java
+++ b/test/src/test/java/hudson/security/PermissionGroupTest.java
@@ -27,6 +27,7 @@ import hudson.model.Hudson;
 import hudson.model.Messages;
 import jenkins.model.Jenkins;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Email;
@@ -45,13 +46,13 @@ public class PermissionGroupTest {
     }
 
     @SuppressWarnings("ResultOfObjectAllocationIgnored")
-    @Test(expected=IllegalStateException.class) public void duplicatedGroups() {
-        new PermissionGroup(Hudson.class, Messages._Hudson_Permissions_Title());
+    @Test public void duplicatedGroups() {
+        assertThrows(IllegalStateException.class, () -> new PermissionGroup(Hudson.class, Messages._Hudson_Permissions_Title()));
     }
 
     @SuppressWarnings("ResultOfObjectAllocationIgnored")
-    @Test(expected=IllegalStateException.class) public void duplicatedPermissions() {
-        new Permission(Jenkins.PERMISSIONS, "Read", Messages._Hudson_ReadPermission_Description(), Permission.READ, PermissionScope.JENKINS);
+    @Test public void duplicatedPermissions() {
+        assertThrows(IllegalStateException.class, () -> new Permission(Jenkins.PERMISSIONS, "Read", Messages._Hudson_ReadPermission_Description(), Permission.READ, PermissionScope.JENKINS));
     }
 
 }

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -38,6 +38,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -69,7 +70,7 @@ public class PingThreadTest {
         assertNotNull(pingThread);
 
         // Simulate lost connection
-        assert new ProcessBuilder("kill", "-TSTP", pid).start().waitFor() == 0;
+        assertEquals(0, new ProcessBuilder("kill", "-TSTP", pid).start().waitFor());
         try {
             // ... do not wait for Ping Thread to notice
             Method onDead = PingThread.class.getDeclaredMethod("onDead", Throwable.class);
@@ -86,7 +87,7 @@ public class PingThreadTest {
             assertNull(slave.getComputer().getChannel());
             assertNull(computer.getChannel());
         } finally {
-            assert new ProcessBuilder("kill", "-CONT", pid).start().waitFor() == 0;
+            assertEquals(0, new ProcessBuilder("kill", "-CONT", pid).start().waitFor());
         }
     }
 

--- a/test/src/test/java/jenkins/model/JenkinsSystemReadAndManagePermissionTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsSystemReadAndManagePermissionTest.java
@@ -13,6 +13,7 @@ import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -79,7 +80,7 @@ public class JenkinsSystemReadAndManagePermissionTest {
         // THEN the changes on fields forbidden to a Jenkins.MANAGE permission are not saved
         Config config = GlobalConfiguration.all().get(Config.class);
 
-        assert config != null;
+        assertNotNull(config);
         assertNull("shouldn't be allowed to change a GlobalConfiguration that needs Overall/Administer", config.getNumber());
     }
 

--- a/test/src/test/java/jenkins/security/UserDetailsCacheTest.java
+++ b/test/src/test/java/jenkins/security/UserDetailsCacheTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -70,17 +71,13 @@ public class UserDetailsCacheTest {
         assertNull(alice1);
     }
 
-    @Test(expected = UsernameNotFoundException.class)
+    @Test
     public void getCachedTrueNotFound() throws Exception {
+
         UserDetailsCache cache = UserDetailsCache.get();
         assertNotNull(cache);
-        try {
-            cache.loadUserByUsername("bob");
-            fail("Bob should not be found");
-        } catch (UsernameNotFoundException e) {
-            //as expected
-        }
-        cache.getCached("bob");
+        assertThrows(UsernameNotFoundException.class, () -> cache.loadUserByUsername("bob"));
+        assertThrows(UsernameNotFoundException.class, () -> cache.getCached("bob"));
     }
 
     @Test


### PR DESCRIPTION
Some test cleanup, mainly eliminating usages of `@Test(expected=[…])`. Such usages are prone to false negatives, since the test passes if _any_ statement throws an exception of the expected type (not just the expected statement). JUnit 4.13 offers a safer and more legible alternative in the form of `Assert#assertThrows`.