### PR TITLE
Enable `AnnotationUseStyle`, `AvoidNoArgumentSuperConstructorCall`, and `NoEnumTrailingComma` Checkstyle checks

### DIFF
--- a/core/src/main/java/hudson/cli/GroovyshCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyshCommand.java
@@ -78,7 +78,7 @@ public class GroovyshCommand extends CLICommand {
         return shell.run(commandLine.toString());
     }
 
-    @SuppressWarnings({"rawtypes"})
+    @SuppressWarnings("rawtypes")
     protected Groovysh createShell(InputStream stdin, PrintStream stdout,
         PrintStream stderr) {
 

--- a/core/src/main/java/hudson/cli/declarative/CLIMethod.java
+++ b/core/src/main/java/hudson/cli/declarative/CLIMethod.java
@@ -59,7 +59,7 @@ import java.lang.annotation.Target;
  */
 @Indexed
 @Retention(RUNTIME)
-@Target({METHOD})
+@Target(METHOD)
 @Documented
 public @interface CLIMethod {
     /**

--- a/core/src/main/java/hudson/cli/declarative/CLIResolver.java
+++ b/core/src/main/java/hudson/cli/declarative/CLIResolver.java
@@ -64,7 +64,7 @@ import java.lang.annotation.Target;
  */
 @Indexed
 @Retention(RUNTIME)
-@Target({METHOD})
+@Target(METHOD)
 @Documented
 public @interface CLIResolver {
 }

--- a/core/src/main/java/hudson/cli/declarative/MethodBinder.java
+++ b/core/src/main/java/hudson/cli/declarative/MethodBinder.java
@@ -126,7 +126,7 @@ class MethodBinder {
     /**
      * {@link Argument} implementation that adds a bias to {@link #index()}.
      */
-    @SuppressWarnings({"ClassExplicitlyAnnotation"})
+    @SuppressWarnings("ClassExplicitlyAnnotation")
     private static final class ArgumentImpl implements Argument {
         private final Argument base;
         private final int bias;

--- a/core/src/main/java/hudson/cli/declarative/OptionHandlerExtension.java
+++ b/core/src/main/java/hudson/cli/declarative/OptionHandlerExtension.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Indexed
 @Retention(RUNTIME)
-@Target({TYPE})
+@Target(TYPE)
 @Documented
 public @interface OptionHandlerExtension {
 }

--- a/core/src/main/java/hudson/model/Actionable.java
+++ b/core/src/main/java/hudson/model/Actionable.java
@@ -146,7 +146,7 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
      * Note: calls to {@link #getAllActions()} that happen before calls to this method may not see the update.
      * <strong>Note: this method will always modify the actions</strong>
      */
-    @SuppressWarnings({"ConstantConditions"})
+    @SuppressWarnings("ConstantConditions")
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     public void addAction(@NonNull Action a) {
         if(a==null) {
@@ -188,7 +188,7 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
      * @return {@code true} if this actions changed as a result of the call
      * @since 2.29
      */
-    @SuppressWarnings({"ConstantConditions"})
+    @SuppressWarnings("ConstantConditions")
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     public boolean addOrReplaceAction(@NonNull Action a) {
         if (a == null) {
@@ -246,7 +246,7 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
      * @return {@code true} if this actions changed as a result of the call
      * @since 2.29
      */
-    @SuppressWarnings({"ConstantConditions"})
+    @SuppressWarnings("ConstantConditions")
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     public boolean removeActions(@NonNull Class<? extends Action> clazz) {
         if (clazz == null) {
@@ -278,7 +278,7 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
      * @return {@code true} if this actions changed as a result of the call
      * @since 2.29
      */
-    @SuppressWarnings({"ConstantConditions"})
+    @SuppressWarnings("ConstantConditions")
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     public boolean replaceActions(@NonNull Class<? extends Action> clazz, @NonNull Action a) {
         if (clazz == null) {

--- a/core/src/main/java/hudson/model/BallColor.java
+++ b/core/src/main/java/hudson/model/BallColor.java
@@ -69,7 +69,7 @@ public enum BallColor implements StatusIcon {
     ABORTED("aborted",Messages._BallColor_Aborted(), ColorPalette.DARK_GREY),
     ABORTED_ANIME("aborted_anime",Messages._BallColor_InProgress(), ColorPalette.DARK_GREY),
     NOTBUILT("nobuilt",Messages._BallColor_NotBuilt(), ColorPalette.LIGHT_GREY),
-    NOTBUILT_ANIME("nobuilt_anime",Messages._BallColor_InProgress(), ColorPalette.LIGHT_GREY),
+    NOTBUILT_ANIME("nobuilt_anime",Messages._BallColor_InProgress(), ColorPalette.LIGHT_GREY)
     ;
 
     private final Localizable description;

--- a/core/src/main/java/hudson/model/BooleanParameterDefinition.java
+++ b/core/src/main/java/hudson/model/BooleanParameterDefinition.java
@@ -121,7 +121,7 @@ public class BooleanParameterDefinition extends SimpleParameterDefinition {
 
     // unlike all the other ParameterDescriptors, using 'booleanParam' as the primary
     // to avoid picking the Java reserved word "boolean" as the primary identifier
-    @Extension @Symbol({"booleanParam"})
+    @Extension @Symbol("booleanParam")
     public static class DescriptorImpl extends ParameterDescriptor {
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/Hudson.java
+++ b/core/src/main/java/hudson/model/Hudson.java
@@ -341,7 +341,6 @@ public class Hudson extends Jenkins {
         }
 
         public CloudList() {// needed for XStream deserialization
-            super();
         }
     }
 }

--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -221,7 +221,7 @@ public abstract class ItemGroupMixIn {
     /**
      * Copies an existing {@link TopLevelItem} to a new name.
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings("unchecked")
     public synchronized <T extends TopLevelItem> T copy(T src, String name) throws IOException {
         acl.checkPermission(Item.CREATE);
         src.checkPermission(Item.EXTENDED_READ);

--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -131,7 +131,7 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
         return Objects.equals(defaultValue, other.defaultValue);
     }
 
-    @Extension @Symbol({"password"})
+    @Extension @Symbol("password")
     public static final class ParameterDescriptorImpl extends ParameterDescriptor {
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -436,7 +436,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
     /**
      * Obtains 'this' in a more type safe signature.
      */   
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings("unchecked")
     protected @NonNull RunT _this() {
         return (RunT)this;
     }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1161,7 +1161,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
      *
      * @since 1.266
      */
-    @SuppressWarnings({"UnusedDeclaration"})
+    @SuppressWarnings("UnusedDeclaration")
     public static class UpdateCenterConfiguration implements ExtensionPoint {
         /**
          * Creates default update center configuration - uses settings for global update center.

--- a/core/src/main/java/hudson/scm/SCMDescriptor.java
+++ b/core/src/main/java/hudson/scm/SCMDescriptor.java
@@ -97,7 +97,7 @@ public abstract class SCMDescriptor<T extends SCM> extends Descriptor<SCM> {
 
     // work around JENKINS-4514. The repositoryBrowser field was marked as non-transient until 1.325,
     // causing the field to be persisted and overwritten on the load method.
-    @SuppressWarnings({"ConstantConditions"})
+    @SuppressWarnings("ConstantConditions")
     @Override
     public void load() {
         Class<? extends RepositoryBrowser> rb = repositoryBrowser;

--- a/core/src/main/java/hudson/util/AlternativeUiTextProvider.java
+++ b/core/src/main/java/hudson/util/AlternativeUiTextProvider.java
@@ -102,7 +102,7 @@ public abstract class AlternativeUiTextProvider implements ExtensionPoint {
         /**
          * Assists pattern matching in the {@link AlternativeUiTextProvider} implementation.
          */
-        @SuppressWarnings({"unchecked"})
+        @SuppressWarnings("unchecked")
         public T cast(Object context) {
             return (T)context;
         }

--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -272,7 +272,7 @@ public class Iterators {
     /**
      * Casts {@link Iterator} by taking advantage of its covariant-ness.
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings("unchecked")
     public static <T> Iterator<T> cast(Iterator<? extends T> itr) {
         return (Iterator)itr;
     }
@@ -280,7 +280,7 @@ public class Iterators {
     /**
      * Casts {@link Iterable} by taking advantage of its covariant-ness.
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings("unchecked")
     public static <T> Iterable<T> cast(Iterable<? extends T> itr) {
         return (Iterable)itr;
     }
@@ -288,7 +288,7 @@ public class Iterators {
     /**
      * Returns an {@link Iterator} that only returns items of the given subtype.
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings("unchecked")
     public static <U,T extends U> Iterator<T> subType(Iterator<U> itr, final Class<T> type) {
         return (Iterator)new FilterIterator<U>(itr) {
             @Override

--- a/core/src/main/java/hudson/util/NoClientBindSSLProtocolSocketFactory.java
+++ b/core/src/main/java/hudson/util/NoClientBindSSLProtocolSocketFactory.java
@@ -62,7 +62,6 @@ public class NoClientBindSSLProtocolSocketFactory implements SecureProtocolSocke
      * Constructor for SSLProtocolSocketFactory.
      */
     public NoClientBindSSLProtocolSocketFactory() {
-        super();
     }
 
     /**

--- a/core/src/main/java/hudson/util/PackedMap.java
+++ b/core/src/main/java/hudson/util/PackedMap.java
@@ -54,7 +54,7 @@ import java.util.TreeMap;
  *
  * @author Kohsuke Kawaguchi
  */
-@SuppressWarnings({"unchecked"})
+@SuppressWarnings("unchecked")
 public final class PackedMap<K,V> extends AbstractMap<K,V> {
     private Object[] kvpairs;
 
@@ -87,7 +87,7 @@ public final class PackedMap<K,V> extends AbstractMap<K,V> {
                 }
 
                 @Override
-                @SuppressWarnings({"unchecked"})
+                @SuppressWarnings("unchecked")
                 public Entry<K, V> next() {
                     final K k = (K)kvpairs[index++];
                     final V v = (V)kvpairs[index++];

--- a/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
+++ b/core/src/main/java/hudson/util/jna/SHELLEXECUTEINFO.java
@@ -95,11 +95,9 @@ public class SHELLEXECUTEINFO extends Structure {
         public Pointer hMonitor;
 
         public DUMMYUNIONNAME_union() {
-            super();
         }
 
         public DUMMYUNIONNAME_union(Pointer hIcon_or_hMonitor) {
-            super();
             this.hMonitor = this.hIcon = hIcon_or_hMonitor;
             setType(Pointer.class);
         }

--- a/core/src/main/java/jenkins/PluginSubtypeMarker.java
+++ b/core/src/main/java/jenkins/PluginSubtypeMarker.java
@@ -55,7 +55,7 @@ import java.util.Set;
  */
 @SupportedAnnotationTypes("*")
 @MetaInfServices(Processor.class)
-@SuppressWarnings({"Since15"})
+@SuppressWarnings("Since15")
 public class PluginSubtypeMarker extends AbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1064,7 +1064,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Maintains backwards compatibility. Invoked by XStream when this object is de-serialized.
      */
-    @SuppressWarnings({"unused"})
+    @SuppressWarnings("unused")
     protected Object readResolve() {
         if (jdks == null) {
             jdks = new ArrayList<>();
@@ -1575,7 +1575,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *      Either {@link Descriptor#getId()} (recommended) or the short name of a {@link Describable} subtype (for compatibility)
      * @throws IllegalArgumentException if a short name was passed which matches multiple IDs (fail fast)
      */
-    @SuppressWarnings({"rawtypes"}) // too late to fix
+    @SuppressWarnings("rawtypes") // too late to fix
     public Descriptor getDescriptor(String id) {
         // legacy descriptors that are registered manually doesn't show up in getExtensionList, so check them explicitly.
         Iterable<Descriptor> descriptors = Iterators.sequence(getExtensionList(Descriptor.class), DescriptorExtensionList.listLegacyInstances());
@@ -2763,7 +2763,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *      Can be an empty list but never null.
      * @see ExtensionList#lookup
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings("unchecked")
     public <T> ExtensionList<T> getExtensionList(Class<T> extensionType) {
         ExtensionList<T> extensionList = extensionLists.get(extensionType);
         return extensionList != null ? extensionList : extensionLists.computeIfAbsent(extensionType, key -> ExtensionList.create(this, key));
@@ -2786,7 +2786,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @return
      *      Can be an empty list but never null.
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings("unchecked")
     public @NonNull <T extends Describable<T>,D extends Descriptor<T>> DescriptorExtensionList<T,D> getDescriptorList(Class<T> type) {
         return descriptorLists.computeIfAbsent(type, key -> DescriptorExtensionList.createDescriptorList(this, key));
     }

--- a/core/src/main/java/jenkins/tasks/filters/impl/RetainVariablesLocalRule.java
+++ b/core/src/main/java/jenkins/tasks/filters/impl/RetainVariablesLocalRule.java
@@ -187,7 +187,6 @@ public class RetainVariablesLocalRule implements EnvVarsFilterLocalRule {
     public static final class DescriptorImpl extends EnvVarsFilterLocalRuleDescriptor {
 
         public DescriptorImpl() {
-            super();
             load();
         }
 

--- a/core/src/main/java/jenkins/util/xml/RestrictiveEntityResolver.java
+++ b/core/src/main/java/jenkins/util/xml/RestrictiveEntityResolver.java
@@ -19,7 +19,6 @@ public final class RestrictiveEntityResolver implements EntityResolver {
 
     private RestrictiveEntityResolver() {
         // prevent multiple instantiation.
-        super();
     }
 
     /**

--- a/core/src/main/java/org/jenkins/ui/icon/IconFormat.java
+++ b/core/src/main/java/org/jenkins/ui/icon/IconFormat.java
@@ -30,5 +30,5 @@ package org.jenkins.ui.icon;
  */
 public enum IconFormat {
     IMG,
-    EXTERNAL_SVG_SPRITE,
+    EXTERNAL_SVG_SPRITE
 }

--- a/core/src/main/java/org/jenkins/ui/icon/IconType.java
+++ b/core/src/main/java/org/jenkins/ui/icon/IconType.java
@@ -33,7 +33,7 @@ import org.apache.commons.jelly.JellyContext;
  */
 public enum IconType {
     CORE,
-    PLUGIN,;
+    PLUGIN;
 
     /**
      * Qualify the supplied icon url.

--- a/core/src/test/java/hudson/model/StubJob.java
+++ b/core/src/test/java/hudson/model/StubJob.java
@@ -31,7 +31,7 @@ import java.util.SortedMap;
  * @deprecated Does not behave very consistently. Either write a real functional test with {@code JenkinsRule}, or use PowerMock/Mockito.
  */
 @Deprecated
-@SuppressWarnings({ "rawtypes" })
+@SuppressWarnings("rawtypes")
 class StubJob extends Job {
 
     public static final String DEFAULT_STUB_JOB_NAME = "StubJob";

--- a/core/src/test/java/hudson/model/listeners/SCMListenerTest.java
+++ b/core/src/test/java/hudson/model/listeners/SCMListenerTest.java
@@ -40,7 +40,7 @@ import org.mockito.Mockito;
 public class SCMListenerTest {
 
     @Issue("JENKINS-23522")
-    @SuppressWarnings({"rawtypes"})
+    @SuppressWarnings("rawtypes")
     @Test public void onChangeLogParsed() throws Exception {
         SCM scm = Mockito.mock(SCM.class);
         BuildListener bl = Mockito.mock(BuildListener.class);

--- a/core/src/test/java/hudson/slaves/ChannelPingerTest.java
+++ b/core/src/test/java/hudson/slaves/ChannelPingerTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ ChannelPinger.class })
+@PrepareForTest(ChannelPinger.class)
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 public class ChannelPingerTest {
 

--- a/core/src/test/java/hudson/util/RunListTest.java
+++ b/core/src/test/java/hudson/util/RunListTest.java
@@ -65,7 +65,7 @@ public class RunListTest {
 		rlist = RunList.fromRuns(list);
 	}
 
-	@PrepareForTest({Run.class})
+	@PrepareForTest(Run.class)
 	@Test
 	public void byTimestampAllRuns() {
 		setUpByTimestampRuns();
@@ -75,7 +75,7 @@ public class RunListTest {
 	}
 
     @Issue("JENKINS-21159")
-	@PrepareForTest({Run.class})
+	@PrepareForTest(Run.class)
 	@Test
 	@SuppressWarnings("deprecation")
 	public void byTimestampFirstRun() {
@@ -86,7 +86,7 @@ public class RunListTest {
 		assertEquals(1, tested.getFirstBuild().getNumber());
 	}
 
-	@PrepareForTest({Run.class})
+	@PrepareForTest(Run.class)
 	@Test
 	@SuppressWarnings("deprecation")
 	public void byTimestampLastRun() {

--- a/core/src/test/java/jenkins/xml/XMLUtilsTest.java
+++ b/core/src/test/java/jenkins/xml/XMLUtilsTest.java
@@ -47,7 +47,7 @@ import org.xml.sax.SAXException;
 public class XMLUtilsTest {
 
     @Issue("SECURITY-167")
-    @Test()
+    @Test
     public void testSafeTransformDoesNotProcessForeignResources() throws Exception {
         final String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
                 "<!DOCTYPE project[\n" +
@@ -80,7 +80,7 @@ public class XMLUtilsTest {
 
 
     @Issue("SECURITY-167")
-    @Test()
+    @Test
     public void testUpdateByXmlIDoesNotFail() throws Exception {
         final String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
                 "<project>\n" +

--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,7 @@ THE SOFTWARE.
                     Annotations: https://checkstyle.sourceforge.io/config_annotation.html
                   -->
                   <module name="MissingOverride" />
+                  <module name="AnnotationUseStyle" />
                   <!--
                     Class Design: https://checkstyle.sourceforge.io/config_design.html
                   -->

--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,7 @@ THE SOFTWARE.
                   <module name="AvoidNoArgumentSuperConstructorCall" />
                   <module name="CovariantEquals" />
                   <module name="EqualsHashCode" />
+                  <module name="NoEnumTrailingComma" />
                   <module name="OneStatementPerLine" />
                   <module name="PackageDeclaration" />
                   <module name="SimplifyBooleanExpression" />

--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,7 @@ THE SOFTWARE.
                   <!--
                     Coding: https://checkstyle.sourceforge.io/config_coding.html
                   -->
+                  <module name="AvoidNoArgumentSuperConstructorCall" />
                   <module name="CovariantEquals" />
                   <module name="EqualsHashCode" />
                   <module name="OneStatementPerLine" />

--- a/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
@@ -188,7 +188,7 @@ public class DisablePluginCommandTest {
     @Ignore("TODO calling restart seems to break Surefire")
     @Test
     @Issue("JENKINS-27177")
-    @WithPlugin({"variant.hpi", "depender-0.0.2.hpi", "mandatory-depender-0.0.2.hpi", "plugin-first.hpi", "dependee-0.0.2.hpi", })
+    @WithPlugin({"variant.hpi", "depender-0.0.2.hpi", "mandatory-depender-0.0.2.hpi", "plugin-first.hpi", "dependee-0.0.2.hpi"})
     public void restartAfterDisablePluginsAndErrors() {
         assumeNotWindows();
         assertThat(disablePluginsCLiCommand("-restart", "variant", "dependee", "depender", "plugin-first", "mandatory-depender"), failedWith(RETURN_CODE_NOT_DISABLED_DEPENDANTS));
@@ -205,7 +205,7 @@ public class DisablePluginCommandTest {
      */
     @Test
     @Issue("JENKINS-27177")
-    @WithPlugin({"variant.hpi", "depender-0.0.2.hpi", "mandatory-depender-0.0.2.hpi", "plugin-first.hpi", "dependee-0.0.2.hpi", })
+    @WithPlugin({"variant.hpi", "depender-0.0.2.hpi", "mandatory-depender-0.0.2.hpi", "plugin-first.hpi", "dependee-0.0.2.hpi"})
     public void disablePluginsStrategyAll() {
         assertPluginEnabled("dependee");
         assertPluginEnabled("depender");
@@ -223,7 +223,7 @@ public class DisablePluginCommandTest {
      */
     @Test
     @Issue("JENKINS-27177")
-    @WithPlugin({"variant.hpi", "depender-0.0.2.hpi", "mandatory-depender-0.0.2.hpi", "plugin-first.hpi", "dependee-0.0.2.hpi", })
+    @WithPlugin({"variant.hpi", "depender-0.0.2.hpi", "mandatory-depender-0.0.2.hpi", "plugin-first.hpi", "dependee-0.0.2.hpi"})
     public void disablePluginsStrategyMandatory() {
         assertThat(disablePluginsCLiCommand("-strategy", "mandatory", "variant", "dependee", "plugin-first"), succeeded());
         assertPluginDisabled("variant");
@@ -239,7 +239,7 @@ public class DisablePluginCommandTest {
      */
     @Test
     @Issue("JENKINS-27177")
-    @WithPlugin({"depender-0.0.2.hpi", "dependee-0.0.2.hpi", })
+    @WithPlugin({"depender-0.0.2.hpi", "dependee-0.0.2.hpi"})
     public void disablePluginsMessageAlreadyDisabled() {
         CLICommandInvoker.Result result = disablePluginsCLiCommand("-strategy", "all", "dependee", "depender");
         assertThat(result, succeeded());

--- a/test/src/test/java/hudson/model/AbstractItemSecurityTest.java
+++ b/test/src/test/java/hudson/model/AbstractItemSecurityTest.java
@@ -47,7 +47,7 @@ public class AbstractItemSecurityTest {
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
     @Issue("SECURITY-167")
-    @Test()
+    @Test
     public void testUpdateByXmlDoesNotProcessForeignResources() throws Exception {
         final String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
                 "<!DOCTYPE project[\n" +
@@ -73,7 +73,7 @@ public class AbstractItemSecurityTest {
 
 
     @Issue("SECURITY-167")
-    @Test()
+    @Test
     public void testUpdateByXmlDoesNotFail() throws Exception {
         final String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
                 "<project>\n" +

--- a/test/src/test/java/hudson/model/UpdateCenterCustomTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterCustomTest.java
@@ -79,7 +79,6 @@ public class UpdateCenterCustomTest {
     public static final class CustomUpdateCenter extends UpdateCenter {
 
         public CustomUpdateCenter() {
-            super();
         }
         
         public CustomUpdateCenter(UpdateCenterConfiguration config) {

--- a/test/src/test/java/hudson/model/ViewDescriptorTest.java
+++ b/test/src/test/java/hudson/model/ViewDescriptorTest.java
@@ -61,7 +61,7 @@ public class ViewDescriptorTest {
         assertContains(r.jenkins.getDescriptorByType(AllView.DescriptorImpl.class).doAutoCompleteCopyNewItemFrom("../d1/", d2), "../d1/prj");
     }
 
-    @SuppressWarnings({"rawtypes"}) // the usual API mistakes
+    @SuppressWarnings("rawtypes") // the usual API mistakes
     public static class RestrictiveFolder extends MockFolder {
 
         public RestrictiveFolder(ItemGroup parent, String name) {

--- a/test/src/test/java/hudson/tasks/BatchFileTest.java
+++ b/test/src/test/java/hudson/tasks/BatchFileTest.java
@@ -49,7 +49,6 @@ public class BatchFileTest {
 
         ReturnCodeFakeLauncher(int code)
         {
-            super();
             this.code = code;
         }
 

--- a/test/src/test/java/hudson/tasks/ShellTest.java
+++ b/test/src/test/java/hudson/tasks/ShellTest.java
@@ -89,7 +89,6 @@ public class ShellTest {
 
         ReturnCodeFakeLauncher(int code)
         {
-            super();
             this.code = code;
         }
 

--- a/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
+++ b/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
@@ -516,7 +516,7 @@ public class DoActionFilterTest extends StaplerAbstractTest {
         public void doWithRequestAndResponse(RequestAndResponse requestAndResponse) { replyOk(); }
         
         // special case to keep Groovy parameter name, but does not seem to indicate it's automatically a web method
-        @CapturedParameterNames({"req"})
+        @CapturedParameterNames("req")
         public void doAnnotatedResponseSuccess(Object req) { replyOk(); }
         
 //        // as mentioned in its documentation, it requires to have JavaScriptMethod, that has its own test

--- a/test/src/test/java/lib/layout/SvgIconTest.java
+++ b/test/src/test/java/lib/layout/SvgIconTest.java
@@ -119,7 +119,7 @@ public class SvgIconTest  {
         assertFalse("XSS not prevented (alert)", alertTriggered.get());
     }
 
-    @TestExtension()
+    @TestExtension
     public static class TestRootAction implements UnprotectedRootAction {
         public String tooltipContent = "";
 


### PR DESCRIPTION
Enables the [`AnnotationUseStyle`](https://checkstyle.sourceforge.io/config_annotation.html#AnnotationUseStyle), [`AvoidNoArgumentSuperConstructorCall`](https://checkstyle.sourceforge.io/config_coding.html#AvoidNoArgumentSuperConstructorCall), and [`NoEnumTrailingComma`](https://checkstyle.sourceforge.io/config_coding.html#NoEnumTrailingComma) Checkstyle checks and fixes all violations. The motivation is to make the code easier to read by using a consistent style throughout.