### PR TITLE
Update at-since annotations up to 2.288

### DIFF
--- a/core/src/main/java/jenkins/UserAgentURLConnectionDecorator.java
+++ b/core/src/main/java/jenkins/UserAgentURLConnectionDecorator.java
@@ -38,7 +38,7 @@ import java.net.URLConnection;
 /**
  * Sets a Jenkins specific user-agent HTTP header for {@link HttpURLConnection}.
  *
- * @since TODO
+ * @since 2.286
  */
 @Extension
 @Restricted(NoExternalUse.class)


### PR DESCRIPTION
List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.286
  - https://github.com/jenkinsci/jenkins/commit/a088584573d86f2d934a352b2830bb572d774735

I manually checked over changes between 2.285 and 2.288, and there are really no other API changes 🤷 Even this one is in a restricted class, which we commonly do not annotate, as they're not API.

### Proposed changelog entries

(skip)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
