### PR TITLE
[JENKINS-65327] File parameters no longer overwrite previous files

### DIFF
--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -172,6 +172,12 @@ public class FileParameterValue extends ParameterValue {
                     }
                     FilePath locationFilePath = ws.child(location);
                     locationFilePath.getParent().mkdirs();
+
+                    // TODO Remove this workaround after FILEUPLOAD-293 is resolved.
+                    if (locationFilePath.exists() && !locationFilePath.isDirectory()) {
+                        locationFilePath.delete();
+                    }
+
             	    locationFilePath.copyFrom(file);
                     locationFilePath.copyTo(new FilePath(getLocationUnderBuild(build)));
             	}


### PR DESCRIPTION
### Steps to reproduce

See [JENKINS-65327](https://issues.jenkins.io/browse/JENKINS-65327). Amends #5174.

- Create a "freestyle" job.
- Define a file parameter.
- Trigger a build, uploading a file that is 15 KiB or greater in size.
- Trigger another build, again uploading a file that is 15 KiB or greater in size.

### Expected result

The file is replaced and the build is successful (2.277 and earlier).

### Actual result

The build fails with

```
Building in workspace /var/jenkins_home/workspace/fs
Copying file to f
FATAL: Destination '/var/jenkins_home/workspace/fs/f' already exists
org.apache.commons.io.FileExistsException: Destination '/var/jenkins_home/workspace/fs/f' already exists
	at org.apache.commons.io.FileUtils.moveFile(FileUtils.java:2266)
	at org.apache.commons.fileupload.disk.DiskFileItem.write(DiskFileItem.java:405)
	at hudson.FilePath.copyFrom(FilePath.java:1092)
	at hudson.model.FileParameterValue$2.setUp(FileParameterValue.java:173)
	at hudson.model.Build$BuildExecution.doRun(Build.java:157)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:513)
	at hudson.model.Run.execute(Run.java:1907)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Finished: FAILURE
```

### Evaluation

This is [FILEUPLOAD-293](https://issues.apache.org/jira/browse/FILEUPLOAD-293), for which an upstream fix has been merged but not released.

### Solution

Work around the upstream bug as suggested in the comments to [FILEUPLOAD-293](https://issues.apache.org/jira/browse/FILEUPLOAD-293) by deleting the destination file if it already exists prior to invoking `DiskFileItem#write`.

### Implementation

In addition to checking that `locationFilePath` already exists before deleting it, we also have to check that it is not a directory in order to avoid changing the existing behavior tested by [`FileParameterValueTest#fileParameter_withSingleDot`](https://github.com/jenkinsci/jenkins/blob/901bf54db6af7d22a94246b0b25c3ef579b7efd3/test/src/test/java/hudson/model/FileParameterValueTest.java#L198-L224). The existing behavior, when the file parameter is a single dot, is to try to copy `file` to `locationFilePath` (which, in the case of a single dot file parameter, is the workspace itself), which is expected to fail (correctly!) with "Is a directory":

```
FATAL: Failed to copy /src/jenkinsci/jenkins/test/target/junit4931590083129211398/junit16315412624186716423.tmp to /src/jenkinsci/jenkins/test/target/j h10498905059775080198/workspace/test0
java.nio.file.FileSystemException: /src/jenkinsci/jenkins/test/target/j h10498905059775080198/workspace/test0: Is a directory
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:100)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:478)
	at java.base/java.nio.file.Files.newOutputStream(Files.java:220)
	at hudson.FilePath.write(FilePath.java:2309)
	at hudson.FilePath.copyTo(FilePath.java:2433)
Caused: java.io.IOException: Failed to copy /src/jenkinsci/jenkins/test/target/junit4931590083129211398/junit16315412624186716423.tmp to /src/jenkinsci/jenkins/test/target/j h10498905059775080198/workspace/test0
	at hudson.FilePath.copyTo(FilePath.java:2437)
	at hudson.model.FileParameterValue$FileItemImpl.write(FileParameterValue.java:309)
	at hudson.FilePath.copyFrom(FilePath.java:1093)
	at hudson.model.FileParameterValue$2.setUp(FileParameterValue.java:179)
	at hudson.model.Build$BuildExecution.doRun(Build.java:157)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:513)
	at hudson.model.Run.execute(Run.java:1906)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Finished: FAILURE
```

Now, if we only checked that `locationFilePath` exists before deleting it, in this scenario we would end up deleting the workspace directory, which is clearly undesirable in and of itself, as well as changing the existing behavior. By checking that `locationFilePath` not only exists but also is not a directory, we avoid this undesirable change in behavior.

### Testing done

- Followed the steps to reproduce described in the Jira issue. Reproduced the problem without the changes in this PR; was no longer able to reproduce the problem with the changes in this PR. Tested against a workspace without an already-uploaded file and with an already-uploaded file.
- Also verified I was able to build a job with a file parameter from the CLI both without an already-uploaded file and with an already-uploaded file.

### Proposed changelog entries

File parameters again correctly overwrite previous files (regression in 2.278, issue [65327](https://issues.jenkins.io/browse/JENKINS-65327)).

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).