### PR TITLE
Use xstream 1.4.16

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -329,7 +329,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.15</version>
+        <version>1.4.16</version>
       </dependency>
       <dependency>
         <groupId>net.sf.kxml</groupId>


### PR DESCRIPTION
## Upgrade from xstream 1.4.15 to [xstream 1.4.16](https://x-stream.github.io/changes.html#1.4.16)

Switches default parser to a fork of Xpp3 instead of using Xpp3 directly.  Resolves security vulnerabilities when unmarshalling with an XStream instance using an uninitialized security framework.  As far as I understand it, Jenkins is not susceptible to those vulnerabilities because it initializes the security framework.

Also fixes two minor items:

* faulty XmlFriendlyNameCoder optimization [issue 237](https://github.com/x-stream/xstream/issues/237)
* enum dereferences fail from older versions [issue 238](https://github.com/x-stream/xstream/issues/238)

### Proposed changelog entries

* Entry 1: Upgrade from xstream 1.4.15 to 1.4.16.  See changelog at https://x-stream.github.io/changes.html#1.4.16

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
