### PR TITLE
Refactored multiple assertion tests into parameterized ones

### DIFF
--- a/cli/src/test/java/hudson/cli/HexDumpTest.java
+++ b/cli/src/test/java/hudson/cli/HexDumpTest.java
@@ -1,41 +1,49 @@
 package hudson.cli;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class HexDumpTest {
 
-  @Test
-  public void testToHex1() {
-    assertEquals("'fooBar'",
-            HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}));
-    assertEquals("0xc3",
-            HexDump.toHex(new byte[] {(byte)'Ã'}));
-    assertEquals("0xac '100'",
-            HexDump.toHex(new byte[] {(byte)'€', '1', '0', '0'}));
-    assertEquals("'1' 0xf7 '2'",
-            HexDump.toHex(new byte[] {'1', (byte)'÷', '2'}));
-    assertEquals("'foo' 0x0a\n'Bar'",
-            HexDump.toHex(new byte[] {'f', 'o', 'o', '\n', 'B', 'a', 'r'}));
+  @ParameterizedTest
+  @MethodSource("testToHex1Sources")
+  public void testToHex1(String expected, byte[] buf) {
+    assertEquals(expected, HexDump.toHex(buf));
   }
 
-  @Test
-  public void testToHex2() {
-    assertEquals("'ooBa'",
-            HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}, 1, 4));
-    assertEquals("0xc3",
-            HexDump.toHex(new byte[] {(byte)'Ã'}, 0, 1));
-    assertEquals("0xac '10'",
-            HexDump.toHex(new byte[] {(byte)'€', '1', '0', '0'}, 0, 3));
-    assertEquals("0xf7 '2'",
-            HexDump.toHex(new byte[] {'1', (byte)'÷', '2'}, 1, 2));
-    assertEquals("'Bar'",
-            HexDump.toHex(new byte[] {'f', 'o', 'o', '\n', 'B', 'a', 'r'}, 4, 3));
-    assertEquals("",
-            HexDump.toHex(new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}, 0, 0));
+  static Stream<Arguments> testToHex1Sources() {
+    return Stream.of(
+            arguments("'fooBar'", new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}),
+            arguments("0xc3", new byte[] {(byte)'Ã'}),
+            arguments("0xac '100'", new byte[] {(byte)'€', '1', '0', '0'}),
+            arguments("'1' 0xf7 '2'", new byte[] {'1', (byte)'÷', '2'}),
+            arguments("'foo' 0x0a\n'Bar'", new byte[] {'f', 'o', 'o', '\n', 'B', 'a', 'r'})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testToHex2Sources")
+  public void testToHex2(String expected, byte[] buf, int start, int len) {
+    assertEquals(expected, HexDump.toHex(buf, start, len));
+  }
+
+  static Stream<Arguments> testToHex2Sources() {
+    return Stream.of(
+            arguments("'ooBa'", new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}, 1, 4),
+            arguments("0xc3", new byte[] {(byte)'Ã'}, 0, 1),
+            arguments("0xac '10'", new byte[] {(byte)'€', '1', '0', '0'}, 0, 3),
+            arguments("0xf7 '2'", new byte[] {'1', (byte)'÷', '2'}, 1, 2),
+            arguments("'Bar'", new byte[] {'f', 'o', 'o', '\n', 'B', 'a', 'r'}, 4, 3),
+            arguments("", new byte[] {'f', 'o', 'o', 'B', 'a', 'r'}, 0, 0)
+    );
   }
 }

--- a/cli/src/test/java/hudson/cli/HexDumpTest.java
+++ b/cli/src/test/java/hudson/cli/HexDumpTest.java
@@ -1,5 +1,6 @@
 package hudson.cli;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,7 +15,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 @Execution(ExecutionMode.CONCURRENT)
 public class HexDumpTest {
 
-  @ParameterizedTest
+  @DisplayName("Test HexDump.toHex(byte[] buf)")
+  @ParameterizedTest(name = "{index} => expected: {0}, buf: {1}")
   @MethodSource("testToHex1Sources")
   public void testToHex1(String expected, byte[] buf) {
     assertEquals(expected, HexDump.toHex(buf));
@@ -30,7 +32,8 @@ public class HexDumpTest {
     );
   }
 
-  @ParameterizedTest
+  @DisplayName("Test HexDump.toHex(byte[] buf, int start, int len)")
+  @ParameterizedTest(name = "{index} => expected: {0}, buf: {1}, start: {2}, len: {3}")
   @MethodSource("testToHex2Sources")
   public void testToHex2(String expected, byte[] buf, int start, int len) {
     assertEquals(expected, HexDump.toHex(buf, start, len));


### PR DESCRIPTION
Problem:
A test method with many individual assertions stops being executed on the first failed assertion, which prevents the remaining ones' execution. In the refactored methods, the difference between the assertions lies in different arguments only.

Solution:
Parameterized tests make it possible to run a test multiple times, with different arguments, as individual and independent tests. This way, we were able to make 2 original tests become 11 independent ones. In this refactoring, no original assertion parameter was changed.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
