### PR TITLE
[JENKINS-64294] Buffer `stdin` for `jenkins-cli.jar`

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -422,10 +422,14 @@ public class CLI {
                 public void run() {
                     try {
                         final OutputStream stdin = streamStdin();
-                        int c;
-                        // TODO check available to avoid sending lots of one-byte frames
-                        while (!complete && (c = System.in.read()) != -1) {
-                           stdin.write(c);
+                        byte[] buf = new byte[60_000]; // less than 64Kb frame size for WS
+                        while (!complete) {
+                            int len = System.in.read(buf);
+                            if (len == -1) {
+                                break;
+                            } else {
+                                stdin.write(buf, 0, len);
+                            }
                         }
                         sendEndStdin();
                     } catch (IOException x) {

--- a/core/src/main/java/hudson/cli/CLIAction.java
+++ b/core/src/main/java/hudson/cli/CLIAction.java
@@ -124,10 +124,13 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
         Authentication authentication = Jenkins.getAuthentication2();
         return WebSockets.upgrade(new WebSocketSession() {
             ServerSideImpl connection;
+            long sentBytes, sentCount, receivedBytes, receivedCount;
             class OutputImpl implements PlainCLIProtocol.Output {
                 @Override
                 public void send(byte[] data) throws IOException {
                     sendBinary(ByteBuffer.wrap(data));
+                    sentBytes += data.length;
+                    sentCount++;
                 }
                 @Override
                 public void close() throws IOException {
@@ -161,6 +164,8 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
             protected void binary(byte[] payload, int offset, int len) {
                 try {
                     connection.handle(new DataInputStream(new ByteArrayInputStream(payload, offset, len)));
+                    receivedBytes += len;
+                    receivedCount++;
                 } catch (IOException x) {
                     error(x);
                 }
@@ -172,6 +177,7 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
             @Override
             protected void closed(int statusCode, String reason) {
                 LOGGER.fine(() -> "closed: " + statusCode + ": " + reason);
+                LOGGER.fine(() -> "received " + receivedCount + " packets of " + receivedBytes + " bytes; sent " + sentCount + " packets of " + sentBytes + " bytes");
                 connection.handleClose();
             }
         });

--- a/test/src/test/java/hudson/cli/CLIActionTest.java
+++ b/test/src/test/java/hudson/cli/CLIActionTest.java
@@ -8,9 +8,13 @@ import hudson.model.Item;
 import hudson.model.User;
 import hudson.util.ProcessTree;
 import hudson.util.StreamTaskListener;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintWriter;
@@ -27,6 +31,10 @@ import jenkins.security.apitoken.ApiTokenTestHelper;
 import jenkins.util.FullDuplexHttpService;
 import jenkins.util.Timer;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.NullInputStream;
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.TeeOutputStream;
 import static org.junit.Assert.assertEquals;
 
@@ -38,6 +46,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.args4j.Option;
 
 public class CLIActionTest {
     @Rule
@@ -207,6 +216,75 @@ public class CLIActionTest {
             return 0;
         }
 
+    }
+
+    @Issue("JENKINS-64294")
+    @Test
+    public void largeTransferWebSocket() throws Exception {
+        logging.record(CLIAction.class, Level.FINE);
+        File jar = tmp.newFile("jenkins-cli.jar");
+        FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
+        CountingOutputStream cos = new CountingOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
+        long size = /*999_*/999_999;
+        // Download:
+        assertEquals(0, new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
+            "java", "-jar", jar.getAbsolutePath(),
+                "-webSocket",
+                "-s", j.getURL().toString(),
+                "large-download",
+                "-size", Long.toString(size)).
+            stdout(cos).stderr(System.err).join());
+        assertEquals(size, cos.getByteCount());
+        // Upload:
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        assertEquals(0, new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
+            "java", "-jar", jar.getAbsolutePath(),
+                "-webSocket",
+                "-s", j.getURL().toString(),
+                "large-upload").
+            stdin(new NullInputStream(size)).
+            stdout(baos).stderr(System.err).join());
+        assertEquals("received " + size + " bytes", baos.toString().trim());
+    }
+
+    @TestExtension("largeTransferWebSocket")
+    public static final class LargeUploadCommand extends CLICommand {
+        @Override
+        protected int run() throws Exception {
+            try (InputStream is = new BufferedInputStream(stdin); CountingOutputStream cos = new CountingOutputStream(NullOutputStream.NULL_OUTPUT_STREAM)) {
+                System.err.println("starting upload");
+                long start = System.nanoTime();
+                IOUtils.copyLarge(is, cos);
+                System.err.printf("finished upload in %.1fs%n", (System.nanoTime() - start) / 1_000_000_000.0);
+                stdout.println("received " + cos.getByteCount() + " bytes");
+                stdout.flush();
+            }
+            return 0;
+        }
+        @Override
+        public String getShortDescription() {
+            return "";
+        }
+    }
+
+    @TestExtension("largeTransferWebSocket")
+    public static final class LargeDownloadCommand extends CLICommand {
+        @Option(name = "-size", required = true)
+        public int size;
+        @Override
+        protected int run() throws Exception {
+            try (OutputStream os = new BufferedOutputStream(stdout)) {
+                System.err.println("starting download");
+                long start = System.nanoTime();
+                IOUtils.copyLarge(new NullInputStream(size), os);
+                System.err.printf("finished download in %.1fs%n", ((System.nanoTime() - start) / 1_000_000_000.0));
+            }
+            return 0;
+        }
+        @Override
+        public String getShortDescription() {
+            return "";
+        }
     }
 
 }


### PR DESCRIPTION
See [JENKINS-64294](https://issues.jenkins-ci.org/browse/JENKINS-64294). I had noticed that the `install-plugin` command hanged when applied to any but the smallest plugins (basically anything with a bundled library) when using the new `-webSocket` mode, but worked fine in the older (implicit) `-http` (“full duplex”) mode. For example, running Jenkins 2.289 locally and using WS mode, trying to upload `aws-java-sdk.hpi` at 187M just sat there; I gave up after 13M had been transferred. With `jenkins-cli.jar` from this patch, the upload succeeded in about 4s. (Note that there is no protocol change here, it is just a change of buffering behavior in the implementation, so you just need the new CLI client to get the benefit with any server version since WebSocket support was introduced.)

The new test run against the status quo:

```console
$ java -jar …/jenkins/test/target/junit…/jenkins-cli.jar -webSocket -s http://localhost:32999/jenkins/ large-download -size 999999
starting download
finished download in 0.0s
   3.283 [id=23]	FINE	hudson.cli.CLIAction$1#closed: closed: 1000: null
   3.284 [id=23]	FINE	hudson.cli.CLIAction$1#closed: received 7 packets of 52 bytes; sent 124 packets of 1000127 bytes
$ java -jar …/jenkins/test/target/junit…/jenkins-cli.jar -webSocket -s http://localhost:32999/jenkins/ large-upload
starting upload
finished upload in 10.7s
  14.498 [id=18]	FINE	hudson.cli.CLIAction$1#closed: closed: 1000: null
  14.498 [id=18]	FINE	hudson.cli.CLIAction$1#closed: received 1000004 packets of 2000031 bytes; sent 3 packets of 29 bytes
```

and after the patch:

```console
$ java -jar …/jenkins/test/target/junit…/jenkins-cli.jar -webSocket -s http://localhost:36823/jenkins/ large-download -size 999999
starting download
finished download in 0.0s
   3.287 [id=23]	FINE	hudson.cli.CLIAction$1#closed: closed: 1000: null
   3.287 [id=23]	FINE	hudson.cli.CLIAction$1#closed: received 7 packets of 52 bytes; sent 124 packets of 1000127 bytes
$ java -jar …/jenkins/test/target/junit…/jenkins-cli.jar -webSocket -s http://localhost:36823/jenkins/ large-upload
starting upload
finished upload in 0.0s
   3.847 [id=17]	FINE	hudson.cli.CLIAction$1#closed: closed: 1000: null
   3.847 [id=17]	FINE	hudson.cli.CLIAction$1#closed: received 22 packets of 1000049 bytes; sent 3 packets of 29 bytes
```

### Proposed changelog entries

* Improve performance for standard input of the Jenkins CLI, for example with the `install-plugin` command.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
