### PR TITLE
[JENKINS-65291] Update recommendations to be more specific

### DIFF
--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.properties
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.properties
@@ -20,4 +20,6 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #THE SOFTWARE.
 
-ExecutorsWarning=You should set up distributed builds. Building on the controller node can be a security issue. See <a href="https://www.jenkins.io/redirect/building-on-controller/" target="_blank" rel="noopener noreferrer">the documentation</a>.
+ExecutorsWarning=Building on the controller node can be a security issue. \
+  You should set the number of executors on the controller to 0. \
+  See <a href="https://www.jenkins.io/redirect/building-on-controller/" target="_blank" rel="noopener noreferrer">the documentation</a>.

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.properties
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.properties
@@ -20,4 +20,6 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #THE SOFTWARE.
 
-ExecutorsWarning=You should set up distributed builds. Building on the controller node can be a security issue. See <a href="https://www.jenkins.io/redirect/building-on-controller/" target="_blank" rel="noopener noreferrer">the documentation</a>.
+ExecutorsWarning=Building on the controller node can be a security issue. \
+  You should set up distributed builds. \
+  See <a href="https://www.jenkins.io/redirect/building-on-controller/" target="_blank" rel="noopener noreferrer">the documentation</a>.


### PR DESCRIPTION
See [JENKINS-65291](https://issues.jenkins-ci.org/browse/JENKINS-65291). Amends #5337.

Looks like I was wrong and @jeffret-b was correct; having a shared message that doesn't exactly apply between the admin monitors is confusing.

"You should set up distributed builds and set the number of executors on the controller to 0" would be a bit long, so choosing to go with more specific individual messages.

### Proposed changelog entries

(too minor)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@saper

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
