### PR TITLE
Lessen the severity of the unavailable update message

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/_table.css
+++ b/core/src/main/resources/hudson/PluginManager/_table.css
@@ -61,7 +61,6 @@ time {
 tr.unavailable span.unavailable-label {
     display: inline-block;
     border: 1px solid #666;
-    background-color: #fcc;
     color: #333;
     border-radius: 4px;
     font-size: 0.75rem;
@@ -72,5 +71,4 @@ tr.unavailable span.unavailable-label {
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
-    text-transform: uppercase;
 }

--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -52,11 +52,14 @@ adoptThisPlugin=\
   <strong>This plugin is up for adoption!</strong> We are looking for new maintainers. \
   Visit our <a href="https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" rel="noopener noreferrer" target="_blank">Adopt a Plugin</a> initiative for more information.
 newerVersionExists=\
-  A newer version than being offered for installation exists (version {0}). \
-  This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied.
-newerVersionEntry=\
-  This version of the plugin exists but it is not being offered as an update. \
+  A newer version than being offered for installation exists (version {0}), so the latest bug fixes or features are not available to you. \
   This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied. \
+  If you are using the latest version of Jenkins offered to you, this plugin release may not be available to your release line yet. \
+  See the <a href="{0}" rel="noopener noreferrer" target="_blank">plugin documentation</a> for information about its requirements.
+newerVersionEntry=\
+  This version of the plugin exists but it is not being offered for installation, so the latest bug fixes or features are not available to you. \
+  This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied. \
+  If you are using the latest version of Jenkins offered to you, newer plugin releases may not be available to your release line yet. \
   See the <a href="{0}" rel="noopener noreferrer" target="_blank">plugin documentation</a> for information about its requirements.
 unavailable=Unavailable
 

--- a/war/src/main/less/plugin-manager-ui.less
+++ b/war/src/main/less/plugin-manager-ui.less
@@ -92,7 +92,6 @@ time {
 tr.unavailable span.unavailable-label {
     display: inline-block;
     border: 1px solid #666;
-    background-color: #fcc;
     color: #333;
     border-radius: 4px;
     font-size: 0.75rem;
@@ -103,5 +102,4 @@ tr.unavailable span.unavailable-label {
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
-    text-transform: uppercase;
 }


### PR DESCRIPTION
This both makes the "Unavailable" presentation looks less like an error, and adds a note about being unavailable even on the latest release to the (now unfortunately quite wordy) message.

### Before

<img width="1679" alt="Screenshot 2021-05-13 at 18 13 21" src="https://user-images.githubusercontent.com/1831569/118154326-33b9e380-b417-11eb-99ec-a9ff8ec709fa.png">

### After

<img width="1687" alt="Screenshot 2021-05-13 at 18 12 37" src="https://user-images.githubusercontent.com/1831569/118154349-3a485b00-b417-11eb-8214-28708b74f9d0.png">


### Proposed changelog entries

* Explain that some plugin updates can be unavailable even on the latest version of a given release line (i.e. LTS).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
