### PR TITLE
Remove some types no longer needed for JEP-200 compatibility

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -27,14 +27,6 @@ com.google.common.collect.SingletonImmutableList
 com.google.common.collect.SingletonImmutableMap
 com.google.common.collect.SingletonImmutableSet
 
-# TODO remove when maven-plugin 3.1 is widely adopted
-hudson.maven.MavenInformation
-
-# TODO remove when https://github.com/jenkinsci/kubernetes-pipeline-plugin/pull/66 is widely adopted
-io.fabric8.docker.api.model.Config
-io.fabric8.docker.api.model.GraphDriverData
-io.fabric8.docker.api.model.ImageInspect
-
 java.io.File
 java.lang.Boolean
 java.lang.Byte
@@ -136,38 +128,9 @@ java.util.logging.Level
 java.util.logging.LogRecord
 java.util.regex.Pattern
 
-# TODO remove when https://github.com/jenkinsci/job-dsl-plugin/pull/1092 is widely adopted
-javaposse.jobdsl.dsl.GeneratedJob
-
-# TODO remove when https://github.com/jenkinsci/monitoring-plugin/pull/6 is widely adopted
-net.bull.javamelody.internal.model.CacheInformations
-net.bull.javamelody.internal.model.HeapHistogram
-net.bull.javamelody.internal.model.HeapHistogram$ClassInfo
-net.bull.javamelody.internal.model.JavaInformations
-net.bull.javamelody.internal.model.JobInformations
-net.bull.javamelody.internal.model.MBeanNode
-net.bull.javamelody.internal.model.MBeanNode$MBeanAttribute
-net.bull.javamelody.internal.model.MemoryInformations
-net.bull.javamelody.internal.model.ProcessInformations
-net.bull.javamelody.internal.model.ThreadInformations
-net.bull.javamelody.internal.model.TomcatInformations
-
 org.apache.commons.fileupload.disk.DiskFileItem
 org.apache.commons.fileupload.util.FileItemHeadersImpl
 org.apache.tools.ant.Location
-
-# TODO remove when git-client 2.7.1+ is widely adopted
-org.eclipse.jgit.lib.ObjectId
-org.eclipse.jgit.lib.ObjectIdOwnerMap$Entry
-org.eclipse.jgit.lib.PersonIdent
-org.eclipse.jgit.revwalk.RevCommit
-org.eclipse.jgit.revwalk.RevObject
-org.eclipse.jgit.revwalk.RevTree
-org.eclipse.jgit.transport.URIish
-
-# TODO remove when https://github.com/jenkinsci/workflow-support-plugin/pull/50 is widely adopted
-org.jboss.marshalling.TraceInformation$FieldInfo
-org.jboss.marshalling.TraceInformation$ObjectInfo
 
 # TODO see main ruby-runtime section below
 org.jenkinsci.jruby.JRubyMapper$DynamicProxy
@@ -200,11 +163,6 @@ org.jruby.runtime.builtin.IRubyObject
 org.jvnet.hudson.MemoryUsage
 org.jvnet.localizer.Localizable
 org.jvnet.localizer.ResourceBundleHolder
-
-# TODO remove when https://github.com/jenkinsci/dependency-check-plugin/pull/20 is widely adopted
-org.owasp.dependencycheck.dependency.Reference
-org.owasp.dependencycheck.dependency.Vulnerability
-org.owasp.dependencycheck.dependency.VulnerableSoftware
 
 org.springframework.security.core.userdetails.User
 


### PR DESCRIPTION
The following plugin releases no longer need these entries:

* https://plugins.jenkins.io/maven-plugin 3.1 (released Jan 2018)
* [Kubernetes Pipeline Steps was fixed in January 2019](https://github.com/jenkinsci/kubernetes-pipeline-plugin/releases/tag/kubernetes-pipeline-project-1.6) and [has been suspended since September 2019](https://github.com/jenkins-infra/update-center2/blob/db053c548c3baf5c9c4510fba8b038bc8ade423e/resources/artifact-ignores.properties#L375-L378)
* https://plugins.jenkins.io/job-dsl 1.67 (released Jan 2018)
* https://plugins.jenkins.io/monitoring 1.71.0 (released Feb 2018)
* https://plugins.jenkins.io/git-client 2.7.1 (released Jan 2018)
* https://plugins.jenkins.io/workflow-support 2.17 (released Jan 2018)
* https://plugins.jenkins.io/dependency-check-jenkins-plugin 3.1.1 (released Jan 2018)

It's been more than three years for all of the still available plugins, so it should be safe to remove these entries.

What's not removed:

* xtrigger-lib because it's still not updated in some downstream plugins.
* ruby-runtime will be done for https://github.com/jenkinsci/jep/tree/master/jep/7 which is getting renewed attention.

### Proposed changelog entries

* Remove JEP-200 compatibility workarounds for releases published before February 2018 of the following plugins: Maven Integration, Job DSL, Monitoring, Git Client, Pipeline: Supporting APIs, OWASP Dependency-Check
  * plugin versions with a fix: (https://github.com/jenkinsci/jenkins/pull/5454#issue-627566656)
  * JEP-200: https://github.com/jenkinsci/jep/tree/master/jep/200

### Proposed upgrade guidelines

JEP-200 workarounds for several plugins have been removed. If you are using any of the following plugins, make sure you use at least the versions specified:

* Maven Integration 3.1 (released Jan 2018)
* Job DSL 1.67 (released Jan 2018)
* Monitoring 1.71.0 (released Feb 2018)
* Git Client 2.7.1 (released Jan 2018)
* Pipeline: Supporting APIs 2.17 (released Jan 2018)
* OWASP Dependency-Check 3.1.1 (released Jan 2018)

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
