### PR TITLE
Change old issue references from #... to JENKINS-...

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1414,7 +1414,7 @@ public class Util {
      * but don't remember it right now.
      *
      * @since 1.204
-     * @deprecated since 2008-05-13. This method is broken (see ISSUE#1666). It should probably
+     * @deprecated since 2008-05-13. This method is broken (see JENKINS-1666). It should probably
      * be removed but I'm not sure if it is considered part of the public API
      * that needs to be maintained for backwards compatibility.
      * Use {@link #encode(String)} instead.

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -169,7 +169,7 @@ public class WebAppMain implements ServletContextListener {
                 }
             });
 
-            // quick check to see if we (seem to) have enough permissions to run. (see #719)
+            // quick check to see if we (seem to) have enough permissions to run. (see JENKINS-719)
             JVM jvm;
             try {
                 jvm = new JVM();
@@ -392,7 +392,7 @@ public class WebAppMain implements ServletContextListener {
                 String value = (String) env.lookup(name);
                 if(value!=null && value.trim().length()>0)
                     return new FileAndDescription(new File(value.trim()),"JNDI/java:comp/env/"+name);
-                // look at one more place. See issue #1314
+                // look at one more place. See issue JENKINS-1314
                 value = (String) iniCtxt.lookup(name);
                 if(value!=null && value.trim().length()>0)
                     return new FileAndDescription(new File(value.trim()),"JNDI/"+name);

--- a/core/src/main/java/hudson/model/BallColor.java
+++ b/core/src/main/java/hudson/model/BallColor.java
@@ -49,7 +49,7 @@ import java.util.Locale;
  * Hudson started to overload colors &mdash; for example grey could mean
  * either disabled, aborted, or not yet built. As a result, {@link BallColor}
  * becomes more like a "logical" color, in the sense that different {@link BallColor}
- * values can map to the same RGB color. See issue #956.
+ * values can map to the same RGB color. See JENKINS-956.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -277,7 +277,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     protected synchronized void saveNextBuildNumber() throws IOException {
-        if (nextBuildNumber == 0) { // #3361
+        if (nextBuildNumber == 0) { // JENKINS-3361
             nextBuildNumber = 1;
         }
         getNextBuildNumberFile().write(String.valueOf(nextBuildNumber) + '\n');

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1949,7 +1949,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
                 // the significance of doing this is that Jenkins
                 // will now see this build as completed.
                 // things like triggering other builds requires this as pre-condition.
-                // see issue #980.
+                // see issue JENKINS-980.
                 LOGGER.log(FINER, "moving into POST_PRODUCTION on {0}", this);
                 state = State.POST_PRODUCTION;
 

--- a/core/src/main/java/hudson/scm/SCM.java
+++ b/core/src/main/java/hudson/scm/SCM.java
@@ -185,7 +185,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
      * The default implementation returns true.
      *
      * <p>
-     * See issue #1348 for more discussion of this feature.
+     * See issue JENKINS-1348 for more discussion of this feature.
      *
      * @since 1.196
      */

--- a/core/src/main/java/hudson/security/AuthenticationProcessingFilter2.java
+++ b/core/src/main/java/hudson/security/AuthenticationProcessingFilter2.java
@@ -78,7 +78,7 @@ public final class AuthenticationProcessingFilter2 extends UsernamePasswordAuthe
             return targetUrl.substring(request.getContextPath().length());
 
         // not sure when this happens, but apparently this happens in some case.
-        // see #1274
+        // see JENKINS-1274
         return targetUrl;
     }
 

--- a/core/src/main/java/hudson/security/HudsonFilter.java
+++ b/core/src/main/java/hudson/security/HudsonFilter.java
@@ -104,7 +104,7 @@ public class HudsonFilter implements Filter {
         try {
             Jenkins hudson = Jenkins.getInstanceOrNull();
             if (hudson != null) {
-                // looks like we are initialized after Hudson came into being. initialize it now. See #3069
+                // looks like we are initialized after Hudson came into being. initialize it now. See JENKINS-3069
                 LOGGER.fine("Security wasn't initialized; Initializing it...");
                 SecurityRealm securityRealm = hudson.getSecurityRealm();
                 reset(securityRealm);

--- a/core/src/main/java/hudson/security/RememberMeServicesProxy.java
+++ b/core/src/main/java/hudson/security/RememberMeServicesProxy.java
@@ -39,7 +39,7 @@ import org.springframework.security.web.authentication.RememberMeServices;
  * In Jenkins, we need {@link Jenkins} instance to perform remember-me service,
  * because it relies on {@link ConfidentialStore}. However, security
  * filters can be initialized before Jenkins is initialized.
- * (See #1210 for example.)
+ * (See JENKINS-1210 for example.)
  *
  * <p>
  * So to work around the problem, we use a proxy.

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -348,7 +348,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
     }
 
     /**
-     * Correct broken data gracefully (#1537)
+     * Correct broken data gracefully (JENKINS-1537)
      */
     private Object readResolve() {
         if(childProjects==null)

--- a/core/src/main/java/hudson/util/ChartUtil.java
+++ b/core/src/main/java/hudson/util/ChartUtil.java
@@ -198,7 +198,7 @@ public class ChartUtil {
      * (So for example if N=3 then we can "fix" the graph as long as we only have less than 1/(3*3)=11.111...% bad data.
      *
      * <p>
-     * Also see issue #1246.
+     * Also see JENKINS-1246.
      */
     public static void adjustChebyshev(CategoryDataset dataset, NumberAxis yAxis) {
         // first compute E(X) and Var(X)

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1549,7 +1549,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Gets the {@link JobPropertyDescriptor} by name. Primarily used for making them web-visible.
      */
     public JobPropertyDescriptor getJobProperty(String shortClassName) {
-        // combining these two lines triggers javac bug. See issue #610.
+        // combining these two lines triggers javac bug. See issue JENKINS-610
         Descriptor d = findDescriptor(shortClassName, JobPropertyDescriptor.all());
         return (JobPropertyDescriptor) d;
     }
@@ -2686,7 +2686,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         try {
             HudsonFilter filter = HudsonFilter.get(servletContext);
             if (filter == null) {
-                // Fix for #3069: This filter is not necessarily initialized before the servlets.
+                // Fix for JENKINS-3069: This filter is not necessarily initialized before the servlets.
                 // when HudsonFilter does come back, it'll initialize itself.
                 LOGGER.fine("HudsonFilter has not yet been initialized: Can't perform security setup for now");
             } else {
@@ -3761,7 +3761,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     private void _cleanUpPersistQueue(List<Throwable> errors) {
         if(getRootDir().exists()) {
             // if we are aborting because we failed to create JENKINS_HOME,
-            // don't try to save. Issue #536
+            // don't try to save. JENKINS-536
             LOGGER.log(Main.isUnitTest ? Level.FINE : Level.INFO, "Persisting build queue");
             try {
                 getQueue().save();
@@ -4679,7 +4679,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         if(qs==null)
             throw new ServletException();
         Cookie cookie = new Cookie("iconSize", Functions.validateIconSize(qs));
-        cookie.setMaxAge(/* ~4 mo. */9999999); // #762
+        cookie.setMaxAge(/* ~4 mo. */9999999); // JENKINS-762
         cookie.setSecure(req.isSecure());
         cookie.setHttpOnly(true);
         rsp.addCookie(cookie);

--- a/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
+++ b/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
@@ -38,8 +38,7 @@ public class BasicHeaderProcessorTest {
 
     @Before
     public void prepareListeners(){
-        //TODO simplify using #3021 into ExtensionList.lookupSingleton(SpySecurityListener.class)
-        this.spySecurityListener = ExtensionList.lookup(SecurityListener.class).get(SpySecurityListenerImpl.class);
+        this.spySecurityListener = ExtensionList.lookupSingleton(SpySecurityListener.class);
     }
 
     /**


### PR DESCRIPTION
Minor cleanup in comments; change `#...` to `JENKINS-...` to reduce ambiguity.

One actual code change in a test: Apply a TODO comment that was waiting for a PR referenced in the same ambiguous manner to be merged (more than 3 years ago).

### Proposed changelog entries

(too minor / non production code only)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
