### PR TITLE
[JENKINS-59412] No reason why `User/builds` or `View/builds` should not work with Pipeline

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -702,8 +702,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     }
 
     /**
-     * Gets the list of {@link Build}s that include changes by this user,
-     * by the timestamp order.
+     * Searches for builds which include changes by this user or which were triggered by this user.
      */
     @SuppressWarnings("unchecked")
     @WithBridgeMethods(List.class)

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -70,6 +70,7 @@ import javax.servlet.http.HttpServletResponse;
 import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithContextMenu;
+import jenkins.scm.RunWithSCM;
 import jenkins.security.ImpersonatingUserDetailsService2;
 import jenkins.security.LastGrantedAuthoritiesProperty;
 import jenkins.security.UserDetailsCache;
@@ -683,10 +684,10 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     }
 
     /**
-     * true if {@link AbstractBuild#hasParticipant} or {@link hudson.model.Cause.UserIdCause}
+     * true if {@link RunWithSCM#hasParticipant} or {@link hudson.model.Cause.UserIdCause}
      */
-    private boolean relatedTo(@NonNull AbstractBuild<?, ?> b) {
-        if (b.hasParticipant(this)) {
+    private boolean relatedTo(@NonNull Run<?, ?> b) {
+        if (b instanceof RunWithSCM && ((RunWithSCM) b).hasParticipant(this)) {
             return true;
         }
         for (Cause cause : b.getCauses()) {
@@ -708,7 +709,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     @WithBridgeMethods(List.class)
     public @NonNull RunList getBuilds() {
         return RunList.fromJobs((Iterable) Jenkins.get().
-                allItems(Job.class)).filter((Predicate<Run<?, ?>>) r -> r instanceof AbstractBuild && relatedTo((AbstractBuild<?, ?>) r));
+                allItems(Job.class)).filter((Predicate<Run<?, ?>>) this::relatedTo);
     }
 
     /**
@@ -918,8 +919,8 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
 
     public void doRssLatest(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         final List<Run> lastBuilds = new ArrayList<>();
-        for (AbstractProject<?, ?> p : Jenkins.get().allItems(AbstractProject.class)) {
-            for (AbstractBuild<?, ?> b = p.getLastBuild(); b != null; b = b.getPreviousBuild()) {
+        for (Job<?, ?> p : Jenkins.get().allItems(Job.class)) {
+            for (Run<?, ?> b = p.getLastBuild(); b != null; b = b.getPreviousBuild()) {
                 if (relatedTo(b)) {
                     lastBuilds.add(b);
                     break;

--- a/core/src/main/resources/hudson/model/User/builds.jelly
+++ b/core/src/main/resources/hudson/model/User/builds.jelly
@@ -30,9 +30,6 @@ THE SOFTWARE.
         <img src="${h.getUserAvatar(it,'48x48')}" alt="" height="48" width="48" />
         ${%title(it)}
       </h1>
-      <p>
-        <em>${%disclaimer}</em>
-      </p>
 
       <!-- TODO consider adding a BuildTimelineWidget (cf. Job, View, Computer) -->
       <t:buildListTable builds="${it.builds}"/>

--- a/core/src/main/resources/hudson/model/User/builds.properties
+++ b/core/src/main/resources/hudson/model/User/builds.properties
@@ -20,4 +20,3 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 title=Builds for {0}
-disclaimer=This does not include stages from pipeline jobs.

--- a/core/src/main/resources/hudson/model/View/builds.jelly
+++ b/core/src/main/resources/hudson/model/View/builds.jelly
@@ -32,9 +32,6 @@ THE SOFTWARE.
         <l:icon class="icon-notepad icon-xlg"/>
         ${%buildHistory(it.class.name=='hudson.model.AllView' ? app.displayName : it.displayName)}
       </h1>
-      <p>
-        <em>${%disclaimer}</em>
-      </p>
 
       <j:if test="${!request.getParameter('suppressTimelineControl')}"> <!-- cf. BuildListTableTest; breaks HtmlUnit -->
         <st:include page="control.jelly" it="${it.timeline}"/>

--- a/core/src/main/resources/hudson/model/View/builds.properties
+++ b/core/src/main/resources/hudson/model/View/builds.properties
@@ -21,4 +21,3 @@
 # THE SOFTWARE.
 
 buildHistory=Build History of {0}
-disclaimer=This history is not guaranteed to include all subtasks executed on the node, e.g. Jenkins Pipeline subtasks will not be displayed.


### PR DESCRIPTION
See [JENKINS-59412](https://issues.jenkins-ci.org/browse/JENKINS-59412). #4207 was mistaken. While `Computer/builds` is truly incompatible with Pipeline for reasons explained in [JENKINS-38877](https://issues.jenkins.io/browse/JENKINS-38877), `User/builds` can be made compatible with only simple changes, and `View/builds` was already fine.

### Proposed changelog entries

* Displaying Pipeline builds among user build history, and removing incorrect warning about view build history.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
