### PR TITLE
Ensure there are no unused imports with Spotless rather than Checkstyle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ You can read a description of the [building and debugging process here].
 If you want simply to build the `jenkins.war` file as fast as possible without tests, run:
 
 ```sh
-mvn -am -pl war,bom -DskipTests -Dspotbugs.skip clean install
+mvn -am -pl war,bom -DskipTests -Dspotbugs.skip -Dspotless.check.skip clean install
 ```
 
 The WAR file will be created in `war/target/jenkins.war`.

--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@ THE SOFTWARE.
             <execution>
               <!-- Runs in verify phase by default -->
               <goals>
-                <!-- Can be disabled using -Dspotless.check.skip=true -->
+                <!-- Can be disabled using -Dspotless.check.skip -->
                 <goal>check</goal>
               </goals>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@ THE SOFTWARE.
     <access-modifier-checker.version>1.21</access-modifier-checker.version>
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
     <powermock.version>2.0.9</powermock.version>
+    <spotless.version>2.10.3</spotless.version>
   </properties>
 
   <!-- Note that the 'repositories' and 'pluginRepositories' blocks below are actually copy-pasted
@@ -489,7 +490,6 @@ THE SOFTWARE.
                     <property name="illegalClasses" value="javax.annotation.MatchesPattern.Checker, javax.annotation.Nonnegative.Checker, javax.annotation.Nonnull.Checker, javax.annotation.RegEx.Checker, javax.annotation.CheckForNull, javax.annotation.CheckForSigned, javax.annotation.CheckReturnValue, javax.annotation.Detainted, javax.annotation.MatchesPattern, javax.annotation.Nonnegative, javax.annotation.Nonnull, javax.annotation.Nullable, javax.annotation.OverridingMethodsMustInvokeSuper, javax.annotation.ParametersAreNonnullByDefault, javax.annotation.ParametersAreNullableByDefault, javax.annotation.PropertyKey, javax.annotation.RegEx, javax.annotation.Signed, javax.annotation.Syntax, javax.annotation.Tainted, javax.annotation.Untainted, javax.annotation.WillClose, javax.annotation.WillCloseWhenClosed, javax.annotation.WillNotClose, javax.annotation.concurrent.GuardedBy, javax.annotation.concurrent.Immutable, javax.annotation.concurrent.NotThreadSafe, javax.annotation.concurrent.ThreadSafe, javax.annotation.meta.TypeQualifierValidator, javax.annotation.meta.When, javax.annotation.meta.Exclusive, javax.annotation.meta.Exhaustive, javax.annotation.meta.TypeQualifier, javax.annotation.meta.TypeQualifierDefault, javax.annotation.meta.TypeQualifierNickname" />
                   </module>
                   <module name="RedundantImport" />
-                  <module name="UnusedImports" />
                   <!--
                     Miscellaneous: https://checkstyle.sourceforge.io/config_misc.html
                   -->
@@ -510,6 +510,25 @@ THE SOFTWARE.
               <id>validate</id>
               <phase>validate</phase>
               <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless.version}</version>
+          <configuration>
+            <java>
+              <removeUnusedImports />
+            </java>
+          </configuration>
+          <executions>
+            <execution>
+              <!-- Runs in verify phase by default -->
+              <goals>
+                <!-- Can be disabled using -Dspotless.check.skip=true -->
                 <goal>check</goal>
               </goals>
             </execution>
@@ -611,6 +630,11 @@ THE SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!-- Version specified in parent POM -->
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
       </plugin>
     </plugins>
 

--- a/test/src/test/java/jenkins/widgets/HistoryPageFilterCaseSensitiveSearchTest.java
+++ b/test/src/test/java/jenkins/widgets/HistoryPageFilterCaseSensitiveSearchTest.java
@@ -3,7 +3,6 @@ package jenkins.widgets;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Rule;


### PR DESCRIPTION
Using [Checkstyle](https://checkstyle.sourceforge.io/) to ensure that there are no unused imports is not ideal because Checkstyle offers no way to automatically fix violations. In contrast, [Spotless](https://github.com/diffplug/spotless) offers both a `check` goal to report violations as well as an `apply` goal to automatically fix all violations, which is far more convenient.

In this PR we disable the [`UnusedImports`](https://checkstyle.sourceforge.io/config_imports.html#UnusedImports) Checkstyle check and replace it with the `removeUnusedImports` Spotless check. The Spotless `check` goal runs in the `verify` phase by default and fails like this if there are any violations:

```
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.10.3:check (default) on project jenkins-test: The following files had format violations:
[ERROR]     src/test/java/jenkins/widgets/HistoryPageFilterCaseSensitiveSearchTest.java
[ERROR]         @@ -3,7 +3,6 @@
[ERROR]          import·java.io.IOException;
[ERROR]          import·java.util.Arrays;
[ERROR]          import·java.util.Collections;
[ERROR]         -import·java.util.List;
[ERROR]          
[ERROR]          import·org.junit.Assert;
[ERROR]          import·org.junit.Rule;
[ERROR] Run 'mvn spotless:apply' to fix these violations.
```

Note that the last line contains a helpful suggestion to run `mvn spotless:apply`, which automatically fixes all violations. The developer can then commit the result and quickly move on.