### PR TITLE
[JENKINS-65288] Bring back support for stapler.jelly.trace

### DIFF
--- a/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/index.jelly
@@ -66,7 +66,7 @@ THE SOFTWARE.
                         }
                       }
                       var scheduleDiv = document.getElementById('scheduleRestartBlock');
-                      scheduleDiv.innerHTML = div.lastChild.innerHTML;
+                      scheduleDiv.innerHTML = div.lastElementChild.innerHTML;
                       refresh();
                   }
               });

--- a/core/src/main/resources/lib/form/advanced/advanced.js
+++ b/core/src/main/resources/lib/form/advanced/advanced.js
@@ -15,8 +15,8 @@ Behaviour.specify("INPUT.advanced-button", 'advanced', 0, function(e) {
 
             // move the contents of the advanced portion into the main table
             var nameRef = tr.getAttribute("nameref");
-            while (container.lastChild != null) {
-                var row = container.lastChild;
+            while (container.lastElementChild != null) {
+                var row = container.lastElementChild;
                 if(nameRef!=null && row.getAttribute("nameref")==null)
                     row.setAttribute("nameref",nameRef); // to handle inner rowSets, don't override existing values
                 $(row).setOpacity(0);

--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -13,7 +13,7 @@ Behaviour.specify("DIV.hetero-list-container", 'hetero-list', -100, function(e) 
         }
         YAHOO.util.Dom.insertAfter(menu,btn);
 
-        var prototypes = $(e.lastChild);
+        var prototypes = $(e.lastElementChild);
         while(!prototypes.hasClassName("prototypes"))
             prototypes = prototypes.previous();
         var insertionPoint = prototypes.previous();    // this is where the new item is inserted.

--- a/core/src/main/resources/lib/form/repeatable/repeatable.js
+++ b/core/src/main/resources/lib/form/repeatable/repeatable.js
@@ -155,7 +155,7 @@ Behaviour.specify("DIV.repeated-container", 'repeatable', -100, function(e) {
         if(isInsideRemovable(e))    return;
 
         // compute the insertion point
-        var ip = $(e.lastChild);
+        var ip = $(e.lastElementChild);
         while (!ip.hasClassName("repeatable-insertion-point"))
             ip = ip.previous();
         // set up the logic

--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -11,7 +11,7 @@ function updateListBox(listBox,url,config) {
     // form entry using tables-to-divs markup.
     function getStatusElement() {
         function getStatusForTabularForms() {
-            return findFollowingTR(listBox, "validation-error-area").firstChild.nextSibling;
+            return findFollowingTR(listBox, "validation-error-area").firstElementChild.nextSibling;
         }
         function getStatusForDivBasedForms() {
             var settingMain = listBox.closest('.setting-main')
@@ -33,7 +33,7 @@ function updateListBox(listBox,url,config) {
         console.warn("Couldn't find the expected status element")
         return;
     }
-    if (status.firstChild && status.firstChild.getAttribute('data-select-ajax-error')) {
+    if (status.firstElementChild && status.firstElementChild.getAttribute('data-select-ajax-error')) {
         status.innerHTML = "";
     }
     config.onSuccess = function (rsp) {
@@ -66,8 +66,8 @@ function updateListBox(listBox,url,config) {
     config.onFailure = function (rsp) {
         l.removeClassName("select-ajax-pending");
         status.innerHTML = rsp.responseText;
-        if (status.firstChild) {
-            status.firstChild.setAttribute('data-select-ajax-error', 'true')
+        if (status.firstElementChild) {
+            status.firstElementChild.setAttribute('data-select-ajax-error', 'true')
         }
         Behaviour.applySubtree(status);
         // deleting values can result in the data loss, so let's not do that unless instructed

--- a/core/src/main/resources/lib/hudson/progressiveText.jelly
+++ b/core/src/main/resources/lib/hudson/progressiveText.jelly
@@ -70,7 +70,7 @@ THE SOFTWARE.
                 // http://www.quirksmode.org/bugreports/archives/2004/11/innerhtml_and_t.html
                 if (p.outerHTML) {
                   p.outerHTML = '<pre>'+text+'</pre>';
-                  p = e.lastChild;
+                  p = e.lastElementChild;
                 }
                 else p.innerHTML = text;
                 Behaviour.applySubtree(p);

--- a/core/src/main/resources/lib/hudson/projectViewNested.js
+++ b/core/src/main/resources/lib/hudson/projectViewNested.js
@@ -38,7 +38,7 @@ Behaviour.specify("IMG.treeview-fold-control", 'projectViewNested', 0, function(
             onComplete : function(x) {
                 var cont = document.createElement("div");
                 cont.innerHTML = x.responseText;
-                var rows = $A(cont.firstChild.rows);
+                var rows = $A(cont.firstElementChild.rows);
                 var anim = { opacity: { from:0, to:1 } };
                 rows.reverse().each(function(r) {
                     YAHOO.util.Dom.setStyle(r, 'opacity', 0); // hide

--- a/core/src/main/resources/lib/layout/ajax.jelly
+++ b/core/src/main/resources/lib/layout/ajax.jelly
@@ -42,18 +42,22 @@ THE SOFTWARE.
       evaluating a page that has called l:layout tag.
     </st:attribute>
   </st:documentation>
-  <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate" />
-  <j:choose>
-    <j:when test="${rootURL!=null}">
+  <!-- 
+    j:if tag is implemented without using TagScript like j:choose and thus, does not trigger the flush of the output
+    this has a consequence when using -Dstapler.jelly.trace=true, which adds comments
+  -->
+  <j:set var="standalone" value="${rootURL==null}"/>
+  <j:if test="${!standalone}">
       <!-- no envelope needed, since this is called during full HTML rendering. Don't overwrite content-type either -->
       <d:invokeBody/>
-    </j:when>
-    <j:otherwise>
-      <!-- called to generate partial HTML. set up HTML headers and etc -->
-      <j:set var="ajax" value="true"/>
-      <l:view contentType="${attrs.contentType?:'text/html;charset=UTF-8'}">
-        <d:invokeBody/>
-      </l:view>
-    </j:otherwise>
-  </j:choose>
+  </j:if>
+  <j:if test="${standalone}">
+    <!-- called to generate partial HTML. set up HTML headers and etc -->
+    <j:set var="ajax" value="true"/>
+    <l:view contentType="${attrs.contentType?:'text/html;charset=UTF-8'}">
+      <!-- No "flushing" tag should be used before the contentType or the status is set on the request -->
+      <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate" />
+      <d:invokeBody/>
+    </l:view>
+  </j:if>
 </j:jelly>

--- a/test/src/test/java/hudson/model/FreeStyleProjectTest.java
+++ b/test/src/test/java/hudson/model/FreeStyleProjectTest.java
@@ -53,6 +53,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.SmokeTest;
+import org.kohsuke.stapler.jelly.JellyFacet;
 
 import java.util.List;
 import java.io.File;
@@ -212,4 +213,36 @@ public class FreeStyleProjectTest {
                     "  <fullName>Foo User</fullName>\n" +
                     "  <badField/>\n" +
                     "</hudson.model.User>\n";
+
+    @Test
+    @Issue("JENKINS-65288")
+    public void submitPossibleWithoutJellyTrace() throws Exception {
+        FreeStyleProject freeStyleProject = j.createFreeStyleProject();
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage htmlPage = wc.goTo(freeStyleProject.getUrl() + "configure");
+        HtmlForm configForm = htmlPage.getFormByName("config");
+        j.assertGoodStatus(j.submit(configForm));
+    }
+
+    /**
+     * Ensure the form is still working when using {@link org.kohsuke.stapler.jelly.JellyFacet#TRACE}=true
+     */
+    @Test
+    @Issue("JENKINS-65288")
+    public void submitPossibleWithJellyTrace() throws Exception {
+        boolean currentValue = JellyFacet.TRACE;
+        try {
+            JellyFacet.TRACE = true;
+
+            FreeStyleProject freeStyleProject = j.createFreeStyleProject();
+
+            JenkinsRule.WebClient wc = j.createWebClient();
+            HtmlPage htmlPage = wc.goTo(freeStyleProject.getUrl() + "configure");
+            HtmlForm configForm = htmlPage.getFormByName("config");
+            j.assertGoodStatus(j.submit(configForm));
+        } finally {
+            JellyFacet.TRACE = currentValue;
+        }
+    }
 }

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -25,12 +25,10 @@ package hudson.security;
 
 import com.gargoylesoftware.htmlunit.CookieManager;
 import com.gargoylesoftware.htmlunit.WebResponse;
-import com.gargoylesoftware.htmlunit.html.HtmlElementUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import hudson.model.Descriptor;
-import hudson.model.FreeStyleProject;
 import hudson.security.captcha.CaptchaSupport;
 import org.junit.Rule;
 import org.junit.Test;

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -25,9 +25,12 @@ package hudson.security;
 
 import com.gargoylesoftware.htmlunit.CookieManager;
 import com.gargoylesoftware.htmlunit.WebResponse;
+import com.gargoylesoftware.htmlunit.html.HtmlElementUtil;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import hudson.model.Descriptor;
+import hudson.model.FreeStyleProject;
 import hudson.security.captcha.CaptchaSupport;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,6 +53,7 @@ import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.jelly.JellyFacet;
 
 public class SecurityRealmTest {
 
@@ -175,4 +179,31 @@ public class SecurityRealmTest {
         public static final class DescriptorImpl extends Descriptor<SecurityRealm> {}
     }
 
+    @Test
+    @Issue("JENKINS-65288")
+    public void submitPossibleWithoutJellyTrace() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage htmlPage = wc.goTo("configureSecurity");
+        HtmlForm configForm = htmlPage.getFormByName("config");
+        j.assertGoodStatus(j.submit(configForm));
+    }
+
+    /**
+     * Ensure the form is still working when using {@link org.kohsuke.stapler.jelly.JellyFacet#TRACE}=true
+     */
+    @Test
+    @Issue("JENKINS-65288")
+    public void submitPossibleWithJellyTrace() throws Exception {
+        boolean currentValue = JellyFacet.TRACE;
+        try {
+            JellyFacet.TRACE = true;
+
+            JenkinsRule.WebClient wc = j.createWebClient();
+            HtmlPage htmlPage = wc.goTo("configureSecurity");
+            HtmlForm configForm = htmlPage.getFormByName("config");
+            j.assertGoodStatus(j.submit(configForm));
+        } finally {
+            JellyFacet.TRACE = currentValue;
+        }
+    }
 }

--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -58,6 +58,7 @@ import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
+import org.kohsuke.stapler.jelly.JellyFacet;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
@@ -374,5 +375,33 @@ public class MavenTest {
         MavenInstallation maven2 = ToolInstallations.configureDefaultMaven();
         assertNotEquals(maven3.hashCode(), maven2.hashCode());
         assertNotEquals(maven3, maven2);
+    }
+
+    @Test
+    @Issue("JENKINS-65288")
+    public void submitPossibleWithoutJellyTrace() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage htmlPage = wc.goTo("configureTools");
+        HtmlForm configForm = htmlPage.getFormByName("config");
+        j.assertGoodStatus(j.submit(configForm));
+    }
+
+    /**
+     * Ensure the form is still working when using {@link org.kohsuke.stapler.jelly.JellyFacet#TRACE}=true
+     */
+    @Test
+    @Issue("JENKINS-65288")
+    public void submitPossibleWithJellyTrace() throws Exception {
+        boolean currentValue = JellyFacet.TRACE;
+        try {
+            JellyFacet.TRACE = true;
+
+            JenkinsRule.WebClient wc = j.createWebClient();
+            HtmlPage htmlPage = wc.goTo("configureTools");
+            HtmlForm configForm = htmlPage.getFormByName("config");
+            j.assertGoodStatus(j.submit(configForm));
+        } finally {
+            JellyFacet.TRACE = currentValue;
+        }
     }
 }

--- a/test/src/test/java/lib/layout/AjaxTest.java
+++ b/test/src/test/java/lib/layout/AjaxTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package lib.layout;
+
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlLink;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.PresetData;
+import org.kohsuke.stapler.jelly.JellyFacet;
+
+public class AjaxTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-21254")
+    @PresetData(PresetData.DataSet.NO_ANONYMOUS_READACCESS)
+    @Test public void rejectedLinks() throws Exception {
+        JenkinsRule.WebClient wc = r.createWebClient();
+        String prefix = r.contextPath + '/';
+        for (DomElement e : wc.goTo("login").getElementsByTagName("link")) {
+            String href = ((HtmlLink) e).getHrefAttribute();
+            if (!href.startsWith(prefix)) {
+                System.err.println("ignoring " + href);
+                continue;
+            }
+            System.err.println("checking " + href);
+            wc.goTo(href.substring(prefix.length()), null);
+        }
+    }
+
+    @Test
+    @Issue("JENKINS-65288")
+    public void ajaxPageRenderingPossibleWithoutJellyTrace() throws Exception {
+        JenkinsRule.WebClient wc = r.createWebClient();
+        HtmlPage htmlPage = wc.goTo("ajaxExecutors");
+        r.assertGoodStatus(htmlPage);
+    }
+
+    /**
+     * Ensure the form is still working when using {@link org.kohsuke.stapler.jelly.JellyFacet#TRACE}=true
+     */
+    @Test
+    @Issue("JENKINS-65288")
+    public void ajaxPageRenderingPossibleWithJellyTrace() throws Exception {
+        boolean currentValue = JellyFacet.TRACE;
+        try {
+            JellyFacet.TRACE = true;
+
+            JenkinsRule.WebClient wc = r.createWebClient();
+            HtmlPage htmlPage = wc.goTo("ajaxExecutors");
+            r.assertGoodStatus(htmlPage);
+        } finally {
+            JellyFacet.TRACE = currentValue;
+        }
+    }
+}

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -387,9 +387,9 @@ function findFollowingTR(node, className, nodeClass) {
 function findInFollowingTR(input, className) {
     var node = findFollowingTR(input, className);
     if (node.tagName == 'TR') {
-        node = node.firstChild.nextSibling;
+        node = node.firstElementChild.nextSibling;
     } else {
-        node = node.firstChild;
+        node = node.firstElementChild;
     }
     return node;
 }
@@ -411,8 +411,8 @@ function findPrevious(src,filter) {
     return find(src,filter,function (e) {
         var p = e.previousSibling;
         if(p==null) return e.parentNode;
-        while(p.lastChild!=null)
-            p = p.lastChild;
+        while(p.lastElementChild!=null)
+            p = p.lastElementChild;
         return p;
     });
 }
@@ -421,8 +421,8 @@ function findNext(src,filter) {
     return find(src,filter,function (e) {
         var n = e.nextSibling;
         if(n==null) return e.parentNode;
-        while(n.firstChild!=null)
-            n = n.firstChild;
+        while(n.firstElementChild!=null)
+            n = n.firstElementChild;
         return n;
     });
 }
@@ -450,13 +450,14 @@ function findNextFormItem(src,name) {
     return findFormItem(src,name,findNext);
 }
 
+// This method seems unused in the ecosystem, only grails-plugin was using it but it's blacklisted now
 /**
  * Parse HTML into DOM.
  */
 function parseHtml(html) {
     var c = document.createElement("div");
     c.innerHTML = html;
-    return c.firstChild;
+    return c.firstElementChild;
 }
 
 /**
@@ -508,7 +509,7 @@ function registerValidator(e) {
         return;
     }
     // find the validation-error-area
-    e.targetElement = tr.firstChild.nextSibling;
+    e.targetElement = tr.firstElementChild.nextSibling;
 
     e.targetUrl = function() {
         var url = this.getAttribute("checkUrl");
@@ -589,7 +590,7 @@ function registerRegexpValidator(e,regexp,message) {
         return;
     }
     // find the validation-error-area
-    e.targetElement = tr.firstChild.nextSibling;
+    e.targetElement = tr.firstElementChild.nextSibling;
     var checkMessage = e.getAttribute('checkMessage');
     if (checkMessage) message = checkMessage;
     var oldOnchange = e.onchange;
@@ -618,7 +619,7 @@ function registerMinMaxValidator(e) {
         return;
     }
     // find the validation-error-area
-    e.targetElement = tr.firstChild.nextSibling;
+    e.targetElement = tr.firstElementChild.nextSibling;
     var checkMessage = e.getAttribute('checkMessage');
     if (checkMessage) message = checkMessage;
     var oldOnchange = e.onchange;
@@ -744,15 +745,15 @@ function renderOnDemand(e,callback,noBehaviour) {
         if (contextTagName=="TBODY") {
             c = document.createElement("DIV");
             c.innerHTML = "<TABLE><TBODY>"+t.responseText+"</TBODY></TABLE>";
-            c = c./*JENKINS-15494*/lastChild.firstChild;
+            c = c./*JENKINS-15494*/lastElementChild.firstElementChild;
         } else {
             c = document.createElement(contextTagName);
             c.innerHTML = t.responseText;
         }
 
         var elements = [];
-        while (c.firstChild!=null) {
-            var n = c.firstChild;
+        while (c.firstElementChild!=null) {
+            var n = c.firstElementChild;
             e.parentNode.insertBefore(n,e);
             if (n.nodeType==1 && !noBehaviour)
                 elements.push(n);
@@ -1105,7 +1106,7 @@ function rowvgStartEachRow(recursive,f) {
                     document.body.appendChild(div);
                     div.innerHTML = x.responseText;
                     var id = "map" + (iota++);
-                    div.firstChild.setAttribute("name", id);
+                    div.firstElementChild.setAttribute("name", id);
                     e.setAttribute("usemap", "#" + id);
                 }
             });
@@ -1297,7 +1298,7 @@ function rowvgStartEachRow(recursive,f) {
             changeTo(this,".png");
         };
         e.parentNode.onclick = function(event) {
-            var e = this.firstChild;
+            var e = this.firstElementChild;
             var s = e.getAttribute("state");
             if(s=="plus") {
                 e.setAttribute("state","minus");
@@ -1333,7 +1334,7 @@ function rowvgStartEachRow(recursive,f) {
         var subForms = [];
         var start = findInFollowingTR(e, 'dropdownList-container'), end;
 
-        do { start = start.firstChild; } while (start && !isTR(start));
+        do { start = start.firstElementChild; } while (start && !isTR(start));
 
         if (start && !Element.hasClassName(start,'dropdownList-start'))
             start = findFollowingTR(start, 'dropdownList-start');
@@ -1415,7 +1416,7 @@ function rowvgStartEachRow(recursive,f) {
 
         var edge = document.createElement("div");
         edge.className = "bottom-sticker-edge";
-        sticker.insertBefore(edge,sticker.firstChild);
+        sticker.insertBefore(edge,sticker.firstElementChild);
 
         function adjustSticker() {
             shadow.style.height = sticker.offsetHeight + "px";
@@ -1456,7 +1457,7 @@ function rowvgStartEachRow(recursive,f) {
 
         var edge = document.createElement("div");
         edge.className = "top-sticker-edge";
-        sticker.insertBefore(edge,sticker.firstChild);
+        sticker.insertBefore(edge,sticker.firstElementChild);
 
         var initialBreadcrumbPosition = DOM.getRegion(shadow);
         function adjustSticker() {
@@ -1620,7 +1621,7 @@ function applyNameRefHelper(s,e,id) {
         if(x.getAttribute("nameRef")==null) {
             x.setAttribute("nameRef",id);
             if (x.hasClassName('tr'))
-                applyNameRefHelper(x.firstChild,null,id);
+                applyNameRefHelper(x.firstElementChild,null,id);
         }
     }
 }
@@ -2562,7 +2563,7 @@ function createSearchBox(searchURL) {
             cssWidth =  getStyle(sizer, "minWidth");
         }
         box.style.width =
-        comp.firstChild.style.minWidth = "calc(60px + " + cssWidth + ")";
+        comp.firstElementChild.style.minWidth = "calc(60px + " + cssWidth + ")";
 
         var pos = YAHOO.util.Dom.getXY(box);
         pos[1] += YAHOO.util.Dom.get(box).offsetHeight + 2;
@@ -2876,7 +2877,7 @@ function loadScript(href,callback) {
 
     // Use insertBefore instead of appendChild  to circumvent an IE6 bug.
     // This arises when a base node is used (#2709 and #4378).
-    head.insertBefore( script, head.firstChild );
+    head.insertBefore( script, head.firstElementChild );
 }
 
 // logic behind <f:validateButton />
@@ -2938,8 +2939,8 @@ function applyErrorMessage(elt, rsp) {
         var error = document.getElementById('error-description'); // cf. oops.jelly
         if (error) {
             var div = document.getElementById(id);
-            while (div.firstChild) {
-                div.removeChild(div.firstChild);
+            while (div.firstElementChild) {
+                div.removeChild(div.firstElementChild);
             }
             div.appendChild(error);
         }
@@ -3028,7 +3029,7 @@ var notificationBar = {
             this.div = document.createElement("div");
             YAHOO.util.Dom.setStyle(this.div,"opacity",0);
             this.div.id="notification-bar";
-            document.body.insertBefore(this.div, document.body.firstChild);
+            document.body.insertBefore(this.div, document.body.firstElementChild);
             var self = this;
             this.div.onclick = function() {
                 self.hide();

--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -71,10 +71,10 @@ var Sortable = (function() {
              * Using the innerHTML will return the escaped content that could be reused directly within the wrapper.
              */
             cell.innerHTML = '<a href="#" class="sortheader">'+cell.innerHTML+'<span class="sortarrow"></span></a>';
-            this.arrows.push(cell.firstChild.lastChild);
+            this.arrows.push(cell.firstElementChild.lastElementChild);
 
             var self = this;
-            cell.firstChild.onclick = function () {
+            cell.firstElementChild.onclick = function () {
                 self.onClicked(this);
                 return false;
             };


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-65288](https://issues.jenkins-ci.org/browse/JENKINS-65288).
Also a comment in [JENKINS-28561](https://issues.jenkins.io/browse/JENKINS-28561).

I tried to re-use `-Dstapler.jelly.trace=true` (coming from [Stapler](https://github.com/stapler/stapler/blob/c8527cc9387c95b5eaa22a4207e15df18c5280b8/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyFacet.java#L127)) and it fails. This system property helps undertanding where the Jelly fragments are coming from by adding comments around the fragments.

There are two reasons for the failure.

**1) ❌ firstChild 🚸**
The firstChild JavaScript method is not expected to return a CommentNode in our JS. `firstChild` can return Element, TextNode or CommentNode, while `firstElementChild` can only return Element.
More details in https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild, especially the paragraph comparing it with firstElementChild.

From the core code I checked, the Element seems to be the only one really desired, but I can be wrong. 
@timja @fqueiruga please review this PR for this :) 

**2) ❌ Flush 🚽**
⚠️ More complicated to explain, the second point is due to the correction we applied to SECURITY-534, i.e. the dispatch allowance introduced to prevent Jelly fragments to be rendered as a standalone page.
The comment from the system property are [directly written to the output](https://github.com/stapler/stapler/blob/0a23a9000de1dafb6a16fa883504697443cc05e3/jelly/src/main/java/org/kohsuke/stapler/jelly/CallTagLibScript.java#L112-L115). By itself it has no impact, but the presence of content inside the output means that the next call to `flush`, a real flush is executed. This is due to the implementation of the StreamEncoder#implFlushBuffer, if there is something in `bb`, the flush is done.
Why flush is important? It's because in the correction, we waited for the first flush before checking if the dispatch is allowed or not. This is either allowed programmatically or by checking the status/contentType of the response. This logic is done in [DefaultScriptInvoker.java#L117-L120](https://github.com/stapler/stapler/blob/c8527cc9387c95b5eaa22a4207e15df18c5280b8/jelly/src/main/java/org/kohsuke/stapler/jelly/DefaultScriptInvoker.java#L117-L120).

The `ajax.jelly` modifications are there to ensure no tags are forcing a flush before the contentType is set. Lots of Jelly/Stapler tags (e.g. st:setHeader or j:choose) are [flushing by default](https://github.com/jenkinsci/jelly/blob/cb7966734f339619e5ee8e57b08009acbf5e1d10/src/java/org/apache/commons/jelly/impl/TagScript.java#L267), but this is not the case for [j:set](https://github.com/jenkinsci/jelly/blob/cb7966734f339619e5ee8e57b08009acbf5e1d10/src/java/org/apache/commons/jelly/tags/core/CoreTagLibrary.java#L109) and [j:if](https://github.com/jenkinsci/jelly/blob/cb7966734f339619e5ee8e57b08009acbf5e1d10/src/java/org/apache/commons/jelly/tags/core/CoreTagLibrary.java#L94). Due to this change, the first flush call is done after the contentType is set and thus, the dispatch is now allowed.

For this part, please @jvz review the PR.

### Testing notes 🧪 

**A) Ensure the correction is working**
Checkout this PR, start the WAR with `-Dstapler.jelly.trace=true`, do in parallel the same with uncorrect Jenkins WAR. Test anything you can imagine, the behavior should be working on the WAR from this PR and potentially not in the regular one.
Example of broken features:
- ajaxExecutors and like ajax requests are broken
- Global Security configuration, Job configuration and Tool configuration submissions are broken

**B) Ensure there is no regression**
Checkout this PR, start the WAR regularly (without the system property), do the same in parallel with a regular Jenkins WAR. All the features working in the regular build should also work on this PR's WAR.

I didn't find anything broken during my local testing.

### Proposed changelog entries

* Developer: `stapler.jelly.trace` support is back

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

✔️ Already mentioned in their related parts.

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
