### PR TITLE
Fixing deprecation link in Util.isAbsoluteUri

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1561,7 +1561,7 @@ public class Util {
      * implementing this by ourselves allow it to be more lenient about
      * escaping of URI.
      *
-     * @deprecated Use {@code isAbsoluteOrSchemeRelativeUri} instead if your goal is to prevent open redirects
+     * @deprecated Use {@link #isSafeToRedirectTo} instead if your goal is to prevent open redirects
      */
     @Deprecated
     @RestrictedSince("1.651.2 / 2.3")


### PR DESCRIPTION
`Util.isAbsoluteOrSchemeRelativeUri` was renamed in e6efae7d0d7 but the Javadoc reference in `isAbsoluteUri` was forgotten.

### Proposed changelog entries

* N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
