### PR TITLE
Deprecate `Util#join(Collection, String)` in favor of `String#join(CharSequence, Iterable)`

### DIFF
--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -261,7 +261,7 @@ public class EnvVars extends TreeMap<String,String> {
             String referrer = cycle.get(refererIndex);
             boolean removed = refereeSetMap.get(referrer).remove(referee);
             assert(removed);
-            LOGGER.warning(String.format("Cyclic reference detected: %s", Util.join(cycle," -> ")));
+            LOGGER.warning(String.format("Cyclic reference detected: %s", String.join(" -> ", cycle)));
             LOGGER.warning(String.format("Cut the reference %s -> %s", referrer, referee));
         }
         

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -499,7 +499,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                                             protected void reactOnCycle(PluginWrapper q, List<PluginWrapper> cycle)
                                                     throws hudson.util.CyclicGraphDetector.CycleDetectedException {
 
-                                                LOGGER.log(Level.SEVERE, "found cycle in plugin dependencies: (root="+q+", deactivating all involved) "+Util.join(cycle," -> "));
+                                                LOGGER.log(Level.SEVERE, "found cycle in plugin dependencies: (root=" + q + ", deactivating all involved) " + cycle.stream().map(Object::toString).collect(Collectors.joining(" -> ")));
                                                 for (PluginWrapper pluginWrapper : cycle) {
                                                     pluginWrapper.setHasCycleDependency(true);
                                                     failedPlugins.add(new FailedPlugin(pluginWrapper.getShortName(), new CycleDetectedException(cycle)));

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1160,7 +1160,9 @@ public class Util {
 
     /**
      * Concatenate multiple strings by inserting a separator.
+     * @deprecated since TODO; use {@link String#join(CharSequence, Iterable)}
      */
+    @Deprecated
     @NonNull
     public static String join(@NonNull Collection<?> strings, @NonNull String separator) {
         StringBuilder buf = new StringBuilder();

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -429,7 +429,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
         List<String> depends = buildFillDependencies(method, new ArrayList<>());
 
         if (!depends.isEmpty())
-            attributes.put("fillDependsOn",Util.join(depends," "));
+            attributes.put("fillDependsOn", String.join(" ", depends));
         attributes.put("fillUrl", String.format("%s/%s/fill%sItems", getCurrentDescriptorByNameUrl(), getDescriptorUrl(), capitalizedFieldName));
     }
 

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -32,6 +32,7 @@ import hudson.model.queue.WorkUnit;
 import hudson.security.ACL;
 import hudson.util.InterceptingProxy;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.CauseOfInterruption.UserInterruption;
 import jenkins.model.InterruptedBuildAction;
@@ -218,7 +219,7 @@ public class Executor extends Thread implements ModelObject {
 
     private void interrupt(Result result, boolean forShutdown, CauseOfInterruption... causes) {
         if (LOGGER.isLoggable(FINE))
-            LOGGER.log(FINE, String.format("%s is interrupted(%s): %s", getDisplayName(), result, Util.join(Arrays.asList(causes),",")), new InterruptedException());
+            LOGGER.log(FINE, String.format("%s is interrupted(%s): %s", getDisplayName(), result, Arrays.stream(causes).map(Object::toString).collect(Collectors.joining(","))), new InterruptedException());
 
         lock.writeLock().lock();
         try {

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1106,7 +1106,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             for (SCM s : scmItem.getSCMs()) {
                 scmNames.add(s.getDescriptor().getDisplayName());
             }
-            scmDisplayName = " " + Util.join(scmNames, ", ");
+            scmDisplayName = " " + String.join(", ", scmNames);
         }
 
         for (RunT r = getLastBuild(); r != null; r = r.getPreviousBuild()) {

--- a/core/src/main/java/hudson/os/SU.java
+++ b/core/src/main/java/hudson/os/SU.java
@@ -85,7 +85,7 @@ public abstract class SU {
                 @Override
                 protected Process sudoWithPass(ArgumentListBuilder args) throws IOException {
                     args.prepend(sudoExe(),"-S");
-                    listener.getLogger().println("$ "+Util.join(args.toList()," "));
+                    listener.getLogger().println("$ " + String.join(" ", args.toList()));
                     ProcessBuilder pb = new ProcessBuilder(args.toCommandArray());
                     Process p = pb.start();
                     // TODO: use -p to detect prompt

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -35,8 +35,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
-import hudson.Util;
 import hudson.util.RunList;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -218,7 +218,7 @@ public class LogRotator extends BuildDiscarder {
             //Collate all encountered exceptions into a single exception and throw that
             String msg = String.format(
                     "Failed to rotate logs for [%s]",
-                    Util.join(exceptionMap.keySet(), ", ")
+                    exceptionMap.keySet().stream().map(Object::toString).collect(Collectors.joining(", "))
             );
             throw new CompositeIOException(msg, new ArrayList<>(exceptionMap.values()));
         }

--- a/core/src/main/java/hudson/util/ClasspathBuilder.java
+++ b/core/src/main/java/hudson/util/ClasspathBuilder.java
@@ -1,7 +1,6 @@
 package hudson.util;
 
 import hudson.FilePath;
-import hudson.Util;
 import hudson.remoting.Which;
 
 import java.io.Serializable;
@@ -65,6 +64,6 @@ public class ClasspathBuilder implements Serializable {
      */
     @Override
     public String toString() {
-        return Util.join(args,File.pathSeparator);
+        return String.join(File.pathSeparator, args);
     }
 }

--- a/core/src/main/java/hudson/util/CyclicGraphDetector.java
+++ b/core/src/main/java/hudson/util/CyclicGraphDetector.java
@@ -1,7 +1,5 @@
 package hudson.util;
 
-import hudson.Util;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -78,7 +76,7 @@ public abstract class CyclicGraphDetector<N> {
         public final List cycle;
 
         public CycleDetectedException(List cycle) {
-            super("Cycle detected: "+Util.join(cycle," -> "));
+            super("Cycle detected: "+ String.join(" -> ", cycle));
             this.cycle = cycle;
         }
     }

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Locale;
 
 import static hudson.Functions.jsStringEscape;
-import static hudson.Util.join;
 import static hudson.Util.singleQuote;
 
 /**
@@ -663,7 +662,7 @@ public abstract class FormValidation extends IOException implements HttpResponse
             if (names==null)    return null;
 
             if (dependsOn==null)
-                dependsOn = join(names," ");
+                dependsOn = String.join(" ", names);
             return dependsOn;
         }
 

--- a/core/src/main/java/jenkins/MissingDependencyException.java
+++ b/core/src/main/java/jenkins/MissingDependencyException.java
@@ -26,9 +26,9 @@ package jenkins;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import hudson.PluginWrapper.Dependency;
-import hudson.Util;
 
 /**
  * Exception thrown if plugin resolution fails due to missing dependencies
@@ -44,7 +44,7 @@ public class MissingDependencyException extends IOException {
 
     public MissingDependencyException(String pluginShortName, List<Dependency> missingDependencies) {
         super("One or more dependencies could not be resolved for " + pluginShortName + " : "
-                + Util.join(missingDependencies, ", "));
+                + missingDependencies.stream().map(Object::toString).collect(Collectors.joining(", ")));
         this.pluginShortName = pluginShortName;
         this.missingDependencies = missingDependencies;
     }

--- a/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java
+++ b/core/src/main/java/jenkins/model/CoreEnvironmentContributor.java
@@ -2,7 +2,6 @@ package jenkins.model;
 
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.EnvironmentContributor;
 import hudson.model.Executor;
@@ -14,6 +13,7 @@ import jenkins.model.Jenkins.MasterComputer;
 import org.jenkinsci.Symbol;
 
 import java.io.IOException;
+import java.util.stream.Collectors;
 
 /**
  * {@link EnvironmentContributor} that adds the basic set of environment variables that
@@ -66,7 +66,7 @@ public class CoreEnvironmentContributor extends EnvironmentContributor {
             }
             Node n = e.getOwner().getNode();
             if (n != null)
-                env.put("NODE_LABELS", Util.join(n.getAssignedLabels(), " "));
+                env.put("NODE_LABELS", n.getAssignedLabels().stream().map(Object::toString).collect(Collectors.joining(" ")));
         }
     }
 }

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -345,7 +345,7 @@ public class FunctionsTest {
 
     private void assertBrokenAs(String plain, String... chunks) {
         assertEquals(
-                Util.join(Arrays.asList(chunks), "<wbr>"),
+                String.join("<wbr>", chunks),
                 Functions.breakableString(plain)
         );
     }

--- a/test/src/test/java/hudson/util/ArgumentListBuilder2Test.java
+++ b/test/src/test/java/hudson/util/ArgumentListBuilder2Test.java
@@ -33,7 +33,6 @@ import hudson.Functions;
 import hudson.Launcher.LocalLauncher;
 import hudson.Launcher.RemoteLauncher;
 import hudson.Proc;
-import hudson.Util;
 import hudson.model.Slave;
 
 import org.apache.tools.ant.util.JavaEnvUtils;
@@ -46,7 +45,6 @@ import org.jvnet.hudson.test.LoggerRule;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.logging.Level;
 import jenkins.util.SystemProperties;
 
@@ -93,7 +91,7 @@ public class ArgumentListBuilder2Test {
 
         String out = echoArgs(specials);
 
-        String expected = String.format("%n%s", Util.join(Arrays.asList(specials), " "));
+        String expected = String.format("%n%s", String.join(" ", specials));
         assertThat(out, containsString(expected));
     }
 


### PR DESCRIPTION
[`String#join(CharSequence, Iterable)`](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#join-java.lang.CharSequence-java.lang.Iterable-) was introduced in Java 8, making our own [`Util#join(Collection, String)`](https://javadoc.jenkins.io/hudson/Util.html#join-java.util.Collection-java.lang.String-) redundant.