### PR TITLE
Use declaring class as qualifier

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -30,7 +30,6 @@ import hudson.model.Computer;
 import hudson.model.Slave;
 import hudson.security.*;
 
-import java.text.SimpleDateFormat;
 import java.util.function.Predicate;
 import jenkins.util.SystemProperties;
 import hudson.cli.CLICommand;
@@ -110,6 +109,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -236,7 +236,7 @@ public class Functions {
      */
     @Restricted(NoExternalUse.class)
     public static String localDate(Date date) {
-        return SimpleDateFormat.getDateInstance(SimpleDateFormat.SHORT).format(date);
+        return DateFormat.getDateInstance(DateFormat.SHORT).format(date);
     }
 
     public static String rfc822Date(Calendar cal) {

--- a/core/src/main/java/hudson/cli/DeleteJobCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteJobCommand.java
@@ -26,6 +26,7 @@ package hudson.cli;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.AbstractItem;
+import hudson.model.Item;
 import jenkins.model.Jenkins;
 import org.kohsuke.args4j.Argument;
 
@@ -68,7 +69,7 @@ public class DeleteJobCommand extends CLICommand {
                     throw new IllegalArgumentException("No such job '" + job_s + "'");
                 }
 
-                job.checkPermission(AbstractItem.DELETE);
+                job.checkPermission(Item.DELETE);
                 job.delete();
             } catch (Exception e) {
                 if(hs.size() == 1) {

--- a/core/src/main/java/hudson/cli/ReloadJobCommand.java
+++ b/core/src/main/java/hudson/cli/ReloadJobCommand.java
@@ -83,7 +83,7 @@ public class ReloadJobCommand extends CLICommand {
                                 job_s, project.getFullName()));
                 }
 
-                job.checkPermission(AbstractItem.CONFIGURE);
+                job.checkPermission(Item.CONFIGURE);
                 job.doReload();
             } catch (Exception e) {
                 if(hs.size() == 1) {

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -410,7 +410,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
     public String getAssignedLabelString() {
         if (canRoam || assignedNode==null)    return null;
         try {
-            LabelExpression.parseExpression(assignedNode);
+            Label.parseExpression(assignedNode);
             return assignedNode;
         } catch (ANTLRException e) {
             // must be old label or host name that includes whitespace or other unsafe chars

--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -121,7 +121,7 @@ public class Api extends AbstractModelObject {
                 for (String exclude : excludes) {
                     XPath xExclude = dom.createXPath(exclude);
                     xExclude.setFunctionContext(functionContext);
-                    List<org.dom4j.Node> list = (List<org.dom4j.Node>)xExclude.selectNodes(dom);
+                    List<org.dom4j.Node> list = xExclude.selectNodes(dom);
                     for (org.dom4j.Node n : list) {
                         Element parent = n.getParent();
                         if(parent!=null)

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1351,7 +1351,7 @@ public class Fingerprint implements ModelObject, Saveable {
         }
 
         FingerprintStorage configuredFingerprintStorage = FingerprintStorage.get();
-        FingerprintStorage fileFingerprintStorage = FileFingerprintStorage.getFileFingerprintStorage();
+        FingerprintStorage fileFingerprintStorage = FingerprintStorage.getFileFingerprintStorage();
 
         Fingerprint loaded = configuredFingerprintStorage.load(id);
 

--- a/core/src/main/java/hudson/model/FingerprintCleanupThread.java
+++ b/core/src/main/java/hudson/model/FingerprintCleanupThread.java
@@ -79,7 +79,7 @@ public class FingerprintCleanupThread extends AsyncPeriodicWork {
 
         if (!(FingerprintStorage.get() instanceof FileFingerprintStorage) &&
                 FingerprintStorage.getFileFingerprintStorage().isReady()) {
-            FileFingerprintStorage.getFileFingerprintStorage().iterateAndCleanupFingerprints(listener);
+            FingerprintStorage.getFileFingerprintStorage().iterateAndCleanupFingerprints(listener);
         }
     }
 

--- a/core/src/main/java/hudson/model/Hudson.java
+++ b/core/src/main/java/hudson/model/Hudson.java
@@ -44,6 +44,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.text.NumberFormat;
@@ -281,7 +282,7 @@ public class Hudson extends Jenkins {
     public static boolean adminCheck(StaplerRequest req,StaplerResponse rsp) throws IOException {
         if (isAdmin(req)) return true;
 
-        rsp.sendError(StaplerResponse.SC_FORBIDDEN);
+        rsp.sendError(HttpServletResponse.SC_FORBIDDEN);
         return false;
     }
 

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -308,7 +308,7 @@ public abstract class Slave extends Node implements Serializable {
     }
 
     public RetentionStrategy getRetentionStrategy() {
-        return retentionStrategy == null ? RetentionStrategy.INSTANCE : retentionStrategy;
+        return retentionStrategy == null ? RetentionStrategy.Always.INSTANCE : retentionStrategy;
     }
 
     @DataBoundSetter

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -308,7 +308,7 @@ public abstract class Slave extends Node implements Serializable {
     }
 
     public RetentionStrategy getRetentionStrategy() {
-        return retentionStrategy == null ? RetentionStrategy.Always.INSTANCE : retentionStrategy;
+        return retentionStrategy == null ? RetentionStrategy.INSTANCE : retentionStrategy;
     }
 
     @DataBoundSetter

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -74,8 +74,8 @@ import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter;
-import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
@@ -329,7 +329,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
     }
 
     private void resetRememberMeCookie(StaplerRequest req, StaplerResponse rsp, String contextPath) {
-        Cookie cookie = new Cookie(TokenBasedRememberMeServices.SPRING_SECURITY_REMEMBER_ME_COOKIE_KEY, "");
+        Cookie cookie = new Cookie(AbstractRememberMeServices.SPRING_SECURITY_REMEMBER_ME_COOKIE_KEY, "");
         cookie.setMaxAge(0);
         cookie.setSecure(req.isSecure());
         cookie.setHttpOnly(true);

--- a/core/src/main/java/hudson/slaves/NodeProperty.java
+++ b/core/src/main/java/hudson/slaves/NodeProperty.java
@@ -34,6 +34,7 @@ import hudson.model.ReconfigurableDescribable;
 import hudson.model.TaskListener;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.scm.SCM;
+import hudson.tools.PropertyDescriptor;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Environment;
@@ -186,6 +187,6 @@ public abstract class NodeProperty<N extends Node> implements ReconfigurableDesc
      * given project.
      */
     public static List<NodePropertyDescriptor> for_(Node node) {
-        return NodePropertyDescriptor.for_(all(),node);
+        return PropertyDescriptor.for_(all(),node);
     }
 }

--- a/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalProjectNamingStrategyConfiguration.java
@@ -25,7 +25,6 @@ package jenkins.model;
 
 import hudson.Extension;
 import hudson.security.Permission;
-import jenkins.model.ProjectNamingStrategy.DefaultProjectNamingStrategy;
 import net.sf.json.JSONObject;
 
 import org.jenkinsci.Symbol;
@@ -58,7 +57,7 @@ public class GlobalProjectNamingStrategyConfiguration extends GlobalConfiguratio
             }
         }
         if (j.getProjectNamingStrategy() == null) {
-            j.setProjectNamingStrategy(DefaultProjectNamingStrategy.DEFAULT_NAMING_STRATEGY);
+            j.setProjectNamingStrategy(ProjectNamingStrategy.DEFAULT_NAMING_STRATEGY);
         }
         return true;
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2570,7 +2570,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     public boolean isUseProjectNamingStrategy(){
-        return projectNamingStrategy != DefaultProjectNamingStrategy.DEFAULT_NAMING_STRATEGY;
+        return projectNamingStrategy != ProjectNamingStrategy.DEFAULT_NAMING_STRATEGY;
     }
 
     /**
@@ -2668,7 +2668,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     public void setProjectNamingStrategy(ProjectNamingStrategy ns) {
         if(ns == null){
-            ns = DefaultProjectNamingStrategy.DEFAULT_NAMING_STRATEGY;
+            ns = ProjectNamingStrategy.DEFAULT_NAMING_STRATEGY;
         }
         projectNamingStrategy = ns;
     }

--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -9,7 +9,6 @@ import hudson.remoting.EngineListener;
 import hudson.remoting.EngineListenerAdapter;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.ComputerListener;
-import jenkins.model.Jenkins.MasterComputer;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -34,7 +33,7 @@ import jenkins.security.MasterToSlaveCallable;
 public class JnlpSlaveRestarterInstaller extends ComputerListener implements Serializable {
     @Override
     public void onOnline(final Computer c, final TaskListener listener) throws IOException, InterruptedException {
-        MasterComputer.threadPoolForRemoting.submit(new Install(c, listener));
+        Computer.threadPoolForRemoting.submit(new Install(c, listener));
     }
     private static class Install implements Callable<Void> {
         private final Computer c;

--- a/core/src/test/java/hudson/model/JobTest.java
+++ b/core/src/test/java/hudson/model/JobTest.java
@@ -8,6 +8,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.Issue;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.MockRepository;
@@ -61,7 +62,7 @@ public class JobTest {
         MockRepository.removeClassMethodInvocationControl(Platform.class);
 
         Job<?, ?> job = Mockito.mock(FreeStyleProject.class);
-        Mockito.when(job.getEnvironment(Mockito.any(Node.class), Mockito.any(TaskListener.class))).thenCallRealMethod();
+        Mockito.when(job.getEnvironment(ArgumentMatchers.any(Node.class), ArgumentMatchers.any(TaskListener.class))).thenCallRealMethod();
         Mockito.when(job.getCharacteristicEnvVars()).thenReturn(emptyEnv);
 
         Computer c = Mockito.mock(Computer.class);
@@ -70,7 +71,7 @@ public class JobTest {
             slaveEnv.put("PATH", "/bin/bash");
         }
         Mockito.when(c.getEnvironment()).thenReturn(slaveEnv);
-        Mockito.when(c.buildEnvironment(Mockito.any(TaskListener.class))).thenReturn(emptyEnv);
+        Mockito.when(c.buildEnvironment(ArgumentMatchers.any(TaskListener.class))).thenReturn(emptyEnv);
 
         Node node = PowerMockito.mock(Node.class);
         PowerMockito.doReturn(c).when(node).toComputer();

--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -15,7 +15,6 @@ import java.nio.file.StandardOpenOption;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 public class FileChannelWriterTest {
     @Rule

--- a/test/src/test/java/hudson/CustomPluginManagerTest.java
+++ b/test/src/test/java/hudson/CustomPluginManagerTest.java
@@ -61,17 +61,17 @@ public class CustomPluginManagerTest {
             @Override
             public void setup(JenkinsRule jenkinsRule, WithCustomLocalPluginManager recipe) throws Exception {
                 jenkinsRule.useLocalPluginManager = true;
-                oldValue = System.getProperty(LocalPluginManager.CUSTOM_PLUGIN_MANAGER);
-                System.setProperty(LocalPluginManager.CUSTOM_PLUGIN_MANAGER, recipe.value().getName());
+                oldValue = System.getProperty(PluginManager.CUSTOM_PLUGIN_MANAGER);
+                System.setProperty(PluginManager.CUSTOM_PLUGIN_MANAGER, recipe.value().getName());
 
             }
 
             @Override
             public void tearDown(JenkinsRule jenkinsRule, WithCustomLocalPluginManager recipe) {
                 if (oldValue != null) {
-                    System.setProperty(LocalPluginManager.CUSTOM_PLUGIN_MANAGER, oldValue);
+                    System.setProperty(PluginManager.CUSTOM_PLUGIN_MANAGER, oldValue);
                 } else {
-                    System.clearProperty(LocalPluginManager.CUSTOM_PLUGIN_MANAGER);
+                    System.clearProperty(PluginManager.CUSTOM_PLUGIN_MANAGER);
                 }
             }
         }

--- a/test/src/test/java/hudson/ProcTest.java
+++ b/test/src/test/java/hudson/ProcTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assume.assumeFalse;
 import hudson.Launcher.LocalLauncher;
 import hudson.Launcher.RemoteLauncher;
 import hudson.Launcher.RemoteLauncher.ProcImpl;
+import hudson.model.TaskListener;
 import hudson.remoting.Pipe;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
@@ -55,7 +56,7 @@ public class ProcTest {
             }
         }.start();
 
-        RemoteLauncher launcher = new RemoteLauncher(StreamTaskListener.NULL, ch, true);
+        RemoteLauncher launcher = new RemoteLauncher(TaskListener.NULL, ch, true);
 
         String str="";
         for (int i=0; i<256; i++)

--- a/test/src/test/java/hudson/cli/AddJobToViewCommandTest.java
+++ b/test/src/test/java/hudson/cli/AddJobToViewCommandTest.java
@@ -26,7 +26,7 @@ package hudson.cli;
 
 import hudson.model.DirectlyModifiableView;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.Item;
 import hudson.model.ListView;
 import hudson.model.View;
 import jenkins.model.Jenkins;
@@ -55,7 +55,7 @@ public class AddJobToViewCommandTest extends ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject");
 
         assertThat(result, succeededSilently());
@@ -74,7 +74,7 @@ public class AddJobToViewCommandTest extends ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project), equalTo(true));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject");
 
         assertThat(result, succeededSilently());
@@ -93,7 +93,7 @@ public class AddJobToViewCommandTest extends ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project2), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject1", "aProject2");
 
         assertThat(result, succeededSilently());
@@ -111,7 +111,7 @@ public class AddJobToViewCommandTest extends ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject", "aProject");
 
         assertThat(result, succeededSilently());

--- a/test/src/test/java/hudson/cli/BuildCommandTest.java
+++ b/test/src/test/java/hudson/cli/BuildCommandTest.java
@@ -35,7 +35,6 @@ import hudson.model.Executor;
 import hudson.model.FileParameterDefinition;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.model.ParameterDefinition.ParameterDescriptor;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;

--- a/test/src/test/java/hudson/cli/ConsoleCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConsoleCommandTest.java
@@ -27,7 +27,6 @@ package hudson.cli;
 import hudson.Functions;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
-import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.labels.LabelAtom;
 import hudson.tasks.BatchFile;
@@ -88,7 +87,7 @@ public class ConsoleCommandTest {
         assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
         
         final CLICommandInvoker.Result result = command	
-                .authorizedTo(Jenkins.READ, Job.READ)	
+                .authorizedTo(Jenkins.READ, Item.READ)	
                 .invokeWithArgs("aProject");	
         
         assertThat(result, succeeded());
@@ -98,7 +97,7 @@ public class ConsoleCommandTest {
     @Test public void consoleShouldFailWhenProjectDoesNotExist() throws Exception {
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("never_created");
 
         assertThat(result, failedWith(3));
@@ -111,7 +110,7 @@ public class ConsoleCommandTest {
         j.createFreeStyleProject("aProject");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject");
 
         assertThat(result, failedWith(4));
@@ -124,7 +123,7 @@ public class ConsoleCommandTest {
         j.createFreeStyleProject("aProject");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "1");
 
         assertThat(result, failedWith(3));
@@ -137,7 +136,7 @@ public class ConsoleCommandTest {
         FreeStyleProject project = j.createFreeStyleProject("aProject");
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "1a");
 
         assertThat(result, failedWith(3));
@@ -148,7 +147,7 @@ public class ConsoleCommandTest {
         project.scheduleBuild2(0).get();
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "1a");
 
         assertThat(result, failedWith(3));
@@ -167,7 +166,7 @@ public class ConsoleCommandTest {
         assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject");
 
         assertThat(result, succeeded());
@@ -187,7 +186,7 @@ public class ConsoleCommandTest {
         assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 3"));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "2");
 
         assertThat(result, succeeded());
@@ -223,7 +222,7 @@ public class ConsoleCommandTest {
         assertThat(project.getBuildByNumber(1).getLog(), not(containsString("after sleep - 1")));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "1");
 
         assertThat(result, succeeded());
@@ -231,7 +230,7 @@ public class ConsoleCommandTest {
         assertThat(result.stdout(), not(containsString("after sleep - 1")));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "1", "-f");
 
         assertThat(result, succeeded());
@@ -255,7 +254,7 @@ public class ConsoleCommandTest {
         assertThat(project.getBuildByNumber(1).getLog(), containsString("echo 5"));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "1", "-n", Functions.isWindows() ? "5" : "4");
 
         assertThat(result, succeeded());
@@ -296,7 +295,7 @@ public class ConsoleCommandTest {
         assertThat(project.getBuildByNumber(1).getLog(), not(containsString("echo 6")));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "1", "-f", "-n", Functions.isWindows() ? "5" : "4");
 
         assertThat(result, succeeded());
@@ -322,7 +321,7 @@ public class ConsoleCommandTest {
         assertThat("Job wasn't scheduled properly - it is running on non-exist node", project.isBuilding(), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Item.BUILD)
+                .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
                 .invokeWithArgs("aProject", "1");
 
         assertThat(result, failedWith(3));

--- a/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
@@ -27,7 +27,7 @@ package hudson.cli;
 import hudson.Functions;
 import hudson.model.ExecutorTest;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.labels.LabelAtom;
 import hudson.tasks.Shell;
@@ -74,7 +74,7 @@ public class DeleteBuildsCommandTest {
         j.createFreeStyleProject("aProject").scheduleBuild2(0).get();
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs("aProject", "1");
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
@@ -83,7 +83,7 @@ public class DeleteBuildsCommandTest {
 
     @Test public void deleteBuildsShouldFailIfJobDoesNotExist() throws Exception {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("never_created", "1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -95,7 +95,7 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("", "1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -107,7 +107,7 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
@@ -119,7 +119,7 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 0 builds"));
@@ -130,7 +130,7 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "0");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 0 builds"));
@@ -143,7 +143,7 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
@@ -161,7 +161,7 @@ public class DeleteBuildsCommandTest {
         assertThat("Job wasn't scheduled properly - it is running on non-exist node", project.isBuilding(), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 0 builds"));
@@ -185,14 +185,14 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(5));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1,2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 2 builds"));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(3));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "3-5");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 3 builds"));
@@ -206,14 +206,14 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1,1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1-1,1-2,2-2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
@@ -227,14 +227,14 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1,3");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "2-3");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
@@ -254,14 +254,14 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(4));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1,2,3");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 2 builds"));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "4-6");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 2 builds"));
@@ -277,14 +277,14 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1,2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "2-3");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
@@ -304,14 +304,14 @@ public class DeleteBuildsCommandTest {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "1,2,3");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ, Run.DELETE)
+                .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("aProject", "3-5");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Deleted 1 builds"));

--- a/test/src/test/java/hudson/cli/DeleteJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteJobCommandTest.java
@@ -24,7 +24,7 @@
 
 package hudson.cli;
 
-import hudson.model.Job;
+import hudson.model.Item;
 import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +59,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Jenkins.READ)
+                .authorizedTo(Item.READ, Jenkins.READ)
                 .invokeWithArgs("aProject");
 
         assertThat(result, failedWith(6));
@@ -72,7 +72,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("aProject");
 
         assertThat(result, failedWith(3));
@@ -85,7 +85,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("aProject");
 
         assertThat(result, succeededSilently());
@@ -95,7 +95,7 @@ public class DeleteJobCommandTest {
     @Test public void deleteJobShouldFailIfJobDoesNotExist() {
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("never_created");
 
         assertThat(result, failedWith(3));
@@ -110,7 +110,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject3");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "aProject2", "aProject3");
 
         assertThat(result, succeededSilently());
@@ -125,7 +125,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("never_created", "aProject1", "aProject2");
 
         assertThat(result, failedWith(5));
@@ -144,7 +144,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("aProject1","never_created", "aProject2");
 
         assertThat(result, failedWith(5));
@@ -163,7 +163,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "aProject2", "never_created");
 
         assertThat(result, failedWith(5));
@@ -182,7 +182,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "never_created1", "never_created2", "aProject2");
 
         assertThat(result, failedWith(5));
@@ -203,7 +203,7 @@ public class DeleteJobCommandTest {
         j.createFreeStyleProject("aProject2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.DELETE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.DELETE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "aProject2", "aProject1");
 
         assertThat(result, succeededSilently());

--- a/test/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/test/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -31,7 +31,6 @@ import hudson.model.DirectlyModifiableView;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
 import hudson.model.ListView;
-import hudson.model.labels.LabelExpression;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -104,7 +103,7 @@ public class ListJobsCommandTest {
                 new Axis("axis", "a", "b")
         ));
 
-        Label label = LabelExpression.get("aws-linux-dummy");
+        Label label = Label.get("aws-linux-dummy");
         matrixProject.setAssignedLabel(label);
 
         CLICommandInvoker.Result result = command.invokeWithArgs("Folder");

--- a/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
@@ -27,7 +27,7 @@ package hudson.cli;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.Item;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Builder;
 import hudson.tasks.Shell;
@@ -67,7 +67,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Jenkins.READ)
+                .authorizedTo(Item.READ, Jenkins.READ)
                 .invokeWithArgs("aProject");
 
         assertThat(result, failedWith(6));
@@ -86,7 +86,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("aProject");
 
         assertThat(result, failedWith(3));
@@ -106,7 +106,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("aProject");
 
         assertThat(result, succeededSilently());
@@ -117,7 +117,7 @@ public class ReloadJobCommandTest {
     @Test public void reloadJobShouldFailIfJobDoesNotExist() throws Exception {
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("never_created");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -129,7 +129,7 @@ public class ReloadJobCommandTest {
         FreeStyleProject project = j.createFreeStyleProject("never_created");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("never_created1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -153,7 +153,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project3, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "aProject2", "aProject3");
 
         assertThat(result, succeededSilently());
@@ -177,7 +177,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("never_created", "aProject1", "aProject2");
 
         assertThat(result, failedWith(5));
@@ -203,7 +203,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "never_created", "aProject2");
 
         assertThat(result, failedWith(5));
@@ -229,7 +229,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "aProject2", "never_created");
 
         assertThat(result, failedWith(5));
@@ -255,7 +255,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "never_created1", "never_created2", "aProject2");
 
         assertThat(result, failedWith(5));
@@ -281,7 +281,7 @@ public class ReloadJobCommandTest {
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Job.CONFIGURE, Jenkins.READ)
+                .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)
                 .invokeWithArgs("aProject1", "aProject2", "aProject1");
 
         assertThat(result, succeededSilently());

--- a/test/src/test/java/hudson/cli/RemoveJobFromViewCommandTest.java
+++ b/test/src/test/java/hudson/cli/RemoveJobFromViewCommandTest.java
@@ -26,7 +26,7 @@ package hudson.cli;
 
 import hudson.model.DirectlyModifiableView;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.Item;
 import hudson.model.ListView;
 import hudson.model.View;
 import jenkins.model.Jenkins;
@@ -56,7 +56,7 @@ public class RemoveJobFromViewCommandTest extends ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project), equalTo(true));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject");
 
         assertThat(result, succeededSilently());
@@ -77,7 +77,7 @@ public class RemoveJobFromViewCommandTest extends ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project2), equalTo(true));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject1", "aProject2");
 
         assertThat(result, succeededSilently());
@@ -96,7 +96,7 @@ public class RemoveJobFromViewCommandTest extends ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project), equalTo(true));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject", "aProject");
 
         assertThat(result, succeededSilently());

--- a/test/src/test/java/hudson/cli/RunRangeCommand2Test.java
+++ b/test/src/test/java/hudson/cli/RunRangeCommand2Test.java
@@ -26,7 +26,7 @@ package hudson.cli;
 
 import hudson.Functions;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.Item;
 import hudson.model.labels.LabelAtom;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
@@ -61,7 +61,7 @@ public class RunRangeCommand2Test {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds().size(), equalTo(1));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs("", "1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -73,7 +73,7 @@ public class RunRangeCommand2Test {
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds().size(), equalTo(1));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(" ", "1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -97,7 +97,7 @@ public class RunRangeCommand2Test {
         }
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs("aProject", "1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1" + System.lineSeparator()));
@@ -115,7 +115,7 @@ public class RunRangeCommand2Test {
                 project.isBuilding(), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs("aProject", "1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: " + System.lineSeparator()));

--- a/test/src/test/java/hudson/cli/RunRangeCommandTest.java
+++ b/test/src/test/java/hudson/cli/RunRangeCommandTest.java
@@ -26,7 +26,7 @@ package hudson.cli;
 
 import hudson.Extension;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.Item;
 import hudson.model.Run;
 import jenkins.model.Jenkins;
 import org.junit.BeforeClass;
@@ -86,7 +86,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeShouldFailIfJobDesNotExist() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs("never_created", "1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -95,7 +95,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeShouldFailIfJobNameIsEmpty() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs("", "1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -105,7 +105,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeShouldFailIfJobNameIsSpace() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(" ", "1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -115,13 +115,13 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeShouldSuccessIfBuildDoesNotExist() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, String.valueOf(BUILDS+1));
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, String.valueOf(deleted[0]));
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+System.lineSeparator()));
@@ -130,35 +130,35 @@ public class RunRangeCommandTest {
     @Test public void dummyRangeNumberSingleShouldSuccess() {
         // First
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1"+System.lineSeparator()));
 
         // First with plus symbol '+'
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1"+System.lineSeparator()));
 
         // In the middle
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "10");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 10"+System.lineSeparator()));
 
         // In the middle with plus symbol '+'
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+10");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 10"+System.lineSeparator()));
 
         // Last
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, String.valueOf(BUILDS));
         assertThat(result, succeeded());
         assertThat(result.stdout(),
@@ -166,7 +166,7 @@ public class RunRangeCommandTest {
 
         // Last with the plus symbol '+'
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, '+' + String.valueOf(BUILDS));
         assertThat(result, succeeded());
         assertThat(result.stdout(),
@@ -175,13 +175,13 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberSingleShouldSuccessIfBuildNumberIsZero() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "0");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+0");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+System.lineSeparator()));
@@ -189,7 +189,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberSingleShouldFailIfBuildNumberIsNegative() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
@@ -198,7 +198,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberSingleShouldFailIfBuildNumberIsTooBig() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "2147483648");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -207,14 +207,14 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberSingleShouldFailIfBuildNumberIsInvalid() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1a");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1a', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "aa");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -223,7 +223,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberSingleShouldSuccessIfBuildNumberIsEmpty() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+System.lineSeparator()));
@@ -231,7 +231,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberSingleShouldFailIfBuildNumberIsSpace() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, " ");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -240,7 +240,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberSingleShouldSuccessIfBuildNumberIsComma() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, ",");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+System.lineSeparator()));
@@ -248,7 +248,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberSingleShouldFailIfBuildNumberIsHyphen() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
@@ -257,40 +257,40 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldSuccess() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
 
         // With plus symbol '+'
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,+2,4");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2,4"+System.lineSeparator()));
 
         // Build specified twice
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,1"+System.lineSeparator()));
 
         // Build with zero build number
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "0,1,2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,0,2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,0");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
@@ -298,19 +298,19 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldSuccessIfSomeBuildDoesNotExist() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,"+deleted[0]);
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, String.format("1,%d,%d", deleted[0], deleted[0]+1));
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString(String.format("Builds: 1,%d"+System.lineSeparator(), deleted[0]+1)));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, String.format("%d,%d,%d", deleted[0]-1, deleted[0], deleted[0]+1));
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString(String.format("Builds: %d,%d"+System.lineSeparator(), deleted[0]-1, deleted[0]+1)));
@@ -318,21 +318,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldFailIfBuildNumberIsNegative() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1,2,3");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1,2,3\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,-2,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1,-2,3', expected string with a range M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,-3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -341,21 +341,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldFailIfBuildNumberIsTooBig() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "2147483648,2,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '2147483648,2,3', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2147483648,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1,2147483648,3', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,2147483648");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -364,42 +364,42 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldFailIfBuildNumberIsInvalid() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1a,2,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1a,2,3', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "aa,2,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse 'aa,2,3', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2a,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1,2a,3', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,aa,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1,aa,3', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,3a");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1,2,3a', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,aa");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -408,21 +408,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldFailIfBuildNumberIsEmpty() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, ",2,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse ',2,3', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1,,3', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -431,21 +431,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldFailIfBuildNumberIsSpace() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, " ,2,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse ' ,2,3', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1, ,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1, ,3', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2, ");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -454,21 +454,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldFailIfBuildNumberIsComma() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, ",,2,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse ',,2,3', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,,,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1,,,3', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,,");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -477,21 +477,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeNumberMultiShouldFailIfBuildNumberIsHyphen() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-,2,3");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-,2,3\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,-,3");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1,-,3', expected string with a range M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1,2,-");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -500,31 +500,31 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldSuccess() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+1-+2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+1-+1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-"+deleted[0]);
         assertThat(result, succeeded());
         String builds = "";
@@ -538,43 +538,43 @@ public class RunRangeCommandTest {
         assertThat(result.stdout(), containsString("Builds: "+builds+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+1-+"+deleted[0]);
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+builds+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "0-1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+0-+1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "0-2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+0-+2");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "0-0");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+0-+0");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: "+System.lineSeparator()));
@@ -582,19 +582,19 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldSuccessIfSomeBuildDoesNotExist() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, String.format("%d-%d", deleted[0], deleted[0]+1));
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString(String.format("Builds: %d"+System.lineSeparator(), deleted[0] + 1)));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, String.format("%d-%d", deleted[0]-1, deleted[0]+1));
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString(String.format("Builds: %d,%d"+System.lineSeparator(), deleted[0]-1, deleted[0]+1)));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, String.format("%d-%d", deleted[0]-1, deleted[0]));
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString(String.format("Builds: %d"+System.lineSeparator(), deleted[0]-1)));
@@ -602,84 +602,84 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeContainsZeroAndNegative() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "0--1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '0--1', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+0--1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '+0--1', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "0--2");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '0--2', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+0--2");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '+0--2', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-0");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1-0', expected string with a range M-N where M<N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+1-+0");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '+1-+0', expected string with a range M-N where M<N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "2-0");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '2-0', expected string with a range M-N where M<N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+2-+0");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '+2-+0', expected string with a range M-N where M<N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1-0");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1-0\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1-+0");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1-+0\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-2-0");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-2-0\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-2-+0");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
@@ -688,70 +688,70 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeContainsANegativeNumber() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1-1");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1-1\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1-+1");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1-+1\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1-2");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1-2\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1-+2");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1-+2\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1--1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1--1', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+1--1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '+1--1', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1--2");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1--2', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "+1--2");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '+1--2', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1--1");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1--1\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-2--1");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
@@ -760,21 +760,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeContainsTooBigNumber() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-2147483648");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1-2147483648', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "2147483648-1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '2147483648-1', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "2147483648-2147483648");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -783,42 +783,42 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeContainsInvalidNumber() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-2a");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1-2a', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-aa");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1-aa', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "2a-2");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '2a-2', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "aa-2");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse 'aa-2', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "2a-2a");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '2a-2a', expected number"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "aa-aa");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -827,21 +827,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeContainsEmptyNumber() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"-1\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1-', expected string with a range M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
@@ -850,21 +850,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeContainsSpace() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, " -1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse ' -1', expected string with a range M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1- ");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1- ', expected string with a range M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, " - ");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -873,21 +873,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeContainsComma() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, ",-1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse ',-1', expected string with a range M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-,");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1-,', expected string with a range M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, ",-,");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -896,21 +896,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeContainsHyphen() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "--1");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: \"--1\" is not a valid option"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1--");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '1--', expected correct notation M,N or M-N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "---");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
@@ -919,21 +919,21 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeIsInverse() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "2-1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '2-1', expected string with a range M-N where M<N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "10-1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: Unable to parse '10-1', expected string with a range M-N where M<N"));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "-1--2");
         assertThat(result, failedWith(2));
         assertThat(result, hasNoStandardOutput());
@@ -942,7 +942,7 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeSingleShouldFailIfBuildRangeIsInvalid() {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-3-");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -951,25 +951,25 @@ public class RunRangeCommandTest {
 
     @Test public void dummyRangeRangeMultiShouldSuccess() {
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-2,3-4");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2,3,4"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-3,3-4");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2,3,3,4"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-4,2-3");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2,3,4,2,3"+System.lineSeparator()));
 
         result = command
-                .authorizedTo(Jenkins.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, Item.READ)
                 .invokeWithArgs(PROJECT_NAME, "1-2,4-5");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: 1,2,4"+System.lineSeparator()));

--- a/test/src/test/java/hudson/cli/SetBuildDescriptionCommandTest.java
+++ b/test/src/test/java/hudson/cli/SetBuildDescriptionCommandTest.java
@@ -27,7 +27,7 @@ package hudson.cli;
 import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.Item;
 import hudson.model.Run;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Builder;
@@ -77,7 +77,7 @@ public class SetBuildDescriptionCommandTest {
         assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Jenkins.READ)
+                .authorizedTo(Item.READ, Jenkins.READ)
                 .invokeWithArgs("aProject", "1", "test");
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
@@ -92,19 +92,19 @@ public class SetBuildDescriptionCommandTest {
         assertThat(build.getDescription(), equalTo(null));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Run.UPDATE, Job.READ, Jenkins.READ)
+                .authorizedTo(Run.UPDATE, Item.READ, Jenkins.READ)
                 .invokeWithArgs("aProject", "1", "test");
         assertThat(result, succeededSilently());
         assertThat(build.getDescription(), equalTo("test"));
 
         result = command
-                .authorizedTo(Run.UPDATE, Job.READ, Jenkins.READ)
+                .authorizedTo(Run.UPDATE, Item.READ, Jenkins.READ)
                 .invokeWithArgs("aProject", "1", "");
         assertThat(result, succeededSilently());
         assertThat(build.getDescription(), equalTo(""));
 
         result = command
-                .authorizedTo(Run.UPDATE, Job.READ, Jenkins.READ)
+                .authorizedTo(Run.UPDATE, Item.READ, Jenkins.READ)
                 .invokeWithArgs("aProject", "1", " ");
         assertThat(result, succeededSilently());
         assertThat(build.getDescription(), equalTo(" "));
@@ -112,7 +112,7 @@ public class SetBuildDescriptionCommandTest {
 
     @Test public void setBuildDescriptionShouldFailIfJobDoesNotExist() throws Exception {
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Run.UPDATE, Job.READ, Jenkins.READ)
+                .authorizedTo(Run.UPDATE, Item.READ, Jenkins.READ)
                 .invokeWithArgs("never_created");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -123,7 +123,7 @@ public class SetBuildDescriptionCommandTest {
         j.createFreeStyleProject("never_created");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Run.UPDATE, Job.READ, Jenkins.READ)
+                .authorizedTo(Run.UPDATE, Item.READ, Jenkins.READ)
                 .invokeWithArgs("never_created1");
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
@@ -136,7 +136,7 @@ public class SetBuildDescriptionCommandTest {
         assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Job.READ, Jenkins.READ)
+                .authorizedTo(Item.READ, Jenkins.READ)
                 .invokeWithArgs("aProject", "2", "test");
 
         assertThat(result, failedWith(3));

--- a/test/src/test/java/hudson/cli/ViewManipulationTestBase.java
+++ b/test/src/test/java/hudson/cli/ViewManipulationTestBase.java
@@ -25,7 +25,7 @@
 package hudson.cli;
 
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.Item;
 import hudson.model.ListView;
 import hudson.model.View;
 import jenkins.model.Jenkins;
@@ -91,7 +91,7 @@ public abstract class ViewManipulationTestBase {
         j.createFreeStyleProject("aProject");
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ)
                 .invokeWithArgs("aView", "aProject");
 
         assertThat(result, failedWith(6));
@@ -107,7 +107,7 @@ public abstract class ViewManipulationTestBase {
         assertThat(j.jenkins.getView("All").contains(project), equalTo(true));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("All", "aProject");
 
         assertThat(result, failedWith(4));
@@ -123,7 +123,7 @@ public abstract class ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").getAllItems().size(), equalTo(0));
 
         CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "never_created");
 
         assertThat(result, failedWith(3));
@@ -135,7 +135,7 @@ public abstract class ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").getAllItems().size(), equalTo(0));
 
         result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject1");
 
         assertThat(result, failedWith(3));
@@ -151,7 +151,7 @@ public abstract class ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").getAllItems().size(), equalTo(0));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "");
 
         assertThat(result, failedWith(3));
@@ -170,7 +170,7 @@ public abstract class ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project2), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "never_created", "aProject1", "aProject2");
 
         assertThat(result, failedWith(3));
@@ -191,7 +191,7 @@ public abstract class ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project2), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject1", "never_created", "aProject2");
 
         assertThat(result, failedWith(3));
@@ -212,7 +212,7 @@ public abstract class ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project2), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject1", "aProject2", "never_created");
 
         assertThat(result, failedWith(3));
@@ -233,7 +233,7 @@ public abstract class ViewManipulationTestBase {
         assertThat(j.jenkins.getView("aView").contains(project2), equalTo(false));
 
         final CLICommandInvoker.Result result = command
-                .authorizedTo(Jenkins.READ, View.READ, Job.READ, View.CONFIGURE)
+                .authorizedTo(Jenkins.READ, View.READ, Item.READ, View.CONFIGURE)
                 .invokeWithArgs("aView", "aProject1", "never_created", "aProject2", "never_created");
 
         assertThat(result, failedWith(3));

--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -143,7 +143,7 @@ public class AbstractProjectTest {
     @Test
     @PresetData(DataSet.ANONYMOUS_READONLY)
     public void wipeWorkspaceProtected2() throws Exception {
-        ((GlobalMatrixAuthorizationStrategy) j.jenkins.getAuthorizationStrategy()).add(AbstractProject.WORKSPACE, "anonymous");
+        ((GlobalMatrixAuthorizationStrategy) j.jenkins.getAuthorizationStrategy()).add(Item.WORKSPACE, "anonymous");
 
         // make sure that the deletion is protected in the same way
         wipeWorkspaceProtected();

--- a/test/src/test/java/hudson/model/MyViewTest.java
+++ b/test/src/test/java/hudson/model/MyViewTest.java
@@ -67,10 +67,10 @@ public class MyViewTest {
         FreeStyleProject job = rule.createFreeStyleProject("job");
         MyView view = new MyView("My", rule.jenkins);
         rule.jenkins.addView(view);
-        auth.add(Job.READ, "User1");
+        auth.add(Item.READ, "User1");
         SecurityContextHolder.getContext().setAuthentication(user.impersonate2());
         assertFalse("View " + view.getDisplayName() + " should not contain job " + job.getDisplayName(), view.contains(job));
-        auth.add(Job.CONFIGURE, "User1");
+        auth.add(Item.CONFIGURE, "User1");
         assertTrue("View " + view.getDisplayName() + " contain job " + job.getDisplayName(), view.contains(job));
     }
     
@@ -101,11 +101,11 @@ public class MyViewTest {
         FreeStyleProject job2 = rule.createFreeStyleProject("job2");
         FreeStyleProject job = rule.createFreeStyleProject("job");
         MyView view = new MyView("My", rule.jenkins);
-        auth.add(Job.READ, "User1");
+        auth.add(Item.READ, "User1");
         SecurityContextHolder.getContext().setAuthentication(user.impersonate2());
         assertFalse("View " + view.getDisplayName() + " should not contains job " + job.getDisplayName(), view.getItems().contains(job));
         assertFalse("View " + view.getDisplayName() + " should not contains job " + job2.getDisplayName(), view.getItems().contains(job2));
-        auth.add(Job.CONFIGURE, "User1");
+        auth.add(Item.CONFIGURE, "User1");
         assertTrue("View " + view.getDisplayName() + " should contain job " + job.getDisplayName(), view.getItems().contains(job));
         assertTrue("View " + view.getDisplayName() + " should contain job " + job2.getDisplayName(), view.getItems().contains(job2));
     }

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -337,7 +337,7 @@ public class NodeTest {
         n4.setLabelString("label1 label");
 
         FreeStyleProject p = j.createFreeStyleProject();
-        p.setAssignedLabel(LabelExpression.parseExpression("label1 && (label2 || label3)"));
+        p.setAssignedLabel(Label.parseExpression("label1 && (label2 || label3)"));
 
         // Node 1 should not be tied to any labels
         TagCloud<LabelAtom> n1LabelCloud = n1.getLabelCloud();

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -448,7 +448,7 @@ public class ProjectTest {
         assertNotNull(ws);
         FilePath path = slave.toComputer().getWorkspaceList().allocate(ws, build).path;
         build.setWorkspace(path);
-        BuildListener listener = new StreamBuildListener(BuildListener.NULL.getLogger(), Charset.defaultCharset());
+        BuildListener listener = new StreamBuildListener(TaskListener.NULL.getLogger(), Charset.defaultCharset());
         assertTrue("Project with null smc should perform checkout without problems.", p.checkout(build, new RemoteLauncher(listener, slave.getChannel(), true), listener, new File(build.getRootDir(),"changelog.xml")));
         p.setScm(scm);
         assertTrue("Project should perform checkout without problems.",p.checkout(build, new RemoteLauncher(listener, slave.getChannel(), true), listener, new File(build.getRootDir(),"changelog.xml")));
@@ -572,8 +572,8 @@ public class ProjectTest {
             }
         } 
         auth.add(Jenkins.READ, user.getId());
-        auth.add(Job.READ, user.getId());
-        auth.add(Job.DELETE, user.getId());
+        auth.add(Item.READ, user.getId());
+        auth.add(Item.DELETE, user.getId());
 
         // use Basic to speedup the test, normally it's pure UI testing
         JenkinsRule.WebClient wc = j.createWebClient();
@@ -608,9 +608,9 @@ public class ProjectTest {
                fail("AccessDeniedException should be thrown.");
             }
         } 
-        auth.add(Job.READ, user.getId());
-        auth.add(Job.BUILD, user.getId());
-        auth.add(Job.WIPEOUT, user.getId());
+        auth.add(Item.READ, user.getId());
+        auth.add(Item.BUILD, user.getId());
+        auth.add(Item.WIPEOUT, user.getId());
         auth.add(Jenkins.READ, user.getId());
         Slave slave = j.createOnlineSlave();
         project.setAssignedLabel(slave.getSelfLabel());
@@ -646,8 +646,8 @@ public class ProjectTest {
                fail("AccessDeniedException should be thrown.");
             }
         } 
-        auth.add(Job.READ, user.getId());
-        auth.add(Job.CONFIGURE, user.getId());
+        auth.add(Item.READ, user.getId());
+        auth.add(Item.CONFIGURE, user.getId());
         auth.add(Jenkins.READ, user.getId());
 
         JenkinsRule.WebClient wc = j.createWebClient();
@@ -684,8 +684,8 @@ public class ProjectTest {
                fail("AccessDeniedException should be thrown.");
             }
         } 
-        auth.add(Job.READ, user.getId());
-        auth.add(Job.CONFIGURE, user.getId());
+        auth.add(Item.READ, user.getId());
+        auth.add(Item.CONFIGURE, user.getId());
         auth.add(Jenkins.READ, user.getId());
 
         JenkinsRule.WebClient wc = j.createWebClient();

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -736,7 +736,7 @@ public class QueueTest {
         TopLevelItemDescriptor descriptor = new TopLevelItemDescriptor(FreeStyleProject.class){
          @Override
             public FreeStyleProject newInstance(ItemGroup parent, String name) {
-                return (FreeStyleProject) new FreeStyleProject(parent,name){
+                return new FreeStyleProject(parent,name){
                      @Override
                     public Label getAssignedLabel(){
                         throw new IllegalArgumentException("Test exception"); //cause dead of executor

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -52,7 +52,6 @@ import hudson.model.Cause.UserIdCause;
 import hudson.model.Queue.BlockedItem;
 import hudson.model.Queue.Executable;
 import hudson.model.Queue.WaitingItem;
-import hudson.model.labels.LabelExpression;
 import hudson.model.listeners.SaveableListener;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
@@ -881,7 +880,7 @@ public class QueueTest {
         matrixProject.setAxes(new AxisList(
                 new Axis("axis", "a", "b")
         ));
-        Label label = LabelExpression.get("aws-linux-dummy");
+        Label label = Label.get("aws-linux-dummy");
         DummyCloudImpl dummyCloud = new DummyCloudImpl(r, 0);
         dummyCloud.label = label;
         r.jenkins.clouds.add(dummyCloud);
@@ -900,7 +899,7 @@ public class QueueTest {
                 new Axis("axis", "a", "b")
         ));
 
-        Label label = LabelExpression.get("aws-linux-dummy");
+        Label label = Label.get("aws-linux-dummy");
         DummyCloudImpl dummyCloud = new DummyCloudImpl(r, 0);
         dummyCloud.label = label;
         BlockDownstreamProjectExecution property = new BlockDownstreamProjectExecution();

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -547,7 +547,7 @@ public class ViewTest {
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
             grant(Jenkins.ADMINISTER).everywhere().to("admin").
             grant(Jenkins.READ).everywhere().toEveryone().
-            grant(Job.READ).everywhere().toEveryone().
+            grant(Item.READ).everywhere().toEveryone().
             grant(Item.CREATE).onFolders(d1).to("dev")); // not on root or d2
         ACL.impersonate2(Jenkins.ANONYMOUS2, new NotReallyRoleSensitiveCallable<Void,Exception>() {
             @Override

--- a/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
@@ -175,7 +175,7 @@ public class LabelExpressionTest {
     }
 
     private void parseAndVerify(String expected, String expr) throws ANTLRException {
-        assertEquals(expected, LabelExpression.parseExpression(expr).getName());
+        assertEquals(expected, Label.parseExpression(expr).getName());
     }
 
     @Test
@@ -243,7 +243,7 @@ public class LabelExpressionTest {
 
     private void parseShouldFail(String expr) {
         try {
-            LabelExpression.parseExpression(expr);
+            Label.parseExpression(expr);
             fail(expr + " should fail to parse");
         } catch (ANTLRException e) {
             // expected

--- a/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
+++ b/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
@@ -1,9 +1,9 @@
 package hudson.model.queue;
 
 import hudson.model.FreeStyleProject;
+import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
-import hudson.model.labels.LabelExpression;
 import hudson.slaves.DumbSlave;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +29,7 @@ public class MaintainCanTakeStrengtheningTest {
     private QueueTaskFuture scheduleBuild(String name, String label) throws Exception {
         FreeStyleProject project = r.createFreeStyleProject(name);
 
-        project.setAssignedLabel(LabelExpression.get(label));
+        project.setAssignedLabel(Label.get(label));
         return project.scheduleBuild2(0);
     }
 
@@ -37,11 +37,11 @@ public class MaintainCanTakeStrengtheningTest {
     @Test
     public void testExceptionOnNodeProperty() throws Exception {
         // A node throwing the exception because of the canTake method of the attached FaultyNodeProperty
-        DumbSlave faultyAgent = r.createOnlineSlave(LabelExpression.get("faulty"));
+        DumbSlave faultyAgent = r.createOnlineSlave(Label.get("faulty"));
         faultyAgent.getNodeProperties().add(new FaultyNodeProperty());
 
         // A good agent
-        r.createOnlineSlave(LabelExpression.get("good"));
+        r.createOnlineSlave(Label.get("good"));
 
         // Only the good ones will be run and the latest doesn't get hung because of the second
         QueueTaskFuture[] taskFuture = new QueueTaskFuture[3];

--- a/test/src/test/java/hudson/security/ACLTest.java
+++ b/test/src/test/java/hudson/security/ACLTest.java
@@ -25,10 +25,10 @@
 package hudson.security;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.model.Build;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.Run;
 import hudson.model.UnprotectedRootAction;
 import hudson.model.User;
 import java.util.Collection;
@@ -146,7 +146,7 @@ public class ACLTest {
 
         try (ACLContext ignored = ACL.as2(manager.impersonate2())) {
             Exception e = Assert.assertThrows(AccessDeniedException.class,
-                    () -> jenkins.getACL().checkAnyPermission(Item.WIPEOUT, Build.ARTIFACTS));
+                    () -> jenkins.getACL().checkAnyPermission(Item.WIPEOUT, Run.ARTIFACTS));
             Assert.assertEquals("manager is missing a permission, one of Job/WipeOut, Run/Artifacts is required", e.getMessage());
         }
     }

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -77,6 +77,7 @@ import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.recipes.WithPlugin;
 import org.kohsuke.stapler.HttpResponse;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -453,7 +454,7 @@ public class JenkinsTest {
             listener.onRestart();
 
         ArgumentCaptor<OfflineCause> captor = ArgumentCaptor.forClass(OfflineCause.class);
-        Mockito.verify(listenerMock).onOffline(Mockito.eq(j.jenkins.toComputer()), captor.capture());
+        Mockito.verify(listenerMock).onOffline(ArgumentMatchers.eq(j.jenkins.toComputer()), captor.capture());
         assertTrue(captor.getValue().toString().contains("restart"));
     }
 

--- a/test/src/test/java/jenkins/security/UserDetailsCacheTest.java
+++ b/test/src/test/java/jenkins/security/UserDetailsCacheTest.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 

--- a/test/src/test/java/lib/form/ComboBoxTest.java
+++ b/test/src/test/java/lib/form/ComboBoxTest.java
@@ -40,7 +40,6 @@ import hudson.util.ComboBoxModel;
 import jenkins.model.OptionalJobProperty;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.HudsonTestCase.WebClient;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;

--- a/test/src/test/java/lib/form/PasswordTest.java
+++ b/test/src/test/java/lib/form/PasswordTest.java
@@ -624,7 +624,7 @@ public class PasswordTest {
         }
 
         final MockAuthorizationStrategy a = new MockAuthorizationStrategy();
-        a.grant(Jenkins.READ, Job.READ, Job.EXTENDED_READ).everywhere().toEveryone();
+        a.grant(Jenkins.READ, Item.READ, Item.EXTENDED_READ).everywhere().toEveryone();
         j.jenkins.setAuthorizationStrategy(a);
 
         /* Now go to the page without Item/Configure and expect asterisks */

--- a/test/src/test/java/lib/layout/AjaxTest.java
+++ b/test/src/test/java/lib/layout/AjaxTest.java
@@ -25,7 +25,6 @@
 package lib.layout;
 
 import com.gargoylesoftware.htmlunit.html.DomElement;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlLink;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.junit.Rule;


### PR DESCRIPTION
Applied an automated Eclipse refactoring to change indirect accesses (through subtypes) to static members to direct accesses. I find the code easier to read when there is a consistent way of referring to a given member.