### PR TITLE
Remove Guava test library

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -39,7 +39,6 @@ THE SOFTWARE.
 
 
   <properties>
-    <guavaVersion>11.0.1</guavaVersion>
     <slf4jVersion>1.7.30</slf4jVersion>
     <stapler.version>1.263</stapler.version>
     <groovy.version>2.4.12</groovy.version>
@@ -92,7 +91,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>${guavaVersion}</version>
+        <version>11.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -95,11 +95,6 @@ THE SOFTWARE.
         <version>${guavaVersion}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava-testlib</artifactId>
-        <version>${guavaVersion}</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>4.0</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -566,11 +566,6 @@ THE SOFTWARE.
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava-testlib</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- Overriding Stapler’s 1.1.3 version to diagnose JENKINS-20618: -->
     <dependency>
       <groupId>com.jcraft</groupId>

--- a/core/src/test/java/hudson/slaves/ChannelPingerTest.java
+++ b/core/src/test/java/hudson/slaves/ChannelPingerTest.java
@@ -1,11 +1,12 @@
 package hudson.slaves;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
-import com.google.common.testing.EqualsTester;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +18,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import hudson.remoting.Channel;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -117,9 +119,31 @@ public class ChannelPingerTest {
 
     @Test
     public void testSetUpRemotePingEquality() {
-         new EqualsTester()
-             .addEqualityGroup(new ChannelPinger.SetUpRemotePing(1, 2), new ChannelPinger.SetUpRemotePing(1, 2))
-             .addEqualityGroup(new ChannelPinger.SetUpRemotePing(2, 3), new ChannelPinger.SetUpRemotePing(2, 3))
-             .testEquals();
+        ChannelPinger.SetUpRemotePing pinger1a = new ChannelPinger.SetUpRemotePing(1, 2);
+        ChannelPinger.SetUpRemotePing pinger1b = new ChannelPinger.SetUpRemotePing(1, 2);
+        ChannelPinger.SetUpRemotePing pinger2a = new ChannelPinger.SetUpRemotePing(2, 3);
+        ChannelPinger.SetUpRemotePing pinger2b = new ChannelPinger.SetUpRemotePing(2, 3);
+
+        for (ChannelPinger.SetUpRemotePing item : Arrays.asList(pinger1a, pinger1b, pinger2a, pinger2b)) {
+            assertNotEquals(null, item);
+            assertEquals(item, item);
+            assertEquals(item.hashCode(), item.hashCode());
+        }
+
+        assertEquals(pinger1a, pinger1b);
+        assertEquals(pinger1b, pinger1a);
+        assertEquals(pinger1a.hashCode(), pinger1b.hashCode());
+        assertNotEquals(pinger1a, pinger2a);
+        assertNotEquals(pinger1a, pinger2b);
+        assertNotEquals(pinger1b, pinger2a);
+        assertNotEquals(pinger1b, pinger2b);
+
+        assertEquals(pinger2a, pinger2b);
+        assertEquals(pinger2b, pinger2a);
+        assertEquals(pinger2a.hashCode(), pinger2b.hashCode());
+        assertNotEquals(pinger2a, pinger1a);
+        assertNotEquals(pinger2a, pinger1b);
+        assertNotEquals(pinger2b, pinger1a);
+        assertNotEquals(pinger2b, pinger1b);
     }
 }


### PR DESCRIPTION
`guava-testlib` naturally depends on Guava. Putting it on our test classpath just increases our dependency on Guava and complicates upgrading Guava or doing fancy things like shading or removing Guava. We really don't need this library. It was just used in one test to facilitate `.equals()` testing. I rewrote that test to do the same thing without Guava.

I'm not sure why this library was ever exposed in the core BOM, because it's a test-scoped dependency. I am removing it from there as well. There are only two plugins that use this library in their tests: [Gravatar](https://github.com/jenkinsci/gravatar-plugin) and [Octoperf](https://github.com/jenkinsci/octoperf-plugin). Each one declare its dependency on this library in its own `pom.xml` file, so they should be unaffected by removal of this library from the core BOM.