### PR TITLE
Remove instance-identity from ALWAYS_READABLE_PATHS

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5397,18 +5397,17 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * <p>See also:{@link #getUnprotectedRootActions}.
      */
     private static final Set<String> ALWAYS_READABLE_PATHS = new HashSet<>(ImmutableSet.of(
-        "login",
-        "loginError",
-        "logout",
-        "accessDenied",
-        "adjuncts",
-        "error",
-        "oops",
-        "signup",
-        "tcpSlaveAgentListener",
-        "federatedLoginService",
-        "securityRealm",
-        "instance-identity"
+        "login", // .jelly
+        "loginError", // .jelly
+        "logout", // #doLogout
+        "accessDenied", // .jelly
+        "adjuncts", // #getAdjuncts
+        "error", // AbstractModelObject/error.jelly
+        "oops", // .jelly
+        "signup", // #doSignup
+        "tcpSlaveAgentListener", // #getTcpSlaveAgentListener
+        "federatedLoginService", // #getFederatedLoginService
+        "securityRealm" // #getSecurityRealm
     ));
 
     static {


### PR DESCRIPTION
A bit of cleanup:

* https://github.com/jenkinsci/jenkins/blob/ca23d03554fefde13b7601862ea363fa7ad67b06/core/src/main/java/jenkins/model/identity/IdentityRootAction.java#L18 does not need to be listed in `ALWAYS_READABLE_PATHS`, so remove it.
* For everything else, include a short reference what it's for.

This was originally added in https://github.com/jenkinsci/jenkins/pull/2480/commits/624c0b13bd35ad2ebb4a8b34179dfbb38918f91b and it's unclear to me why.

Untested.

### Proposed changelog entries

internal only

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
