### PR TITLE
Add a small gap between build status icon and text

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -47,10 +47,7 @@ THE SOFTWARE.
         </div>
       </div>
 
-      <t:buildCaption>
-        ${%Build} ${it.displayName}
-        (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)
-      </t:buildCaption>
+      <t:buildCaption>${%Build} ${it.displayName} (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</t:buildCaption>
 
       <div>
         <t:editableDescription permission="${it.UPDATE}" />

--- a/core/src/main/resources/hudson/model/Run/artifacts-index.jelly
+++ b/core/src/main/resources/hudson/model/Run/artifacts-index.jelly
@@ -28,9 +28,7 @@ THE SOFTWARE.
     <l:layout title="${it.fullDisplayName} Artifacts">
       <st:include page="sidepanel.jelly" />
       <l:main-panel>
-        <t:buildCaption>
-          ${%Build Artifacts}
-        </t:buildCaption>
+        <t:buildCaption>${%Build Artifacts}</t:buildCaption>
         <table class="fileList">
           <j:forEach var="f" items="${it.artifacts}">
             <tr>

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -32,9 +32,7 @@ THE SOFTWARE.
   <l:layout title="${it.fullDisplayName} Console">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <t:buildCaption>
-        <span style="margin-left:.2em;">${%Console Output}</span>
-      </t:buildCaption>
+      <t:buildCaption>${%Console Output}</t:buildCaption>
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
       <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->
       <j:set var="offset" value="${empty(consoleFull) ? it.logText.length()-threshold*1024 : 0}" />

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <t:buildCaption>
-        ${%Console Output}
+        <span style="margin-left:.2em;">${%Console Output}</span>
       </t:buildCaption>
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
       <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->
@@ -54,7 +54,7 @@ THE SOFTWARE.
         <j:when test="${it.isLogUpdated()}">
           <pre id="out" class="console-output" />
             <div id="spinner">
-              <img src="${imagesURL}/spinner.gif" alt="" /> 
+              <img src="${imagesURL}/spinner.gif" alt="" />
             </div>
           <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
                startOffset="${offset}" onFinishEvent="jenkins:consoleFinished"/>

--- a/core/src/main/resources/lib/hudson/buildCaption.jelly
+++ b/core/src/main/resources/lib/hudson/buildCaption.jelly
@@ -43,7 +43,7 @@ THE SOFTWARE.
 	      </tr></table>
 	    </div>
 	  </j:if>
-	  
+
 	  <l:icon alt="${it.iconColor.description}" class="${it.buildStatusIconClassName} icon-xlg" tooltip="${it.iconColor.description}"/>
         <script>
           (function(){
@@ -71,6 +71,8 @@ THE SOFTWARE.
 
           })();
         </script>
-	  <d:invokeBody />
-	</h1>
+        <span style="margin-left:.2em;">
+          <d:invokeBody trim="true"/>
+        </span>
+    </h1>
 </j:jelly>


### PR DESCRIPTION
A small followup to https://github.com/jenkinsci/jenkins/pull/5471. Currently the build status icon is too narrow to the text "Console Output". 

**Note:** this does not work for pipelines, seems that that part of the code has been duplicated somewhere in the pipeline modules. 

### Before:

![Bildschirmfoto 2021-05-20 um 17 29 32](https://user-images.githubusercontent.com/503338/119006873-0928d700-b991-11eb-8052-330068c35388.png)

### After: 

![Bildschirmfoto 2021-05-20 um 17 29 38](https://user-images.githubusercontent.com/503338/119006895-0ded8b00-b991-11eb-8dbf-ac0f8048b9d5.png)

### Proposed changelog entries

* Entry 1: Enhancement, Improve layout of console output header

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
