### PR TITLE
Ignore jetty 10.x and jetty 11.x updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,6 @@ updates:
       - dependency-name: "log4j:log4j"
       # using a newer version clashes in RequireUpperBoundDeps with plugins using a valid script-security dependency
       - dependency-name: "org.jenkins-ci:symbol-annotation"
+      # Must remain within jetty 9.x until Java 8 support is removed, ignore jetty 10.x and jetty 11.x updates
+      - dependency-name: "org.eclipse.jetty:jetty-maven-plugin"
+        versions: ["10.x", "11.x"]


### PR DESCRIPTION
## Exclude Jetty 10.x and Jetty 11.x from dependabot updates

See #5384 and [dependabot ignore options](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#ignore)

Jetty 11.x requires Java 11 as minimum.  We can't use Jetty 11 until we drop support for Java 8.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers



### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
