### PR TITLE
[JENKINS-52356] Support ZIP64 in ZipArchiver

### DIFF
--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -94,6 +94,7 @@ final class ZipArchiver extends Archiver {
             ZipEntry fileZipEntry = new ZipEntry(this.prefix + relativePath);
             if (mode!=-1)   fileZipEntry.setUnixMode(mode);
             fileZipEntry.setTime(f.lastModified());
+            fileZipEntry.setSize(f.length());
             zip.putNextEntry(fileZipEntry);
             try (InputStream in = Files.newInputStream(f.toPath(), openOptions)) {
                 int len;

--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -51,8 +51,7 @@ public class ZipArchiverTest {
         // create huge64bitFileTest.txt
         Path hugeFile = tmp.newFolder().toPath().resolve("huge64bitFileTest.txt");
         long length = 4L * 1024 * 1024 * 1024 + 2;
-        try {
-            RandomAccessFile largeFile = new RandomAccessFile(hugeFile.toFile(), "rw");
+        try (RandomAccessFile largeFile = new RandomAccessFile(hugeFile.toFile(), "rw")) {
             largeFile.setLength(length);
         } catch (IOException e) {
             // We probably don't have enough free disk space. That's ok, we'll skip this test...

--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -2,173 +2,84 @@ package hudson.util.io;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.nio.file.Path;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
 public class ZipArchiverTest {
 
-    private static final Logger LOGGER = Logger.getLogger(ZipArchiverTest.class.getName());
-
-    private File tmpDir;
-
-    @Before
-    public void setUp() {
-        try {
-            // initialize temp directory
-            tmpDir = File.createTempFile("temp", ".dir");
-            tmpDir.delete();
-            tmpDir.mkdir();
-        } catch (IOException e) {
-            fail("unable to create temp directory", e);
-        }
-    }
-
-    @After
-    public void tearDown() {
-        deleteDir(tmpDir);
-    }
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
     @Issue("JENKINS-9942")
     @Test
-    public void backwardsSlashesOnWindows()  {
+    public void backwardsSlashesOnWindows() throws IOException {
         // create foo/bar/baz/Test.txt
-        File tmpFile = null;
-        try {
-            File baz = new File(new File(new File(tmpDir, "foo"), "bar"), "baz");
-            baz.mkdirs();
-
-            tmpFile = new File(baz, "Test.txt");
-            tmpFile.createNewFile();
-        } catch (IOException e) {
-            fail("unable to prepare source directory for zipping", e);
-        }
+        Path baz = tmp.newFolder().toPath().resolve("foo").resolve("bar").resolve("baz");
+        Files.createDirectories(baz);
+        Path tmpFile = baz.resolve("Test.txt");
+        Files.createFile(tmpFile);
 
         // a file to store the zip archive in
-        File zipFile = null;
+        Path zipFile = Files.createTempFile(tmp.getRoot().toPath(), "test", ".zip");
 
         // create zip from tmpDir
-        ZipArchiver archiver = null;
-
-        try {
-            zipFile = File.createTempFile("test", ".zip");
-            archiver = new ZipArchiver(Files.newOutputStream(zipFile.toPath()));
-
-            archiver.visit(tmpFile, "foo\\bar\\baz\\Test.txt");
-        } catch (Exception e) {
-            fail("exception driving ZipArchiver", e);
-        } finally {
-            if (archiver != null) {
-                try {
-                    archiver.close();
-                } catch (IOException e) {
-                    // ignored
-                }
-            }
+        try (ZipArchiver archiver = new ZipArchiver(Files.newOutputStream(zipFile))) {
+            archiver.visit(tmpFile.toFile(), "foo\\bar\\baz\\Test.txt");
         }
 
         // examine zip contents and assert that none of the entry names (paths) have
         // back-slashes ("\")
-        String zipEntryName = null;
-
-        try (ZipFile zipFileVerify = new ZipFile(zipFile)) {
-
-            zipEntryName = ((ZipEntry) zipFileVerify.entries().nextElement()).getName();
-        } catch (Exception e) {
-            fail("failure enumerating zip entries", e);
+        try (ZipFile zipFileVerify = new ZipFile(zipFile.toFile())) {
+            assertEquals(1, zipFileVerify.size());
+            ZipEntry zipEntry = zipFileVerify.entries().nextElement();
+            assertEquals("foo/bar/baz/Test.txt", zipEntry.getName());
         }
-
-        assertEquals("foo/bar/baz/Test.txt", zipEntryName);
     }
 
     @Test
-    public void huge64bitFile()  {
+    public void huge64bitFile() throws IOException {
         // create huge64bitFileTest.txt
-
-        File hugeFile = new File(tmpDir, "huge64bitFileTest.txt");
+        Path hugeFile = tmp.newFolder().toPath().resolve("huge64bitFileTest.txt");
+        long length = 4L * 1024 * 1024 * 1024 + 2;
         try {
-            RandomAccessFile largeFile = new RandomAccessFile(hugeFile, "rw");
-            largeFile.setLength(4 * 1024 * 1024 * 1024 + 2);
+            RandomAccessFile largeFile = new RandomAccessFile(hugeFile.toFile(), "rw");
+            largeFile.setLength(length);
         } catch (IOException e) {
-            /* We probably don't have enough free disk space
-             * That's ok, we'll skip this test...
-             */
-            LOGGER.log(Level.SEVERE, "Couldn't set up huge file for huge64bitFile test", e);
-            return;
+            // We probably don't have enough free disk space. That's ok, we'll skip this test...
+            Assume.assumeNoException(e);
         }
 
         // a file to store the zip archive in
-        File zipFile = null;
+        Path zipFile = Files.createTempFile(tmp.getRoot().toPath(), "test", ".zip");
 
         // create zip from tmpDir
-        ZipArchiver archiver = null;
-
-        try {
-            zipFile = File.createTempFile("test", ".zip");
-            archiver = new ZipArchiver(Files.newOutputStream(zipFile.toPath()));
-
-            archiver.visit(hugeFile, "huge64bitFileTest.txt");
-        } catch (Exception e) {
-            fail("exception driving ZipArchiver", e);
-        } finally {
-            if (archiver != null) {
-                try {
-                    archiver.close();
-                } catch (IOException e) {
-                    // ignored
-                }
-            }
+        try (ZipArchiver archiver = new ZipArchiver(Files.newOutputStream(zipFile))) {
+            archiver.visit(hugeFile.toFile(), "huge64bitFileTest.txt");
         }
 
         // examine zip contents and assert that there's an item there...
-        String zipEntryName = null;
-
-        try (ZipFile zipFileVerify = new ZipFile(zipFile)) {
-
-            zipEntryName = ((ZipEntry) zipFileVerify.entries().nextElement()).getName();
-        } catch (Exception e) {
-            fail("failure enumerating zip entries", e);
-        }
-
-        assertEquals("huge64bitFileTest.txt", zipEntryName);
-    }
-
-    /**
-     * Convenience method for failing with a cause.
-     *
-     * @param msg the failure description
-     * @param cause the root cause of the failure
-     */
-    private void fail(final String msg, final Throwable cause) {
-        LOGGER.log(Level.SEVERE, msg, cause);
-        Assert.fail(msg);
-    }
-
-    /**
-     * Recursively deletes a directory and all of its children.
-     *
-     * @param f the File (neé, directory) to delete
-     */
-    private void deleteDir(final File f) {
-        for (File c : f.listFiles()) {
-            if (c.isDirectory()) {
-                deleteDir(c);
+        try (ZipFile zipFileVerify = new ZipFile(zipFile.toFile())) {
+            assertEquals(1, zipFileVerify.size());
+            ZipEntry zipEntry = zipFileVerify.entries().nextElement();
+            assertEquals("huge64bitFileTest.txt", zipEntry.getName());
+            assertEquals(length, zipEntry.getSize());
+        } catch (ZipException e) {
+            if (e.getMessage().contains("invalid CEN header (bad signature)")) {
+                // Probably running on OpenJDK 8 and hitting JDK-8186464
+                Assume.assumeNoException(e);
             } else {
-                c.delete();
+                throw e;
             }
         }
-
-        f.delete();
     }
 }


### PR DESCRIPTION
See [JENKINS-52356](https://issues.jenkins.io/browse/JENKINS-52356). Amends #3536. Supersedes #4884.

#3536 contained a bug in the newly-added test, which hid a bug in the newly-added production code. This PR fixes both bugs: the test now correctly creates a 4 GiB file (the change from `4` to `4L` in the test), and the production code now correctly sets the length in the resulting archive (the change to `core/src/main/java/hudson/util/io/ZipArchiver.java`).

I also simplified and rewrote the test significantly to make it easier to read and improve error handling (while also eliminating 88 lines of code).

The result passes on OpenJDK 11.0.10 but not on OpenJDK 1.8.0_282 (Ubuntu), where it fails trying to open the large archive with `invalid CEN header (bad signature)`. This seemed odd, so I created a large ZIP file with `truncate(1)` and `zip(1)` and tried to open it with `new ZipFile()` on OpenJDK 11.0.10 (passed) and OpenJDK 1.8.0_282 (failed). This told me that the problem was not related to Jenkins. Searching the OpenJDK bug tracker I think this is a likely case of [JDK-8186464](https://bugs.openjdk.java.net/browse/JDK-8186464), which does not appear to have been backported to OpenJDK 8. In this case I think it is reasonable to skip the test when running on buggy versions of OpenJDK.

### Proposed changelog entries

JENKINS-52356 Fix an issue archiving files greater than 4 GiB in size when creating ZIP64 archives

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
