### PR TITLE
Reduce usages of com.google.common.base

### DIFF
--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -23,7 +23,7 @@
  */
 package hudson.diagnosis;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -325,12 +325,9 @@ public class OldDataMonitor extends AdministrativeMonitor {
         final String thruVerParam = req.getParameter("thruVer");
         final VersionNumber thruVer = thruVerParam.equals("all") ? null : new VersionNumber(thruVerParam);
 
-        saveAndRemoveEntries(new Predicate<Map.Entry<SaveableReference, VersionRange>>() {
-            @Override
-            public boolean apply(Map.Entry<SaveableReference, VersionRange> entry) {
-                VersionNumber version = entry.getValue().max;
-                return version != null && (thruVer == null || !version.isNewerThan(thruVer));
-            }
+        saveAndRemoveEntries(entry -> {
+            VersionNumber version = entry.getValue().max;
+            return version != null && (thruVer == null || !version.isNewerThan(thruVer));
         });
 
         return HttpResponses.forwardToPreviousPage();
@@ -342,12 +339,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
      */
     @RequirePOST
     public HttpResponse doDiscard(StaplerRequest req, StaplerResponse rsp) {
-        saveAndRemoveEntries( new Predicate<Map.Entry<SaveableReference,VersionRange>>() {
-            @Override
-            public boolean apply(Map.Entry<SaveableReference, VersionRange> entry) {
-                return entry.getValue().max == null;
-            }
-        });
+        saveAndRemoveEntries(entry -> entry.getValue().max == null);
 
         return HttpResponses.forwardToPreviousPage();
     }
@@ -366,7 +358,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
          */
         List<SaveableReference> removed = new ArrayList<>();
         for (Map.Entry<SaveableReference,VersionRange> entry : data.entrySet()) {
-            if (matchingPredicate.apply(entry)) {
+            if (matchingPredicate.test(entry)) {
                 Saveable s = entry.getKey().get();
                 if (s != null) {
                     try {

--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -23,7 +23,6 @@
  */
 package hudson.security;
 
-import com.google.common.base.Strings;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Functions;
 import java.io.IOException;
@@ -35,6 +34,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
@@ -78,7 +78,7 @@ public class HudsonAuthenticationEntryPoint implements AuthenticationEntryPoint 
         } else {
             // give the opportunity to include the target URL
             String uriFrom = req.getRequestURI();
-            if(!Strings.isNullOrEmpty(req.getQueryString())) uriFrom += "?" + req.getQueryString();
+            if(!StringUtils.isEmpty(req.getQueryString())) uriFrom += "?" + req.getQueryString();
             String loginForm = req.getContextPath() + loginFormUrl;
             loginForm = MessageFormat.format(loginForm, URLEncoder.encode(uriFrom,"UTF-8"));
             req.setAttribute("loginForm", loginForm);

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -36,11 +36,11 @@ import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.logging.Logger;
 
+import hudson.Util;
 import hudson.util.RunList;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 
 import hudson.Extension;
@@ -217,7 +217,7 @@ public class LogRotator extends BuildDiscarder {
             //Collate all encountered exceptions into a single exception and throw that
             String msg = String.format(
                     "Failed to rotate logs for [%s]",
-                    Joiner.on(", ").join(exceptionMap.keySet())
+                    Util.join(exceptionMap.keySet(), ", ")
             );
             throw new CompositeIOException(msg, new ArrayList<>(exceptionMap.values()));
         }

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -25,7 +25,6 @@
 package hudson.triggers;
 
 import antlr.ANTLRException;
-import com.google.common.base.Preconditions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Functions;
@@ -556,8 +555,11 @@ public class SCMTrigger extends Trigger<Item> {
             this(null);
         }
         
+        @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH", justification = "False positive")
         public Runner(Action[] actions) {
-            Preconditions.checkNotNull(job, "Runner can't be instantiated when job is null");
+            if (job == null) {
+                throw new NullPointerException("Runner can't be instantiated when job is null");
+            }
 
             if (actions == null) {
                 additionalActions = new Action[0];

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -45,7 +45,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 import com.thoughtworks.xstream.XStream;
 
 import hudson.Functions;

--- a/test/src/test/java/hudson/model/UsageStatisticsTest.java
+++ b/test/src/test/java/hudson/model/UsageStatisticsTest.java
@@ -23,12 +23,14 @@
  */
 package hudson.model;
 
-import com.google.common.io.Resources;
 import hudson.Util;
 import hudson.model.UsageStatistics.CombinedCipherInputStream;
 import hudson.node_monitors.ArchitectureMonitor;
 
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.Set;
 import jenkins.model.Jenkins;
@@ -162,10 +164,10 @@ public class UsageStatisticsTest {
         return sorted;
     }
 
-    private void compareWithFile(String fileName, Object object) throws IOException {
+    private void compareWithFile(String fileName, Object object) throws IOException, URISyntaxException {
 
         Class clazz = this.getClass();
-        String fileContent = Resources.toString(clazz.getResource(clazz.getSimpleName() + "/" + fileName), StandardCharsets.UTF_8);
+        String fileContent = new String(Files.readAllBytes(Paths.get(clazz.getResource(clazz.getSimpleName() + "/" + fileName).toURI())), StandardCharsets.UTF_8);
         fileContent = fileContent.replace("JVMVENDOR", System.getProperty("java.vm.vendor"));
         fileContent = fileContent.replace("JVMNAME", System.getProperty("java.vm.name"));
         fileContent = fileContent.replace("JVMVERSION", System.getProperty("java.version"));

--- a/test/src/test/java/hudson/model/UserPropertyTest.java
+++ b/test/src/test/java/hudson/model/UserPropertyTest.java
@@ -1,6 +1,5 @@
 package hudson.model;
 
-import com.google.common.base.Throwables;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -15,6 +14,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -185,7 +185,7 @@ public class UserPropertyTest {
                 File userFile = getUserFile();
                 writeStringToFile(userFile, String.valueOf(currentTimeMillis()), true);
             } catch (IOException e) {
-                Throwables.propagate(e);
+                throw new UncheckedIOException(e);
             }
         }
 

--- a/test/src/test/java/hudson/util/ArgumentListBuilder2Test.java
+++ b/test/src/test/java/hudson/util/ArgumentListBuilder2Test.java
@@ -32,6 +32,7 @@ import hudson.Functions;
 import hudson.Launcher.LocalLauncher;
 import hudson.Launcher.RemoteLauncher;
 import hudson.Proc;
+import hudson.Util;
 import hudson.model.Slave;
 
 import org.apache.tools.ant.util.JavaEnvUtils;
@@ -41,11 +42,10 @@ import org.jvnet.hudson.test.Email;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 
-import com.google.common.base.Joiner;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.logging.Level;
 import jenkins.util.SystemProperties;
 
@@ -92,7 +92,7 @@ public class ArgumentListBuilder2Test {
 
         String out = echoArgs(specials);
 
-        String expected = String.format("%n%s", Joiner.on(" ").join(specials));
+        String expected = String.format("%n%s", Util.join(Arrays.asList(specials), " "));
         assertThat(out, containsString(expected));
     }
 


### PR DESCRIPTION
Replaces most usages of `com.google.common.base` with native Java or Jenkins functionality. The underlying motivation is to make the code easier to read by using a consistent paradigm as much as possible (namely, JDK classes rather than a mixture of JDK classes and Guava classes).