### PR TITLE
[JENKINS-36707] Add `CI` environment variable

### DIFF
--- a/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java
+++ b/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java
@@ -41,6 +41,8 @@ public class CoreEnvironmentContributor extends EnvironmentContributor {
 
     @Override
     public void buildEnvironmentFor(Job j, EnvVars env, TaskListener listener) throws IOException, InterruptedException {
+        env.put("CI", "true");
+
         Jenkins jenkins = Jenkins.get();
         String rootUrl = jenkins.getRootUrl();
         if(rootUrl!=null) {

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
@@ -3,7 +3,7 @@ package jenkins.model.CoreEnvironmentContributor
 def l = namespace(lib.JenkinsTagLib)
 
 // also advertises those contributed by Run.getCharacteristicEnvVars()
-["BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "JOB_BASE_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","WORKSPACE_TMP","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
+["CI","BUILD_NUMBER","BUILD_ID","BUILD_DISPLAY_NAME","JOB_NAME", "JOB_BASE_NAME","BUILD_TAG","EXECUTOR_NUMBER","NODE_NAME","NODE_LABELS","WORKSPACE","WORKSPACE_TMP","JENKINS_HOME","JENKINS_URL","BUILD_URL","JOB_URL"].each { name ->
     l.buildEnvVar(name:name) {
         raw(_("${name}.blurb"))
     }

--- a/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
+++ b/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.properties
@@ -1,5 +1,6 @@
-BUILD_NUMBER.blurb=The current build number, such as "153"
-BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds created in 1.597+, but a YYYY-MM-DD_hh-mm-ss timestamp for older builds
+CI.blurb=Statically set to the string "true" to indicate a "continuous integration" execution environment.
+BUILD_NUMBER.blurb=The current build number, such as "153".
+BUILD_ID.blurb=The current build ID, identical to BUILD_NUMBER for builds created in 1.597+, but a YYYY-MM-DD_hh-mm-ss timestamp for older builds.
 BUILD_DISPLAY_NAME.blurb=The display name of the current build, which is something like "#153" by default.
 JOB_NAME.blurb=Name of the project of this build, such as "foo" or "foo/bar".
 JOB_BASE_NAME.blurb=Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".
@@ -9,7 +10,7 @@ EXECUTOR_NUMBER.blurb=\
   (among executors of the same machine) that\u2019s \
   carrying out this build. This is the number you see in \
   the "build executor status", except that the number starts from 0, not 1.
-NODE_NAME.blurb=Name of the agent if the build is on an agent, or "master" if run on master
+NODE_NAME.blurb=Name of the agent if the build is on an agent, or "master" if run on master.
 NODE_LABELS.blurb=Whitespace-separated list of labels that the node is assigned.
 WORKSPACE.blurb=The absolute path of the directory assigned to the build as a workspace.
 WORKSPACE_TMP.blurb=\
@@ -17,6 +18,6 @@ WORKSPACE_TMP.blurb=\
   May not initially exist, so be sure to create the directory as needed (e.g., <code>mkdir -p</code> on Linux). \
   Not defined when the regular workspace is a drive root.
 JENKINS_HOME.blurb=The absolute path of the directory assigned on the master node for Jenkins to store data.
-JENKINS_URL.blurb=Full URL of Jenkins, like <tt>http://server:port/jenkins/</tt> (note: only available if <i>Jenkins URL</i> set in system configuration)
-BUILD_URL.blurb=Full URL of this build, like <tt>http://server:port/jenkins/job/foo/15/</tt> (<i>Jenkins URL</i> must be set)
-JOB_URL.blurb=Full URL of this job, like <tt>http://server:port/jenkins/job/foo/</tt> (<i>Jenkins URL</i> must be set)
+JENKINS_URL.blurb=Full URL of Jenkins, like <tt>http://server:port/jenkins/</tt> (note: only available if <i>Jenkins URL</i> set in system configuration).
+BUILD_URL.blurb=Full URL of this build, like <tt>http://server:port/jenkins/job/foo/15/</tt> (<i>Jenkins URL</i> must be set).
+JOB_URL.blurb=Full URL of this job, like <tt>http://server:port/jenkins/job/foo/</tt> (<i>Jenkins URL</i> must be set).


### PR DESCRIPTION
See [JENKINS-36707](https://issues.jenkins-ci.org/browse/JENKINS-36707).

Introduces a standard `CI` env var that is always set to "true" in order
to allow pipelines and tools to know they're executing in a continuous
integration context. This has emerged as a best practice used by most
other popular CI solutions, and a number of tools look for this variable
in order to make CI-appropriate optimizations (cf. the ticket).

Closes JENKINS-36707.

### Proposed changelog entries

* JENKINS-36707, Adds a "CI" environment variable, always set to "true" as in most other CI solutions. Note that the presence of this variable may change behavior of some of the tools used in your pipelines.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs _(N/A)_

### Desired reviewers

@daniel-beck (since he's active on the ticket, but anyone can review)

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
