### PR TITLE
Bump mailer from 1.33 to 1.34

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -57,12 +57,6 @@ THE SOFTWARE.
         <version>1.11</version>
       </dependency>
       <dependency>
-        <!-- requireUpperBoundDeps via mailer and junit -->
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>display-url-api</artifactId>
-        <version>2.3.4</version>
-      </dependency>
-      <dependency>
         <!-- requireUpperBoundDeps via matrix-project and junit -->
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>script-security</artifactId>
@@ -105,7 +99,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.33</version>
+      <version>1.34</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Bumps [Mailer](https://plugins.jenkins.io/mailer/) to the latest version and removes a now-unneeded entry from the `<dependencyManagement>` section that was originally added to deal with a `requireUpperBoundDeps` error that is no longer present. May or may not require a revert of commit cbe2b0f1d3 to adapt to jenkinsci/mailer-plugin#112 but I can't run the test locally to find out, so let's see what happens in the CI run.