### PR TITLE
Terminology: Clean up X-to-Y-Callables

### DIFF
--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -28,7 +28,7 @@ import hudson.util.CaseInsensitiveComparator;
 import hudson.util.CyclicGraphDetector;
 import hudson.util.CyclicGraphDetector.CycleDetectedException;
 import hudson.util.VariableResolver;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 
 import java.io.File;
 import java.io.IOException;
@@ -438,7 +438,7 @@ public class EnvVars extends TreeMap<String,String> {
         return channel.call(new GetEnvVars());
     }
 
-    private static final class GetEnvVars extends MasterToSlaveCallable<EnvVars,RuntimeException> {
+    private static final class GetEnvVars extends ControllerToAgentCallable<EnvVars,RuntimeException> {
         @Override
         public EnvVars call() {
             return new EnvVars(EnvVars.masterEnvVars);

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -39,7 +39,7 @@ import hudson.remoting.VirtualChannel;
 import hudson.util.StreamCopyThread;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.ProcessTree;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.tasks.filters.EnvVarsFilterRuleWrapper;
 import jenkins.tasks.filters.EnvVarsFilterLocalRule;
 import jenkins.tasks.filters.EnvVarsFilterableBuilder;
@@ -1154,7 +1154,7 @@ public abstract class Launcher {
             return "RemoteLauncher[" + getChannel() + "]";
         }
 
-        private static final class KillTask extends MasterToSlaveCallable<Void,RuntimeException> {
+        private static final class KillTask extends ControllerToAgentCallable<Void,RuntimeException> {
             private final Map<String, String> modelEnvVars;
 
             KillTask(Map<String, String> modelEnvVars) {
@@ -1333,7 +1333,7 @@ public abstract class Launcher {
         IOTriplet getIOtriplet();
     }
 
-    private static class RemoteLaunchCallable extends MasterToSlaveCallable<RemoteProcess,IOException> {
+    private static class RemoteLaunchCallable extends ControllerToAgentCallable<RemoteProcess,IOException> {
         private final @NonNull List<String> cmd;
         private final @CheckForNull boolean[] masks;
         private final @CheckForNull String[] env;
@@ -1436,7 +1436,7 @@ public abstract class Launcher {
         private static final long serialVersionUID = 1L;
     }
 
-    private static class RemoteChannelLaunchCallable extends MasterToSlaveCallable<OutputStream,IOException> {
+    private static class RemoteChannelLaunchCallable extends ControllerToAgentCallable<OutputStream,IOException> {
         @NonNull
         private final String[] cmd;
         @NonNull

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -45,7 +45,7 @@ import hudson.slaves.ComputerListener;
 import hudson.util.CopyOnWriteList;
 import hudson.util.RingBufferLogHandler;
 import hudson.util.XStream2;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -284,7 +284,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
         }
     }
 
-    private static final class SetLevel extends MasterToSlaveCallable<Void,Error> {
+    private static final class SetLevel extends ControllerToAgentCallable<Void,Error> {
         /** known loggers (kept per agent), to avoid GC */
         @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") private static final Set<Logger> loggers = new HashSet<>();
         private final String name;

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -67,7 +67,7 @@ import hudson.util.NamingThreadFactory;
 import jenkins.model.Jenkins;
 import jenkins.util.ContextResettingExecutorService;
 import jenkins.util.SystemProperties;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.security.ImpersonatingExecutorService;
 
 import org.apache.commons.lang.StringUtils;
@@ -1316,7 +1316,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         oneOffExecutors.remove(e);
     }
 
-    private static class ListPossibleNames extends MasterToSlaveCallable<List<String>,IOException> {
+    private static class ListPossibleNames extends ControllerToAgentCallable<List<String>,IOException> {
         /**
          * In the normal case we would use {@link Computer} as the logger's name, however to
          * do that we would have to send the {@link Computer} class over to the remote classloader
@@ -1358,7 +1358,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         private static final long serialVersionUID = 1L;
     }
 
-    private static class GetFallbackName extends MasterToSlaveCallable<String,IOException> {
+    private static class GetFallbackName extends ControllerToAgentCallable<String,IOException> {
         @Override
         public String call() throws IOException {
             return SystemProperties.getString("host.name");
@@ -1460,7 +1460,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         }
     }
 
-    private static final class DumpExportTableTask extends MasterToSlaveCallable<String,IOException> {
+    private static final class DumpExportTableTask extends ControllerToAgentCallable<String,IOException> {
         @Override
         public String call() throws IOException {
             final Channel ch = getChannelOrFail();

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.security.ResourceDomainConfiguration;
 import jenkins.security.ResourceDomainRootAction;
 import jenkins.util.SystemProperties;
@@ -700,7 +700,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         }
     }
 
-    private static final class BuildChildPaths extends MasterToSlaveCallable<List<List<Path>>,IOException> {
+    private static final class BuildChildPaths extends ControllerToAgentCallable<List<List<Path>>,IOException> {
         private VirtualFile root;
         private final VirtualFile cur;
         private final Locale locale;

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -117,7 +117,7 @@ import jenkins.model.RunAction2;
 import jenkins.model.StandardArtifactManager;
 import jenkins.model.lazy.BuildReference;
 import jenkins.model.lazy.LazyBuildMixIn;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.util.VirtualFile;
 import jenkins.util.io.OnMaster;
 import net.sf.json.JSONObject;
@@ -1177,7 +1177,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
         return !getArtifactsUpTo(1).isEmpty();
     }
 
-    private static final class AddArtifacts extends MasterToSlaveCallable<SerializableArtifactList, IOException> {
+    private static final class AddArtifacts extends ControllerToAgentCallable<SerializableArtifactList, IOException> {
         private static final long serialVersionUID = 1L;
         private final VirtualFile root;
         private final int artifactsNumber;

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -70,7 +70,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.slaves.WorkspaceLocator;
 import jenkins.util.SystemProperties;
 import org.apache.commons.io.IOUtils;
@@ -693,7 +693,7 @@ public abstract class Slave extends Node implements Serializable {
      *     <li>When it's read on this side as a return value, it morphs itself into {@link ClockDifference}.
      * </ol>
      */
-    private static final class GetClockDifference1 extends MasterToSlaveCallable<ClockDifference,IOException> {
+    private static final class GetClockDifference1 extends ControllerToAgentCallable<ClockDifference,IOException> {
         @Override
         public ClockDifference call() {
             // this method must be being invoked locally, which means the clock is in sync
@@ -707,7 +707,7 @@ public abstract class Slave extends Node implements Serializable {
         private static final long serialVersionUID = 1L;
     }
 
-    private static final class GetClockDifference2 extends MasterToSlaveCallable<GetClockDifference3,IOException> {
+    private static final class GetClockDifference2 extends ControllerToAgentCallable<GetClockDifference3,IOException> {
         /**
          * Capture the time on the master when this object is sent to remote, which is when
          * {@link GetClockDifference1#writeReplace()} is run.

--- a/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
@@ -26,7 +26,7 @@ package hudson.node_monitors;
 import hudson.model.Computer;
 import hudson.remoting.Callable;
 import hudson.Extension;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
@@ -60,7 +60,7 @@ public class ArchitectureMonitor extends NodeMonitor {
     /**
      * Obtains the string that represents the architecture.
      */
-    private static class GetArchTask extends MasterToSlaveCallable<String,IOException> {
+    private static class GetArchTask extends ControllerToAgentCallable<String,IOException> {
         @Override
         public String call() {
             String os = System.getProperty("os.name");

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
@@ -24,7 +24,7 @@
 package hudson.node_monitors;
 
 import hudson.Functions;
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import hudson.remoting.VirtualChannel;
 import hudson.Util;
 import hudson.node_monitors.DiskSpaceMonitorDescriptor.DiskSpace;
@@ -167,7 +167,7 @@ public abstract class DiskSpaceMonitorDescriptor extends AbstractAsyncNodeMonito
         private static final long serialVersionUID = 2L;
     }
 
-    protected static final class GetUsableSpace extends MasterToSlaveFileCallable<DiskSpace> {
+    protected static final class GetUsableSpace extends ControllerToAgentFileCallable<DiskSpace> {
         public GetUsableSpace() {}
         @Override
         public DiskSpace invoke(File f, VirtualChannel channel) throws IOException {

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -26,7 +26,7 @@ package hudson.node_monitors;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.remoting.Callable;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -92,7 +92,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
         }
     };
 
-    private static final class Step1 extends MasterToSlaveCallable<Data,IOException> {
+    private static final class Step1 extends ControllerToAgentCallable<Data,IOException> {
         private Data cur;
 
         private Step1(Data cur) {
@@ -112,7 +112,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
         private static final long serialVersionUID = 1L;
     }
 
-    private static final class Step2 extends MasterToSlaveCallable<Step3,IOException> {
+    private static final class Step2 extends ControllerToAgentCallable<Step3,IOException> {
         private final Data cur;
         private final long start = System.currentTimeMillis();
 

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -28,7 +28,7 @@ import hudson.Extension;
 import hudson.Functions;
 import hudson.model.Computer;
 import jenkins.model.Jenkins;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.jvnet.hudson.MemoryMonitor;
@@ -113,7 +113,7 @@ public class SwapSpaceMonitor extends NodeMonitor {
     /**
      * Obtains the string that represents the architecture.
      */
-    private static class MonitorTask extends MasterToSlaveCallable<MemoryUsage,IOException> {
+    private static class MonitorTask extends ControllerToAgentCallable<MemoryUsage,IOException> {
         @Override
         public MemoryUsage call() throws IOException {
             MemoryMonitor mm;

--- a/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
@@ -25,7 +25,7 @@ package hudson.node_monitors;
 
 import hudson.Extension;
 import hudson.FilePath;
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.remoting.Callable;
@@ -100,7 +100,7 @@ public class TemporarySpaceMonitor extends AbstractDiskSpaceMonitor {
         return DESCRIPTOR;
     }
     
-    protected static final class GetTempSpace extends MasterToSlaveFileCallable<DiskSpace> {
+    protected static final class GetTempSpace extends ControllerToAgentFileCallable<DiskSpace> {
         @Override
         public DiskSpace invoke(File f, VirtualChannel channel) throws IOException {
                 // if the disk is really filled up we can't even create a single file,

--- a/core/src/main/java/hudson/slaves/ChannelPinger.java
+++ b/core/src/main/java/hudson/slaves/ChannelPinger.java
@@ -32,7 +32,7 @@ import hudson.model.Slave;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.PingThread;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.slaves.PingFailureAnalyzer;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -123,7 +123,7 @@ public class ChannelPinger extends ComputerListener {
 
     @VisibleForTesting
     @Restricted(NoExternalUse.class)
-    public static class SetUpRemotePing extends MasterToSlaveCallable<Void, IOException> {
+    public static class SetUpRemotePing extends ControllerToAgentCallable<Void, IOException> {
         private static final long serialVersionUID = -2702219700841759872L;
         @Deprecated
         private transient int pingInterval;

--- a/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
+++ b/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
@@ -31,8 +31,8 @@ import java.util.concurrent.TimeUnit;
 import hudson.remoting.VirtualChannel;
 import hudson.remoting.Channel;
 import hudson.Extension;
+import jenkins.security.AgentToControllerCallable;
 import jenkins.util.SystemProperties;
-import jenkins.security.SlaveToMasterCallable;
 import org.jenkinsci.Symbol;
 
 import java.io.IOException;
@@ -106,7 +106,7 @@ public class ConnectionActivityMonitor extends AsyncPeriodicWork {
     public boolean enabled = SystemProperties.getBoolean(ConnectionActivityMonitor.class.getName()+".enabled");
 
     private static final PingCommand PING_COMMAND = new PingCommand();
-    private static final class PingCommand extends SlaveToMasterCallable<Void,RuntimeException> {
+    private static final class PingCommand extends AgentToControllerCallable<Void,RuntimeException> {
         @Override
         public Void call() throws RuntimeException {
             return null;

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -57,7 +57,7 @@ import hudson.util.io.RewindableRotatingFileOutputStream;
 import jenkins.agents.AgentComputerUtil;
 import jenkins.model.Jenkins;
 import jenkins.security.ChannelConfigurator;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.slaves.EncryptedSlaveAgentJnlpFile;
 import jenkins.slaves.JnlpAgentReceiver;
 import jenkins.slaves.RemotingVersionInfo;
@@ -561,7 +561,7 @@ public class SlaveComputer extends Computer {
         }
     }
 
-    static class LoadingCount extends MasterToSlaveCallable<Integer,RuntimeException> {
+    static class LoadingCount extends ControllerToAgentCallable<Integer,RuntimeException> {
         private final boolean resource;
         LoadingCount(boolean resource) {
             this.resource = resource;
@@ -575,7 +575,7 @@ public class SlaveComputer extends Computer {
         }
     }
 
-    static class LoadingPrefetchCacheCount extends MasterToSlaveCallable<Integer,RuntimeException> {
+    static class LoadingPrefetchCacheCount extends ControllerToAgentCallable<Integer,RuntimeException> {
         @Override public Integer call() {
             Channel c = Channel.current();
             if (c == null) {
@@ -585,7 +585,7 @@ public class SlaveComputer extends Computer {
         }
     }
 
-    static class LoadingTime extends MasterToSlaveCallable<Long,RuntimeException> {
+    static class LoadingTime extends ControllerToAgentCallable<Long,RuntimeException> {
         private final boolean resource;
         LoadingTime(boolean resource) {
             this.resource = resource;
@@ -969,7 +969,7 @@ public class SlaveComputer extends Computer {
         }
     }
 
-    private static class ListFullEnvironment extends MasterToSlaveCallable<Map<String,String>,IOException> {
+    private static class ListFullEnvironment extends ControllerToAgentCallable<Map<String,String>,IOException> {
         @Override
         public Map<String,String> call() throws IOException {
             Map<String, String> env = new TreeMap<>(System.getenv());
@@ -985,21 +985,21 @@ public class SlaveComputer extends Computer {
 
     private static final Logger logger = Logger.getLogger(SlaveComputer.class.getName());
 
-    private static final class SlaveVersion extends MasterToSlaveCallable<String,IOException> {
+    private static final class SlaveVersion extends ControllerToAgentCallable<String,IOException> {
         @Override
         public String call() throws IOException {
             try { return Launcher.VERSION; }
             catch (Throwable ex) { return "< 1.335"; } // Older agent.jar won't have VERSION
         }
     }
-    private static final class DetectOS extends MasterToSlaveCallable<Boolean,IOException> {
+    private static final class DetectOS extends ControllerToAgentCallable<Boolean,IOException> {
         @Override
         public Boolean call() throws IOException {
             return File.pathSeparatorChar==':';
         }
     }
 
-    private static final class AbsolutePath extends MasterToSlaveCallable<String,IOException> {
+    private static final class AbsolutePath extends ControllerToAgentCallable<String,IOException> {
 
         private static final long serialVersionUID = 1L;
 
@@ -1015,7 +1015,7 @@ public class SlaveComputer extends Computer {
         }
     }
 
-    private static final class DetectDefaultCharset extends MasterToSlaveCallable<String,IOException> {
+    private static final class DetectDefaultCharset extends ControllerToAgentCallable<String,IOException> {
         @Override
         public String call() throws IOException {
             return Charset.defaultCharset().name();
@@ -1033,7 +1033,7 @@ public class SlaveComputer extends Computer {
         static RingBufferLogHandler SLAVE_LOG_HANDLER;
     }
 
-    private static class SlaveInitializer extends MasterToSlaveCallable<Void,RuntimeException> {
+    private static class SlaveInitializer extends ControllerToAgentCallable<Void,RuntimeException> {
         final int ringBufferSize;
 
         SlaveInitializer(int ringBufferSize) {
@@ -1096,7 +1096,7 @@ public class SlaveComputer extends Computer {
         return SlaveSystemInfo.all();
     }
 
-    private static class SlaveLogFetcher extends MasterToSlaveCallable<List<LogRecord>,RuntimeException> {
+    private static class SlaveLogFetcher extends ControllerToAgentCallable<List<LogRecord>,RuntimeException> {
         @Override
         public List<LogRecord> call() {
             return new ArrayList<>(SLAVE_LOG_HANDLER.getView());

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -28,7 +28,7 @@ import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.Extension;
@@ -292,7 +292,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
         }
     }
 
-    private static final class ListFiles extends MasterToSlaveFileCallable<Map<String,String>> {
+    private static final class ListFiles extends ControllerToAgentFileCallable<Map<String,String>> {
         private static final long serialVersionUID = 1;
         private final String includes, excludes;
         private final boolean defaultExcludes;

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -27,7 +27,7 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Functions;
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import hudson.Launcher;
 import jenkins.util.SystemProperties;
 import hudson.Util;
@@ -266,7 +266,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
         private static final long serialVersionUID = 1L;
     }
 
-    private static final class FindRecords extends MasterToSlaveFileCallable<List<Record>> {
+    private static final class FindRecords extends ControllerToAgentFileCallable<List<Record>> {
 
         private final String targets;
         private final String excludes;

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -25,7 +25,7 @@ package hudson.tasks;
 
 import hudson.Extension;
 import hudson.model.PersistentDescriptor;
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import hudson.Launcher;
 import hudson.Functions;
 import hudson.EnvVars;
@@ -59,7 +59,7 @@ import hudson.util.VariableResolver.ByMap;
 import hudson.util.VariableResolver.Union;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
@@ -249,7 +249,7 @@ public class Maven extends Builder {
      * Looks for {@code pom.xlm} or {@code project.xml} to determine the maven executable
      * name.
      */
-    private static final class DecideDefaultMavenCommand extends MasterToSlaveFileCallable<String> {
+    private static final class DecideDefaultMavenCommand extends ControllerToAgentFileCallable<String> {
         private static final long serialVersionUID = -2327576423452215146L;
         // command line arguments.
         private final String arguments;
@@ -575,7 +575,7 @@ public class Maven extends Builder {
             return false;
             
         }
-        private static class GetMavenVersion extends MasterToSlaveCallable<String, IOException> {
+        private static class GetMavenVersion extends ControllerToAgentCallable<String, IOException> {
             private final String home;
             GetMavenVersion(String home) {
                 this.home = home;
@@ -616,7 +616,7 @@ public class Maven extends Builder {
         public String getExecutable(Launcher launcher) throws IOException, InterruptedException {
             return launcher.getChannel().call(new GetExecutable(getHome()));
         }
-        private static class GetExecutable extends MasterToSlaveCallable<String, IOException> {
+        private static class GetExecutable extends ControllerToAgentCallable<String, IOException> {
             private final String rawHome;
             GetExecutable(String rawHome) {
                 this.rawHome = rawHome;

--- a/core/src/main/java/hudson/tasks/Shell.java
+++ b/core/src/main/java/hudson/tasks/Shell.java
@@ -33,7 +33,7 @@ import hudson.util.FormValidation;
 import java.io.IOException;
 
 import hudson.util.LineEndingConversion;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.tasks.filters.EnvVarsFilterLocalRule;
 import jenkins.tasks.filters.EnvVarsFilterLocalRuleDescriptor;
 import net.sf.json.JSONObject;
@@ -247,7 +247,7 @@ public class Shell extends CommandInterpreter {
             return FormValidation.validateExecutable(value);
         }
 
-        private static final class Shellinterpreter extends MasterToSlaveCallable<String, IOException> {
+        private static final class Shellinterpreter extends ControllerToAgentCallable<String, IOException> {
 
             private static final long serialVersionUID = 1L;
 

--- a/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
+++ b/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
@@ -26,7 +26,7 @@ package hudson.tools;
 
 import hudson.Extension;
 import hudson.FilePath;
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import hudson.ProxyConfiguration;
 import hudson.Util;
 import hudson.Functions;
@@ -125,7 +125,7 @@ public class ZipExtractionInstaller extends ToolInstaller {
      * Sets execute permission on all files, since unzip etc. might not do this.
      * Hackish, is there a better way?
      */
-    static class ChmodRecAPlusX extends MasterToSlaveFileCallable<Void> {
+    static class ChmodRecAPlusX extends ControllerToAgentFileCallable<Void> {
         private static final long serialVersionUID = 1L;
         @Override
         public Void invoke(File d, VirtualChannel channel) throws IOException {

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -38,7 +38,7 @@ import hudson.util.ProcessKillingVeto.VetoCause;
 import hudson.util.ProcessTree.OSProcess;
 import hudson.util.ProcessTreeRemoting.IOSProcess;
 import hudson.util.ProcessTreeRemoting.IProcessTree;
-import jenkins.security.SlaveToMasterCallable;
+import jenkins.security.AgentToControllerCallable;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 import jenkins.util.java.JavaUtils;
 import org.jvnet.winp.WinProcess;
@@ -208,7 +208,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             }
         return killers;
     }
-    private static class ListAll extends SlaveToMasterCallable<List<ProcessKiller>, IOException> {
+    private static class ListAll extends AgentToControllerCallable<List<ProcessKiller>, IOException> {
         @Override
         public List<ProcessKiller> call() throws IOException {
             return new ArrayList<>(ProcessKiller.all());
@@ -365,7 +365,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             return new SerializedProcess(pid);
         }
         
-        private class CheckVetoes extends SlaveToMasterCallable<String, IOException> {
+        private class CheckVetoes extends AgentToControllerCallable<String, IOException> {
             private IOSProcess process;
             
             CheckVetoes(IOSProcess processToCheck) {
@@ -478,7 +478,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         return DEFAULT;
     }
     
-    private static class DoVetoersExist extends SlaveToMasterCallable<Boolean, IOException> {
+    private static class DoVetoersExist extends AgentToControllerCallable<Boolean, IOException> {
         @Override
         public Boolean call() throws IOException {
             return ProcessKillingVeto.all().size() > 0;

--- a/core/src/main/java/hudson/util/RemotingDiagnostics.java
+++ b/core/src/main/java/hudson/util/RemotingDiagnostics.java
@@ -33,7 +33,7 @@ import hudson.remoting.DelegatingCallable;
 import hudson.remoting.Future;
 import hudson.remoting.VirtualChannel;
 import hudson.security.AccessControlled;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
@@ -73,7 +73,7 @@ public final class RemotingDiagnostics {
         return channel.call(new GetSystemProperties());
     }
 
-    private static final class GetSystemProperties extends MasterToSlaveCallable<Map<Object,Object>,RuntimeException> {
+    private static final class GetSystemProperties extends ControllerToAgentCallable<Map<Object,Object>,RuntimeException> {
         @Override
         public Map<Object,Object> call() {
             return new TreeMap<>(System.getProperties());
@@ -93,7 +93,7 @@ public final class RemotingDiagnostics {
         return channel.callAsync(new GetThreadDump());
     }
 
-    private static final class GetThreadDump extends MasterToSlaveCallable<Map<String,String>,RuntimeException> {
+    private static final class GetThreadDump extends ControllerToAgentCallable<Map<String,String>,RuntimeException> {
         @Override
         public Map<String,String> call() {
             Map<String,String> r = new LinkedHashMap<>();
@@ -113,7 +113,7 @@ public final class RemotingDiagnostics {
         return channel.call(new Script(script));
     }
 
-    private static final class Script extends MasterToSlaveCallable<String,RuntimeException> implements DelegatingCallable<String,RuntimeException> {
+    private static final class Script extends ControllerToAgentCallable<String,RuntimeException> implements DelegatingCallable<String,RuntimeException> {
         private final String script;
         private transient ClassLoader cl;
 
@@ -159,7 +159,7 @@ public final class RemotingDiagnostics {
     public static FilePath getHeapDump(VirtualChannel channel) throws IOException, InterruptedException {
         return channel.call(new GetHeapDump());
     }
-    private static class GetHeapDump extends MasterToSlaveCallable<FilePath, IOException> {
+    private static class GetHeapDump extends ControllerToAgentCallable<FilePath, IOException> {
             @Override
             public FilePath call() throws IOException {
                 final File hprof = File.createTempFile("hudson-heapdump", "hprof");

--- a/core/src/main/java/hudson/util/io/ParserConfigurator.java
+++ b/core/src/main/java/hudson/util/io/ParserConfigurator.java
@@ -27,7 +27,7 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.remoting.Channel;
 import jenkins.model.Jenkins;
-import jenkins.security.SlaveToMasterCallable;
+import jenkins.security.AgentToControllerCallable;
 import org.dom4j.io.SAXReader;
 
 import java.io.IOException;
@@ -86,7 +86,7 @@ public abstract class ParserConfigurator implements ExtensionPoint, Serializable
         for (ParserConfigurator pc : all)
             pc.configure(reader,context);
     }
-    private static class GetParserConfigurators extends SlaveToMasterCallable<Collection<ParserConfigurator>, IOException> {
+    private static class GetParserConfigurators extends AgentToControllerCallable<Collection<ParserConfigurator>, IOException> {
         private static final long serialVersionUID = -2178106894481500733L;
         @Override
         public Collection<ParserConfigurator> call() throws IOException {

--- a/core/src/main/java/jenkins/AgentToControllerFileCallable.java
+++ b/core/src/main/java/jenkins/AgentToControllerFileCallable.java
@@ -1,0 +1,19 @@
+package jenkins;
+
+import hudson.FilePath;
+import jenkins.security.Roles;
+import org.jenkinsci.remoting.RoleChecker;
+
+/**
+ * {@link FilePath.FileCallable}s that can be executed on the controller, sent by the agent.
+ * Note that any serializable fields must either be defined in your plugin or included in the stock JEP-200 whitelist.
+ * @since TODO
+ */
+public abstract class AgentToControllerFileCallable<T> implements FilePath.FileCallable<T> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+        checker.check(this, Roles.CONTROLLER);
+    }
+}

--- a/core/src/main/java/jenkins/ControllerToAgentFileCallable.java
+++ b/core/src/main/java/jenkins/ControllerToAgentFileCallable.java
@@ -1,0 +1,27 @@
+package jenkins;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import jenkins.security.Roles;
+import jenkins.slaves.RemotingVersionInfo;
+import org.jenkinsci.remoting.RoleChecker;
+
+import java.io.File;
+
+/**
+ * {@link FilePath.FileCallable}s that are meant to be only used on the controller.
+ *
+ * Note that the logic within {@link #invoke(File, VirtualChannel)} should use API of a minimum supported Remoting version.
+ * See {@link RemotingVersionInfo#getMinimumSupportedVersion()}.
+ *
+ * @since TODO
+ * @param <T> the return type; note that this must either be defined in your plugin or included in the stock JEP-200 whitelist
+ */
+public abstract class ControllerToAgentFileCallable<T> implements FilePath.FileCallable<T> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+        checker.check(this, Roles.AGENT);
+    }
+}

--- a/core/src/main/java/jenkins/MasterToSlaveFileCallable.java
+++ b/core/src/main/java/jenkins/MasterToSlaveFileCallable.java
@@ -1,26 +1,9 @@
 package jenkins;
 
-import hudson.FilePath.FileCallable;
-import hudson.remoting.VirtualChannel;
-import jenkins.security.Roles;
-import jenkins.slaves.RemotingVersionInfo;
-import org.jenkinsci.remoting.RoleChecker;
-
-import java.io.File;
-
 /**
- * {@link FileCallable}s that are meant to be only used on the master.
- *
- * Note that the logic within {@link #invoke(File, VirtualChannel)} should use API of a minimum supported Remoting version.
- * See {@link RemotingVersionInfo#getMinimumSupportedVersion()}.
- *
  * @since 1.587 / 1.580.1
- * @param <T> the return type; note that this must either be defined in your plugin or included in the stock JEP-200 whitelist
+ * @deprecated Use {@link ControllerToAgentFileCallable}
  */
-public abstract class MasterToSlaveFileCallable<T> implements FileCallable<T> {
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        checker.check(this, Roles.SLAVE);
-    }
-    private static final long serialVersionUID = 1L;
+@Deprecated
+public abstract class MasterToSlaveFileCallable<T> extends ControllerToAgentFileCallable<T> {
 }

--- a/core/src/main/java/jenkins/SlaveToMasterFileCallable.java
+++ b/core/src/main/java/jenkins/SlaveToMasterFileCallable.java
@@ -1,18 +1,9 @@
 package jenkins;
 
-import hudson.FilePath.FileCallable;
-import jenkins.security.Roles;
-import org.jenkinsci.remoting.RoleChecker;
-
 /**
- * {@link FileCallable}s that can be executed on the master, sent by the agent.
- * Note that any serializable fields must either be defined in your plugin or included in the stock JEP-200 whitelist.
  * @since 1.587 / 1.580.1
+ * @deprecated Use {@link AgentToControllerFileCallable}
  */
-public abstract class SlaveToMasterFileCallable<T> implements FileCallable<T> {
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        checker.check(this, Roles.MASTER);
-    }
-    private static final long serialVersionUID = 1L;
+@Deprecated
+public abstract class SlaveToMasterFileCallable<T> extends AgentToControllerFileCallable<T> {
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -214,7 +214,7 @@ import jenkins.security.ClassFilterImpl;
 import jenkins.security.ConfidentialKey;
 import jenkins.security.ConfidentialStore;
 import jenkins.security.SecurityListener;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import jenkins.slaves.WorkspaceLocator;
 import jenkins.util.JenkinsJVM;
 import jenkins.util.Timer;
@@ -2609,7 +2609,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public Callable<ClockDifference, IOException> getClockDifferenceCallable() {
         return new ClockDifferenceCallable();
     }
-    private static class ClockDifferenceCallable extends MasterToSlaveCallable<ClockDifference, IOException> {
+    private static class ClockDifferenceCallable extends ControllerToAgentCallable<ClockDifference, IOException> {
         @Override
         public ClockDifference call() throws IOException {
             return new ClockDifference(0);

--- a/core/src/main/java/jenkins/security/AgentToControllerCallable.java
+++ b/core/src/main/java/jenkins/security/AgentToControllerCallable.java
@@ -1,0 +1,19 @@
+package jenkins.security;
+
+import hudson.remoting.Callable;
+import org.jenkinsci.remoting.RoleChecker;
+
+/**
+ * Convenient {@link Callable} that are meant to run on the controller (sent by agent/CLI/etc).
+ * Note that any serializable fields must either be defined in your plugin or included in the stock JEP-200 whitelist.
+ *
+ * @since TODO
+ */
+public abstract class AgentToControllerCallable<V, T extends Throwable> implements Callable<V, T> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+        checker.check(this, Roles.CONTROLLER);
+    }
+}

--- a/core/src/main/java/jenkins/security/ControllerToAgentCallable.java
+++ b/core/src/main/java/jenkins/security/ControllerToAgentCallable.java
@@ -1,0 +1,45 @@
+package jenkins.security;
+
+import hudson.remoting.Callable;
+import hudson.remoting.Channel;
+import hudson.remoting.ChannelClosedException;
+import jenkins.slaves.RemotingVersionInfo;
+import org.jenkinsci.remoting.RoleChecker;
+
+/**
+ * Convenient {@link Callable} meant to be run on agent.
+ *
+ * Note that the logic within {@link #call()} should use API of a minimum supported Remoting version.
+ * See {@link RemotingVersionInfo#getMinimumSupportedVersion()}.
+ *
+ * @since TODO
+ * @param <V> the return type; note that this must either be defined in your plugin or included in the stock JEP-200 whitelist
+ */
+public abstract class ControllerToAgentCallable<V, T extends Throwable> implements Callable<V, T> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void checkRoles(RoleChecker checker) throws SecurityException {
+        checker.check(this, Roles.AGENT);
+    }
+
+    //TODO: remove once Minimum supported Remoting version is 3.15 or above
+    @Override
+    public Channel getChannelOrFail() throws ChannelClosedException {
+        final Channel ch = Channel.current();
+        if (ch == null) {
+            throw new ChannelClosedException(ch, new IllegalStateException("No channel associated with the thread"));
+        }
+        return ch;
+    }
+
+    //TODO: remove Callable#getOpenChannelOrFail() once minimum supported Remoting version is 3.15 or above
+    @Override
+    public Channel getOpenChannelOrFail() throws ChannelClosedException {
+        final Channel ch = getChannelOrFail();
+        if (ch.isClosingOrClosed()) { // TODO: Since Remoting 2.33, we still need to explicitly declare minimum Remoting version
+            throw new ChannelClosedException(ch, new IllegalStateException("The associated channel " + ch + " is closing down or has closed down", ch.getCloseRequestCause()));
+        }
+        return ch;
+    }
+}

--- a/core/src/main/java/jenkins/security/MasterToSlaveCallable.java
+++ b/core/src/main/java/jenkins/security/MasterToSlaveCallable.java
@@ -1,48 +1,9 @@
 package jenkins.security;
 
-import hudson.remoting.Callable;
-import hudson.remoting.Channel;
-import hudson.remoting.ChannelClosedException;
-import jenkins.slaves.RemotingVersionInfo;
-import org.jenkinsci.remoting.RoleChecker;
-
-
 /**
- * Convenient {@link Callable} meant to be run on agent.
- *
- * Note that the logic within {@link #call()} should use API of a minimum supported Remoting version.
- * See {@link RemotingVersionInfo#getMinimumSupportedVersion()}.
- *
- * @author Kohsuke Kawaguchi
  * @since 1.587 / 1.580.1
- * @param <V> the return type; note that this must either be defined in your plugin or included in the stock JEP-200 whitelist
+ * @deprecated Use {@link ControllerToAgentCallable}
  */
-public abstract class MasterToSlaveCallable<V, T extends Throwable> implements Callable<V,T> {
-
-    private static final long serialVersionUID = 1L;
-
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        checker.check(this,Roles.SLAVE);
-    }
-
-    //TODO: remove once Minimum supported Remoting version is 3.15 or above
-    @Override
-    public Channel getChannelOrFail() throws ChannelClosedException {
-        final Channel ch = Channel.current();
-        if (ch == null) {
-            throw new ChannelClosedException(ch, new IllegalStateException("No channel associated with the thread"));
-        }
-        return ch;
-    }
-
-    //TODO: remove Callable#getOpenChannelOrFail() once minimum supported Remoting version is 3.15 or above
-    @Override
-    public Channel getOpenChannelOrFail() throws ChannelClosedException {
-        final Channel ch = getChannelOrFail();
-        if (ch.isClosingOrClosed()) { // TODO: Since Remoting 2.33, we still need to explicitly declare minimum Remoting version
-            throw new ChannelClosedException(ch, new IllegalStateException("The associated channel " + ch + " is closing down or has closed down", ch.getCloseRequestCause()));
-        }
-        return ch;
-    }
+@Deprecated
+public abstract class MasterToSlaveCallable<V, T extends Throwable> extends ControllerToAgentCallable<V, T> {
 }

--- a/core/src/main/java/jenkins/security/Roles.java
+++ b/core/src/main/java/jenkins/security/Roles.java
@@ -6,9 +6,9 @@ import org.jenkinsci.remoting.Role;
  * Predefined {@link Role}s in Jenkins.
  *
  * <p>
- * In Jenkins, there is really only one interesting role, which is the Jenkins master.
- * Agents, CLI, and Maven processes are all going to load classes from the master,
- * which means it accepts anything that the master asks for, and thus they need
+ * In Jenkins, there is really only one interesting role, which is the Jenkins controller.
+ * Agents, CLI, and Maven processes are all going to load classes from the controller,
+ * which means it accepts anything that the controller asks for, and thus they need
  * not have any role.
  *
  * @author Kohsuke Kawaguchi
@@ -16,19 +16,34 @@ import org.jenkinsci.remoting.Role;
  */
 public class Roles {
     /**
-     * Indicates that a callable runs on masters, requested by agents/CLI/maven/whatever.
+     * Indicates that a callable runs on controllers, requested by agents/CLI/maven/whatever.
+     * @since TODO
      */
-    public static final Role MASTER = new Role("master");
+    public static final Role CONTROLLER = new Role("controller");
+
+    /**
+     * @deprecated Use {@link #CONTROLLER}
+     */
+    @Deprecated
+    public static final Role MASTER = CONTROLLER;
 
     /**
      * Indicates that a callable is meant to run on agents.
      *
      * This isn't used to reject callables to run on the agent, but rather to allow
-     * the master to promptly reject callables that are really not meant to be run on
-     * the master (as opposed to ones that do not have that information, which gets
+     * the controller to promptly reject callables that are really not meant to be run on
+     * the controller (as opposed to ones that do not have that information, which gets
      * {@link Role#UNKNOWN})
+     *
+     * @since TODO
      */
-    public static final Role SLAVE = new Role("slave");
+    public static final Role AGENT = new Role("agent");
+
+    /**
+     * @deprecated Use {@link #AGENT}
+     */
+    @Deprecated
+    public static final Role SLAVE = AGENT;
 
     private Roles() {}
 }

--- a/core/src/main/java/jenkins/security/SlaveToMasterCallable.java
+++ b/core/src/main/java/jenkins/security/SlaveToMasterCallable.java
@@ -1,20 +1,9 @@
 package jenkins.security;
 
-import hudson.remoting.Callable;
-import org.jenkinsci.remoting.RoleChecker;
-
-
 /**
- * Convenient {@link Callable} that are meant to run on the master (sent by agent/CLI/etc).
- * Note that any serializable fields must either be defined in your plugin or included in the stock JEP-200 whitelist.
- * @author Kohsuke Kawaguchi
+ * @deprecated Use {@link AgentToControllerCallable}
  * @since 1.587 / 1.580.1
  */
-public abstract class SlaveToMasterCallable<V, T extends Throwable> implements Callable<V,T> {
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        checker.check(this,Roles.MASTER);
-    }
-
-    private static final long serialVersionUID = 1L;
+@Deprecated
+public abstract class SlaveToMasterCallable<V, T extends Throwable> extends AgentToControllerCallable<V, T> {
 }

--- a/core/src/main/java/jenkins/security/s2m/CallableDirectionChecker.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableDirectionChecker.java
@@ -51,8 +51,8 @@ public class CallableDirectionChecker extends RoleChecker {
     public void check(RoleSensitive subject, @NonNull Collection<Role> expected) throws SecurityException {
         final String name = subject.getClass().getName();
 
-        if (expected.contains(Roles.MASTER)) {
-            LOGGER.log(Level.FINE, "Executing {0} is allowed since it is targeted for the master role", name);
+        if (expected.contains(Roles.CONTROLLER)) {
+            LOGGER.log(Level.FINE, "Executing {0} is allowed since it is targeted for the controller role", name);
             return;    // known to be safe
         }
 

--- a/core/src/main/java/jenkins/slaves/RemotingVersionInfo.java
+++ b/core/src/main/java/jenkins/slaves/RemotingVersionInfo.java
@@ -100,7 +100,7 @@ public class RemotingVersionInfo {
 
     /**
      * Gets Remoting version which is supported by the core.
-     * Jenkins core and plugins make invoke operations on agents (e.g. {@link jenkins.security.MasterToSlaveCallable})
+     * Jenkins core and plugins make invoke operations on agents (e.g. {@link jenkins.security.ControllerToAgentCallable})
      * and use Remoting-internal API within them.
      * In such case this API should be present on the remote side.
      * This method defines a minimum expected version, so that all calls should use a compatible API.

--- a/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
+++ b/core/src/main/java/jenkins/slaves/StandardOutputSwapper.java
@@ -9,7 +9,7 @@ import hudson.remoting.Channel;
 import hudson.remoting.StandardOutputStream;
 import hudson.slaves.ComputerListener;
 import hudson.util.jna.GNUCLibrary;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 
 import java.io.File;
 import java.io.FileDescriptor;
@@ -37,7 +37,7 @@ public class StandardOutputSwapper extends ComputerListener {
         }
     }
 
-    private static final class ChannelSwapper extends MasterToSlaveCallable<Boolean,Exception> {
+    private static final class ChannelSwapper extends ControllerToAgentCallable<Boolean,Exception> {
         @Override
         public Boolean call() throws Exception {
             if (File.pathSeparatorChar==';')    return false;   // Windows

--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 
 /**
  * Actual agent restart logic.
@@ -64,7 +64,7 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
             Functions.printStackTrace(e, listener.error("Failed to install restarter"));
         }
     }
-    private static class FindEffectiveRestarters extends MasterToSlaveCallable<List<SlaveRestarter>, IOException> {
+    private static class FindEffectiveRestarters extends ControllerToAgentCallable<List<SlaveRestarter>, IOException> {
         private final List<SlaveRestarter> restarters;
         FindEffectiveRestarters(List<SlaveRestarter> restarters) {
             this.restarters = restarters;

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -44,7 +44,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 
 import jenkins.util.io.OnMaster;
 import org.apache.commons.lang.StringUtils;
@@ -138,7 +138,7 @@ public class SystemProperties {
         public void preOnline(Computer c, Channel channel, FilePath root, TaskListener listener) throws IOException, InterruptedException {
             channel.call(new CopySystemProperties());
         }
-        private static final class CopySystemProperties extends MasterToSlaveCallable<Void, RuntimeException> {
+        private static final class CopySystemProperties extends ControllerToAgentCallable<Void, RuntimeException> {
             private static final long serialVersionUID = 1;
             private final Map<String, String> snapshot;
             CopySystemProperties() {

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -60,9 +60,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 import hudson.util.io.Archiver;
 import hudson.util.io.ArchiverFactory;
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import jenkins.model.ArtifactManager;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.AbstractFileSet;
@@ -301,7 +301,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
         return false;
     }
 
-    private static final class CollectFiles extends MasterToSlaveCallable<Collection<String>, IOException> {
+    private static final class CollectFiles extends ControllerToAgentCallable<Collection<String>, IOException> {
         private static final long serialVersionUID = 1;
         private final VirtualFile root;
         CollectFiles(VirtualFile root) {
@@ -1103,7 +1103,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
             return joinWithForwardSlashes(relativePath);
         }
     }
-    private static final class Scanner extends MasterToSlaveFileCallable<List<String>> {
+    private static final class Scanner extends ControllerToAgentFileCallable<List<String>> {
         private final String includes, excludes;
         private final boolean useDefaultExcludes;
         private final String verificationRoot;
@@ -1138,7 +1138,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
         }
 
     }
-    private static final class Readable extends MasterToSlaveFileCallable<Boolean> {
+    private static final class Readable extends ControllerToAgentFileCallable<Boolean> {
         @Override public Boolean invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
             return f.canRead();
         }

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -32,7 +32,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.charset.Charset;
 
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import org.apache.commons.io.FileUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -81,7 +81,7 @@ public class LauncherTest {
             // hangs and on agent machine pgrep sleep => one process; after manual kill, script returns.
     }
 
-    private static class NoopCallable extends MasterToSlaveCallable<Object,RuntimeException> {
+    private static class NoopCallable extends ControllerToAgentCallable<Object,RuntimeException> {
         @Override
         public Object call() throws RuntimeException {
             return null;

--- a/core/src/test/java/hudson/os/SUTester.java
+++ b/core/src/test/java/hudson/os/SUTester.java
@@ -3,7 +3,7 @@ package hudson.os;
 import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.nio.file.Files;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -13,7 +13,7 @@ public class SUTester {
         SU.execute(StreamTaskListener.fromStdout(),"kohsuke","bogus", new TouchingCallable());
     }
 
-    private static class TouchingCallable extends MasterToSlaveCallable<Object, Throwable> {
+    private static class TouchingCallable extends ControllerToAgentCallable<Object, Throwable> {
         @Override
         public Object call() throws Throwable {
             System.out.println("Touching /tmp/x");

--- a/core/src/test/java/hudson/util/ProcessTreeTest.java
+++ b/core/src/test/java/hudson/util/ProcessTreeTest.java
@@ -6,7 +6,7 @@ import hudson.util.ProcessTree.OSProcess;
 import hudson.util.ProcessTree.ProcessCallable;
 import java.io.IOException;
 import java.io.Serializable;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
@@ -46,7 +46,7 @@ public class ProcessTreeTest {
         t.p.act(new ProcessCallableImpl());
     }
 
-    private static class MyCallable extends MasterToSlaveCallable<Tag, IOException> implements Serializable {
+    private static class MyCallable extends ControllerToAgentCallable<Tag, IOException> implements Serializable {
         @Override
         public Tag call() throws IOException {
             Tag t = new Tag();

--- a/test/src/test/java/hudson/ProcTest.java
+++ b/test/src/test/java/hudson/ProcTest.java
@@ -13,7 +13,7 @@ import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
 import hudson.util.IOUtils;
 import hudson.util.StreamTaskListener;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -82,7 +82,7 @@ public class ProcTest {
         return ch;
     }
 
-    private static class ChannelFiller extends MasterToSlaveCallable<Void,IOException> {
+    private static class ChannelFiller extends ControllerToAgentCallable<Void,IOException> {
         private final OutputStream o;
 
         private ChannelFiller(OutputStream o) {

--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -23,7 +23,7 @@
  */
 package hudson.logging;
 
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import org.jvnet.hudson.test.Url;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -120,7 +120,7 @@ public class LogRecorderManagerTest {
         assertFalse(text, text.contains("LambdaLog @FINER"));
     }
 
-    private static final class Log extends MasterToSlaveCallable<Boolean,Error> {
+    private static final class Log extends ControllerToAgentCallable<Boolean,Error> {
         private final Level level;
         private final String logger;
         private final String message;
@@ -145,7 +145,7 @@ public class LogRecorderManagerTest {
         }
     }
 
-    private static final class LambdaLog extends MasterToSlaveCallable<Boolean,Error> {
+    private static final class LambdaLog extends ControllerToAgentCallable<Boolean,Error> {
         private final Level level;
         private final String logger;
         LambdaLog(Level level, String logger) {

--- a/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
+++ b/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -217,7 +217,7 @@ public class WorkspaceCleanupThreadTest {
         }
     }
 
-    private static final class Touch extends MasterToSlaveFileCallable<Void> {
+    private static final class Touch extends ControllerToAgentFileCallable<Void> {
         private static final long serialVersionUID = 1L;
         private final long time;
 

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -34,7 +34,7 @@ import hudson.model.Slave;
 import hudson.remoting.Which;
 import hudson.util.ArgumentListBuilder;
 
-import jenkins.security.SlaveToMasterCallable;
+import jenkins.security.AgentToControllerCallable;
 import jenkins.slaves.RemotingWorkDirSettings;
 
 import org.junit.Assume;
@@ -278,7 +278,7 @@ public class JNLPLauncherTest {
         return c;
     }
 
-    private static class NoopTask extends SlaveToMasterCallable<String,RuntimeException> {
+    private static class NoopTask extends AgentToControllerCallable<String,RuntimeException> {
         @Override
         public String call() {
             return "done";

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -28,7 +28,7 @@ import hudson.model.Computer;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelClosedException;
 import hudson.remoting.PingThread;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -91,7 +91,7 @@ public class PingThreadTest {
         }
     }
 
-    private static final class GetPid extends MasterToSlaveCallable<String, IOException> {
+    private static final class GetPid extends ControllerToAgentCallable<String, IOException> {
         @Override public String call() throws IOException {
             return ManagementFactory.getRuntimeMXBean().getName().replaceAll("@.*", "");
         }

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -46,7 +46,7 @@ import java.util.List;
 import hudson.model.Run;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
-import jenkins.MasterToSlaveFileCallable;
+import jenkins.ControllerToAgentFileCallable;
 import jenkins.model.StandardArtifactManager;
 import jenkins.util.VirtualFile;
 import org.hamcrest.Matchers;
@@ -444,7 +444,7 @@ public class ArtifactArchiverTest {
         assertEquals("8", artifact.getLength());
     }
 
-    private static class RemoveReadPermission extends MasterToSlaveFileCallable<Object> {
+    private static class RemoveReadPermission extends ControllerToAgentFileCallable<Object> {
         @Override
         public Object invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
             assertTrue(f.createNewFile());

--- a/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
+++ b/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
@@ -39,7 +39,8 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.security.SlaveToMasterCallable;
+
+import jenkins.security.AgentToControllerCallable;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.ant.util.JavaEnvUtils;
 import org.junit.ClassRule;
@@ -118,14 +119,14 @@ public class WebSocketAgentsTest {
         }
     }
 
-    private static class DummyTask extends SlaveToMasterCallable<String, RuntimeException> {
+    private static class DummyTask extends AgentToControllerCallable<String, RuntimeException> {
         @Override
         public String call() {
             return "response";
         }
     }
 
-    private static class FatTask extends SlaveToMasterCallable<String, RuntimeException> {
+    private static class FatTask extends AgentToControllerCallable<String, RuntimeException> {
         private byte[] payload;
 
         private FatTask() {

--- a/test/src/test/java/jenkins/security/ClassFilterImplTest.java
+++ b/test/src/test/java/jenkins/security/ClassFilterImplTest.java
@@ -96,7 +96,7 @@ public class ClassFilterImplTest {
             }
         }
     }
-    private static class M2S extends MasterToSlaveCallable<String, RuntimeException> {
+    private static class M2S extends ControllerToAgentCallable<String, RuntimeException> {
         private final LinkedListMultimap<?, ?> obj = LinkedListMultimap.create();
         @Override
         public String call() throws RuntimeException {
@@ -129,7 +129,7 @@ public class ClassFilterImplTest {
             }
         }
     }
-    private static class S2M extends MasterToSlaveCallable<LinkedListMultimap<?, ?>, RuntimeException> {
+    private static class S2M extends ControllerToAgentCallable<LinkedListMultimap<?, ?>, RuntimeException> {
         @Override
         public LinkedListMultimap<?, ?> call() throws RuntimeException {
             return LinkedListMultimap.create();

--- a/test/src/test/java/jenkins/security/Security218Test.java
+++ b/test/src/test/java/jenkins/security/Security218Test.java
@@ -80,7 +80,7 @@ public class Security218Test implements Serializable {
             assertThat(e.getMessage(), containsString(MethodClosure.class.getName()));
         }
     }
-    private static class EvilReturnValue extends MasterToSlaveCallable<Object, RuntimeException> {
+    private static class EvilReturnValue extends ControllerToAgentCallable<Object, RuntimeException> {
         @Override
         public Object call() {
             return new MethodClosure("oops", "trim");

--- a/test/src/test/java/jenkins/security/Security637Test.java
+++ b/test/src/test/java/jenkins/security/Security637Test.java
@@ -75,7 +75,7 @@ public class Security637Test {
         });
     }
     
-    private static class URLHandlerCallable extends MasterToSlaveCallable<String, Exception> {
+    private static class URLHandlerCallable extends ControllerToAgentCallable<String, Exception> {
         private URL url;
         
         URLHandlerCallable(URL url) {
@@ -127,7 +127,7 @@ public class Security637Test {
         });
     }
     
-    private static class URLBuilderCallable extends MasterToSlaveCallable<URL, Exception> {
+    private static class URLBuilderCallable extends ControllerToAgentCallable<URL, Exception> {
         private String url;
         
         URLBuilderCallable(String url) {
@@ -167,7 +167,7 @@ public class Security637Test {
     }
     
     // the URL is serialized / deserialized twice, master => agent and then agent => master
-    private static class URLTransferCallable extends MasterToSlaveCallable<URL, Exception> {
+    private static class URLTransferCallable extends ControllerToAgentCallable<URL, Exception> {
         private URL url;
         
         URLTransferCallable(URL url) {

--- a/test/src/test/java/jenkins/slaves/OldRemotingAgentTest.java
+++ b/test/src/test/java/jenkins/slaves/OldRemotingAgentTest.java
@@ -44,7 +44,7 @@ import hudson.node_monitors.NodeMonitor;
 import hudson.slaves.ComputerLauncher;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -132,7 +132,7 @@ public class OldRemotingAgentTest {
         }
         assertThat(sw.toString(), containsString("@@@ANNOTATED@@@"));
     }
-    private static final class RemoteConsoleNotePrinter extends MasterToSlaveCallable<Void, IOException> {
+    private static final class RemoteConsoleNotePrinter extends ControllerToAgentCallable<Void, IOException> {
         private final TaskListener listener;
         RemoteConsoleNotePrinter(TaskListener listener) {
             this.listener = listener;

--- a/test/src/test/java/jenkins/util/JenkinsJVMRealTest.java
+++ b/test/src/test/java/jenkins/util/JenkinsJVMRealTest.java
@@ -2,7 +2,7 @@ package jenkins.util;
 
 import hudson.slaves.DumbSlave;
 import java.io.IOException;
-import jenkins.security.MasterToSlaveCallable;
+import jenkins.security.ControllerToAgentCallable;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -22,7 +22,7 @@ public class JenkinsJVMRealTest {
         assertThat(slave.getChannel().call(new IsJenkinsJVM()), is(false));
     }
 
-    public static class IsJenkinsJVM extends MasterToSlaveCallable<Boolean, IOException> {
+    public static class IsJenkinsJVM extends ControllerToAgentCallable<Boolean, IOException> {
 
         @Override
         public Boolean call() throws IOException {


### PR DESCRIPTION
Related to #5425. I'm submitting this in a separate PR because I expect potential issues in review and don't think this should end up blocking the other PR.

This cleans up callable class names involved in the agent-to-controller security subsystem.

Existing types are retained as subclasses of the new ones (similar to `Hudson extends Jenkins`), but deprecated.

### Proposed changelog entries

* Terminology cleanup: Deprecate `SlaveToMaster[File]Callable`, `MasterToSlave[File]Callable`, `Role.MASTER` and `Role.SLAVE` in favor of the new `AgentToController[File]Callable`, `ControllerToAgent[File]Callable`, `Role.CONTROLLER` and `Role.AGENT`.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
