### PR TITLE
[JENKINS-65442] - Improve performance when encoding unicode characters in JSON API + Remove Stapler's Guava dependency

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
   <properties>
     <guavaVersion>11.0.1</guavaVersion>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <stapler.version>1531.v3338be17c99b</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/220 -->
+    <stapler.version>1532.vfcf95addcb5f</stapler.version>
     <groovy.version>2.4.12</groovy.version>
   </properties>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
   <properties>
     <guavaVersion>11.0.1</guavaVersion>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <stapler.version>1.264-rc1517.e1191cc1f5ea</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/213 -->
+    <stapler.version>1531.v3338be17c99b</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/220 -->
     <groovy.version>2.4.12</groovy.version>
   </properties>
 
@@ -354,13 +354,6 @@ THE SOFTWARE.
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>stapler</artifactId>
         <version>${stapler.version}</version>
-        <exclusions>
-          <!-- This artifact is shaded and we do not want to expose it to plugins. -->
-          <exclusion>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.kohsuke.stapler</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
   <properties>
     <guavaVersion>11.0.1</guavaVersion>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <stapler.version>1.263</stapler.version>
+    <stapler.version>1.264-rc1517.e1191cc1f5ea</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/213 -->
     <groovy.version>2.4.12</groovy.version>
   </properties>
 
@@ -354,6 +354,13 @@ THE SOFTWARE.
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>stapler</artifactId>
         <version>${stapler.version}</version>
+        <exclusions>
+          <!-- This artifact is shaded and we do not want to expose it to plugins. -->
+          <exclusion>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
See [JENKINS-65442](https://issues.jenkins.io/browse/JENKINS-65442). This PR updates Stapler to the latest version, which includes the fix for JENKINS-65442 and stapler/stapler#220 (which removes Stapler's dependency on Guava).

### Proposed changelog entries

* rfe, JENKINS-65442 - Improve performance when encoding unicode characters in JSON API
  * Stapler 1527.ve41b3ce15c05 changelog: https://github.com/stapler/stapler/releases/tag/1527.ve41b3ce15c05 
* internal - Remove dependency on Guava in Stapler
  * Stapler 1527.ve41b3ce15c05 changelog: https://github.com/stapler/stapler/releases/tag/1527.ve41b3ce15c05 
  * Stapler 1532.vfcf95addcb5f changelog: https://github.com/stapler/stapler/releases/tag/1532.vfcf95addcb5f

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).