### PR TITLE
Reduce usages of `com.google.common.collect` in favor of native Java functionality

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -563,7 +563,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             }
 
             public List<IndexItem<?, Object>> getLoadedIndex() {
-                return Collections.unmodifiableList(loadedIndex);
+                return Collections.unmodifiableList(new ArrayList<>(loadedIndex));
             }
 
             @Override

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -23,8 +23,6 @@
  */
 package hudson;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.google.inject.AbstractModule;
 import com.google.inject.Binding;
 import com.google.inject.Guice;
@@ -69,6 +67,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Discovers the implementations of an extension point.
@@ -305,12 +305,14 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             }
         }
 
-        private ImmutableList<IndexItem<?, Object>> loadSezpozIndices(ClassLoader classLoader) {
+        private List<IndexItem<?, Object>> loadSezpozIndices(ClassLoader classLoader) {
             List<IndexItem<?,Object>> indices = new ArrayList<>();
             for (GuiceExtensionAnnotation<?> gea : extensionAnnotations.values()) {
-                Iterables.addAll(indices, Index.load(gea.annotationType, Object.class, classLoader));
+                for (IndexItem<?, Object> indexItem : Index.load(gea.annotationType, Object.class, classLoader)) {
+                    indices.add(indexItem);
+                }
             }
-            return ImmutableList.copyOf(indices);
+            return Collections.unmodifiableList(indices);
         }
 
         public Injector getContainer() {
@@ -646,7 +648,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             // 5. dead lock
             if (indices==null) {
                 ClassLoader cl = Jenkins.get().getPluginManager().uberClassLoader;
-                indices = ImmutableList.copyOf(Index.load(Extension.class, Object.class, cl));
+                indices = Collections.unmodifiableList(StreamSupport.stream(Index.load(Extension.class, Object.class, cl).spliterator(), false).collect(Collectors.toList()));
             }
             return indices;
         }
@@ -666,7 +668,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
 
             List<IndexItem<Extension,Object>> r = new ArrayList<>(old);
             r.addAll(delta);
-            indices = ImmutableList.copyOf(r);
+            indices = Collections.unmodifiableList(r);
 
             return new ExtensionComponentSet() {
                 @Override

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -24,7 +24,6 @@
  */
 package hudson;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import hudson.PluginManager.PluginInstanceStore;
 import hudson.model.AdministrativeMonitor;
@@ -220,7 +219,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      * The core can depend on a plugin if it is bundled. Sometimes it's the only thing that
      * depends on the plugin e.g. UI support library bundle plugin.
      */
-    private static Set<String> CORE_ONLY_DEPENDANT = ImmutableSet.copyOf(Collections.singletonList("jenkins-core"));
+    private static Set<String> CORE_ONLY_DEPENDANT = Collections.singleton("jenkins-core");
 
     /**
      * Set the list of components that depend on this plugin.

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -23,8 +23,6 @@
  */
 package hudson.model;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedSet;
 import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -85,6 +83,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -702,10 +702,10 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
                 post2(listener);
             } finally {
                 // update the culprit list
-                HashSet<String> r = new HashSet<>();
+                SortedSet<String> r = new TreeSet<>();
                 for (User u : getCulprits())
                     r.add(u.getId());
-                culprits = ImmutableSortedSet.copyOf(r);
+                culprits = Collections.unmodifiableSet(r);
                 CheckPoint.CULPRITS_DETERMINED.report();
             }
         }
@@ -986,7 +986,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             return new EnvironmentList(buildEnvironments); 
         }
         
-        return new EnvironmentList(buildEnvironments==null ? Collections.emptyList() : ImmutableList.copyOf(buildEnvironments));
+        return new EnvironmentList(buildEnvironments==null ? Collections.emptyList() : Collections.unmodifiableList(buildEnvironments));
     }
 
     public Calendar due() {

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -986,7 +986,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
             return new EnvironmentList(buildEnvironments); 
         }
         
-        return new EnvironmentList(buildEnvironments==null ? Collections.emptyList() : Collections.unmodifiableList(buildEnvironments));
+        return new EnvironmentList(buildEnvironments==null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(buildEnvironments)));
     }
 
     public Calendar due() {

--- a/core/src/main/java/hudson/model/DependencyGraph.java
+++ b/core/src/main/java/hudson/model/DependencyGraph.java
@@ -26,7 +26,6 @@ package hudson.model;
 
 import hudson.security.ACLContext;
 import jenkins.model.DependencyDeclarer;
-import com.google.common.collect.ImmutableList;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
 import jenkins.util.DirectedGraph;
@@ -213,13 +212,13 @@ public class DependencyGraph implements Comparator<AbstractProject> {
     private List<Dependency> get(Map<AbstractProject, List<DependencyGroup>> map, AbstractProject src) {
         List<DependencyGroup> v = map.get(src);
         if(v==null) {
-            return ImmutableList.of();
+            return Collections.emptyList();
         } else {
-            ImmutableList.Builder<Dependency> builder = ImmutableList.builder();
+            List<Dependency> builder = new ArrayList<>();
             for (DependencyGroup dependencyGroup : v) {
                 builder.addAll(dependencyGroup.getGroup());
             }
-            return builder.build();
+            return Collections.unmodifiableList(builder);
         }
 
     }

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -23,7 +23,6 @@
  */
 package hudson.model;
 
-import com.google.common.collect.ImmutableList;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
@@ -68,6 +67,8 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.springframework.security.access.AccessDeniedException;
@@ -1177,13 +1178,13 @@ public class Fingerprint implements ModelObject, Saveable {
             for (TransientFingerprintFacetFactory fff : TransientFingerprintFacetFactory.all()) {
                 fff.createFor(this,transientFacets);
             }
-            this.transientFacets = ImmutableList.copyOf(transientFacets);
+            this.transientFacets = Collections.unmodifiableList(transientFacets);
         }
 
         return new AbstractCollection<FingerprintFacet>() {
             @Override
             public Iterator<FingerprintFacet> iterator() {
-                return Iterators.sequence(facets.iterator(), transientFacets.iterator());
+                return Stream.concat(StreamSupport.stream(facets.spliterator(), false), transientFacets.stream()).iterator();
             }
 
             @Override

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -24,7 +24,6 @@
  */
 package hudson.model;
 
-import com.google.common.collect.ImmutableSet;
 import hudson.DescriptorExtensionList;
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -57,7 +56,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.JarFile;
@@ -742,5 +744,5 @@ public abstract class Slave extends Node implements Serializable {
     /**
      * Provides a collection of file names, which are accessible via /jnlpJars link.
      */
-    private static final Set<String> ALLOWED_JNLPJARS_FILES = ImmutableSet.of("agent.jar", "slave.jar", "remoting.jar", "jenkins-cli.jar", "hudson-cli.jar");
+    private static final Set<String> ALLOWED_JNLPJARS_FILES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("agent.jar", "slave.jar", "remoting.jar", "jenkins-cli.jar", "hudson-cli.jar")));
 }

--- a/core/src/main/java/hudson/model/queue/BackFiller.java
+++ b/core/src/main/java/hudson/model/queue/BackFiller.java
@@ -1,6 +1,5 @@
 package hudson.model.queue;
 
-import com.google.common.collect.Iterables;
 import hudson.Extension;
 import jenkins.util.SystemProperties;
 import hudson.model.Computer;
@@ -20,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.StreamSupport;
 
 /**
  * Experimental.
@@ -134,9 +134,8 @@ public class BackFiller extends LoadPredictor {
                 Computer computer = e.getKey();
                 Timeline timeline = new Timeline();
                 for (LoadPredictor lp : LoadPredictor.all()) {
-                    for (FutureLoad fl : Iterables.limit(lp.predict(worksheet, computer, slot.start, slot.end),100)) {
-                        timeline.insert(fl.startTime, fl.startTime+fl.duration, fl.numExecutors);
-                    }
+                    StreamSupport.stream(lp.predict(worksheet, computer, slot.start, slot.end).spliterator(), false).limit(100).forEach(fl ->
+                            timeline.insert(fl.startTime, fl.startTime + fl.duration, fl.numExecutors));
                 }
 
                 Long x = timeline.fit(slot.start, slot.duration, computer.countExecutors()-e.getValue());

--- a/core/src/main/java/hudson/model/queue/MappingWorksheet.java
+++ b/core/src/main/java/hudson/model/queue/MappingWorksheet.java
@@ -23,7 +23,6 @@
  */
 package hudson.model.queue;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import hudson.model.Computer;
 import hudson.model.Executor;
@@ -41,6 +40,7 @@ import hudson.security.ACL;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -370,7 +370,7 @@ public class MappingWorksheet {
             if (ec.node==null)  continue;   // evict out of sync node
             executors.add(ec);
         }
-        this.executors = ImmutableList.copyOf(executors);
+        this.executors = Collections.unmodifiableList(executors);
 
         // group execution units into chunks. use of LinkedHashMap ensures that the main work comes at the top
         Map<Object,List<SubTask>> m = new LinkedHashMap<>();
@@ -387,7 +387,7 @@ public class MappingWorksheet {
         for (List<SubTask> group : m.values()) {
             works.add(new WorkChunk(group,works.size()));
         }
-        this.works = ImmutableList.copyOf(works);
+        this.works = Collections.unmodifiableList(works);
     }
 
     public WorkChunk works(int index) {

--- a/core/src/main/java/hudson/security/Permission.java
+++ b/core/src/main/java/hudson/security/Permission.java
@@ -23,13 +23,14 @@
  */
 package hudson.security;
 
-import com.google.common.collect.ImmutableSet;
 import hudson.model.Hudson;
 import jenkins.model.Jenkins;
 import net.sf.json.util.JSONUtils;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -158,7 +159,7 @@ public final class Permission {
         this.description = description;
         this.impliedBy = impliedBy;
         this.enabled = enable;
-        this.scopes = ImmutableSet.copyOf(scopes);
+        this.scopes = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(scopes)));
         this.id = owner.getName() + '.' + name;
 
         group.add(this);

--- a/core/src/main/java/hudson/security/PermissionScope.java
+++ b/core/src/main/java/hudson/security/PermissionScope.java
@@ -23,7 +23,6 @@
  */
 package hudson.security;
 
-import com.google.common.collect.ImmutableSet;
 import hudson.model.Build;
 import hudson.model.Computer;
 import hudson.model.Item;
@@ -34,6 +33,9 @@ import hudson.model.Node;
 import hudson.model.Run;
 import jenkins.model.Jenkins;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -69,7 +71,7 @@ public final class PermissionScope {
 
     public PermissionScope(Class<? extends ModelObject> modelClass, PermissionScope... containers) {
         this.modelClass = modelClass;
-        this.containers = ImmutableSet.copyOf(containers);
+        this.containers = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(containers)));
     }
 
     /**

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -23,7 +23,6 @@
  */
 package hudson.tasks;
 
-import com.google.common.collect.ImmutableMap;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -65,6 +64,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -461,7 +461,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
                 }
             }
 
-            m = ImmutableMap.copyOf(m);
+            m = Collections.unmodifiableMap(m);
             ref = new WeakReference<>(m);
             return m;
         }

--- a/core/src/main/java/hudson/util/PersistedList.java
+++ b/core/src/main/java/hudson/util/PersistedList.java
@@ -23,7 +23,6 @@
  */
 package hudson.util;
 
-import com.google.common.collect.ImmutableSet;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
@@ -38,7 +37,10 @@ import hudson.model.Saveable;
 import java.io.IOException;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -198,7 +200,7 @@ public class PersistedList<T> extends AbstractList<T> {
     }
 
     // TODO until https://github.com/jenkinsci/jenkins-test-harness/pull/243 is widely adopted:
-    private static final Set<String> IGNORED_CLASSES = ImmutableSet.of("org.jvnet.hudson.test.TestBuilder", "org.jvnet.hudson.test.TestNotifier");
+    private static final Set<String> IGNORED_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("org.jvnet.hudson.test.TestBuilder", "org.jvnet.hudson.test.TestNotifier")));
     // (SingleFileSCM & ExtractResourceWithChangesSCM would also be nice to suppress, but they are not kept in a PersistedList.)
     private static boolean ignoreSerializationErrors(Object o) {
         if (o != null) {

--- a/core/src/main/java/jenkins/InitReactorRunner.java
+++ b/core/src/main/java/jenkins/InitReactorRunner.java
@@ -1,6 +1,5 @@
 package jenkins;
 
-import com.google.common.collect.Lists;
 import jenkins.util.SystemProperties;
 import hudson.init.InitMilestone;
 import hudson.init.InitReactorListener;
@@ -25,6 +24,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static java.util.logging.Level.SEVERE;
 import org.kohsuke.accmod.Restricted;
@@ -61,7 +62,7 @@ public class InitReactorRunner {
      * As such there's no way for plugins to participate into this process.
      */
     private ReactorListener buildReactorListener() throws IOException {
-        List<ReactorListener> r = Lists.newArrayList(ServiceLoader.load(InitReactorListener.class, Thread.currentThread().getContextClassLoader()));
+        List<ReactorListener> r = StreamSupport.stream(ServiceLoader.load(InitReactorListener.class, Thread.currentThread().getContextClassLoader()).spliterator(), false).collect(Collectors.toList());
         r.add(new ReactorListener() {
             final Level level = Level.parse( SystemProperties.getString(Jenkins.class.getName() + "." + "initLogLevel", "FINE") );
             @Override

--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -24,7 +24,6 @@
 
 package jenkins.agents;
 
-import com.google.common.collect.ImmutableMap;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Computer;
@@ -41,6 +40,8 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.slaves.JnlpAgentReceiver;
@@ -87,11 +88,11 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         state.setRemoteEndpointDescription(req.getRemoteAddr());
         state.fireBeforeProperties();
         LOGGER.fine(() -> "connecting " + agent);
-        state.fireAfterProperties(ImmutableMap.of(
-            // TODO or just pass all request headers?
-            JnlpConnectionState.CLIENT_NAME_KEY, agent,
-            JnlpConnectionState.SECRET_KEY, secret
-        ));
+        // TODO or just pass all request headers?
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JnlpConnectionState.CLIENT_NAME_KEY, agent);
+        properties.put(JnlpConnectionState.SECRET_KEY, secret);
+        state.fireAfterProperties(Collections.unmodifiableMap(properties));
         Capability remoteCapability = Capability.fromASCII(remoteCapabilityStr);
         LOGGER.fine(() -> "received " + remoteCapability);
         rsp.setHeader(Capability.KEY, new Capability().toASCII());

--- a/core/src/main/java/jenkins/model/InterruptedBuildAction.java
+++ b/core/src/main/java/jenkins/model/InterruptedBuildAction.java
@@ -23,13 +23,14 @@
  */
 package jenkins.model;
 
-import com.google.common.collect.ImmutableList;
 import hudson.model.InvisibleAction;
 import hudson.model.Run;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -43,7 +44,7 @@ public class InterruptedBuildAction extends InvisibleAction {
     private final List<CauseOfInterruption> causes;
 
     public InterruptedBuildAction(Collection<? extends CauseOfInterruption> causes) {
-        this.causes = ImmutableList.copyOf(causes);
+        this.causes = Collections.unmodifiableList(new ArrayList<>(causes));
     }
 
     @Exported

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -28,8 +28,6 @@ package jenkins.model;
 
 import antlr.ANTLRException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.thoughtworks.xstream.XStream;
@@ -2571,11 +2569,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     @Restricted(NoExternalUse.class)
     public static String expandVariablesForDirectory(String base, String itemFullName, String itemRootDir) {
-        return Util.replaceMacro(base, ImmutableMap.of(
-                "JENKINS_HOME", Jenkins.get().getRootDir().getPath(),
-                "ITEM_ROOTDIR", itemRootDir,
-                "ITEM_FULLNAME", itemFullName,   // legacy, deprecated
-                "ITEM_FULL_NAME", itemFullName.replace(':','$'))); // safe, see JENKINS-12251
+        Map<String, String> properties = new HashMap<>();
+        properties.put("JENKINS_HOME", Jenkins.get().getRootDir().getPath());
+        properties.put("ITEM_ROOTDIR", itemRootDir);
+        properties.put("ITEM_FULLNAME", itemFullName); // legacy, deprecated
+        properties.put("ITEM_FULL_NAME", itemFullName.replace(':','$')); // safe, see JENKINS-12251
+        return Util.replaceMacro(base, Collections.unmodifiableMap(properties));
 
     }
 
@@ -5480,7 +5479,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * <p>See also:{@link #getUnprotectedRootActions}.
      */
-    private static final Set<String> ALWAYS_READABLE_PATHS = new HashSet<>(ImmutableSet.of(
+    private static final Set<String> ALWAYS_READABLE_PATHS = new HashSet<>(Arrays.asList(
         "login", // .jelly
         "loginError", // .jelly
         "logout", // #doLogout

--- a/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
+++ b/core/src/main/java/jenkins/plugins/DetachedPluginsUtil.java
@@ -1,8 +1,6 @@
 package jenkins.plugins;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import hudson.ClassicPluginStrategy;
 import hudson.PluginWrapper;
 import hudson.util.VersionNumber;
@@ -16,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -52,7 +51,7 @@ public class DetachedPluginsUtil {
 
     static {
         try (InputStream is = ClassicPluginStrategy.class.getResourceAsStream("/jenkins/split-plugins.txt")) {
-            DETACHED_LIST = ImmutableList.copyOf(configLines(is).map(line -> {
+            DETACHED_LIST = Collections.unmodifiableList(configLines(is).map(line -> {
                 String[] pieces = line.split(" ");
 
                 // defaults to Java 1.0 to install unconditionally if unspecified
@@ -65,7 +64,7 @@ public class DetachedPluginsUtil {
             throw new ExceptionInInitializerError(x);
         }
         try (InputStream is = ClassicPluginStrategy.class.getResourceAsStream("/jenkins/split-plugin-cycles.txt")) {
-            BREAK_CYCLES = ImmutableSet.copyOf(configLines(is).collect(Collectors.toSet()));
+            BREAK_CYCLES = Collections.unmodifiableSet(configLines(is).collect(Collectors.toSet()));
         } catch (IOException x) {
             throw new ExceptionInInitializerError(x);
         }

--- a/core/src/main/java/jenkins/scm/RunWithSCM.java
+++ b/core/src/main/java/jenkins/scm/RunWithSCM.java
@@ -24,7 +24,6 @@
 
 package jenkins.scm;
 
-import com.google.common.collect.ImmutableSet;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -37,6 +36,7 @@ import org.kohsuke.stapler.export.Exported;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.AbstractSet;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -96,7 +96,7 @@ public interface RunWithSCM<JobT extends Job<JobT, RunT>,
         }
 
         return new AbstractSet<User>() {
-            private Set<String> culpritIds = ImmutableSet.copyOf(getCulpritIds());
+            private Set<String> culpritIds = Collections.unmodifiableSet(getCulpritIds());
 
             @Override
             public Iterator<User> iterator() {

--- a/core/src/main/java/jenkins/scm/RunWithSCM.java
+++ b/core/src/main/java/jenkins/scm/RunWithSCM.java
@@ -96,7 +96,7 @@ public interface RunWithSCM<JobT extends Job<JobT, RunT>,
         }
 
         return new AbstractSet<User>() {
-            private Set<String> culpritIds = Collections.unmodifiableSet(getCulpritIds());
+            private Set<String> culpritIds = Collections.unmodifiableSet(new HashSet<>(getCulpritIds()));
 
             @Override
             public Iterator<User> iterator() {

--- a/core/src/main/java/jenkins/security/ClassFilterImpl.java
+++ b/core/src/main/java/jenkins/security/ClassFilterImpl.java
@@ -25,7 +25,6 @@
 package jenkins.security;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import hudson.ExtensionList;
 import hudson.Main;
 import hudson.remoting.ClassFilter;
@@ -117,7 +116,7 @@ public class ClassFilterImpl extends ClassFilter {
     static final Set<String> WHITELISTED_CLASSES;
     static {
         try (InputStream is = ClassFilterImpl.class.getResourceAsStream("whitelisted-classes.txt")) {
-            WHITELISTED_CLASSES = ImmutableSet.copyOf(IOUtils.readLines(is, StandardCharsets.UTF_8).stream().filter(line -> !line.matches("#.*|\\s*")).collect(Collectors.toSet()));
+            WHITELISTED_CLASSES = Collections.unmodifiableSet(IOUtils.readLines(is, StandardCharsets.UTF_8).stream().filter(line -> !line.matches("#.*|\\s*")).collect(Collectors.toSet()));
         } catch (IOException x) {
             throw new ExceptionInInitializerError(x);
         }

--- a/core/src/main/java/jenkins/security/s2m/CallableRejectionConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableRejectionConfig.java
@@ -32,7 +32,7 @@ public class CallableRejectionConfig extends ConfigFile<Class,Set<Class>> {
 
     @Override
     protected Set<Class> readOnly(Set<Class> base) {
-        return Collections.unmodifiableSet(base);
+        return Collections.unmodifiableSet(new HashSet<>(base));
     }
 
     @Override

--- a/core/src/main/java/jenkins/security/s2m/CallableRejectionConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableRejectionConfig.java
@@ -1,11 +1,11 @@
 package jenkins.security.s2m;
 
-import com.google.common.collect.ImmutableSet;
 import jenkins.model.Jenkins;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,7 +32,7 @@ public class CallableRejectionConfig extends ConfigFile<Class,Set<Class>> {
 
     @Override
     protected Set<Class> readOnly(Set<Class> base) {
-        return ImmutableSet.copyOf(base);
+        return Collections.unmodifiableSet(base);
     }
 
     @Override

--- a/core/src/main/java/jenkins/security/s2m/CallableWhitelistConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableWhitelistConfig.java
@@ -1,10 +1,10 @@
 package jenkins.security.s2m;
 
-import com.google.common.collect.ImmutableSet;
 import hudson.Util;
 import org.jenkinsci.remoting.RoleSensitive;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,7 +25,7 @@ class CallableWhitelistConfig extends ConfigDirectory<String,Set<String>> {
 
     @Override
     protected Set<String> readOnly(Set<String> base) {
-        return ImmutableSet.copyOf(base);
+        return Collections.unmodifiableSet(base);
     }
 
     @Override

--- a/core/src/main/java/jenkins/security/s2m/CallableWhitelistConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableWhitelistConfig.java
@@ -25,7 +25,7 @@ class CallableWhitelistConfig extends ConfigDirectory<String,Set<String>> {
 
     @Override
     protected Set<String> readOnly(Set<String> base) {
-        return Collections.unmodifiableSet(base);
+        return Collections.unmodifiableSet(new HashSet<>(base));
     }
 
     @Override

--- a/core/src/main/java/jenkins/security/s2m/FilePathRuleConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/FilePathRuleConfig.java
@@ -1,14 +1,16 @@
 package jenkins.security.s2m;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import hudson.Functions;
 import hudson.model.Failure;
 import jenkins.model.Jenkins;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,7 +33,7 @@ class FilePathRuleConfig extends ConfigDirectory<FilePathRule,List<FilePathRule>
 
     @Override
     protected List<FilePathRule> readOnly(List<FilePathRule> base) {
-        return ImmutableList.copyOf(base);
+        return Collections.unmodifiableList(base);
     }
 
     @Override
@@ -66,7 +68,7 @@ class FilePathRuleConfig extends ConfigDirectory<FilePathRule,List<FilePathRule>
         if (token.equals("all"))
             return OpMatcher.ALL;
 
-        final ImmutableSet ops = ImmutableSet.copyOf(token.split(","));
+        final Set<String> ops = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(token.split(","))));
         return new OpMatcher() {
             @Override
             public boolean matches(String op) {

--- a/core/src/main/java/jenkins/security/s2m/FilePathRuleConfig.java
+++ b/core/src/main/java/jenkins/security/s2m/FilePathRuleConfig.java
@@ -33,7 +33,7 @@ class FilePathRuleConfig extends ConfigDirectory<FilePathRule,List<FilePathRule>
 
     @Override
     protected List<FilePathRule> readOnly(List<FilePathRule> base) {
-        return Collections.unmodifiableList(base);
+        return Collections.unmodifiableList(new ArrayList<>(base));
     }
 
     @Override


### PR DESCRIPTION
A subset of #5344 that is hopefully non-controversial and safe to land in the short term because it avoids any changes that have a risk of regression.

The underlying motivation is to make the code easier to read by using a consistent paradigm as much as possible (namely, JDK classes rather than a mixture of JDK classes and Guava classes).