### PR TITLE
Fix typo in Turkish translation of Configuration

### DIFF
--- a/core/src/main/resources/jenkins/management/Messages_tr.properties
+++ b/core/src/main/resources/jenkins/management/Messages_tr.properties
@@ -23,7 +23,7 @@
 #
 
 SystemLogLink.Description=Sistem logu Jenkins''le ilgili olan <tt>java.util.logging</tt> \u00E7\u0131kt\u0131lar\u0131n\u0131 yakalar.
-ReloadLink.DisplayName=Konfig\u00FCrasayonu Disk''ten Y\u00FCkle
+ReloadLink.DisplayName=Konfig\u00FCrasyonu Disk''ten Y\u00FCkle
 ReloadLink.Description=Haf\u0131zada tutulan yap\u0131lm\u0131\u015F t\u00FCm de\u011Fi\u015Fiklikleri iptal et ve her\u015Feyi dosya sisteminden y\u00FCkle.\n\
                        Konfig\u00FCrasyon dosyalar\u0131n\u0131 do\u011Frudan diskten de\u011Fi\u015Ftirdiyseniz kullan\u0131\u015Fl\u0131d\u0131r
 PluginsLink.DisplayName=Eklentileri Y\u00F6net


### PR DESCRIPTION
Correct word is "Konfigürasyon" not "Konfigürasayon"