### PR TITLE
Ignore Dependabot updates for japicmp-maven-plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,5 @@ updates:
       # Must remain within jetty 9.x until Java 8 support is removed, ignore jetty 10.x and jetty 11.x updates
       - dependency-name: "org.eclipse.jetty:jetty-maven-plugin"
         versions: ["10.x", "11.x"]
+      # Pending https://github.com/siom79/japicmp/pull/266
+      - dependency-name: "com.github.siom79.japicmp:japicmp-maven-plugin"


### PR DESCRIPTION
See [#5345 (comment)](https://github.com/jenkinsci/jenkins/pull/5345#pullrequestreview-636053021).