### PR TITLE
Deprecate `LinesStream` in favor of `Stream<String>`

### DIFF
--- a/core/src/main/java/hudson/util/TextFile.java
+++ b/core/src/main/java/hudson/util/TextFile.java
@@ -40,6 +40,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
 
 /**
  * Represents a text file.
@@ -83,7 +84,7 @@ public class TextFile {
     /**
      * @throws RuntimeException in the case of {@link IOException} in {@link #linesStream()}
      * @deprecated This method does not properly propagate errors and may lead to file descriptor leaks
-     *             if the collection is not fully iterated. Use {@link #linesStream()} instead.
+     *             if the collection is not fully iterated. Use {@link #lines2()} instead.
      */
     @Deprecated
     public @NonNull Iterable<String> lines() {
@@ -95,6 +96,21 @@ public class TextFile {
     }
 
     /**
+     * Read all lines from the file as a {@link Stream}. Bytes from the file are decoded into
+     * characters using the {@link StandardCharsets#UTF_8 UTF-8} {@link Charset charset}. If timely
+     * disposal of file system resources is required, the try-with-resources construct should be
+     * used to ensure that {@link Stream#close()} is invoked after the stream operations are
+     * completed.
+     *
+     * @return the lines from the file as a {@link Stream}
+     * @throws IOException if an I/O error occurs opening the file
+     */
+    @NonNull
+    public Stream<String> lines2() throws IOException {
+        return Files.lines(Util.fileToPath(file));
+    }
+
+    /**
      * Creates a new {@link jenkins.util.io.LinesStream} of the file.
      * <p>
      * Note: The caller is responsible for closing the returned
@@ -102,8 +118,10 @@ public class TextFile {
      * @throws IOException if the file cannot be converted to a
      * {@link java.nio.file.Path} or if the file cannot be opened for reading
      * @since 2.111
+     * @deprecated use {@link #lines2}
      */
     @CreatesObligation
+    @Deprecated
     public @NonNull LinesStream linesStream() throws IOException {
         return new LinesStream(Util.fileToPath(file));
     }

--- a/core/src/main/java/jenkins/security/s2m/ConfigFile.java
+++ b/core/src/main/java/jenkins/security/s2m/ConfigFile.java
@@ -3,13 +3,13 @@ package jenkins.security.s2m;
 import hudson.CopyOnWrite;
 import hudson.util.TextFile;
 import jenkins.model.Jenkins;
-import jenkins.util.io.LinesStream;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Abstraction of a line-by-line configuration text file that gets parsed into some in-memory data form.
@@ -56,13 +56,13 @@ abstract class ConfigFile<T,COL extends Collection<T>> extends TextFile {
         COL result = create();
 
         if (exists()) {
-            try (LinesStream stream = linesStream()) {
-                for (String line : stream) {
-                    if (line.startsWith("#")) continue;   // comment
+            try (Stream<String> stream = lines2()) {
+                stream.forEach(line -> {
+                    if (line.startsWith("#")) return;   // comment
                     T r = parse(line);
                     if (r != null)
                         result.add(r);
-                }
+                });
             }
         }
 

--- a/core/src/main/java/jenkins/util/io/LinesStream.java
+++ b/core/src/main/java/jenkins/util/io/LinesStream.java
@@ -59,7 +59,9 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * {@link IllegalStateException}.
  *
  * @since 2.111
+ * @deprecated use {@link Files#lines(Path)}
  */
+@Deprecated
 @CleanupObligation
 public class LinesStream implements Closeable, Iterable<String> {
 


### PR DESCRIPTION
#3211 introduced a `LinesStream` and a corresponding `TextFile#linesStream()` method that produces it. This seems redundant, since Java already has `File#lines` which produces `Stream<String>`. This change deprecates our custom functionality in favor of the standard paradigm. There was only one consumer that had to be migrated.