### PR TITLE
Remove queue locking requirement when adding new nodes

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -212,12 +212,9 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
     protected void updateNewComputer(final Node n, boolean automaticSlaveLaunch) {
         final String nodeName = n.getNodeName();
         final Map<Node, Computer> computers = getComputerMap();
-        for (Computer c : computers.values()) {
-            Node computerNode = c.getNode();
-            if (computerNode != null && computerNode.getNodeName().equals(nodeName)) {
-                LOGGER.warning("Node " + nodeName + " is not a new node skipping");
-                return;
-            }
+        if (computers.containsKey(n)) {
+            LOGGER.warning("Node " + nodeName + " is not a new node skipping");
+            return;
         }
         createNewComputerForNode(n, automaticSlaveLaunch);
         getQueue().scheduleMaintenance();

--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -145,14 +145,15 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
                 LOGGER.log(Level.WARNING, "Error updating node " + n.getNodeName() + ", continuing", e);
             }
         } else {
-            c = updateNewComputer(n, automaticSlaveLaunch);
+            c = createNewComputerForNode(n, automaticSlaveLaunch);
             if (c != null) {
                 used.add(c);
             }
         }
     }
 
-    private Computer updateNewComputer(Node n, boolean automaticSlaveLaunch) {
+    @CheckForNull
+    private Computer createNewComputerForNode(Node n, boolean automaticSlaveLaunch) {
         Computer c = null;
         Map<Node,Computer> computers = getComputerMap();
         // we always need Computer for the master as a fallback in case there's no other Computer.
@@ -208,7 +209,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
         return computers.get(n);
     }
 
-    protected void addNewComputerForNode(final Node n, boolean automaticSlaveLaunch) {
+    protected void updateNewComputer(final Node n, boolean automaticSlaveLaunch) {
         final String nodeName = n.getNodeName();
         final Map<Node, Computer> computers = getComputerMap();
         for (Computer c : computers.values()) {
@@ -218,7 +219,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
                 return;
             }
         }
-        updateNewComputer(n, automaticSlaveLaunch);
+        createNewComputerForNode(n, automaticSlaveLaunch);
         getQueue().scheduleMaintenance();
         for (ComputerListener cl : ComputerListener.all()) {
             try {

--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -216,120 +216,105 @@ public class NodeProvisioner {
         try {
             lastSuggestedReview = System.currentTimeMillis();
             queuedReview = false;
-            // We need to get the lock on Queue for two reasons:
-            // 1. We will potentially adding a lot of nodes and we don't want to fight with Queue#maintain to acquire
-            //    the Queue#lock in order to add each node. Much better is to hold the Queue#lock until all nodes
-            //    that were provisioned since last we checked have been added.
-            // 2. We want to know the idle executors count, which can only be measured if you hold the Queue#lock
-            //    Strictly speaking we don't need an accurate measure for this, but as we had to get the Queue#lock
-            //    anyway, we might as well get an accurate measure.
-            //
-            // We do not need the Queue#lock to get the count of items in the queue as that is a lock-free call
-            // Since adding a node should not (in principle) confuse Queue#maintain (it is only removal of nodes
-            // that causes issues in Queue#maintain) we should be able to remove the need for Queue#lock
-            //
-            // TODO once Nodes#addNode is made lock free, we should be able to remove the requirement for Queue#lock
-            Queue.withLock(() -> {
-                    Jenkins jenkins = Jenkins.get();
-                    // clean up the cancelled launch activity, then count the # of executors that we are about to
-                    // bring up.
+            Jenkins jenkins = Jenkins.get();
+            // clean up the cancelled launch activity, then count the # of executors that we are about to
+            // bring up.
 
-                    int plannedCapacitySnapshot = 0;
+            int plannedCapacitySnapshot = 0;
 
-                    List<PlannedNode> snapPendingLaunches = new ArrayList<>(pendingLaunches.get());
-                    for (PlannedNode f : snapPendingLaunches) {
-                        if (f.future.isDone()) {
-                            try {
-                                Node node = null;
-                                try {
-                                    node = f.future.get();
-                                } catch (InterruptedException e) {
-                                    throw new AssertionError("InterruptedException occurred", e); // since we confirmed that the future is already done
-                                } catch (ExecutionException e) {
-                                    Throwable cause = e.getCause();
-                                    if (!(cause instanceof AbortException)) {
-                                        LOGGER.log(Level.WARNING,
-                                                "Unexpected exception encountered while provisioning agent "
-                                                        + f.displayName,
-                                                cause);
-                                    }
-                                    fireOnFailure(f, cause);
-                                }
-
-                                if (node != null) {
-                                    fireOnComplete(f, node);
-
-                                    try {
-                                        jenkins.addNode(node);
-                                        LOGGER.log(Level.INFO,
-                                                "{0} provisioning successfully completed. "
-                                                        + "We have now {1,number,integer} computer(s)",
-                                                new Object[]{f.displayName, jenkins.getComputers().length});
-                                        fireOnCommit(f, node);
-                                    } catch (IOException e) {
-                                        LOGGER.log(Level.WARNING,
-                                                "Provisioned agent " + f.displayName + " failed to launch",
-                                                e);
-                                        fireOnRollback(f, node, e);
-                                    }
-                                }
-                            } catch (Error e) {
-                                // we are not supposed to try and recover from Errors
-                                throw e;
-                            } catch (Throwable e) {
-                                // Just log it
-                                LOGGER.log(Level.SEVERE,
-                                        "Unexpected uncaught exception encountered while processing agent "
+            List<PlannedNode> snapPendingLaunches = new ArrayList<>(pendingLaunches.get());
+            for (PlannedNode f : snapPendingLaunches) {
+                if (f.future.isDone()) {
+                    try {
+                        Node node = null;
+                        try {
+                            node = f.future.get();
+                        } catch (InterruptedException e) {
+                            throw new AssertionError("InterruptedException occurred", e); // since we confirmed that the future is already done
+                        } catch (ExecutionException e) {
+                            Throwable cause = e.getCause();
+                            if (!(cause instanceof AbortException)) {
+                                LOGGER.log(Level.WARNING,
+                                        "Unexpected exception encountered while provisioning agent "
                                                 + f.displayName,
-                                        e);
-                            } finally {
-                                while (true) {
-                                    List<PlannedNode> orig = pendingLaunches.get();
-                                    List<PlannedNode> repl = new ArrayList<>(orig);
-                                    // the contract for List.remove(o) is that the first element i where
-                                    // (o==null ? get(i)==null : o.equals(get(i)))
-                                    // is true will be removed from the list
-                                    // since PlannedNode.equals(o) is not final and we cannot assume
-                                    // that subclasses do not override with an equals which does not
-                                    // assure object identity comparison, we need to manually
-                                    // do the removal based on instance identity not equality
-                                    boolean changed = false;
-                                    for (Iterator<PlannedNode> iterator = repl.iterator(); iterator.hasNext(); ) {
-                                        PlannedNode p = iterator.next();
-                                        if (p == f) {
-                                            iterator.remove();
-                                            changed = true;
-                                            break;
-                                        }
-                                    }
-                                    if (!changed || pendingLaunches.compareAndSet(orig, repl)) {
-                                        break;
-                                    }
-                                }
-                                f.spent();
+                                        cause);
                             }
-                        } else {
-                            plannedCapacitySnapshot += f.numExecutors;
+                            fireOnFailure(f, cause);
                         }
+
+                        if (node != null) {
+                            fireOnComplete(f, node);
+
+                            try {
+                                jenkins.addNode(node);
+                                LOGGER.log(Level.INFO,
+                                        "{0} provisioning successfully completed. "
+                                                + "We have now {1,number,integer} computer(s)",
+                                        new Object[]{f.displayName, jenkins.getComputers().length});
+                                fireOnCommit(f, node);
+                            } catch (IOException e) {
+                                LOGGER.log(Level.WARNING,
+                                        "Provisioned agent " + f.displayName + " failed to launch",
+                                        e);
+                                fireOnRollback(f, node, e);
+                            }
+                        }
+                    } catch (Error e) {
+                        // we are not supposed to try and recover from Errors
+                        throw e;
+                    } catch (Throwable e) {
+                        // Just log it
+                        LOGGER.log(Level.SEVERE,
+                                "Unexpected uncaught exception encountered while processing agent "
+                                        + f.displayName,
+                                e);
+                    } finally {
+                        while (true) {
+                            List<PlannedNode> orig = pendingLaunches.get();
+                            List<PlannedNode> repl = new ArrayList<>(orig);
+                            // the contract for List.remove(o) is that the first element i where
+                            // (o==null ? get(i)==null : o.equals(get(i)))
+                            // is true will be removed from the list
+                            // since PlannedNode.equals(o) is not final and we cannot assume
+                            // that subclasses do not override with an equals which does not
+                            // assure object identity comparison, we need to manually
+                            // do the removal based on instance identity not equality
+                            boolean changed = false;
+                            for (Iterator<PlannedNode> iterator = repl.iterator(); iterator.hasNext(); ) {
+                                PlannedNode p = iterator.next();
+                                if (p == f) {
+                                    iterator.remove();
+                                    changed = true;
+                                    break;
+                                }
+                            }
+                            if (!changed || pendingLaunches.compareAndSet(orig, repl)) {
+                                break;
+                            }
+                        }
+                        f.spent();
                     }
+                } else {
+                    plannedCapacitySnapshot += f.numExecutors;
+                }
+            }
 
-                    float plannedCapacity = plannedCapacitySnapshot;
-                    plannedCapacitiesEMA.update(plannedCapacity);
+            float plannedCapacity = plannedCapacitySnapshot;
+            plannedCapacitiesEMA.update(plannedCapacity);
 
-                    final LoadStatistics.LoadStatisticsSnapshot snapshot = stat.computeSnapshot();
+            final LoadStatistics.LoadStatisticsSnapshot snapshot = stat.computeSnapshot();
 
-                    int availableSnapshot = snapshot.getAvailableExecutors();
-                    int queueLengthSnapshot = snapshot.getQueueLength();
+            int availableSnapshot = snapshot.getAvailableExecutors();
+            int queueLengthSnapshot = snapshot.getQueueLength();
 
-                    if (queueLengthSnapshot <= availableSnapshot) {
-                        LOGGER.log(Level.FINER,
-                                "Queue length {0} is less than the available capacity {1}. No provisioning strategy required",
-                                new Object[]{queueLengthSnapshot, availableSnapshot});
-                        provisioningState = null;
-                    } else {
-                        provisioningState = new StrategyState(snapshot, label, plannedCapacitySnapshot);
-                    }
-            });
+            if (queueLengthSnapshot <= availableSnapshot) {
+                LOGGER.log(Level.FINER,
+                        "Queue length {0} is less than the available capacity {1}. No provisioning strategy required",
+                        new Object[]{queueLengthSnapshot, availableSnapshot});
+                provisioningState = null;
+            } else {
+                provisioningState = new StrategyState(snapshot, label, plannedCapacitySnapshot);
+            }
 
             if (provisioningState != null) {
                 List<Strategy> strategies = Jenkins.get().getExtensionList(Strategy.class);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1665,6 +1665,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return null;
     }
 
+    protected void addNewComputerForNode(Node n) {
+        addNewComputerForNode(n, AUTOMATIC_SLAVE_LAUNCH);
+    }
+
     protected void updateComputerList() {
         updateComputerList(AUTOMATIC_SLAVE_LAUNCH);
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1665,8 +1665,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return null;
     }
 
-    protected void addNewComputerForNode(Node n) {
-        addNewComputerForNode(n, AUTOMATIC_SLAVE_LAUNCH);
+    protected void updateNewComputer(Node n) {
+        updateNewComputer(n, AUTOMATIC_SLAVE_LAUNCH);
     }
 
     protected void updateComputerList() {

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -141,11 +141,9 @@ public class Nodes implements Saveable {
 
         Node oldNode = nodes.get(node.getNodeName());
         if (node != oldNode) {
-            // TODO we should not need to lock the queue for adding nodes but until we have a way to update the
-            // computer list for just the new node
             AtomicReference<Node> old = new AtomicReference<>();
             old.set(nodes.put(node.getNodeName(), node));
-            jenkins.addNewComputerForNode(node);
+            jenkins.updateNewComputer(node);
             jenkins.trimLabels();
             // TODO there is a theoretical race whereby the node instance is updated/removed after lock release
             try {

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -144,14 +144,9 @@ public class Nodes implements Saveable {
             // TODO we should not need to lock the queue for adding nodes but until we have a way to update the
             // computer list for just the new node
             AtomicReference<Node> old = new AtomicReference<>();
-            Queue.withLock(new Runnable() {
-                @Override
-                public void run() {
-                    old.set(nodes.put(node.getNodeName(), node));
-                    jenkins.updateComputerList();
-                    jenkins.trimLabels();
-                }
-            });
+            old.set(nodes.put(node.getNodeName(), node));
+            jenkins.addNewComputerForNode(node);
+            jenkins.trimLabels();
             // TODO there is a theoretical race whereby the node instance is updated/removed after lock release
             try {
                 persistNode(node);


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-65501](https://issues.jenkins-ci.org/browse/JENKINS-65501).

While investigating I saw that technically addNode can be made lock-free so this is a stab at it. This would greatly help cloud implementations when provisioning a large number of nodes but of course this will not help removal as that will still require locking.

It can be made non locking because a Node with no computers will not have any executors, this will ensure that it does not confuse Queue#maintain(). But because updateComputerList deals with other computers as well this method needs to lock. Adding a separate method for a single new computer should remove this locking requirement.

References:
[Queue#maintain()](https://github.com/jenkinsci/jenkins/blob/53823453a276de2e4fff20ec0b15c91aa806a0e3/core/src/main/java/hudson/model/Queue.java#L1478-L1499)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Remove the requirement for locking the queue when adding a new node

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
