### PR TITLE
Backporting for LTS 2.277.4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -329,7 +329,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.15</version>
+        <version>1.4.16</version>
       </dependency>
       <dependency>
         <groupId>net.sf.kxml</groupId>

--- a/core/src/main/java/jenkins/model/NewViewLink.java
+++ b/core/src/main/java/jenkins/model/NewViewLink.java
@@ -3,8 +3,10 @@ package jenkins.model;
 import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.model.Action;
+import hudson.model.ModifiableViewGroup;
 import hudson.model.TransientViewActionFactory;
 import hudson.model.View;
+import hudson.model.ViewGroup;
 import java.util.Collections;
 import java.util.List;
 
@@ -21,36 +23,46 @@ public class NewViewLink extends TransientViewActionFactory {
     public static final String URL_NAME = "newView";
 
     @Override
-    public List<Action> createFor(View v) {
-        return Collections.singletonList(new Action() {
+    public List<Action> createFor(final View v) {
+        // do not show the action if the viewgroup is not modifiable
+        ViewGroup vg = v.getOwner();
+        if (vg instanceof ModifiableViewGroup) {
+            return Collections.singletonList(new NewViewLinkAction((ModifiableViewGroup)vg));
+        }
+        return Collections.emptyList();
+    }
 
-            @Override
-            public String getIconFileName() {
-                if (!hasPermission(v)) {
-                    return null;
-                }
+    private static class NewViewLinkAction implements Action {
 
+        private ModifiableViewGroup target;
+
+        private NewViewLinkAction(ModifiableViewGroup target) {
+            this.target = target;
+        }
+
+        @Override
+        public String getIconFileName() {
+            if (hasPermission()) {
                 return ICON_FILE_NAME;
             }
+            return null;
+        }
 
-            @Override
-            public String getDisplayName() {
-                if (!hasPermission(v)) {
-                    return null;
-                }
+        @Override
+        public String getDisplayName() {
+            return Messages.NewViewLink_NewView();
+        }
 
-                return Messages.NewViewLink_NewView();
-            }
+        @Override
+        public String getUrlName() {
+            // getUrl returns the path from the root (without the context and no leading slash)
+            // we need to add the slash so that this is not relative to the current URL but to the context
+            return "/" + target.getUrl() + URL_NAME;
+        }
 
-            @Override
-            public String getUrlName() {
-                return Jenkins.get().getRootUrl() + URL_NAME;
-            }
+        private boolean hasPermission() {
+            return target.hasPermission(View.CREATE);
+        }
 
-            private boolean hasPermission(View view) {
-                return view.hasPermission(View.CREATE);
-            }
-
-        });
     }
 }

--- a/core/src/main/resources/hudson/model/LoadStatistics/resources.js
+++ b/core/src/main/resources/hudson/model/LoadStatistics/resources.js
@@ -39,7 +39,7 @@
                 var graphWidth = availableWidth - padding - quirkyBrowserAdjustment;
 
                 // type in {sec10, min, hour}
-                var graphUrl = baseUrl + "/graph?type" + type + "&width=" + graphWidth + "&height=500";
+                var graphUrl = baseUrl + "/graph?type=" + type + "&width=" + graphWidth + "&height=500";
                 var graphImgTag = document.createElement("img");
                 graphImgTag.src = graphUrl;
                 graphImgTag.alt = graphAlt;

--- a/war/src/main/less/base/yui-compatibility.less
+++ b/war/src/main/less/base/yui-compatibility.less
@@ -90,6 +90,13 @@
     &:visited {
       color: var(--menu-text-color);
     }
+
+    // Disabled items
+    &.yuimenuitemlabel-disabled {
+      cursor: default;
+      color: #A6A6A6;
+    }
+
   }
 
   .yuimenu {


### PR DESCRIPTION
```
Fixed
-----

JENKINS-65336           Minor                   2.288 - Apr 13, 2021
        Load statistics timespan does not affect image
        regression
        https://issues.jenkins.io/browse/JENKINS-65336

JENKINS-65281           Minor                   2.285
        Update to xstream 1.4.16 to avoid security scanner complaints
        https://issues.jenkins.io/browse/JENKINS-65281

JENKINS-65021           Minor                   2.286 released on 30 Mar 2021
        Disabled dropdown items no longer look disabled
        regression
        https://issues.jenkins.io/browse/JENKINS-65021

JENKINS-56934           Minor                   2.288 - Apr 13, 2021
        Side panel "new View" link is no longer relative to the current folder
        https://issues.jenkins.io/browse/JENKINS-56934
```