### PR TITLE
Do not shorten "number" to "#"

### DIFF
--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -251,7 +251,7 @@ Run.Summary.BrokenSinceThisBuild=broken since this build
 Run.Summary.BrokenSince=broken since build {0}
 Run.Summary.Unknown=?
 
-Slave.InvalidConfig.Executors=Invalid agent configuration for {0}. Invalid # of executors.
+Slave.InvalidConfig.Executors=Invalid agent configuration for {0}. Invalid number of executors.
 Slave.InvalidConfig.NoName=Invalid agent configuration. Name is empty
 Slave.Network.Mounted.File.System.Warning=Are you sure you want to use network mounted file system for FS root? Note that this directory does not need to be visible to the master.
 Slave.Remote.Director.Mandatory=Remote directory is mandatory

--- a/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
+++ b/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
     <f:textbox field="nodeDescription" />
   </f:entry>
 
-  <f:entry title="${%# of executors}" field="numExecutors">
+  <f:entry title="${%Number of executors}" field="numExecutors">
     <f:number clazz="positive-number-required" min="1" step="1" default="1"/>
   </f:entry>
 

--- a/core/src/main/resources/jenkins/model/Jenkins/MasterComputer/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/MasterComputer/configure.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
         </f:entry>
         -->
 
-        <f:entry title="${%# of executors}" field="numExecutors">
+        <f:entry title="${%Number of executors}" field="numExecutors">
           <f:number clazz="non-negative-number-required" min="0" step="1"/>
         </f:entry>
 

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -26,7 +26,7 @@
 Hudson.BadPortNumber=Bad port number {0}
 Hudson.Computer.Caption=Master
 Hudson.Computer.DisplayName=master
-Hudson.Computer.IncorrectNumberOfExecutors=Incorrect field "# of executors". It should be a non-negative number.
+Hudson.Computer.IncorrectNumberOfExecutors=Incorrect field "Number of executors". It should be a non-negative number.
 Hudson.ControlCodeNotAllowed=No control code is allowed: {0}
 Hudson.DisplayName=Jenkins
 Hudson.JobAlreadyExists=A job already exists with the name \u2018{0}\u2019


### PR DESCRIPTION
Noticed this looks weird when working on #5395.

With the div-based form layout, there's no need to keep labels very short anymore.

### Proposed changelog entries

too minor

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
