### PR TITLE
Reduce usages of com.google.common.collect in tests

### DIFF
--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -24,7 +24,6 @@
 
 package jenkins.util;
 
-import com.google.common.collect.ImmutableSet;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Util;
@@ -56,6 +55,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -120,7 +120,7 @@ public class VirtualFileTest {
     @Test public void list() throws Exception {
         File root = tmp.getRoot();
         FilePath rootF = new FilePath(root);
-        Set<String> paths = ImmutableSet.of("top.txt", "sub/mid.txt", "sub/subsub/lowest.txt", ".hg/config.txt", "very/deep/path/here");
+        Set<String> paths = new HashSet<>(Arrays.asList("top.txt", "sub/mid.txt", "sub/subsub/lowest.txt", ".hg/config.txt", "very/deep/path/here"));
         for (String path : paths) {
             rootF.child(path).write("", null);
         }

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -43,14 +43,11 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
@@ -331,44 +328,44 @@ public class HistoryPageFilterTest {
     @Test
     @Issue("JENKINS-42645")
     public void should_be_case_insensitive_by_default() throws IOException {
-        List<ModelObject> runs = Lists.newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+        Iterable<ModelObject> runs = Arrays.asList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
         assertOneMatchingBuildForGivenSearchStringAndRunItems("failure", runs);
     }
 
     @Test
     public void should_lower_case_search_string_in_case_insensitive_search() throws IOException {
-        List<ModelObject> runs = Lists.newArrayList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+        Iterable<ModelObject> runs = Arrays.asList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
         assertOneMatchingBuildForGivenSearchStringAndRunItems("FAILure", runs);
     }
 
     @Test
     @Issue("JENKINS-40718")
     public void should_search_builds_by_build_variables() throws IOException {
-        List<ModelObject> runs = ImmutableList.of(
-                new MockBuild(2).withBuildVariables(ImmutableMap.of("env", "dummyEnv")),
-                new MockBuild(1).withBuildVariables(ImmutableMap.of("env", "otherEnv")));
+        Iterable<ModelObject> runs = Arrays.asList(
+                new MockBuild(2).withBuildVariables(Collections.singletonMap("env", "dummyEnv")),
+                new MockBuild(1).withBuildVariables(Collections.singletonMap("env", "otherEnv")));
         assertOneMatchingBuildForGivenSearchStringAndRunItems("dummyEnv", runs);
     }
 
     @Test
     @Issue("JENKINS-40718")
     public void should_search_builds_by_build_params() throws IOException {
-        List<ModelObject> runs = ImmutableList.of(
-                new MockBuild(2).withBuildParameters(ImmutableMap.of("env", "dummyEnv")),
-                new MockBuild(1).withBuildParameters(ImmutableMap.of("env", "otherEnv")));
+        Iterable<ModelObject> runs = Arrays.asList(
+                new MockBuild(2).withBuildParameters(Collections.singletonMap("env", "dummyEnv")),
+                new MockBuild(1).withBuildParameters(Collections.singletonMap("env", "otherEnv")));
         assertOneMatchingBuildForGivenSearchStringAndRunItems("dummyEnv", runs);
     }
 
     @Test
     @Issue("JENKINS-40718")
     public void should_ignore_sensitive_parameters_in_search_builds_by_build_params() throws IOException {
-        List<ModelObject> runs = ImmutableList.of(
-                new MockBuild(2).withBuildParameters(ImmutableMap.of("plainPassword", "pass1plain")),
+        Iterable<ModelObject> runs = Arrays.asList(
+                new MockBuild(2).withBuildParameters(Collections.singletonMap("plainPassword", "pass1plain")),
                 new MockBuild(1).withSensitiveBuildParameters("password", "pass1"));
         assertOneMatchingBuildForGivenSearchStringAndRunItems("pass1", runs);
     }
 
-    private void assertOneMatchingBuildForGivenSearchStringAndRunItems(String searchString, List<ModelObject> runs) {
+    private void assertOneMatchingBuildForGivenSearchStringAndRunItems(String searchString, Iterable<ModelObject> runs) {
         //given
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
         //and
@@ -511,8 +508,8 @@ public class HistoryPageFilterTest {
         }
 
         MockBuild withSensitiveBuildParameters(String paramName, String paramValue) throws IOException {
-            addAction(new ParametersAction(ImmutableList.of(createSensitiveStringParameterValue(paramName, paramValue)),
-                    ImmutableList.of(paramName)));
+            addAction(new ParametersAction(Collections.singletonList(createSensitiveStringParameterValue(paramName, paramValue)),
+                    Collections.singletonList(paramName)));
             return this;
         }
 

--- a/test/src/test/java/hudson/cli/CLIActionTest.java
+++ b/test/src/test/java/hudson/cli/CLIActionTest.java
@@ -1,7 +1,5 @@
 package hudson.cli;
 
-import com.google.common.collect.Lists;
-
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.Proc;
@@ -18,6 +16,7 @@ import java.io.PipedOutputStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -92,7 +91,7 @@ public class CLIActionTest {
     private static final String ADMIN = "admin@mycorp.com";
 
     private void assertExitCode(int code, boolean useApiToken, File jar, String... args) throws IOException, InterruptedException {
-        List<String> commands = Lists.newArrayList("java", "-jar", jar.getAbsolutePath(), "-s", j.getURL().toString(), /* TODO until it is the default */ "-webSocket");
+        List<String> commands = new ArrayList<>(Arrays.asList("java", "-jar", jar.getAbsolutePath(), "-s", j.getURL().toString(), /* TODO until it is the default */ "-webSocket"));
         if (useApiToken) {
             commands.add("-auth");
             commands.add(ADMIN + ":" + User.getOrCreateByIdOrFullName(ADMIN).getProperty(ApiTokenProperty.class).getApiToken());

--- a/test/src/test/java/hudson/cli/CLITest.java
+++ b/test/src/test/java/hudson/cli/CLITest.java
@@ -25,7 +25,6 @@
 package hudson.cli;
 
 import com.gargoylesoftware.htmlunit.WebResponse;
-import com.google.common.collect.Lists;
 import hudson.Launcher;
 import hudson.Proc;
 import hudson.model.FreeStyleProject;
@@ -37,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -103,7 +103,7 @@ public class CLITest {
     }
     private void doInterrupt(FreeStyleProject p, String... modeArgs) throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        List<String> args = Lists.newArrayList("java", "-jar", jar.getAbsolutePath(), "-s", r.getURL().toString());
+        List<String> args = new ArrayList<>(Arrays.asList("java", "-jar", jar.getAbsolutePath(), "-s", r.getURL().toString()));
         args.addAll(Arrays.asList(modeArgs));
         args.addAll(Arrays.asList("build", "-s", "-v", "p"));
         Proc proc = new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(args).stdout(new TeeOutputStream(baos, System.out)).stderr(System.err).start();

--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -34,7 +34,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.google.common.collect.Iterables;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Launcher;
@@ -282,19 +281,19 @@ public class AbstractProjectTest {
     public void renameJobLostBuilds() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject("initial");
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertEquals(1, Iterables.size(p.getBuilds()));
+        assertEquals(1, p.getBuilds().stream().count());
         p.renameTo("edited");
         p._getRuns().purgeCache();
-        assertEquals(1, Iterables.size(p.getBuilds()));
+        assertEquals(1, p.getBuilds().stream().count());
         MockFolder d = j.jenkins.createProject(MockFolder.class, "d");
         Items.move(p, d);
         assertEquals(p, j.jenkins.getItemByFullName("d/edited"));
         p._getRuns().purgeCache();
-        assertEquals(1, Iterables.size(p.getBuilds()));
+        assertEquals(1, p.getBuilds().stream().count());
         d.renameTo("d2");
         p = j.jenkins.getItemByFullName("d2/edited", FreeStyleProject.class);
         p._getRuns().purgeCache();
-        assertEquals(1, Iterables.size(p.getBuilds()));
+        assertEquals(1, p.getBuilds().stream().count());
     }
 
     @Test

--- a/test/src/test/java/hudson/security/TokenBasedRememberMeServices2Test.java
+++ b/test/src/test/java/hudson/security/TokenBasedRememberMeServices2Test.java
@@ -3,7 +3,7 @@ package hudson.security;
 import com.gargoylesoftware.htmlunit.CookieManager;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
-import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.stream.Collectors;
 
@@ -128,7 +128,7 @@ public class TokenBasedRememberMeServices2Test {
         wc.executeOnServer(() -> {
             Authentication a = Jenkins.getAuthentication2();
             assertEquals("bob", a.getName());
-            assertEquals(ImmutableList.of("authenticated", "myteam"), a.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList()));
+            assertEquals(Arrays.asList("authenticated", "myteam"), a.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList()));
             return null;
         });
     }

--- a/test/src/test/java/hudson/tasks/FingerprinterTest.java
+++ b/test/src/test/java/hudson/tasks/FingerprinterTest.java
@@ -24,8 +24,6 @@
 
 package hudson.tasks;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.Util;
@@ -45,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -120,7 +119,7 @@ public class FingerprinterTest {
     private static class FingerprintAddingBuilder extends Builder {
         @Override
         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-            build.addAction(new Fingerprinter.FingerprintAction(build, ImmutableMap.of(singleFiles2[0], "fakefingerprint")));
+            build.addAction(new Fingerprinter.FingerprintAction(build, Collections.singletonMap(singleFiles2[0], "fakefingerprint")));
             return true;
         }
     }
@@ -134,7 +133,7 @@ public class FingerprinterTest {
         assertThat(build.getActions(Fingerprinter.FingerprintAction.class), hasSize(1));
 
         Fingerprinter.FingerprintAction action = build.getAction(Fingerprinter.FingerprintAction.class);
-        assertEquals(action.getRecords().keySet(), ImmutableSet.of(singleFiles2[0], singleFiles[0]));
+        assertThat(action.getRecords().keySet(), containsInAnyOrder(singleFiles2[0], singleFiles[0]));
     }
 
     @Test public void multipleUpstreamDependencies() throws Exception {

--- a/test/src/test/java/hudson/util/ProcessTreeTest.java
+++ b/test/src/test/java/hudson/util/ProcessTreeTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assume.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collections;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
@@ -30,7 +31,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
-import com.google.common.collect.ImmutableMap;
 
 
 public class ProcessTreeTest {
@@ -144,7 +144,7 @@ public class ProcessTreeTest {
         process = pb.start();
 
         ProcessTree processTree = ProcessTree.get();
-        processTree.killAll(ImmutableMap.of("cookie", "testKeepDaemonsAlive"));
+        processTree.killAll(Collections.singletonMap("cookie", "testKeepDaemonsAlive"));
         try {
             process.exitValue();
             fail("Process should have been excluded from the killing");
@@ -179,7 +179,7 @@ public class ProcessTreeTest {
 
         // Call killall (somewhat roundabout though) to (not) kill it
         StringWriter out = new StringWriter();
-        s.createLauncher(new StreamTaskListener(out)).kill(ImmutableMap.of("cookie", "testKeepDaemonsAlive"));
+        s.createLauncher(new StreamTaskListener(out)).kill(Collections.singletonMap("cookie", "testKeepDaemonsAlive"));
 
         try {
             process.exitValue();

--- a/test/src/test/java/jenkins/ClassPathTest.java
+++ b/test/src/test/java/jenkins/ClassPathTest.java
@@ -24,12 +24,13 @@
 
 package jenkins;
 
-import com.google.common.collect.Iterators;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -51,13 +52,13 @@ public class ClassPathTest {
         for (File jar : new File(WarExploder.getExplodedDir(), "WEB-INF/lib").listFiles((dir, name) -> name.endsWith(".jar"))) {
             String jarname = jar.getName();
             try (JarFile jf = new JarFile(jar)) {
-                Iterators.forEnumeration(jf.entries()).forEachRemaining(e -> {
+                for (JarEntry e : Collections.list(jf.entries())) {
                     String name = e.getName();
                     if (name.startsWith("META-INF/") || name.endsWith("/") || !name.contains("/")) {
-                        return;
+                        continue;
                     }
                     entries.computeIfAbsent(name, k -> new ArrayList<>()).add(jarname);
-                });
+                }
             }
         }
         entries.forEach((name, jarnames) -> {

--- a/test/src/test/java/jenkins/widgets/HistoryPageFilterCaseSensitiveSearchTest.java
+++ b/test/src/test/java/jenkins/widgets/HistoryPageFilterCaseSensitiveSearchTest.java
@@ -1,6 +1,7 @@
 package jenkins.widgets;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -11,7 +12,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mockito;
 
-import com.google.common.collect.ImmutableList;
 import hudson.model.Job;
 import hudson.model.ModelObject;
 import hudson.model.Result;
@@ -68,13 +68,13 @@ public class HistoryPageFilterCaseSensitiveSearchTest {
             User.getOrCreateByIdOrFullName(TEST_USER_NAME).addProperty(new UserSearchProperty(false));
 
             //test logic
-            final List<ModelObject> runs = ImmutableList.of(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+            final Iterable<ModelObject> runs = Arrays.asList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
             assertNoMatchingBuildsForGivenSearchStringAndRunItems(searchString, runs, assertionOnSearchResults);
         }
 
     }
 
-    private void assertNoMatchingBuildsForGivenSearchStringAndRunItems(String searchString, List<ModelObject> runs,
+    private void assertNoMatchingBuildsForGivenSearchStringAndRunItems(String searchString, Iterable<ModelObject> runs,
                                                                        SearchResultAssertFunction assertionOnSearchResults) {
         //given
         HistoryPageFilter<ModelObject> historyPageFilter = new HistoryPageFilter<>(5);

--- a/test/src/test/java/lib/layout/IconTest.java
+++ b/test/src/test/java/lib/layout/IconTest.java
@@ -26,7 +26,6 @@ package lib.layout;
 import com.gargoylesoftware.htmlunit.html.DomElement;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.google.common.collect.Lists;
 import hudson.model.BallColor;
 import hudson.model.InvisibleAction;
 import hudson.model.RootAction;
@@ -45,6 +44,8 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
@@ -62,7 +63,7 @@ public class IconTest  {
     public void testIcons() throws Exception {
         HtmlPage p = j.createWebClient().goTo("testIcons");
         DomElement iconsBlock = p.getElementById("iconsBlock");
-        List<DomElement> icons = Lists.newArrayList(iconsBlock.getChildElements());
+        List<DomElement> icons = StreamSupport.stream(iconsBlock.getChildElements().spliterator(), false).collect(Collectors.toList());
 
         assertIconToImageOkay(icons.get(0), "/images/16x16/empty.png", "icon-empty icon-sm");
         assertIconToImageOkay(icons.get(1), "/images/24x24/empty.png", "icon-empty icon-md");
@@ -90,11 +91,11 @@ public class IconTest  {
         HtmlPage p = j.createWebClient().goTo("testBallColorTd");
 
         DomElement ballColorAborted = p.getElementById("ballColorAborted");
-        List<DomElement> ballIcons = Lists.newArrayList(ballColorAborted.getChildElements());
+        List<DomElement> ballIcons = StreamSupport.stream(ballColorAborted.getChildElements().spliterator(), false).collect(Collectors.toList());
         assertIconToSvgOkay(ballIcons.get(0), "icon-aborted icon-lg");
 
         DomElement statusIcons = p.getElementById("statusIcons");
-        List<DomElement> statusIconsList = Lists.newArrayList(statusIcons.getChildElements());
+        List<DomElement> statusIconsList = StreamSupport.stream(statusIcons.getChildElements().spliterator(), false).collect(Collectors.toList());
         assertIconToImageOkay(statusIconsList.get(0), "/images/32x32/folder.png", "icon-folder icon-lg");
 
         assertIconToImageOkay(statusIconsList.get(1), "/plugin/12345/icons/s2.png");
@@ -135,7 +136,7 @@ public class IconTest  {
         HtmlPage p = j.createWebClient().goTo("testTasks");
 
         DomElement tasksDiv = p.getElementById("tasks");
-        List<DomElement> taskDivs = Lists.newArrayList(tasksDiv.getChildElements());
+        List<DomElement> taskDivs = StreamSupport.stream(tasksDiv.getChildElements().spliterator(), false).collect(Collectors.toList());
 
         assertIconToImageOkay(taskDivs.get(0).getElementsByTagName("img").get(0), "/images/24x24/up.png", "icon-up icon-md");
         assertIconToImageOkay(taskDivs.get(1).getElementsByTagName("img").get(0), "/images/24x24/folder.png", "icon-folder icon-md");


### PR DESCRIPTION
A subset of #5344 that is hopefully non-controversial and safe to land in the short term because it only affects test code.

The underlying motivation is to make the code easier to read by using a consistent paradigm as much as possible (namely, JDK classes rather than a mixture of JDK classes and Guava classes).