### PR TITLE
[JENKINS-65172] Better support for remote platform-plugins.json

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -235,7 +235,7 @@ public class UpdateSite {
         }
 
         if (signatureCheck) {
-            FormValidation e = verifySignature(o);
+            FormValidation e = verifySignatureInternal(o);
             if (e.kind!=Kind.OK) {
                 LOGGER.severe(e.toString());
                 return e;
@@ -250,7 +250,7 @@ public class UpdateSite {
     }
 
     public FormValidation doVerifySignature() throws IOException {
-        return verifySignature(getJSONObject());
+        return verifySignatureInternal(getJSONObject());
     }
 
     /**
@@ -270,7 +270,8 @@ public class UpdateSite {
     /**
      * Verifies the signature in the update center data file.
      */
-    private FormValidation verifySignature(JSONObject o) throws IOException {
+    @Restricted(NoExternalUse.class)
+    public final FormValidation verifySignatureInternal(JSONObject o) throws IOException {
         return getJsonSignatureValidator().verifySignature(o);
     }
 

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -25,8 +25,10 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.DownloadService;
 import hudson.security.csrf.GlobalCrumbIssuerConfiguration;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.util.FormValidation;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.security.ApiTokenProperty;
 import jenkins.security.apitoken.TokenUuidAndPlainValue;
@@ -550,19 +552,52 @@ public class SetupWizard extends PageDecorator {
         updateSiteList: for (UpdateSite updateSite : Jenkins.get().getUpdateCenter().getSiteList()) {
             String updateCenterJsonUrl = updateSite.getUrl();
             String suggestedPluginUrl = updateCenterJsonUrl.replace("/update-center.json", "/platform-plugins.json");
+            VersionNumber version = Jenkins.getVersion();
+            if (version != null && (suggestedPluginUrl.startsWith("https://") || suggestedPluginUrl.startsWith("http://"))) {
+                // Allow remote update site to distinguish based on the current version
+                // This looks a bit hacky but UpdateCenter#toUpdateCenterCheckUrl does something similar
+                suggestedPluginUrl = suggestedPluginUrl + (suggestedPluginUrl.contains("?") ? "&" : "?") + "version=" + version;
+            }
             try {
                 URLConnection connection = ProxyConfiguration.open(new URL(suggestedPluginUrl));
                 
                 try {
+                    String initialPluginJson = IOUtils.toString(connection.getInputStream(), StandardCharsets.UTF_8);
+
+                    JSONObject initialPluginObject = null;
+
                     if(connection instanceof HttpURLConnection) {
                         int responseCode = ((HttpURLConnection)connection).getResponseCode();
                         if(HttpURLConnection.HTTP_OK != responseCode) {
                             throw new HttpRetryException("Invalid response code (" + responseCode + ") from URL: " + suggestedPluginUrl, responseCode);
                         }
+
+                        if (DownloadService.signatureCheck) {
+                            /* If the platform-plugins.json file was obtained remotely, assume that it's a JSONObject and perform a signature check on it */
+                            initialPluginObject = JSONObject.fromObject(initialPluginJson);
+                            final FormValidation result = updateSite.verifySignatureInternal(initialPluginObject);
+                            if (result.kind != FormValidation.Kind.OK) {
+                                LOGGER.log(Level.WARNING, "Ignoring remote platform-plugins.json: " + result.getMessage());
+                                throw result;
+                            }
+                        }
                     }
-                    
-                    String initialPluginJson = IOUtils.toString(connection.getInputStream(), StandardCharsets.UTF_8);
-                    initialPluginList = JSONArray.fromObject(initialPluginJson);
+
+                    /*
+                        The initial version of this code expected platform-plugins.json to be an array.
+                        This structure does not work when we want to add a signature block, so a wrapper object is also supported.
+                        In that case, the original array is expected to be in the 'categories' key.
+                     */
+                    if (initialPluginObject != null) {
+                        initialPluginList = initialPluginObject.getJSONArray("categories");
+                    } else {
+                        try {
+                            initialPluginList = JSONArray.fromObject(initialPluginJson);
+                        } catch (Exception ex) {
+                            /* Second attempt: It's not a remote file, but still wrapped */
+                            initialPluginList = JSONObject.fromObject(initialPluginJson).getJSONArray("categories");
+                        }
+                    }
                     break updateSiteList;
                 } catch(Exception e) {
                     // not found or otherwise unavailable

--- a/test/src/test/java/jenkins/install/SetupWizardTest.java
+++ b/test/src/test/java/jenkins/install/SetupWizardTest.java
@@ -24,7 +24,9 @@
 package jenkins.install;
 
 import com.gargoylesoftware.htmlunit.Page;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
+import hudson.model.DownloadService;
 import hudson.model.UpdateSite;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.SecurityRealm;
@@ -32,8 +34,25 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.HashSet;
+import java.util.Set;
+
+import jenkins.model.Jenkins;
+import jenkins.util.JSONSignatureValidator;
 import org.apache.commons.io.FileUtils;
 import static org.hamcrest.Matchers.*;
+
+import org.apache.tools.ant.filters.StringInputStream;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,13 +63,17 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.SmokeTest;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Tests of {@link SetupWizard}.
  * @author Oleg Nenashev
  */
 @Category(SmokeTest.class)
 public class SetupWizardTest {
-    
+
     @Rule
     public JenkinsRule j = new JenkinsRule();
     
@@ -82,15 +105,15 @@ public class SetupWizardTest {
         assertThat("Missing plugin is suggestions ", response, containsString("active-directory"));
         assertThat("Missing category is suggestions ", response, containsString("Pipelines and Continuous Delivery"));
     }
-    
+
     @Test
     @Issue("JENKINS-34833")
     public void shouldReturnUpdateSiteJSONIfSpecified() throws Exception {
         // Init the update site
-        CustomUpdateSite us = new CustomUpdateSite(tmpdir.getRoot());
+        CustomLocalUpdateSite us = new CustomLocalUpdateSite(tmpdir.getRoot());
         us.init();
         j.jenkins.getUpdateCenter().getSites().add(us);
-        
+
         // Prepare the connection
         JenkinsRule.WebClient wc = j.createWebClient();
         // TODO: This is a hack, wc.login does not work with the form
@@ -98,14 +121,37 @@ public class SetupWizardTest {
         j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED);
         // wc.setCredentialsProvider(adminCredentialsProvider);
         // wc.login("admin");
-        
+
         String response = jsonRequest(wc, "setupWizard/platformPluginList");
-        assertThat("Missing plugin is suggestions ", response, containsString("antisamy-markup-formatter"));
-        assertThat("Missing category is suggestions ", response, containsString("Organization and Administration"));
-        assertThat("Missing plugin is suggestions ", response, not(containsString("active-directory")));
-        assertThat("Missing category is suggestions ", response, not(containsString("Pipelines and Continuous Delivery")));
+        assertThat("Missing plugin in suggestions ", response, containsString("antisamy-markup-formatter"));
+        assertThat("Missing category in suggestions ", response, containsString("Organization and Administration"));
+        assertThat("Unexpected plugin in suggestions ", response, not(containsString("active-directory")));
+        assertThat("Unexpected category in suggestions ", response, not(containsString("Pipelines and Continuous Delivery")));
     }
-    
+
+    @Test
+    @Issue("JENKINS-34833")
+    public void shouldReturnWrappedUpdateSiteJSONIfSpecified() throws Exception {
+        // Init the update site
+        CustomLocalUpdateSiteWithWrapperJSON us = new CustomLocalUpdateSiteWithWrapperJSON(tmpdir.getRoot());
+        us.init();
+        j.jenkins.getUpdateCenter().getSites().add(us);
+
+        // Prepare the connection
+        JenkinsRule.WebClient wc = j.createWebClient();
+        // TODO: This is a hack, wc.login does not work with the form
+        j.jenkins.setSecurityRealm(SecurityRealm.NO_AUTHENTICATION);
+        j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED);
+        // wc.setCredentialsProvider(adminCredentialsProvider);
+        // wc.login("admin");
+
+        String response = jsonRequest(wc, "setupWizard/platformPluginList");
+        assertThat("Missing plugin in suggestions ", response, containsString("dashboard-view"));
+        assertThat("Missing category in suggestions ", response, containsString("Administration and Organization"));
+        assertThat("Unexpected plugin in suggestions ", response, not(containsString("matrix-auth")));
+        assertThat("Unexpected category in suggestions ", response, not(containsString("Pipelines and Continuous Delivery")));
+    }
+
     @Test
     public void shouldProhibitAccessToPluginListWithoutAuth() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
@@ -126,12 +172,12 @@ public class SetupWizardTest {
         final String responseJSON = res.getWebResponse().getContentAsString();
         return responseJSON;
     }
-    
-    private static final class CustomUpdateSite extends UpdateSite {
-        
+
+    private static final class CustomLocalUpdateSite extends UpdateSite {
+
         private final File tmpdir;
-        
-        CustomUpdateSite(File tmpdir) throws MalformedURLException {
+
+        CustomLocalUpdateSite(File tmpdir) throws MalformedURLException {
             super("custom-uc", tmpdir.toURI().toURL().toString() + "update-center.json");
             this.tmpdir = tmpdir;
         }
@@ -140,9 +186,267 @@ public class SetupWizardTest {
             File newFile = new File(tmpdir, "platform-plugins.json");
             FileUtils.write(newFile, "[ { "
                     + "\"category\":\"Organization and Administration\", "
-                    + "\"plugins\": [ { \"name\": \"dashboard-view\"}, { \"name\": \"antisamy-markup-formatter\" } ]"
+                    + "\"plugins\": [ { \"name\": \"antisamy-markup-formatter\" } ]"
                     + "} ]");
         }
-        
     }
+
+    private static final class CustomLocalUpdateSiteWithWrapperJSON extends UpdateSite {
+
+        private final File tmpdir;
+
+        CustomLocalUpdateSiteWithWrapperJSON(File tmpdir) throws MalformedURLException {
+            super("custom-uc2", tmpdir.toURI().toURL().toString() + "update-center.json");
+            this.tmpdir = tmpdir;
+        }
+
+        public void init() throws IOException {
+            File newFile = new File(tmpdir, "platform-plugins.json");
+            FileUtils.write(newFile, "{ \"categories\" : [ { "
+                    + "\"category\":\"Administration and Organization\", "
+                    + "\"plugins\": [ { \"name\": \"dashboard-view\"} ]"
+                    + "} ] }");
+        }
+    }
+
+    @Test
+    public void testRemoteUpdateSiteFailingValidation() throws Exception {
+        URL baseUrl;
+        final String serverContext = "/_relative/";
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        server.addConnector(connector);
+        server.setHandler(new RemoteUpdateSiteHandler(serverContext, true));
+        try {
+            server.start();
+            baseUrl = new URL("http", "localhost", connector.getLocalPort(), serverContext);
+
+            // Init the update site
+            CustomRemoteUpdateSite us = new CustomRemoteUpdateSite(baseUrl.toString(), false);
+            j.jenkins.getUpdateCenter().getSites().add(us);
+
+            // Prepare the connection
+            JenkinsRule.WebClient wc = j.createWebClient();
+            // TODO: This is a hack, wc.login does not work with the form
+            j.jenkins.setSecurityRealm(SecurityRealm.NO_AUTHENTICATION);
+            j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED);
+            // wc.setCredentialsProvider(adminCredentialsProvider);
+            // wc.login("admin");
+
+            String response = jsonRequest(wc, "setupWizard/platformPluginList");
+            // We need to assert that signature check fails, and we're falling back to the bundled resource
+            assertThat("Missing plugin in suggestions ", response, not(containsString("my-plugin")));
+            assertThat("Missing category in suggestions ", response, not(containsString("Very Useful Category")));
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testRemoteUpdateSiteSkippingValidation() throws Exception {
+        URL baseUrl;
+        final String serverContext = "/_relative/";
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        server.addConnector(connector);
+        server.setHandler(new RemoteUpdateSiteHandler(serverContext, true));
+        try {
+            server.start();
+            DownloadService.signatureCheck = false;
+            baseUrl = new URL("http", "localhost", connector.getLocalPort(), serverContext);
+
+            // Init the update site
+            CustomRemoteUpdateSite us = new CustomRemoteUpdateSite(baseUrl.toString(), false);
+            j.jenkins.getUpdateCenter().getSites().add(us);
+
+
+            // Prepare the connection
+            JenkinsRule.WebClient wc = j.createWebClient();
+            // TODO: This is a hack, wc.login does not work with the form
+            j.jenkins.setSecurityRealm(SecurityRealm.NO_AUTHENTICATION);
+            j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED);
+            // wc.setCredentialsProvider(adminCredentialsProvider);
+            // wc.login("admin");
+
+            String response = jsonRequest(wc, "setupWizard/platformPluginList");
+            // We need to assert that signature check fails, and we're falling back to the bundled resource
+            assertThat("Missing plugin in suggestions ", response, containsString("my-plugin"));
+            assertThat("Missing category in suggestions ", response, containsString("Very Useful Category"));
+            assertThat("Unexpected plugin in suggestions ", response, not(containsString("matrix-auth")));
+            assertThat("Unexpected category in suggestions ", response, not(containsString("Pipelines and Continuous Delivery")));
+        } finally {
+            DownloadService.signatureCheck = true;
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testRemoteUpdateSitePerformingValidation() throws Exception {
+        URL baseUrl;
+        final String serverContext = "/_relative/";
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        server.addConnector(connector);
+        server.setHandler(new RemoteUpdateSiteHandler(serverContext, true));
+        try {
+            server.start();
+            baseUrl = new URL("http", "localhost", connector.getLocalPort(), serverContext);
+
+            // Init the update site
+            CustomRemoteUpdateSite us = new CustomRemoteUpdateSite(baseUrl.toString(), true);
+            j.jenkins.getUpdateCenter().getSites().add(us);
+
+
+            // Prepare the connection
+            JenkinsRule.WebClient wc = j.createWebClient();
+            // TODO: This is a hack, wc.login does not work with the form
+            j.jenkins.setSecurityRealm(SecurityRealm.NO_AUTHENTICATION);
+            j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED);
+            // wc.setCredentialsProvider(adminCredentialsProvider);
+            // wc.login("admin");
+
+            String response = jsonRequest(wc, "setupWizard/platformPluginList");
+            // We need to assert that signature check fails, and we're falling back to the bundled resource
+            assertThat("Missing plugin in suggestions ", response, containsString("my-plugin"));
+            assertThat("Missing category in suggestions ", response, containsString("Very Useful Category"));
+            assertThat("Unexpected plugin in suggestions ", response, not(containsString("matrix-auth")));
+            assertThat("Unexpected category in suggestions ", response, not(containsString("Pipelines and Continuous Delivery")));
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static final class CustomRemoteUpdateSite extends UpdateSite {
+        private boolean customValidator;
+
+        CustomRemoteUpdateSite(String baseUrl, boolean customValidator) throws MalformedURLException {
+            super("custom-uc2", baseUrl + "update-center.json");
+            this.customValidator = customValidator;
+        }
+
+        @NonNull
+        @Override
+        protected JSONSignatureValidator getJsonSignatureValidator(String name) {
+            if (customValidator) {
+                return new CustomJSONSignatureValidator(CERT);
+            }
+            return super.getJsonSignatureValidator(name);
+        }
+    }
+
+    private static class RemoteUpdateSiteHandler extends AbstractHandler {
+        private String serverContext;
+        private boolean includeSignature;
+
+        // TODO we can always include the signature, a signature that isn't configured client-side behaves as if unsigned.
+        RemoteUpdateSiteHandler(String serverContext, boolean includeSignature) {
+            this.serverContext = serverContext;
+            this.includeSignature = includeSignature;
+        }
+
+        @Override
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+            String responseBody = getWebServerResource(target, request.getParameter("version"));
+            if (responseBody != null) {
+                baseRequest.setHandled(true);
+                response.setContentType("text/plain; charset=utf-8");
+                response.setStatus(HttpServletResponse.SC_OK);
+                response.getOutputStream().write(responseBody.getBytes());
+            } else {
+                response.sendError(404);
+            }
+        }
+
+        private String getWebServerResource(String target, String version) throws IOException {
+            if (target.equals(serverContext + "platform-plugins.json")) {
+                if (version == null) {
+                    throw new IOException("?version parameter value is missing");
+                }
+                if (!version.equals(Jenkins.getVersion().toString())) {
+                    throw new IOException("Unexpected ?version parameter value: " + version);
+                }
+                if (includeSignature) {
+                    return "{ \"categories\":[ {\n" +
+                            "\"category\":\"Very Useful Category\",\n" +
+                            "\"plugins\":[ {\"name\":\"my-plugin\", \"suggested\":false } ]\n" +
+                            "} ],\n" +
+                            "\"signature\":{\n" +
+                            "\"certificates\":[\n" +
+                            "\"MIIFdDCCA1wCCQC9xxIN0UapszANBgkqhkiG9w0BAQsFADB8MRowGAYDVQQKDBFsb2NhbC1kZXZlbG9wbWVudDEaMBgGA1UECwwRbG9jYWwtZGV2ZWxvcG1lbnQxGjAYBgNVBAMMEWxvY2FsLWRldmVsb3BtZW50MSYwJAYJKoZIhvcNAQkBFhdleGFtcGxlQGV4YW1wbGUuaW52YWxpZDAeFw0yMTAzMTgxODM0MzFaFw0yNjAyMjAxODM0MzFaMHwxGjAYBgNVBAoMEWxvY2FsLWRldmVsb3BtZW50MRowGAYDVQQLDBFsb2NhbC1kZXZlbG9wbWVudDEaMBgGA1UEAwwRbG9jYWwtZGV2ZWxvcG1lbnQxJjAkBgkqhkiG9w0BCQEWF2V4YW1wbGVAZXhhbXBsZS5pbnZhbGlkMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAz0k6D4HtPoSvLUKrtcHkBHTyd4Zd1EZkwD7V3CgoLOFYboozjPX3U+q3paGUaQZ9Ejggbq5Cwsv7PHpn89OQ20Cy53RF19pChX2Zx/uuF5SjMapchtAJIwj0EjQNo5MqYuRjm6kOFA6ZwD13nLxeH1YfWeKN7xPkmbMkc1ruXrZNd9XPYtmGNFR8oH/N1CYc7dZ3RNZLwMNZv3981yVcZ19T5JvyxlTCaWDsr6ODgNx0zG0mc0nAdDi+TSNxzJfoIF+klkc9IODsqhrE6CpD0R1Wny7sedUc/cxviO2lmKGq+3bqUIq4Xlr/q8kCFVC478QM9zj6/SmFzMioXGq4JFHj0m1Am6pIpay1hqCZeKXXIRMs80KC3XCQ2+z+woP/Iu4fJyclwGxfPh0zq+cPDwtyH5VkX1QBMv3ge2Ks7wESTd3HaZrkt+/2Mk9eo7o0IVxeq/BQ9rwvtzfrxynuhLBXOTh1ViZYC58wYT8UZ/3F8GKveW3LlgXf0cdpTl7xGUdw4dOq5IkgPgJZZ6oB757NXPLa68wlcx8acRA7xv4IqdjuSDEZVF48UJi57GPJKnhi+9bWFpz7l1c0Yh2LGY3DoHPJ4WXctFrHTaY3+vAyiSBgFMCwYyxTdI33b5MeMlS56xuBUxZCqsnwlqvDH2jECa+oqzOa29s0EftdMn8CAwEAATANBgkqhkiG9w0BAQsFAAOCAgEAQ42dkh6fmFVoCRzh/UUC/XCyiXL3DvzzPmjuwKB2l3+C2ysvTtpCsiVj3KZcJztxbPMysllQ5M6VGbKuzwxtsBNn+XQwpbM9MBYJH7q9Xl1p+T3/KOHY3mbXh5+Ka1m7cJHkj6E1P6yIykDLC3pF4MEzqMW33NBxymeax3Xgztq+sPxfV0qv8102rezFOsO5ke1a52zlLgyuzTMPLgc1mBiQfM1q0b+aQl05dU54k1dEN8DVCPBZXbFc2s6ewXmPu+yyDqK/iMORa8jmHJtZpL+UMzPNrLxC7k32LQBVt/OZFiQDCW9oATI7wVKhC/yls/cP5mfrhckrP/uxqTKwOS6TgkwT/rHQ11TzBlLCKX1RqfGn20zQ/lMyvfK4uFBpiMZkg/m9Wr5DiOMLHj44thlI3oH9Qko3kBLj4nr01Vg29IJgsPbkNYKrOwGFXgCWqpNJZEVqjA5SNpRNFMUpRtDLrJla3xIWRxo/rCCe5GNBoJeT9d0TlKu//lCOQUwzcWE8K5yesjWXPXCXDRA0a+/LSi9YIqGUNWAvoPQ5FWyRekcAu5mKr6BqaertX2dzF3/PYJ2VgW9jT8nDi1D0zmEdbrtKVGuKqR04SI6ZI8NvyheUbzsV0q4Qt2V2uHcQ4j8AErff7WDPFdn7P7FyaV0h0zBv6/XJs1JSb3nwtHA=\"\n" +
+                            "],\n" +
+                            "\"correct_digest\":\"Gm5yn9FM+pTT5yHYCZZchmXjd4U=\",\n" +
+                            "\"correct_digest512\":\"67a9853b8a3fe322a321af26915c7fd503d89be787b3f7c1e8d8a8413d7458ad75f12f75fe1b5d9c672e048e1bd3b60fc294779f8606701e0435b41dc5602e97\",\n" +
+                            "\"correct_signature\":\"XjqrkmZ4FB8WDewkKymuoG13P477SlnugZ/rIea6/tP27urcwHhLq9HpvfqFHBN+xcMStXat+m2E0MZvxEg4Tdaiw2rELHvPCglm1pUPIBeXSNMppoyTy+qg9w2Z3nNGB8ZoCkJy2/Bq28P/CzKwgBuBeKObAk6t6Xuhwm+MbxDHAg1j/Hman9pj9X9AeOW6mlGXG7wVgtS3CwGf7dtNQNnNjIWosvMe4WLw9Yo2JuVBi+p3VtxMfwafMbZEwGK9Dh1EFZHiBsjb+ksvSFfEa/h3C2EXQYi8+jIbGYO0HCVZPvFv3TRvj30ogku2yXvUrK0uAw5e65e2dZmRMr5yCrOfzRYAafxd47peSn2+kyWquxsTzUqwhelquvY3w9fE3Hmv4tSIU9lJvBUeu/IQEDJ3ET5XzFX3fHhw5O3FV54eLWLsTx4tfRWVfn90Nu/YEpz5F67CZE75ci9wGzOTcqVkC9aW2jqAS8TlpgkDgaflggG2mjJIjOHuyrUBMD9X0Ie7UUY/6H/j4fnTkHy+ea80VKhrn9S+qggIjbvp9VH+xgl0vHQ5I3+NwOchVOdIsCU6dZkZeOkohfcc4LLSihJ86zovi9PJmVRv2CATGwghika6hhfAhKjh7ZbD0Dcd3qO3qbqud/LEN5l7fJBaO4iMMKWzlV0Sa7k1q/zWxp8=\",\n" +
+                            "\"correct_signature512\":\"a197809570f986fa34f3e264b11a3beed3e08794b0f8991302a1418544ef7d75beb296c5fa0e17b8eeb06305e5279ea8680ee2f161b2ec9c926b2491aa1286ecd82865e9141f790114762fa09e1f23f4f521f2838753082226a6cb28f1439312ec1eec66aea7f220035b2808bd3f30300f81a6685e8f89b82a20f470706bc83c2ffb2e5d65c0a682263d291849dddafe0be442d9b73e3737a86b5992d96698272b9d9efaa8c2475a4020e5cd8d56b715fb6844d98539ab4c31eb7a8080b8231ee2452fc765407203f858af5211a3288ee8f2f9cefa4dd02f5164a1b241681cf7c81b203ded13e47484a041dc10eb988c398a0a94bed8ddd70a0c65a6a378f09e5e138a802300731865fc9e894c7eeeaf59efbe8f8f845ae101cbcd32ebba017d4413c806cbca1a0ef0e586fe1f43b9d015574ef8d2da0808df574fe6946c6301d82b2267f9751e977888568946870b17c001f3a09203f71f79035b55b7d77b2fd2ef00db89a0839cd21ee5bd2bc1b552c67d48f8d0c76888b8b64d1007a6594d0975b6b3220d180daadb075607a406b5e5ecd4f44c79536017bb37847d6e5bbd309579e88527e7dddb459c8d722157ea22dbb2686a2ef4e3d9ca27b59144326ea1f6eab27b51dadb7355414c41f9d0c9185a63ab3b0a4da40a37cb2680d0999d46cddddfdad2d10fe11d1104486db5923a95c2b1ad98f26882ee91c3c5f347b6\"\n" +
+                            "} }";
+                } else {
+                    return "{ \"categories\" : [ { "
+                            + "\"category\":\"Very Useful Category\", "
+                            + "\"plugins\": [ { \"name\": \"my-plugin\"} ]"
+                            + "} ] }";
+                }
+            }
+            return null;
+        }
+    }
+
+    private static class CustomJSONSignatureValidator extends JSONSignatureValidator {
+        private String cert;
+
+        public CustomJSONSignatureValidator(String cert) {
+            super("Custom JSON signature validator");
+            this.cert = cert;
+        }
+
+        @Override
+        protected Set<TrustAnchor> loadTrustAnchors(CertificateFactory cf) throws IOException {
+            Set<TrustAnchor> trustAnchors = new HashSet<>();
+            try {
+                Certificate certificate = cf.generateCertificate(new StringInputStream(cert));
+                trustAnchors.add(new TrustAnchor((X509Certificate) certificate, null));
+            } catch (CertificateException ex) {
+                throw new IOException(ex);
+            }
+            return trustAnchors;
+        }
+    }
+
+    // Used to test signature validation in remote platform-plugins JSON
+    // Generated using:
+    // openssl genrsa -out demo.key 4096
+    // openssl req -new -x509 -days 1800 -key demo.key -out demo.crt -subj "/C=/ST=/L=/O=local-development/OU=local-development/CN=local-development/emailAddress=example@example.invalid"
+    // Then signed using update-center2 args: --key demo.key --certificate demo.crt --pretty-json --root-certificate demo.crt --generate-platform-plugins --skip-update-center --www-dir output
+    private static final String CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIFdDCCA1wCCQC9xxIN0UapszANBgkqhkiG9w0BAQsFADB8MRowGAYDVQQKDBFs\n" +
+            "b2NhbC1kZXZlbG9wbWVudDEaMBgGA1UECwwRbG9jYWwtZGV2ZWxvcG1lbnQxGjAY\n" +
+            "BgNVBAMMEWxvY2FsLWRldmVsb3BtZW50MSYwJAYJKoZIhvcNAQkBFhdleGFtcGxl\n" +
+            "QGV4YW1wbGUuaW52YWxpZDAeFw0yMTAzMTgxODM0MzFaFw0yNjAyMjAxODM0MzFa\n" +
+            "MHwxGjAYBgNVBAoMEWxvY2FsLWRldmVsb3BtZW50MRowGAYDVQQLDBFsb2NhbC1k\n" +
+            "ZXZlbG9wbWVudDEaMBgGA1UEAwwRbG9jYWwtZGV2ZWxvcG1lbnQxJjAkBgkqhkiG\n" +
+            "9w0BCQEWF2V4YW1wbGVAZXhhbXBsZS5pbnZhbGlkMIICIjANBgkqhkiG9w0BAQEF\n" +
+            "AAOCAg8AMIICCgKCAgEAz0k6D4HtPoSvLUKrtcHkBHTyd4Zd1EZkwD7V3CgoLOFY\n" +
+            "boozjPX3U+q3paGUaQZ9Ejggbq5Cwsv7PHpn89OQ20Cy53RF19pChX2Zx/uuF5Sj\n" +
+            "MapchtAJIwj0EjQNo5MqYuRjm6kOFA6ZwD13nLxeH1YfWeKN7xPkmbMkc1ruXrZN\n" +
+            "d9XPYtmGNFR8oH/N1CYc7dZ3RNZLwMNZv3981yVcZ19T5JvyxlTCaWDsr6ODgNx0\n" +
+            "zG0mc0nAdDi+TSNxzJfoIF+klkc9IODsqhrE6CpD0R1Wny7sedUc/cxviO2lmKGq\n" +
+            "+3bqUIq4Xlr/q8kCFVC478QM9zj6/SmFzMioXGq4JFHj0m1Am6pIpay1hqCZeKXX\n" +
+            "IRMs80KC3XCQ2+z+woP/Iu4fJyclwGxfPh0zq+cPDwtyH5VkX1QBMv3ge2Ks7wES\n" +
+            "Td3HaZrkt+/2Mk9eo7o0IVxeq/BQ9rwvtzfrxynuhLBXOTh1ViZYC58wYT8UZ/3F\n" +
+            "8GKveW3LlgXf0cdpTl7xGUdw4dOq5IkgPgJZZ6oB757NXPLa68wlcx8acRA7xv4I\n" +
+            "qdjuSDEZVF48UJi57GPJKnhi+9bWFpz7l1c0Yh2LGY3DoHPJ4WXctFrHTaY3+vAy\n" +
+            "iSBgFMCwYyxTdI33b5MeMlS56xuBUxZCqsnwlqvDH2jECa+oqzOa29s0EftdMn8C\n" +
+            "AwEAATANBgkqhkiG9w0BAQsFAAOCAgEAQ42dkh6fmFVoCRzh/UUC/XCyiXL3Dvzz\n" +
+            "PmjuwKB2l3+C2ysvTtpCsiVj3KZcJztxbPMysllQ5M6VGbKuzwxtsBNn+XQwpbM9\n" +
+            "MBYJH7q9Xl1p+T3/KOHY3mbXh5+Ka1m7cJHkj6E1P6yIykDLC3pF4MEzqMW33NBx\n" +
+            "ymeax3Xgztq+sPxfV0qv8102rezFOsO5ke1a52zlLgyuzTMPLgc1mBiQfM1q0b+a\n" +
+            "Ql05dU54k1dEN8DVCPBZXbFc2s6ewXmPu+yyDqK/iMORa8jmHJtZpL+UMzPNrLxC\n" +
+            "7k32LQBVt/OZFiQDCW9oATI7wVKhC/yls/cP5mfrhckrP/uxqTKwOS6TgkwT/rHQ\n" +
+            "11TzBlLCKX1RqfGn20zQ/lMyvfK4uFBpiMZkg/m9Wr5DiOMLHj44thlI3oH9Qko3\n" +
+            "kBLj4nr01Vg29IJgsPbkNYKrOwGFXgCWqpNJZEVqjA5SNpRNFMUpRtDLrJla3xIW\n" +
+            "Rxo/rCCe5GNBoJeT9d0TlKu//lCOQUwzcWE8K5yesjWXPXCXDRA0a+/LSi9YIqGU\n" +
+            "NWAvoPQ5FWyRekcAu5mKr6BqaertX2dzF3/PYJ2VgW9jT8nDi1D0zmEdbrtKVGuK\n" +
+            "qR04SI6ZI8NvyheUbzsV0q4Qt2V2uHcQ4j8AErff7WDPFdn7P7FyaV0h0zBv6/XJ\n" +
+            "s1JSb3nwtHA=\n" +
+            "-----END CERTIFICATE-----\n";
+
 }


### PR DESCRIPTION
See [JENKINS-65172](https://issues.jenkins-ci.org/browse/JENKINS-65172).

Discussions around setup wizard contents come up occasionally. We haven't done a lot in this space since the initial definition of suggestions in 2.0 except e.g. removing few unmaintained or otherwise suspended plugins (#5016), but given the age of these suggestions and evolution of Jenkins I expect more substantial changes to come.

The Jenkins setup wizard has supported retrieving `platform-plugins.json`, the file controlling which plugins are suggested, from update sites since 2.0 (or shortly afterwards). The file is requested and, if not found, Jenkins falls back to the local resource file. This feature could be used to apply changes to setup wizard contents retroactively (whether additions or removals like the one linked above).

This change adds support for Jenkins project infra requirements:

* We add a `?version` parameter to allow for Jenkins version-specific redirects. Not all additions/removals may make sense for all versions of Jenkins.
* We wrap the list in a new object that can be signed like everything else we serve.

Support for the existing, simpler format is retained for local update sites (not an `HttpURLConnection`, e.g. `file:` URLs).

The corresponding infra improvement is https://github.com/jenkins-infra/update-center2/pull/498, which is a fairly minimal implementation for this. It can always be enhanced once we decide to start providing wizard suggestions from update sites.

How to test:

Generate `platform-plugins.json` using `update-center2` and set up a web server with that and the `update-center.*` files. Then run with an empty `JENKINS_HOME`:

> `java -Dhudson.model.UpdateCenter.updateCenterUrl=http://localhost:9000/ -Dhudson.model.DownloadService.noSignatureCheck=true -jar war/target/jenkins.war`


### Proposed changelog entries

* Improve support for update site-defined setup wizard suggestions.


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
