### PR TITLE
Fixes JENKINS-45124. findFormItem() now finds the first checked radio button of a given name.

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -427,16 +427,24 @@ function findNext(src,filter) {
     });
 }
 
-function findFormItem(src,name,directionF) {
-    var name2 = "_."+name; // handles <textbox field="..." /> notation silently
-    return directionF(src,function(e){ 
-        if (e.tagName == "INPUT" && e.type=="radio" && e.checked==true) {
-            var r = 0;
-            while (e.name.substring(r,r+8)=='removeme') //radio buttons have must be unique in repeatable blocks so name is prefixed
-                r = e.name.indexOf('_',r+8)+1;
-            return name == e.name.substring(r);
+function findFormItem(src, name, directionF) {
+    return directionF(src, function(e) {
+        if (e.tagName == "INPUT" && e.type == "radio") {
+            if (e.checked) {
+                var r = 0;
+                // Radio buttons have must be unique in repeatable blocks so name is prefixed
+                while (e.name.substring(r, r + 8) == "removeme") {
+                    r = e.name.indexOf("_" , r + 8) + 1;
+                }
+                return name == e.name.substring(r);
+            }
+            return false
+        } else {
+            var name2 = "_." + name;  // Handles <textbox field="..." /> notation silently
+            return (e.tagName == "INPUT" || e.tagName == "TEXTAREA" || e.tagName == "SELECT") &&
+                   (e.name == name || e.name == name2);
         }
-        return (e.tagName=="INPUT" || e.tagName=="TEXTAREA" || e.tagName=="SELECT") && (e.name==name || e.name==name2); });
+    });
 }
 
 /**


### PR DESCRIPTION
Fixes [JENKINS-45124](https://issues.jenkins.io/browse/JENKINS-45124): Value of radioBlock passed weird through @QueryParameter.

Previously, `findFormItem()` found the first radio button of the name regardless of whether it's checked. This means that a form validate button that takes `@QueryParameter` will always get the value of the first radio button seen, making it wrong and useless.