### PR TITLE
Ensure files end with a newline with Spotless rather than Checkstyle

### DIFF
--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -549,14 +549,3 @@ public class QuotedStringTokenizer
      */
     private static final String ESCAPABLE_CHARS = "\\\"' ";
 }
-
-
-
-
-
-
-
-
-
-
-

--- a/core/src/main/java/hudson/cli/CopyJobCommand.java
+++ b/core/src/main/java/hudson/cli/CopyJobCommand.java
@@ -78,4 +78,3 @@ public class CopyJobCommand extends CLICommand {
         return 0;
     }
 }
-

--- a/core/src/main/java/hudson/cli/CreateJobCommand.java
+++ b/core/src/main/java/hudson/cli/CreateJobCommand.java
@@ -74,5 +74,3 @@ public class CreateJobCommand extends CLICommand {
         return 0;
     }
 }
-
-

--- a/core/src/main/java/hudson/cli/GroovyCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyCommand.java
@@ -86,4 +86,3 @@ public class GroovyCommand extends CLICommand {
         return null; // never called
     }
 }
-

--- a/core/src/main/java/hudson/cli/SessionIdCommand.java
+++ b/core/src/main/java/hudson/cli/SessionIdCommand.java
@@ -22,4 +22,3 @@ public class SessionIdCommand extends CLICommand {
         return 0;
     }
 }
-

--- a/core/src/main/java/hudson/cli/UpdateJobCommand.java
+++ b/core/src/main/java/hudson/cli/UpdateJobCommand.java
@@ -49,4 +49,3 @@ public class UpdateJobCommand extends CLICommand {
         return 0;
     }
 }
-

--- a/core/src/main/java/hudson/cli/WhoAmICommand.java
+++ b/core/src/main/java/hudson/cli/WhoAmICommand.java
@@ -51,4 +51,3 @@ public class WhoAmICommand extends CLICommand {
         return 0;
     }
 }
-

--- a/core/src/main/java/hudson/cli/handlers/package-info.java
+++ b/core/src/main/java/hudson/cli/handlers/package-info.java
@@ -2,4 +2,3 @@
  * {@link org.kohsuke.args4j.spi.OptionHandler} implementations for Hudson.
  */
 package hudson.cli.handlers;
-

--- a/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
@@ -131,4 +131,3 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
         return Messages.ReverseProxySetupMonitor_DisplayName();
     }
 }
-

--- a/core/src/main/java/hudson/init/package-info.java
+++ b/core/src/main/java/hudson/init/package-info.java
@@ -43,4 +43,3 @@
  * </ol>
  */
 package hudson.init;
-

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -1407,4 +1407,3 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
 
     private static final Logger LOGGER = Logger.getLogger(AbstractBuild.class.getName());
 }
-

--- a/core/src/main/java/hudson/model/BuildableItemWithBuildWrappers.java
+++ b/core/src/main/java/hudson/model/BuildableItemWithBuildWrappers.java
@@ -29,4 +29,3 @@ public interface BuildableItemWithBuildWrappers extends BuildableItem {
      */
     DescribableList<BuildWrapper,Descriptor<BuildWrapper>> getBuildWrappersList();
 }
-

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -495,4 +495,3 @@ public class DownloadService {
      */
     public static boolean signatureCheck = !SystemProperties.getBoolean(DownloadService.class.getName()+".noSignatureCheck");
 }
-

--- a/core/src/main/java/hudson/model/ResourceController.java
+++ b/core/src/main/java/hudson/model/ResourceController.java
@@ -193,4 +193,3 @@ public class ResourceController {
         }
     }
 }
-

--- a/core/src/main/java/hudson/model/TaskAction.java
+++ b/core/src/main/java/hudson/model/TaskAction.java
@@ -147,4 +147,3 @@ public abstract class TaskAction extends AbstractModelObject implements Action {
         rsp.sendRedirect(".");
     }
 }
-

--- a/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
+++ b/core/src/main/java/hudson/org/apache/tools/tar/TarOutputStream.java
@@ -368,5 +368,3 @@ public class TarOutputStream extends FilterOutputStream {
         this.buffer.writeRecord(this.recordBuf);
     }
 }
-
-

--- a/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
+++ b/core/src/main/java/hudson/slaves/CloudProvisioningListener.java
@@ -139,4 +139,3 @@ public abstract class CloudProvisioningListener implements ExtensionPoint {
     }
 
 }
-

--- a/core/src/main/java/hudson/tasks/BuildWrapperDescriptor.java
+++ b/core/src/main/java/hudson/tasks/BuildWrapperDescriptor.java
@@ -58,4 +58,3 @@ public abstract class BuildWrapperDescriptor extends Descriptor<BuildWrapper> {
      */
     public abstract boolean isApplicable(AbstractProject<?,?> item);
 }
-

--- a/core/src/main/java/hudson/tasks/_maven/MavenErrorNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenErrorNote.java
@@ -55,4 +55,3 @@ public class MavenErrorNote extends ConsoleNote {
 
     public static final Pattern PATTERN = Pattern.compile("^\\[ERROR\\]");
 }
-

--- a/core/src/main/java/hudson/tools/ToolPropertyDescriptor.java
+++ b/core/src/main/java/hudson/tools/ToolPropertyDescriptor.java
@@ -43,4 +43,3 @@ public abstract class ToolPropertyDescriptor extends PropertyDescriptor<ToolProp
     protected ToolPropertyDescriptor() {
     }
 }
-

--- a/core/src/main/java/hudson/util/AWTProblem.java
+++ b/core/src/main/java/hudson/util/AWTProblem.java
@@ -38,4 +38,3 @@ public class AWTProblem extends BootFailure {
         this.cause = cause;
     }
 }
-

--- a/core/src/main/java/hudson/util/CompoundEnumeration.java
+++ b/core/src/main/java/hudson/util/CompoundEnumeration.java
@@ -36,4 +36,3 @@ public class CompoundEnumeration<T> implements Enumeration<T> {
         return cur.nextElement();
     }
 }
-

--- a/core/src/main/java/hudson/util/FlushProofOutputStream.java
+++ b/core/src/main/java/hudson/util/FlushProofOutputStream.java
@@ -17,4 +17,3 @@ public class FlushProofOutputStream extends DelegatingOutputStream {
     public void flush() throws IOException {
     }
 }
-

--- a/core/src/main/java/hudson/util/LineEndingConversion.java
+++ b/core/src/main/java/hudson/util/LineEndingConversion.java
@@ -63,4 +63,3 @@ public class LineEndingConversion {
         return input;
     }
 }
-

--- a/core/src/main/java/hudson/util/PersistedList.java
+++ b/core/src/main/java/hudson/util/PersistedList.java
@@ -300,4 +300,3 @@ public class PersistedList<T> extends AbstractList<T> {
         }
     }
 }
-

--- a/core/src/main/java/hudson/views/GlobalDefaultViewConfiguration.java
+++ b/core/src/main/java/hudson/views/GlobalDefaultViewConfiguration.java
@@ -57,5 +57,3 @@ public class GlobalDefaultViewConfiguration extends GlobalConfiguration {
         return true;
     }
 }
-
-

--- a/core/src/main/java/jenkins/model/Configuration.java
+++ b/core/src/main/java/jenkins/model/Configuration.java
@@ -44,4 +44,3 @@ public class Configuration {
         return (value==null)?defaultValue:value;
     }
 }
-

--- a/core/src/main/java/jenkins/model/MasterBuildConfiguration.java
+++ b/core/src/main/java/jenkins/model/MasterBuildConfiguration.java
@@ -70,4 +70,3 @@ public class MasterBuildConfiguration extends GlobalConfiguration {
         }
     }
 }
-

--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -51,4 +51,3 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
         return jenkins.hasPermission(Jenkins.ADMINISTER) && jenkins.isUseSecurity();
     }
 }
-

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -225,4 +225,3 @@ public class IsOverriddenTest {
 
 
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,6 @@ THE SOFTWARE.
             <!-- define here because checkstyle and multi module is a PITA -->
             <checkstyleRules>
               <module name="Checker">
-                <module name="NewlineAtEndOfFile" />
                 <module name="UniqueProperties" />
                 <module name="TreeWalker">
                   <!--
@@ -521,6 +520,7 @@ THE SOFTWARE.
           <version>${spotless.version}</version>
           <configuration>
             <java>
+              <endWithNewline />
               <removeUnusedImports />
             </java>
           </configuration>

--- a/test/src/test/java/hudson/triggers/TriggerTest.java
+++ b/test/src/test/java/hudson/triggers/TriggerTest.java
@@ -87,5 +87,3 @@ public class TriggerTest {
         }
     }
 }
-
-

--- a/test/src/test/java/jenkins/security/SpySecurityListener.java
+++ b/test/src/test/java/jenkins/security/SpySecurityListener.java
@@ -111,4 +111,3 @@ public abstract class SpySecurityListener extends SecurityListener {
         }
     }
 }
-


### PR DESCRIPTION
Using [Checkstyle](https://checkstyle.sourceforge.io/) to ensure that there is a newline at the end of each file is not ideal because Checkstyle offers no way to automatically fix violations. In contrast, [Spotless](https://github.com/diffplug/spotless) offers both a `check` goal to report violations as well as an `apply` goal to automatically fix all violations, which is far more convenient.

In this PR we disable the [`NewlineAtEndOfFile`](https://checkstyle.sourceforge.io/config_misc.html#NewlineAtEndOfFile) Checkstyle check and replace it with the `endWithNewline` Spotless check. The Spotless `check` goal runs in the `verify` phase by default and fails if there are any violations. The developer can then run `mvn spotless:apply`, which automatically fixes all violations.

Note that while the Checkstyle version of this check enforced that there were one or more newlines at the end of each file, the Spotless version enforces that there is exactly one newline at the end of each file. So this contains a few changes to remove duplicate newlines as well.