### PR TITLE
Improve design of last-unstable SVG icon

### DIFF
--- a/war/src/main/webapp/images/build-status/build-status-sprite.svg
+++ b/war/src/main/webapp/images/build-status/build-status-sprite.svg
@@ -28,8 +28,11 @@
 		<path d="M10.843 16.894L6.6 12.65l2.121-2.121 2.121 2.121 4.951-4.95 2.122 2.121-7.072 7.073z"></path>
 	</symbol>
 
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22" id="last-unstable">
-		<path fill="currentColor" d="M15.504 14.5c.55 0 .774-.384.498-.86l-4.504-7.78c-.275-.475-.72-.476-.996 0l-4.504 7.78c-.275.475-.053.86.498.86h9.008zM11.5 13h-1v-1h1v1zm0-2h-1V9h1v2z" fill-rule="evenodd"/>
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="last-unstable">
+		<g stroke="currentColor" stroke-width="1">
+			<circle cx="12" cy="16.5" r="1"/>
+			<path d="M11 6.5h2v6h-2z"/>
+		</g>
 	</svg>
 
 	<symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="last-aborted">


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
Followup to #5065 (modernize build status icons): this PR provides a better image for unstable builds. It only uses an exclamation mark and is better scalable then the previous one that uses a warning triangle in combination with the exclamation mark. 

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Screenshots

Here are some screenshots, before screenshots are part of  #5065.

#### Large 
![Bildschirmfoto 2021-04-05 um 12 35 47](https://user-images.githubusercontent.com/503338/113569233-6b608f00-9612-11eb-89ca-e47660640d75.png)

#### Medium
![Bildschirmfoto 2021-04-05 um 12 36 02](https://user-images.githubusercontent.com/503338/113569232-6b608f00-9612-11eb-8b86-028507a434c6.png)

#### Small
![Bildschirmfoto 2021-04-05 um 12 36 36](https://user-images.githubusercontent.com/503338/113569230-6ac7f880-9612-11eb-9be0-a1f8ffe9532c.png)

#### Builds
![Bildschirmfoto 2021-04-05 um 12 37 00](https://user-images.githubusercontent.com/503338/113569226-6996cb80-9612-11eb-8d12-e0b82d97af43.png)

### Proposed changelog entries

* Entry 1: Enhancement, Simplify icon for unstable builds (use an exclamation mark)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja @fqueiruga @daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
