### PR TITLE
Add missing Turkish translations for home page

### DIFF
--- a/core/src/main/resources/hudson/markup/Messages_tr.properties
+++ b/core/src/main/resources/hudson/markup/Messages_tr.properties
@@ -1,6 +1,6 @@
 # The MIT License
 # 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oguz Dag
+# Copyright (c) 2021, Mustafa Ulu
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-sign\ up=kay\u0131t ol
+EscapedMarkupFormatter.DisplayName=D\u00FCz metin

--- a/core/src/main/resources/hudson/model/AllView/noJob.groovy
+++ b/core/src/main/resources/hudson/model/AllView/noJob.groovy
@@ -88,12 +88,12 @@ div {
             // we're in a folder
 
             section(class: "empty-state-section") {
-                h2("This folder is empty", class: "h4")
+                h2(_("This folder is empty"), class: "h4")
 
                 ul(class: "empty-state-section-list") {
                     li(class: "content-block") {
                         a(href: "newJob", class: "content-block__link") {
-                            span("Create a job")
+                            span(_("createJob"))
                             span(class: "trailing-icon") {
                                 l.svgIcon(
                                         class: "icon-sm",
@@ -122,7 +122,7 @@ div {
                     li(class: "content-block") {
                         a(href: "${rootURL}/${app.securityRealm.loginUrl}?from=${request.requestURI}",
                                 class: "content-block__link") {
-                            span("Log in to Jenkins")
+                            span(_("Log in to Jenkins"))
                             span(class: "trailing-icon") {
                                 l.svgIcon(
                                         class: "icon-sm",
@@ -134,7 +134,7 @@ div {
                     if (canSignUp) {
                         li(class: "content-block") {
                             a(href: "signup", class: "content-block__link") {
-                                span("Sign up for Jenkins")
+                                span(_("Sign up for Jenkins"))
                                 span(class: "trailing-icon") {
                                     l.svgIcon(
                                             class: "icon-sm",

--- a/core/src/main/resources/hudson/model/AllView/noJob.properties
+++ b/core/src/main/resources/hudson/model/AllView/noJob.properties
@@ -32,5 +32,3 @@ createJob=Create a job
 
 anonymousDescription=Log in now to view or create jobs.
 anonymousDescriptionSignUpEnabled=Log in now to view or create jobs. If you don''t already have an account, you can sign up.
-login=Log in to Jenkins
-signup=Sign up to Jenkins

--- a/core/src/main/resources/hudson/model/AllView/noJob_tr.properties
+++ b/core/src/main/resources/hudson/model/AllView/noJob_tr.properties
@@ -23,6 +23,7 @@
 Welcome\ to\ Jenkins\!=Jenkins''e ho\u015f geldiniz\!
 
 noJobDescription=Bu sayfa, Jenkins i\u015flerinin g\u00f6r\u00fcnt\u00fclenece\u011fi yerdir. Ba\u015flamak i\u00e7in da\u011f\u0131t\u0131lm\u0131\u015f yap\u0131land\u0131rmalar kurabilir veya bir yaz\u0131l\u0131m projesi yap\u0131land\u0131rmaya ba\u015flayabilirsiniz.
+This\ folder\ is\ empty=Bu klas\u00f6r bo\u015f
 
 setUpDistributedBuilds=Da\u011f\u0131t\u0131lm\u0131\u015f bir yap\u0131land\u0131rma kurun
 setUpAgent=Bir ajan kur
@@ -35,5 +36,5 @@ createJob=Bir i\u015f olu\u015ftur
 
 anonymousDescription=\u0130\u015fleri g\u00f6r\u00fcnt\u00fclemek veya is olu\u015fturmak i\u00e7in \u015fimdi giri\u015f yap\u0131n.
 anonymousDescriptionSignUpEnabled=\u0130\u015fleri g\u00f6r\u00fcnt\u00fclemek veya i\u015f olu\u015fturmak i\u00e7in \u015fimdi giri\u015f yap\u0131n. Hen\u00fcz bir hesab\u0131n\u0131z yoksa kaydolabilirsiniz.
-login=Jenkins''e giri\u015f yap
-signup=Jenkins''e kay\u0131t ol
+Log\ in\ to\ Jenkins=Jenkins''e giri\u015f yap
+Sign\ up\ for\ Jenkins=Jenkins''e kay\u0131t ol

--- a/core/src/main/resources/hudson/model/AllView/noJob_tr.properties
+++ b/core/src/main/resources/hudson/model/AllView/noJob_tr.properties
@@ -20,4 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Welcome\ to\ Jenkins\!=Jenkins''e Ho\u015fgeldiniz\!
+Welcome\ to\ Jenkins\!=Jenkins''e ho\u015f geldiniz\!
+
+noJobDescription=Bu sayfa, Jenkins i\u015flerinin g\u00f6r\u00fcnt\u00fclenece\u011fi yerdir. Ba\u015flamak i\u00e7in da\u011f\u0131t\u0131lm\u0131\u015f yap\u0131land\u0131rmalar kurabilir veya bir yaz\u0131l\u0131m projesi yap\u0131land\u0131rmaya ba\u015flayabilirsiniz.
+
+setUpDistributedBuilds=Da\u011f\u0131t\u0131lm\u0131\u015f bir yap\u0131land\u0131rma kurun
+setUpAgent=Bir ajan kur
+setUpCloud=Bir bulut ayarla
+learnMoreDistributedBuilds=Da\u011f\u0131t\u0131lm\u0131\u015f yap\u0131land\u0131rmalar hakk\u0131nda daha fazla bilgi edinin
+
+startBuilding=Yaz\u0131l\u0131m projenizi yap\u0131land\u0131rmaya ba\u015flay\u0131n
+
+createJob=Bir i\u015f olu\u015ftur
+
+anonymousDescription=\u0130\u015fleri g\u00f6r\u00fcnt\u00fclemek veya is olu\u015fturmak i\u00e7in \u015fimdi giri\u015f yap\u0131n.
+anonymousDescriptionSignUpEnabled=\u0130\u015fleri g\u00f6r\u00fcnt\u00fclemek veya i\u015f olu\u015fturmak i\u00e7in \u015fimdi giri\u015f yap\u0131n. Hen\u00fcz bir hesab\u0131n\u0131z yoksa kaydolabilirsiniz.
+login=Jenkins''e giri\u015f yap
+signup=Jenkins''e kay\u0131t ol

--- a/core/src/main/resources/hudson/model/Messages_tr.properties
+++ b/core/src/main/resources/hudson/model/Messages_tr.properties
@@ -23,6 +23,8 @@
 AbstractBuild.BuildingRemotely={0} \u00fczerinde uzaktan yap\u0131land\u0131rma i\u015flemi y\u00fcr\u00fct\u00fcl\u00fcyor
 AbstractBuild.KeptBecause={0} y\u00fcz\u00fcnden tutulmu\u015f
 
+AbstractItem.Pronoun=\u00d6\u011fe
+
 AbstractProject.NewBuildForWorkspace=\u00c7al\u0131\u015fma alan\u0131 olu\u015fturmak i\u00e7in bir yap\u0131land\u0131rma planlan\u0131yor
 AbstractProject.Pronoun=Proje
 AbstractProject.Aborted=Durduruldu
@@ -80,6 +82,10 @@ Job.NOfMFailed=Son {1} yap\u0131land\u0131rmadan {0} tanesi ba\u015far\u0131s\u0
 Job.NoRecentBuildFailed=Son yap\u0131land\u0131rmalar\u0131n hepsi ba\u015far\u0131l\u0131 oldu
 Job.Pronoun=Proje
 Job.minutes=dak
+
+MyView.DisplayName=Ki\u015fisel G\u00f6r\u00fcn\u00fcm
+MyViewsProperty.DisplayName=Ki\u015fisel G\u00f6r\u00fcn\u00fcmler
+MyViewsProperty.GlobalAction.DisplayName=Ki\u015fisel G\u00f6r\u00fcn\u00fcmler
 
 Queue.BlockedBy={0} taraf\u0131ndan engellendi
 Queue.InProgress=Bir yap\u0131land\u0131rma zaten i\u015flemde

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message_tr.properties
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message_tr.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oguz Dag
-# 
+#
+# Copyright (c) 2021, Mustafa Ulu
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-sign\ up=kay\u0131t ol
+Dismiss=Reddet

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsApiData/monitorsList_tr.properties
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsApiData/monitorsList_tr.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oguz Dag
-# 
+#
+# Copyright (c) 2021, Mustafa Ulu
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-sign\ up=kay\u0131t ol
+Manage\ Jenkins=Jenkins''i Y\u00f6net

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/footer_tr.properties
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/footer_tr.properties
@@ -1,6 +1,6 @@
 # The MIT License
 # 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oguz Dag
+# Copyright (c) 2021, Mustafa Ulu
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,4 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-sign\ up=kay\u0131t ol
+Manage\ Jenkins=Jenkins''i Y\u00f6net
+tooltip={0} adet aktif y\u00f6netimsel g\u00f6sterge var.
+tooltipSec={0} adet aktif y\u00f6netimsel g\u00FCvenlik g\u00f6stergesi var.

--- a/core/src/main/resources/jenkins/model/Messages_tr.properties
+++ b/core/src/main/resources/jenkins/model/Messages_tr.properties
@@ -30,6 +30,7 @@ Hudson.NoJavaInPath=java, PATH i\u00e7erisinde de\u011fil. <a href=''{0}/configu
 Hudson.NoName=\u0130sim belirtilmedi
 Hudson.UnsafeChar=''{0}'' g\u00fcvenli olmayan bir karakter
 Hudson.ViewName=Hepsi
+NewViewLink.NewView=Yeni G\u00f6r\u00fcn\u00fcm
 ParameterizedJobMixIn.build_now=\u015eimdi Yap\u0131land\u0131r
 BlockedBecauseOfBuildInProgress.shortDescription=Yap\u0131land\u0131rma #{0} zaten i\u015flemde {1}
 BlockedBecauseOfBuildInProgress.ETA=\ (ETA: {0})

--- a/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchWarning/message_tr.properties
+++ b/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchWarning/message_tr.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oguz Dag
-# 
+#
+# Copyright (c) 2021, Mustafa Ulu
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,4 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-sign\ up=kay\u0131t ol
+Examine=Denetle
+Dismiss=Reddet

--- a/core/src/main/resources/lib/hudson/editableDescription_tr.properties
+++ b/core/src/main/resources/lib/hudson/editableDescription_tr.properties
@@ -20,5 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-add\ description=A\u00E7\u0131klama Ekle
+add\ description=a\u00E7\u0131klama ekle
 edit\ description=a\u00e7\u0131klamay\u0131 de\u011fi\u015ftir

--- a/core/src/main/resources/lib/layout/breadcrumbBar_tr.properties
+++ b/core/src/main/resources/lib/layout/breadcrumbBar_tr.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oguz Dag
-# 
+#
+# Copyright (c) 2021, Mustafa Ulu
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-sign\ up=kay\u0131t ol
+Dashboard=Kontrol Merkezi

--- a/core/src/main/resources/lib/layout/pane_tr.properties
+++ b/core/src/main/resources/lib/layout/pane_tr.properties
@@ -1,6 +1,6 @@
 # The MIT License
 # 
-# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oguz Dag
+# Copyright (c) 2021, Mustafa Ulu
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,4 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-sign\ up=kay\u0131t ol
+collapse=daralt
+expand=geni\u015Flet


### PR DESCRIPTION
Here is a screenshot of the home page with Turkish translations.

<img width="1623" alt="Screen Shot 2021-04-10 at 05 14 22" src="https://user-images.githubusercontent.com/881222/114255124-162ecf80-99bc-11eb-908f-742b24136955.png">
