### PR TITLE
Add a Jenkins User-Agent header to outgoing HTTP requests

### DIFF
--- a/core/src/main/java/jenkins/UserAgentURLConnectionDecorator.java
+++ b/core/src/main/java/jenkins/UserAgentURLConnectionDecorator.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins;
+
+import hudson.Extension;
+import hudson.URLConnectionDecorator;
+import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URLConnection;
+
+/**
+ * Sets a Jenkins specific user-agent HTTP header for {@link HttpURLConnection}.
+ *
+ * @since TODO
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+@Symbol("userAgent")
+public class UserAgentURLConnectionDecorator extends URLConnectionDecorator {
+    private static /* non-final for Groovy */ boolean DISABLED = SystemProperties.getBoolean(UserAgentURLConnectionDecorator.class.getName() + ".DISABLED");
+
+    @Override
+    public void decorate(URLConnection con) throws IOException {
+        if (!DISABLED && con instanceof HttpURLConnection) {
+            HttpURLConnection httpConnection = (HttpURLConnection) con;
+            httpConnection.setRequestProperty("User-Agent", "Jenkins/" + Jenkins.getVersion());
+        }
+    }
+}


### PR DESCRIPTION
Minor enhancement: Report "Jenkins" and the version in outgoing HTTP requests.

In case of problems (unlikely) or if someone prefers to report the Java runtime version over the Jenkins version (the current behavior), this can be disabled through script console or system property (which will I will document on jenkins.io once this is merged).

### Proposed changelog entries

* Add a Jenkins User-Agent header to outgoing HTTP requests by default. Use `jenkins.UserAgentURLConnectionDecorator.disabled` to disable it if needed.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
