### PR TITLE
Terminology: Add tcp-agent-listener root action

### DIFF
--- a/core/src/main/java/jenkins/agents/TcpAgentListenerRootAction.java
+++ b/core/src/main/java/jenkins/agents/TcpAgentListenerRootAction.java
@@ -1,0 +1,37 @@
+package jenkins.agents;
+
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.StaplerProxy;
+
+/**
+ * Provides the {@code /tcp-agent-listener} URL.
+ *
+ * @since TODO
+ */
+@Restricted(NoExternalUse.class)
+@Extension
+public class TcpAgentListenerRootAction implements UnprotectedRootAction, StaplerProxy {
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return "tcp-agent-listener";
+    }
+
+    @Override
+    public Object getTarget() {
+        return Jenkins.get().getTcpSlaveAgentListener();
+    }
+}

--- a/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
+++ b/test/src/test/java/hudson/TcpSlaveAgentListenerTest.java
@@ -29,9 +29,13 @@ public class TcpSlaveAgentListenerTest {
 
         r.getInstance().setSlaveAgentPort(-1);
         wc.assertFails("tcpSlaveAgentListener", HttpURLConnection.HTTP_NOT_FOUND);
+        wc.assertFails("tcp-agent-listener", HttpURLConnection.HTTP_NOT_FOUND);
 
         r.getInstance().setSlaveAgentPort(0);
         Page p = wc.goTo("tcpSlaveAgentListener", "text/plain");
+        assertEquals(HttpURLConnection.HTTP_OK, p.getWebResponse().getStatusCode());
+        assertThat(p.getWebResponse().getResponseHeaderValue("X-Instance-Identity"), notNullValue());
+        p = wc.goTo("tcp-agent-listener", "text/plain");
         assertEquals(HttpURLConnection.HTTP_OK, p.getWebResponse().getStatusCode());
         assertThat(p.getWebResponse().getResponseHeaderValue("X-Instance-Identity"), notNullValue());
     }


### PR DESCRIPTION
Split from #5425 as it needs a corresponding PR to https://github.com/jenkinsci/remoting/ and is therefore better delivered independently.

### Proposed changelog entries

* Terminology cleanup: Add `tcp-agent-listener` URL as an alternative to `tcpSlaveAgentListener` for inbound agent connections.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
