### PR TITLE
Bump `commons-discovery` from 0.4 to 0.5

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
   <properties>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <stapler.version>1532.vfcf95addcb5f</stapler.version>
+    <stapler.version>1533.v6ad90a2a1314</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/222 -->
     <groovy.version>2.4.12</groovy.version>
   </properties>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
   <properties>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <stapler.version>1533.v6ad90a2a1314</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/222 -->
+    <stapler.version>1533.v66f4accc776a</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/222 -->
     <groovy.version>2.4.12</groovy.version>
   </properties>
 


### PR DESCRIPTION
See stapler/stapler#222. Jenkins core ships `commons-discovery` 0.4 in the WAR file, via Stapler. This version was released sometime in 2006. The latest version of `commons-discovery` is 0.5, released sometime around 2011 (see the [release notes](https://archive.apache.org/dist/commons/discovery/RELEASE-NOTES.txt)). `usage-in-plugins` shows that nothing uses this library in the Jenkins ecosystem beyond Stapler and Jenkins core itself in `CLICommand`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).