### PR TITLE
Remove bundled External Monitor Job Type, LDAP, and PAM Authentication plugins

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -253,24 +253,6 @@ THE SOFTWARE.
                 -->
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>external-monitor-job</artifactId>
-                  <version>1.4</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>ldap</artifactId>
-                  <version>2.0</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>pam-auth</artifactId>
-                  <version>1.5.1</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>display-url-api</artifactId>
                   <version>2.3.1</version>
                   <type>hpi</type>


### PR DESCRIPTION
Previously: #4242, #5102, and #5338. Dealing with bundled plugins in Jenkins core is painful. The fewer of these we have, the better. Here we stop bundling [External Monitor Job Type](https://plugins.jenkins.io/external-monitor-job/), [LDAP](https://plugins.jenkins.io/ldap/), and [PAM Authentication](https://plugins.jenkins.io/pam-auth/) in the Jenkins WAR. As I explain below, we do not actually need to bundle these any longer, just like in #4242, #5102, and #5338.

### Testing Done

First, I verified that none of the other plugins we bundle in the WAR have a (non-implied) dependency on External Monitor Job Type, LDAP, or PAM Authentication. It turns out that 0 plugins on the Update Center explicitly depend on External Monitor Job Type, LDAP, or PAM Authentication. So we are good to go there.

Next, I did a realistic smoke test by starting up Jenkins with `java -jar jenkins.war` (after verifying the WAR no longer contained External Monitor Job Type, LDAP, or PAM Authentication in `WEB-INF/detached-plugins`) and running through the wizard. This installed LDAP and PAM Authentication (which are both suggested plugins), but that was expected. The wizard completed successfully with no errors. Note that External Monitor Job Type was not present in the list of installed plugins after completing the wizard.

Finally I had to make sure this wouldn't break any plugins consuming the classes provided by External Monitor Job Type, LDAP, or PAM Authentication. The last core release still containing External Monitor Job Type, LDAP, and PAM Authentication functionality was 1.467. Trawling through the graveyard I found 291 plugins whose required core was ≤ 1.467. Of those, 286 returned no results for the following `grep(1)` commands:

```bash
$ grep -Hn --binary-files=without-match -ri hudson.security.pam .
$ grep -Hn --binary-files=without-match -ri jenkins.security.plugins.ldap .
$ grep -Hn --binary-files=without-match -ri hudson.security.ldap .
$ grep -Hn --binary-files=without-match -ri hudson.security.GeneralizedTime .
$ grep -Hn --binary-files=without-match -ri hudson.security.UserAttributesHelper .
$ grep -Hn --binary-files=without-match -ri org.jenkinsci.plugins.externalmonitorjob .
$ grep -Hn --binary-files=without-match -ri hudson.model.ExternalRun .
$ grep -Hn --binary-files=without-match -ri hudson.model.ExternalJob .
$ grep -Hn --binary-files=without-match -ri hudson.cli.SetExternalBuildResultCommand .
$ grep -Hn --binary-files=without-match -ri externaljob.png .
```

My `grep(1)` commands only found a match in [`crittercism-dsym`](https://github.com/jenkinsci/crittercism-dsym-plugin), but it was a false positive: someone had erroneously committed the `target/jenkins-for-test/` directory into the source tree.

I could not find the source code for these four plugins …

- [Prerequisite build step](https://plugins.jenkins.io/prereq-buildstep/), a plugin last released 10 years ago with 867 installs whose required core is 1.392
- [Project Health Report](https://plugins.jenkins.io/project-health-report/), a plugin last released 10 years ago with 550 installs whose required core is 1.392
- [Meme Generator](https://plugins.jenkins.io/memegen/), a plugin last released 5 years ago with 149 installs whose required core is 1.428
- [DevStack](https://plugins.jenkins.io/devstack/) a plugin last released 9 years ago with 16 installs whose required core is 1.432

… but these all seem outdated and unlikely to depend on External Monitor Job Type, LDAP, or PAM Authentication. I do not anticipate this being a major issue.

### Proposed changelog entries

* Stop bundling the [External Monitor Job Type](https://plugins.jenkins.io/external-monitor-job/), [LDAP](https://plugins.jenkins.io/ldap/), and [PAM Authentication](https://plugins.jenkins.io/pam-auth/) plugins. Jenkins will no longer automatically install the External Monitor Job Type, LDAP, or PAM Authentication plugins on startup if a plugin depending on Jenkins (then Hudson) 1.467 or earlier is discovered. If you use such a plugin that also relies on the functionality provided by the External Monitor Job Type, LDAP, or PAM Authentication plugin and manage plugins outside Jenkins' plugin manager, you will now need to ensure that a recent release of the External Monitor Job Type, LDAP, or PAM Authentication plugin is installed. Jenkins will attempt to load such plugins but may fail at any time during startup or afterwards with `ClassNotFoundException` or similar.

### Proposed upgrade guidelines

See above.

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
