### PR TITLE
Show implied plugin dependencies

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -1071,6 +1071,27 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     }
 
     /**
+     * Get list of implied dependencies.
+     * @since TODO
+     */
+    @Restricted(NoExternalUse.class)
+    public @NonNull Set<String> getImpliedDependents() {
+        if (!isDetached()) {
+            return Collections.emptySet();
+        }
+
+        Set<String> implied = new HashSet<>();
+        for (PluginWrapper p : Jenkins.get().getPluginManager().getPlugins()) {
+            for (Dependency dependency : DetachedPluginsUtil.getImpliedDependencies(p.shortName, p.getRequiredCoreVersion())) {
+                if (dependency.shortName.equals(shortName)) {
+                    implied.add(p.shortName);
+                }
+            }
+        }
+        return implied;
+    }
+
+    /**
      * Sort by short name.
      */
     @Override

--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -258,43 +258,16 @@ Behaviour.specify("#filter-box", '_table', 0, function(e) {
                         pluginTR.addClassName('all-dependents-disabled');
                         return false;
                     }
-                    
-                    var dependentsDiv = pluginMetadata.dependentsDiv;
-                    var dependentSpans = pluginMetadata.dependents;
 
                     infoContainer.update('<div class="title">' + i18n('cannot-disable') + '</div><div class="subtitle">' + i18n('enabled-dependents') + '.</div>');
-                    
-                    // Go through each dependent <span> element. Show the spans where the dependent is
-                    // enabled. Hide the others. 
-                    for (var i = 0; i < dependentSpans.length; i++) {
-                        var dependentSpan = dependentSpans[i];
-                        var dependentId = dependentSpan.getAttribute('data-plugin-id');
-                        
-                        if (dependentId === 'jenkins-core') {
-                            // show the span
-                            dependentSpan.setStyle({display: 'inline-block'});
-                        } else {
-                            var depPluginTR = getPluginTR(dependentId);
-                            var depPluginMetadata = depPluginTR.jenkinsPluginMetadata;
-                            if (depPluginMetadata.enableInput.checked) {
-                                // It's enabled ... show the span
-                                dependentSpan.setStyle({display: 'inline-block'});
-                            } else {
-                                // It's disabled ... hide the span
-                                dependentSpan.setStyle({display: 'none'});
-                            }
-                        }
-                    }
-                    
-                    dependentsDiv.setStyle({display: 'inherit'});
-                    infoContainer.appendChild(dependentsDiv);
-
+                    infoContainer.appendChild(getDependentsDiv(pluginTR, true));
                     return true;
                 }
             }
 
             if (pluginTR.hasClassName('possibly-has-implied-dependents')) {
                 infoContainer.update('<div class="title">' + i18n('detached-disable') + '</div><div class="subtitle">' + i18n('detached-possible-dependents') + '</div>');
+                infoContainer.appendChild(getDependentsDiv(pluginTR, true));
                 return true;
             }
             
@@ -307,30 +280,48 @@ Behaviour.specify("#filter-box", '_table', 0, function(e) {
             infoContainer.addClassName('uninstall-state-info');
 
             if (pluginTR.hasClassName('has-dependents')) {
-                var pluginMetadata = pluginTR.jenkinsPluginMetadata;
-                var dependentsDiv = pluginMetadata.dependentsDiv;
-                var dependentSpans = pluginMetadata.dependents;
-
                 infoContainer.update('<div class="title">' + i18n('cannot-uninstall') + '</div><div class="subtitle">' + i18n('installed-dependents') + '.</div>');
-                
-                // Go through each dependent <span> element. Show them all. 
-                for (var i = 0; i < dependentSpans.length; i++) {
-                    var dependentSpan = dependentSpans[i];
-                    dependentSpan.setStyle({display: 'inline-block'});
-                }
-                
-                dependentsDiv.setStyle({display: 'inherit'});
-                infoContainer.appendChild(dependentsDiv);
-                
+                infoContainer.appendChild(getDependentsDiv(pluginTR, false));
                 return true;
             }
-            
+
             if (pluginTR.hasClassName('possibly-has-implied-dependents')) {
                 infoContainer.update('<div class="title">' + i18n('detached-uninstall') + '</div><div class="subtitle">' + i18n('detached-possible-dependents') + '</div>');
+                infoContainer.appendChild(getDependentsDiv(pluginTR, false));
                 return true;
             }
 
             return false;
+        }
+
+        function getDependentsDiv(pluginTR, hideDisabled) {
+            var pluginMetadata = pluginTR.jenkinsPluginMetadata;
+            var dependentsDiv = pluginMetadata.dependentsDiv;
+            var dependentSpans = pluginMetadata.dependents;
+
+            // Go through each dependent <span> element. If disabled should be hidden, show the spans where
+            // the dependent is enabled and hide the others. Otherwise show them all.
+            for (var i = 0; i < dependentSpans.length; i++) {
+                var dependentSpan = dependentSpans[i];
+                var dependentId = dependentSpan.getAttribute('data-plugin-id');
+
+                if (!hideDisabled || dependentId === 'jenkins-core') {
+                    dependentSpan.setStyle({display: 'inline-block'});
+                } else {
+                    var depPluginTR = getPluginTR(dependentId);
+                    var depPluginMetadata = depPluginTR.jenkinsPluginMetadata;
+                    if (depPluginMetadata.enableInput.checked) {
+                        // It's enabled ... show the span
+                        dependentSpan.setStyle({display: 'inline-block'});
+                    } else {
+                        // It's disabled ... hide the span
+                        dependentSpan.setStyle({display: 'none'});
+                    }
+                }
+            }
+
+            dependentsDiv.setStyle({display: 'inherit'});
+            return dependentsDiv;
         }
 
         function initPluginRowHandling(pluginTR) {

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -154,7 +154,7 @@ THE SOFTWARE.
                     </j:if>
                   </td>
                   <j:choose>
-                      <j:when test="${p.hasMandatoryDependents() or p.hasMandatoryDependents()}">
+                      <j:when test="${p.hasMandatoryDependents()}">
                             <j:set var="uninstallPossible" value="true"/>
                       </j:when>
                       <j:otherwise>
@@ -167,11 +167,22 @@ THE SOFTWARE.
                         <p>${%Uninstallation pending}</p>
                       </j:when>
                       <j:otherwise>
-                          <j:if test="${p.hasMandatoryDependents()}">
+                          <j:if test="${p.hasMandatoryDependents() or p.hasImpliedDependents()}">
                             <div class="dependent-list">
                               <j:forEach var="dependent" items="${p.mandatoryDependents}">
                                 <span data-plugin-id="${dependent}"></span>
                               </j:forEach>
+                              <j:set var="impliedDependents" value="${p.impliedDependents}" />
+                              <j:choose>
+                                <j:when test="${impliedDependents.size() lt 15}">
+                                  <j:forEach var="dependent" items="${impliedDependents}">
+                                    <span data-plugin-id="${dependent}"></span>
+                                  </j:forEach>
+                                </j:when>
+                                <j:otherwise>
+                                  <p>${%detached-many-dependents(impliedDependents.size())}</p>
+                                </j:otherwise>
+                              </j:choose>
                             </div>
                           </j:if>
                           <j:if test="${p.hasMandatoryDependencies()}">

--- a/core/src/main/resources/hudson/PluginManager/installed.properties
+++ b/core/src/main/resources/hudson/PluginManager/installed.properties
@@ -24,6 +24,7 @@ requires.restart=This Jenkins instance requires a restart. Changing the state of
 detached-disable=This plugin may not be safe to disable
 detached-uninstall=This plugin may not be safe to uninstall
 detached-possible-dependents=Its functionality was at one point moved out of Jenkins core, and another plugin with a core dependency predating the split may be relying on it implicitly.
+detached-many-dependents=There are still {0} plugins with an implied dependency installed.
 deprecationWarning=<strong>This plugin is deprecated.</strong> In general, this means that it is either obsolete, no longer being developed, or may no longer work. <a href="{0}" rel="noopener noreferrer" target="_blank">Learn more.</a>
 securityWarning=\
   Warning: The currently installed plugin version may not be safe to use. Please review the following security notices:

--- a/core/src/main/resources/hudson/PluginManager/installed.properties
+++ b/core/src/main/resources/hudson/PluginManager/installed.properties
@@ -24,7 +24,7 @@ requires.restart=This Jenkins instance requires a restart. Changing the state of
 detached-disable=This plugin may not be safe to disable
 detached-uninstall=This plugin may not be safe to uninstall
 detached-possible-dependents=Its functionality was at one point moved out of Jenkins core, and another plugin with a core dependency predating the split may be relying on it implicitly.
-detached-many-dependents=There are still {0} plugins with an implied dependency installed.
+detached-many-dependents=There are {0} plugins with an implied dependency installed.
 deprecationWarning=<strong>This plugin is deprecated.</strong> In general, this means that it is either obsolete, no longer being developed, or may no longer work. <a href="{0}" rel="noopener noreferrer" target="_blank">Learn more.</a>
 securityWarning=\
   Warning: The currently installed plugin version may not be safe to use. Please review the following security notices:


### PR DESCRIPTION
This is a minor change in the presentation of the warning message when the admin tries to disable/uninstall a plugin which was split from core and might still be required by another plugin.

Screenshots (before/after):

Disable:
![before](https://user-images.githubusercontent.com/78534/117545319-89604b80-b025-11eb-925b-a1d72d9bd857.png)
![after_disable_trilead](https://user-images.githubusercontent.com/78534/117545586-b5300100-b026-11eb-8a9f-eb702d7ef6c6.png)

Uninstall:
![before](https://user-images.githubusercontent.com/78534/117545339-a137cf80-b025-11eb-82a9-48ddf0e017ec.png)
![after](https://user-images.githubusercontent.com/78534/117545342-a4cb5680-b025-11eb-9a3b-b6975d850e1b.png)


### Proposed changelog entries

* In the plugin manager, show which plugins keep a plugin that was split from core installed.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
