### PR TITLE
Remove usages of deprecated (in Java 9 and above) `Class#newInstance`

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -31,6 +31,7 @@ import hudson.util.CyclicGraphDetector;
 import hudson.util.CyclicGraphDetector.CycleDetectedException;
 import hudson.util.IOUtils;
 import hudson.util.MaskingClassLoader;
+import java.lang.reflect.InvocationTargetException;
 import jenkins.ClassLoaderReflectionToolkit;
 import jenkins.ExtensionFilter;
 import jenkins.plugins.DetachedPluginsUtil;
@@ -379,14 +380,14 @@ public class ClassicPluginStrategy implements PluginStrategy {
             } else {
                 try {
                     Class<?> clazz = wrapper.classLoader.loadClass(className);
-                    Object o = clazz.newInstance();
+                    Object o = clazz.getDeclaredConstructor().newInstance();
                     if(!(o instanceof Plugin)) {
                         throw new IOException(className+" doesn't extend from hudson.Plugin");
                     }
                     wrapper.setPlugin((Plugin) o);
                 } catch (LinkageError | ClassNotFoundException e) {
                     throw new IOException("Unable to load " + className + " from " + wrapper.getShortName(),e);
-                } catch (IllegalAccessException | InstantiationException e) {
+                } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
                     throw new IOException("Unable to create instance of " + className + " from " + wrapper.getShortName(),e);
                 }
             }

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -40,6 +40,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.util.List;
@@ -481,9 +482,9 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
      */
     protected CLICommand createClone() {
         try {
-            return getClass().newInstance();
-        } catch (IllegalAccessException | InstantiationException e) {
-            throw new AssertionError(e);
+            return getClass().getDeclaredConstructor().newInstance();
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 

--- a/core/src/main/java/hudson/cli/Connection.java
+++ b/core/src/main/java/hudson/cli/Connection.java
@@ -268,7 +268,7 @@ public class Connection {
 
             return spk;
         } catch (ClassNotFoundException e) {
-            throw new LinkageError(e.getMessage(), e); // impossible
+            throw new AssertionError(e); // impossible
         }
     }
 

--- a/core/src/main/java/hudson/cli/Connection.java
+++ b/core/src/main/java/hudson/cli/Connection.java
@@ -268,7 +268,7 @@ public class Connection {
 
             return spk;
         } catch (ClassNotFoundException e) {
-            throw new Error(e); // impossible
+            throw new LinkageError(e.getMessage(), e); // impossible
         }
     }
 

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -25,6 +25,7 @@ package hudson.lifecycle;
 
 import hudson.ExtensionPoint;
 import hudson.Functions;
+import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import jenkins.util.SystemProperties;
 import hudson.Util;
@@ -81,7 +82,18 @@ public abstract class Lifecycle implements ExtensionPoint {
                     x.initCause(e);
                     throw x;
                 } catch (InvocationTargetException e) {
-                    throw new LinkageError(e.getMessage(), e);
+                    Throwable t = e.getCause();
+                    if (t instanceof RuntimeException) {
+                        throw (RuntimeException) t;
+                    } else if (t instanceof IOException) {
+                        throw new UncheckedIOException((IOException) t);
+                    } else if (t instanceof Exception) {
+                        throw new RuntimeException(t);
+                    } else if (t instanceof Error) {
+                        throw (Error) t;
+                    } else {
+                        throw new Error(e);
+                    }
                 }
             } else {
                 if(Functions.isWindows()) {

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -25,6 +25,7 @@ package hudson.lifecycle;
 
 import hudson.ExtensionPoint;
 import hudson.Functions;
+import java.lang.reflect.InvocationTargetException;
 import jenkins.util.SystemProperties;
 import hudson.Util;
 import jenkins.model.Jenkins;
@@ -62,7 +63,11 @@ public abstract class Lifecycle implements ExtensionPoint {
             if(p!=null) {
                 try {
                     ClassLoader cl = Jenkins.get().getPluginManager().uberClassLoader;
-                    instance = (Lifecycle)cl.loadClass(p).newInstance();
+                    instance = (Lifecycle)cl.loadClass(p).getDeclaredConstructor().newInstance();
+                } catch (NoSuchMethodException e) {
+                    NoSuchMethodError x = new NoSuchMethodError(e.getMessage());
+                    x.initCause(e);
+                    throw x;
                 } catch (InstantiationException e) {
                     InstantiationError x = new InstantiationError(e.getMessage());
                     x.initCause(e);
@@ -75,6 +80,8 @@ public abstract class Lifecycle implements ExtensionPoint {
                     NoClassDefFoundError x = new NoClassDefFoundError(e.getMessage());
                     x.initCause(e);
                     throw x;
+                } catch (InvocationTargetException e) {
+                    throw new LinkageError(e.getMessage(), e);
                 }
             } else {
                 if(Functions.isWindows()) {

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -37,6 +37,7 @@ import hudson.triggers.SafeTimerTask;
 import hudson.util.DescribableList;
 import hudson.util.FormApply;
 import hudson.util.FormValidation;
+import java.lang.reflect.InvocationTargetException;
 import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ModelObjectWithContextMenu.ContextMenu;
@@ -474,10 +475,10 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
     private static NodeMonitor createDefaultInstance(Descriptor<NodeMonitor> d, boolean ignored) {
         try {
-            NodeMonitor nm = d.clazz.newInstance();
+            NodeMonitor nm = d.clazz.getDeclaredConstructor().newInstance();
             nm.setIgnored(ignored);
             return nm;
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
             LOGGER.log(Level.SEVERE, "Failed to instantiate "+d.clazz,e);
         }
         return null;

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -37,6 +37,7 @@ import hudson.util.FormValidation.CheckMethod;
 import hudson.util.ReflectionUtils;
 import hudson.util.ReflectionUtils.Parameter;
 import hudson.views.ListViewColumn;
+import java.lang.reflect.InvocationTargetException;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
@@ -589,7 +590,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
             } else {
                 if (req==null) {
                     // yes, req is supposed to be always non-null, but see the note above
-                    return verifyNewInstance(clazz.newInstance());
+                    return verifyNewInstance(clazz.getDeclaredConstructor().newInstance());
                 }
 
                 // new behavior as of 1.206
@@ -608,10 +609,8 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
                     req.setBindInterceptor(oldInterceptor);
                 }
             }
-        } catch (NoSuchMethodException e) {
-            throw new AssertionError(e); // impossible
-        } catch (InstantiationException | IllegalAccessException | RuntimeException e) {
-            throw new Error("Failed to instantiate "+clazz+" from "+RedactSecretJsonInErrorMessageSanitizer.INSTANCE.sanitize(formData),e);
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException | RuntimeException e) {
+            throw new LinkageError("Failed to instantiate "+clazz+" from "+RedactSecretJsonInErrorMessageSanitizer.INSTANCE.sanitize(formData),e);
         }
     }
 

--- a/core/src/main/java/hudson/util/DescribableList.java
+++ b/core/src/main/java/hudson/util/DescribableList.java
@@ -31,6 +31,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.Mapper;
 import hudson.model.AbstractProject;
+import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import jenkins.model.DependencyDeclarer;
 import hudson.model.DependencyGraph;
@@ -293,7 +294,18 @@ public class DescribableList<T extends Describable<T>, D extends Descriptor<T>> 
                 x.initCause(e);
                 throw x;
             } catch (InvocationTargetException e) {
-                throw new LinkageError(e.getMessage(), e);
+                Throwable t = e.getCause();
+                if (t instanceof RuntimeException) {
+                    throw (RuntimeException) t;
+                } else if (t instanceof IOException) {
+                    throw new UncheckedIOException((IOException) t);
+                } else if (t instanceof Exception) {
+                    throw new RuntimeException(t);
+                } else if (t instanceof Error) {
+                    throw (Error) t;
+                } else {
+                    throw new Error(e);
+                }
             }
         }
     }

--- a/core/src/main/java/hudson/util/DescribableList.java
+++ b/core/src/main/java/hudson/util/DescribableList.java
@@ -31,6 +31,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.Mapper;
 import hudson.model.AbstractProject;
+import java.lang.reflect.InvocationTargetException;
 import jenkins.model.DependencyDeclarer;
 import hudson.model.DependencyGraph;
 import hudson.model.Describable;
@@ -275,10 +276,14 @@ public class DescribableList<T extends Describable<T>, D extends Descriptor<T>> 
         @Override
         public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
             try {
-                DescribableList r = (DescribableList) context.getRequiredType().asSubclass(DescribableList.class).newInstance();
+                DescribableList r = (DescribableList) context.getRequiredType().asSubclass(DescribableList.class).getDeclaredConstructor().newInstance();
                 CopyOnWriteList core = copyOnWriteListConverter.unmarshal(reader, context);
                 r.data.replaceBy(core);
                 return r;
+            } catch (NoSuchMethodException e) {
+                NoSuchMethodError x = new NoSuchMethodError();
+                x.initCause(e);
+                throw x;
             } catch (InstantiationException e) {
                 InstantiationError x = new InstantiationError();
                 x.initCause(e);
@@ -287,6 +292,8 @@ public class DescribableList<T extends Describable<T>, D extends Descriptor<T>> 
                 IllegalAccessError x = new IllegalAccessError();
                 x.initCause(e);
                 throw x;
+            } catch (InvocationTargetException e) {
+                throw new LinkageError(e.getMessage(), e);
             }
         }
     }

--- a/core/src/main/java/hudson/util/DescriptorList.java
+++ b/core/src/main/java/hudson/util/DescriptorList.java
@@ -212,7 +212,7 @@ public final class DescriptorList<T extends Describable<T>> extends AbstractList
         try {
             Class.forName(c.getName(), true, c.getClassLoader());
         } catch (ClassNotFoundException e) {
-            throw new LinkageError(e.getMessage(), e);  // Can't happen
+            throw new AssertionError(e);  // Can't happen
         }
     }
 

--- a/core/src/main/java/hudson/util/DescriptorList.java
+++ b/core/src/main/java/hudson/util/DescriptorList.java
@@ -212,7 +212,7 @@ public final class DescriptorList<T extends Describable<T>> extends AbstractList
         try {
             Class.forName(c.getName(), true, c.getClassLoader());
         } catch (ClassNotFoundException e) {
-            throw new AssertionError(e);  // Can't happen
+            throw new LinkageError(e.getMessage(), e);  // Can't happen
         }
     }
 

--- a/core/src/main/java/hudson/util/PersistedList.java
+++ b/core/src/main/java/hudson/util/PersistedList.java
@@ -35,6 +35,7 @@ import hudson.model.Describable;
 import hudson.model.Saveable;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -287,9 +288,13 @@ public class PersistedList<T> extends AbstractList<T> {
             CopyOnWriteList core = copyOnWriteListConverter.unmarshal(reader, context);
 
             try {
-                PersistedList r = (PersistedList)context.getRequiredType().newInstance();
+                PersistedList r = (PersistedList)context.getRequiredType().getDeclaredConstructor().newInstance();
                 r.data.replaceBy(core);
                 return r;
+            } catch (NoSuchMethodException e) {
+                NoSuchMethodError x = new NoSuchMethodError();
+                x.initCause(e);
+                throw x;
             } catch (InstantiationException e) {
                 InstantiationError x = new InstantiationError();
                 x.initCause(e);
@@ -298,6 +303,8 @@ public class PersistedList<T> extends AbstractList<T> {
                 IllegalAccessError x = new IllegalAccessError();
                 x.initCause(e);
                 throw x;
+            } catch (InvocationTargetException e) {
+                throw new LinkageError(e.getMessage(), e);
             }
         }
     }

--- a/core/src/main/java/hudson/util/PersistedList.java
+++ b/core/src/main/java/hudson/util/PersistedList.java
@@ -35,6 +35,7 @@ import hudson.model.Describable;
 import hudson.model.Saveable;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -304,7 +305,18 @@ public class PersistedList<T> extends AbstractList<T> {
                 x.initCause(e);
                 throw x;
             } catch (InvocationTargetException e) {
-                throw new LinkageError(e.getMessage(), e);
+                Throwable t = e.getCause();
+                if (t instanceof RuntimeException) {
+                    throw (RuntimeException) t;
+                } else if (t instanceof IOException) {
+                    throw new UncheckedIOException((IOException) t);
+                } else if (t instanceof Exception) {
+                    throw new RuntimeException(t);
+                } else if (t instanceof Error) {
+                    throw (Error) t;
+                } else {
+                    throw new Error(e);
+                }
             }
         }
     }

--- a/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
+++ b/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
@@ -31,7 +31,7 @@ public class ClassLoaderReflectionToolkit {
         try {
             return method.invoke(obj, args);
         } catch (IllegalAccessException x) {
-            throw new AssertionError(x);
+            throw new LinkageError(x.getMessage(), x);
         } catch (InvocationTargetException x) {
             Throwable x2 = x.getCause();
             if (x2 instanceof RuntimeException) {
@@ -193,7 +193,7 @@ public class ClassLoaderReflectionToolkit {
         try {
             return (Class)FindLoadedClass.FIND_LOADED_CLASS.invoke(cl,name);
         } catch (IllegalAccessException e) {
-            throw new Error(e);
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 
@@ -203,7 +203,7 @@ public class ClassLoaderReflectionToolkit {
         try {
             return (Class)FindClass.FIND_CLASS.invoke(cl,name);
         } catch (IllegalAccessException e) {
-            throw new Error(e);
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 
@@ -213,7 +213,7 @@ public class ClassLoaderReflectionToolkit {
         try {
             return (URL)FindResource.FIND_RESOURCE.invoke(cl,name);
         } catch (IllegalAccessException e) {
-            throw new Error(e);
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 
@@ -223,7 +223,7 @@ public class ClassLoaderReflectionToolkit {
         try {
             return (Enumeration<URL>)FindResources.FIND_RESOURCES.invoke(cl,name);
         } catch (IllegalAccessException e) {
-            throw new Error(e);
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -165,7 +165,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT,RunT> & Queue.Task & 
         try {
             return getBuildClass().getConstructor(asJob().getClass(), File.class).newInstance(asJob(), dir);
         } catch (InstantiationException | NoSuchMethodException | IllegalAccessException e) {
-            throw new Error(e);
+            throw new LinkageError(e.getMessage(), e);
         } catch (InvocationTargetException e) {
             throw handleInvocationTargetException(e);
         }
@@ -187,7 +187,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT,RunT> & Queue.Task & 
             throw handleInvocationTargetException(e);
         } catch (ReflectiveOperationException | IllegalStateException e) {
             LOGGER.log(Level.WARNING, String.format("A new build could not be created in job %s", asJob().getFullName()), e);
-            throw new Error(e);
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 

--- a/core/src/main/java/jenkins/util/AntWithFindResourceClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntWithFindResourceClassLoader.java
@@ -23,7 +23,7 @@ public class AntWithFindResourceClassLoader extends AntClassLoader implements Cl
             $pathComponents.setAccessible(true);
             pathComponents = (ArrayList<File>)$pathComponents.get(this);
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new Error(e);
+            throw new LinkageError(e.getMessage(), e);
         }
     }
 

--- a/core/src/test/java/hudson/util/SubClassGeneratorTest.java
+++ b/core/src/test/java/hudson/util/SubClassGeneratorTest.java
@@ -49,7 +49,7 @@ public class SubClassGeneratorTest {
         Class<? extends Foo> c = new SubClassGenerator(getClass().getClassLoader()).generate(Foo.class, "12345");
         assertEquals("12345",c.getName());
 
-        c.newInstance();
+        c.getDeclaredConstructor().newInstance();
 
         Foo f = c.getConstructor(String.class).newInstance("aaa");
         assertEquals("aaa",f.s);

--- a/test/src/test/java/hudson/tools/ZipExtractionInstallerTest.java
+++ b/test/src/test/java/hudson/tools/ZipExtractionInstallerTest.java
@@ -160,7 +160,7 @@ public class ZipExtractionInstallerTest {
                         }
                     }
                 } catch (NoSuchFieldException | IllegalAccessException e) {
-                    e.printStackTrace();
+                    throw new LinkageError(e.getMessage(), e);
                 }
             }
             return super.callFunction(page, function, scope, thisObject, args);


### PR DESCRIPTION
### Problem

The documentation for [`Class#newInstance`](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#newInstance--) includes the following warning:

> Note that this method propagates any exception thrown by the nullary constructor, including a checked exception. Use of this method effectively bypasses the compile-time exception checking that would otherwise be performed by the compiler. The [`Constructor#newInstance`](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Constructor.html#newInstance-java.lang.Object...-) method avoids this problem by wrapping any exception thrown by the constructor in a (checked) [`InvocationTargetException`](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/InvocationTargetException.html).

For this reason, the `Class#newInstance` method has been deprecated in Java 9 and above.

### Solution

We should always prefer `myClass.getConstructor().newInstance()` to calling `myClass.newInstance()` directly. The latter sequence of calls is inferred to be able to throw the additional exception types [`InvocationTargetException`](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/InvocationTargetException.html) and [`NoSuchMethodException`](https://docs.oracle.com/javase/8/docs/api/java/lang/NoSuchMethodException.html). Both of these exception types are subclasses of [`ReflectiveOperationException`](https://docs.oracle.com/javase/8/docs/api/java/lang/ReflectiveOperationException.html). This PR updates our usages accordingly.

### Bonus

In addition, I noticed this codebase was using a mixture of `Error` and `AssertionError` for "impossible" reflection errors. [Error Prone](https://errorprone.info/bugpattern/RethrowReflectiveOperationExceptionAsLinkageError) recommends against this in favor of `LinkageError` for rethrowing `ReflectiveOperationException` exceptions as unchecked. While the reasoning isn't explicitly stated, presumably it is because `LinkageError` is more specific. I've updated our usage to match this recommendation.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).