### PR TITLE
Exclude Winstone upgrades from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,5 @@ updates:
         versions: ["10.x", "11.x"]
       # Pending https://github.com/siom79/japicmp/pull/266
       - dependency-name: "com.github.siom79.japicmp:japicmp-maven-plugin"
+      # Winstone upgrades require multiple changes in pom.xml.  See https://github.com/jenkinsci/jenkins/pull/5439#discussion_r616418468
+      - dependency-name: "org.jenkins-ci:winstone"


### PR DESCRIPTION
## Exclude Winstone upgrades from dependabot

See [comment from Daniel Beck](https://github.com/jenkinsci/jenkins/pull/5439#discussion_r616418468).

### Proposed changelog entries

* N/A (skip-changelog)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@mention

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
