### PR TITLE
2.277.3 backporting

### DIFF
--- a/test/src/test/java/jenkins/telemetry/MissingClassTelemetryTest.java
+++ b/test/src/test/java/jenkins/telemetry/MissingClassTelemetryTest.java
@@ -48,6 +48,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.chrono.ChronoLocalDate;
 
 import static org.junit.Assert.assertEquals;
 
@@ -79,7 +81,7 @@ public class MissingClassTelemetryTest {
     @Test
     public void telemetrySentWorks() throws InterruptedException {
         Assume.assumeTrue("The telemetry should be enabled", MissingClassTelemetry.enabled());
-
+        Assume.assumeTrue("The telemetry shouldn't be ended", Telemetry.all().get(MissingClassTelemetry.class).getEnd().isAfter(ChronoLocalDate.from(Instant.now())));
         // Generate 5 events
         for(int i = 0; i < 5; i++) {
             try {

--- a/test/src/test/java/jenkins/telemetry/MissingClassTelemetryTest.java
+++ b/test/src/test/java/jenkins/telemetry/MissingClassTelemetryTest.java
@@ -23,6 +23,7 @@
  */
 package jenkins.telemetry;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ExtensionList;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
@@ -40,7 +41,6 @@ import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -48,8 +48,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.chrono.ChronoLocalDate;
+import java.time.LocalDate;
 
 import static org.junit.Assert.assertEquals;
 
@@ -81,7 +80,7 @@ public class MissingClassTelemetryTest {
     @Test
     public void telemetrySentWorks() throws InterruptedException {
         Assume.assumeTrue("The telemetry should be enabled", MissingClassTelemetry.enabled());
-        Assume.assumeTrue("The telemetry shouldn't be ended", Telemetry.all().get(MissingClassTelemetry.class).getEnd().isAfter(ChronoLocalDate.from(Instant.now())));
+        Assume.assumeTrue("The telemetry shouldn't be ended", Telemetry.all().get(MissingClassTelemetry.class).getEnd().isAfter(LocalDate.now()));
         // Generate 5 events
         for(int i = 0; i < 5; i++) {
             try {

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -104,7 +104,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>5.15</version>
+      <version>5.16</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -453,7 +453,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.4.38.v20210224</version>
+        <version>9.4.39.v20210325</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
## 2.277.3 backporting

```
Fixed
-----

JENKINS-65280           Minor                   Wed, 14 Apr 2021 15:51:16 +0000
        Update Winstone 5.16 which includes Jetty 9.4.39.v20210325
        https://issues.jenkins.io/browse/JENKINS-65280
```

See [JENKINS-65280](https://issues.jenkins-ci.org/browse/JENKINS-65280) and the [Jetty 9.4.39 changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.39.v20210325)

(cherry picked from commit 82c73972c47557ebac883ff6a1b5c6e878c277ff)

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@wadeck or @daniel-beck

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
