### PR TITLE
Fix `BadImport` Error Prone violations

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -63,7 +63,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -398,7 +397,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
         }
 
         private <U> void _find(Class<U> type, List<ExtensionComponent<U>> result, Injector container) {
-            for (Entry<Key<?>, Binding<?>> e : container.getBindings().entrySet()) {
+            for (Map.Entry<Key<?>, Binding<?>> e : container.getBindings().entrySet()) {
                 if (type.isAssignableFrom(e.getKey().getTypeLiteral().getRawType())) {
                     Annotation a = annotations.get(e.getKey());
                     Object o = e.getValue().getProvider().get();

--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Map.Entry;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
 
@@ -112,7 +111,7 @@ public class BuildCommand extends CLICommand {
             //TODO: switch to type annotations after the migration to Java 1.8
             List<ParameterValue> values = new ArrayList<>();
 
-            for (Entry<String, String> e : parameters.entrySet()) {
+            for (Map.Entry<String, String> e : parameters.entrySet()) {
                 String name = e.getKey();
                 ParameterDefinition pd = pdp.getParameterDefinition(name);
                 if (pd==null) {

--- a/core/src/main/java/hudson/cli/ListChangesCommand.java
+++ b/core/src/main/java/hudson/cli/ListChangesCommand.java
@@ -3,7 +3,6 @@ package hudson.cli;
 import hudson.Extension;
 import hudson.model.Run;
 import hudson.scm.ChangeLogSet;
-import hudson.scm.ChangeLogSet.Entry;
 import hudson.util.QuotedStringTokenizer;
 import jenkins.scm.RunWithSCM;
 import org.kohsuke.args4j.Option;
@@ -67,7 +66,7 @@ public class ListChangesCommand extends RunRangeCommand {
             for (Run<?, ?> build : builds) {
                 if (build instanceof RunWithSCM) {
                     for (ChangeLogSet<?> cs : ((RunWithSCM<?, ?>) build).getChangeSets()) {
-                        for (Entry e : cs) {
+                        for (ChangeLogSet.Entry e : cs) {
                             stdout.printf("%s,%s%n",
                                     QuotedStringTokenizer.quote(e.getAuthor().getId()),
                                     QuotedStringTokenizer.quote(e.getMsg()));
@@ -80,7 +79,7 @@ public class ListChangesCommand extends RunRangeCommand {
             for (Run<?, ?> build : builds) {
                 if (build instanceof RunWithSCM) {
                     for (ChangeLogSet<?> cs : ((RunWithSCM<?, ?>) build).getChangeSets()) {
-                        for (Entry e : cs) {
+                        for (ChangeLogSet.Entry e : cs) {
                             stdout.printf("%s\t%s%n", e.getAuthor(), e.getMsg());
                             for (String p : e.getAffectedPaths()) {
                                 stdout.println("  " + p);

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -41,7 +41,6 @@ import hudson.remoting.ChannelClosedException;
 import hudson.remoting.RequestAbortedException;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.ChangeLogSet;
-import hudson.scm.ChangeLogSet.Entry;
 import hudson.scm.NullChangeLogParser;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
@@ -136,7 +135,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
     /**
      * Changes in this build.
      */
-    private transient volatile WeakReference<ChangeLogSet<? extends Entry>> changeSet;
+    private transient volatile WeakReference<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSet;
 
     /**
      * Cumulative list of people who contributed to the build problem.
@@ -890,14 +889,14 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
      * @return never null.
      */
     @Exported
-    @NonNull public ChangeLogSet<? extends Entry> getChangeSet() {
+    @NonNull public ChangeLogSet<? extends ChangeLogSet.Entry> getChangeSet() {
         synchronized (changeSetLock) {
             if (scm==null) {
                 scm = NullChangeLogParser.INSTANCE;                
             }
         }
 
-        ChangeLogSet<? extends Entry> cs = null;
+        ChangeLogSet<? extends ChangeLogSet.Entry> cs = null;
         if (changeSet!=null)
             cs = changeSet.get();
 
@@ -916,7 +915,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
 
     @Override
     @NonNull public List<ChangeLogSet<? extends ChangeLogSet.Entry>> getChangeSets() {
-        ChangeLogSet<? extends Entry> cs = getChangeSet();
+        ChangeLogSet<? extends ChangeLogSet.Entry> cs = getChangeSet();
         return cs.isEmptySet() ? Collections.emptyList() : Collections.singletonList(cs);
     }
 
@@ -928,7 +927,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         return changelogFile.exists();
     }
 
-    private ChangeLogSet<? extends Entry> calcChangeSet() {
+    private ChangeLogSet<? extends ChangeLogSet.Entry> calcChangeSet() {
         File changelogFile = new File(getRootDir(), "changelog.xml");
         if (!changelogFile.exists())
             return ChangeLogSet.createEmpty(this);

--- a/core/src/main/java/hudson/model/DependencyGraph.java
+++ b/core/src/main/java/hudson/model/DependencyGraph.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Stack;
 
@@ -341,7 +340,7 @@ public class DependencyGraph implements Comparator<AbstractProject> {
     }
 
     private Map<AbstractProject, List<DependencyGroup>> finalize(Map<AbstractProject, List<DependencyGroup>> m) {
-        for (Entry<AbstractProject, List<DependencyGroup>> e : m.entrySet()) {
+        for (Map.Entry<AbstractProject, List<DependencyGroup>> e : m.entrySet()) {
             e.getValue().sort(NAME_COMPARATOR);
             e.setValue( Collections.unmodifiableList(e.getValue()) );
         }

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -34,7 +34,6 @@ import jenkins.util.SystemProperties;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.util.FormValidation;
-import hudson.util.FormValidation.Kind;
 import hudson.util.TextFile;
 import static java.util.concurrent.TimeUnit.DAYS;
 import java.io.File;
@@ -386,7 +385,7 @@ public class DownloadService {
                 JSONObject o = JSONObject.fromObject(jsonString);
                 if (signatureCheck) {
                     FormValidation e = updatesite.getJsonSignatureValidator(signatureValidatorPrefix +" '"+id+"'").verifySignature(o);
-                    if (e.kind!= Kind.OK) {
+                    if (e.kind!= FormValidation.Kind.OK) {
                         LOGGER.log(Level.WARNING, "signature check failed for " + site, e );
                         continue;
                     }

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -63,7 +63,7 @@ import java.util.Date;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1009,7 +1009,7 @@ public class Fingerprint implements ModelObject, Saveable {
     public @NonNull List<RangeItem> _getUsages() {
         List<RangeItem> r = new ArrayList<>();
         final Jenkins instance = Jenkins.get();
-        for (Entry<String, RangeSet> e : usages.entrySet()) {
+        for (Map.Entry<String, RangeSet> e : usages.entrySet()) {
             final String itemName = e.getKey();
             if (instance.hasPermission(Jenkins.ADMINISTER) || canDiscoverItem(itemName)) {
                 r.add(new RangeItem(itemName, e.getValue()));
@@ -1074,7 +1074,7 @@ public class Fingerprint implements ModelObject, Saveable {
         if(original!=null && original.isAlive())
             return true;
 
-        for (Entry<String,RangeSet> e : usages.entrySet()) {
+        for (Map.Entry<String,RangeSet> e : usages.entrySet()) {
             Job j = Jenkins.get().getItemByFullName(e.getKey(),Job.class);
             if(j==null)
                 continue;
@@ -1101,7 +1101,7 @@ public class Fingerprint implements ModelObject, Saveable {
     public synchronized boolean trim() throws IOException {
         boolean modified = false;
 
-        for (Entry<String,RangeSet> e : new Hashtable<>(usages).entrySet()) {// copy because we mutate
+        for (Map.Entry<String,RangeSet> e : new Hashtable<>(usages).entrySet()) {// copy because we mutate
             Job j = Jenkins.get().getItemByFullName(e.getKey(),Job.class);
             if(j==null) {// no such job any more. recycle the record
                 modified = true;

--- a/core/src/main/java/hudson/model/FullDuplexHttpChannel.java
+++ b/core/src/main/java/hudson/model/FullDuplexHttpChannel.java
@@ -25,7 +25,6 @@ package hudson.model;
 
 import hudson.remoting.Channel;
 import hudson.remoting.PingThread;
-import hudson.remoting.Channel.Mode;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -53,7 +52,7 @@ public abstract class FullDuplexHttpChannel extends FullDuplexHttpService {
     @Override
     protected void run(final InputStream upload, OutputStream download) throws IOException, InterruptedException {
         channel = new Channel("HTTP full-duplex channel " + uuid,
-                Computer.threadPoolForRemoting, Mode.BINARY, upload, download, null, restricted);
+                Computer.threadPoolForRemoting, Channel.Mode.BINARY, upload, download, null, restricted);
 
         // so that we can detect dead clients, periodically send something
         PingThread ping = new PingThread(channel) {

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -76,7 +76,6 @@ import hudson.triggers.SafeTimerTask;
 import java.util.concurrent.TimeUnit;
 import hudson.util.XStream2;
 import hudson.util.ConsistentHash;
-import hudson.util.ConsistentHash.Hash;
 
 import java.io.File;
 import java.io.IOException;
@@ -1780,7 +1779,7 @@ public class Queue extends ResourceController implements Saveable {
         };
     }
 
-    private static final Hash<Node> NODE_HASH = Node::getNodeName;
+    private static final ConsistentHash.Hash<Node> NODE_HASH = Node::getNodeName;
 
     private boolean makePending(BuildableItem p) {
         // LOGGER.info("Making "+p.task+" pending"); // REMOVE

--- a/core/src/main/java/hudson/model/ResourceList.java
+++ b/core/src/main/java/hudson/model/ResourceList.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map.Entry;
 import java.util.logging.Logger;
 
 /**
@@ -83,7 +82,7 @@ public final class ResourceList {
             ResourceList r = new ResourceList();
             for (ResourceList l : lists) {
                 r.all.addAll(l.all);
-                for (Entry<Resource, Integer> e : l.write.entrySet())
+                for (Map.Entry<Resource, Integer> e : l.write.entrySet())
                     r.write.put(e.getKey(), unbox(r.write.get(e.getKey()))+e.getValue());
             }
             return r;
@@ -125,7 +124,7 @@ public final class ResourceList {
     }
 
     private Resource _getConflict(ResourceList lhs, ResourceList rhs) {
-        for (Entry<Resource,Integer> r : lhs.write.entrySet()) {
+        for (Map.Entry<Resource,Integer> r : lhs.write.entrySet()) {
             for (Resource l : rhs.all) {
                 Integer v = rhs.write.get(l);
                 if(v!=null) // this is write/write conflict.
@@ -146,7 +145,7 @@ public final class ResourceList {
         Map<Resource,String> m = new HashMap<>();
         for (Resource r : all)
             m.put(r,"R");
-        for (Entry<Resource,Integer> e : write.entrySet())
+        for (Map.Entry<Resource,Integer> e : write.entrySet())
             m.put(e.getKey(),"W"+e.getValue());
         return m.toString();
     }

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -32,7 +32,6 @@ import hudson.Util;
 import hudson.lifecycle.Lifecycle;
 import hudson.model.UpdateCenter.UpdateCenterJob;
 import hudson.util.FormValidation;
-import hudson.util.FormValidation.Kind;
 import hudson.util.HttpResponses;
 import static jenkins.util.MemoryReductionUtil.EMPTY_STRING_ARRAY;
 import static jenkins.util.MemoryReductionUtil.getPresizedMutableMap;
@@ -239,7 +238,7 @@ public class UpdateSite {
 
         if (signatureCheck) {
             FormValidation e = verifySignatureInternal(o);
-            if (e.kind!=Kind.OK) {
+            if (e.kind!=FormValidation.Kind.OK) {
                 LOGGER.severe(e.toString());
                 return e;
             }

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -27,7 +27,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.PluginWrapper;
 import hudson.Util;
 import hudson.Extension;
-import hudson.node_monitors.ArchitectureMonitor.DescriptorImpl;
+import hudson.node_monitors.ArchitectureMonitor;
 import hudson.security.Permission;
 import hudson.util.Secret;
 import static java.util.concurrent.TimeUnit.DAYS;
@@ -143,7 +143,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
                 n.put("jvm-version", System.getProperty("java.version"));
             }
             n.put("executors",c.getNumExecutors());
-            DescriptorImpl descriptor = j.getDescriptorByType(DescriptorImpl.class);
+            ArchitectureMonitor.DescriptorImpl descriptor = j.getDescriptorByType(ArchitectureMonitor.DescriptorImpl.class);
             n.put("os", descriptor.get(c));
             nodes.add(n);
         }

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -35,7 +35,6 @@ import hudson.Util;
 import hudson.model.Descriptor.FormException;
 import hudson.model.listeners.ItemListener;
 import hudson.scm.ChangeLogSet;
-import hudson.scm.ChangeLogSet.Entry;
 import hudson.search.CollectionSearchIndex;
 import hudson.search.SearchIndexBuilder;
 import hudson.security.ACL;
@@ -757,8 +756,8 @@ public abstract class View extends AbstractModelObject implements AccessControll
                         if (r instanceof RunWithSCM) {
                             RunWithSCM<?,?> runWithSCM = (RunWithSCM<?,?>) r;
 
-                            for (ChangeLogSet<? extends Entry> c : runWithSCM.getChangeSets()) {
-                                for (Entry entry : c) {
+                            for (ChangeLogSet<? extends ChangeLogSet.Entry> c : runWithSCM.getChangeSets()) {
+                                for (ChangeLogSet.Entry entry : c) {
                                     User user = entry.getAuthor();
 
                                     UserInfo info = users.get(user);
@@ -799,8 +798,8 @@ public abstract class View extends AbstractModelObject implements AccessControll
                     for (Run<?,?> r : runs) {
                         if (r instanceof RunWithSCM) {
                             RunWithSCM<?,?> runWithSCM = (RunWithSCM<?,?>) r;
-                            for (ChangeLogSet<? extends Entry> c : runWithSCM.getChangeSets()) {
-                                for (Entry entry : c) {
+                            for (ChangeLogSet<? extends ChangeLogSet.Entry> c : runWithSCM.getChangeSets()) {
+                                for (ChangeLogSet.Entry entry : c) {
                                     User user = entry.getAuthor();
                                     if (user != null)
                                         return true;

--- a/core/src/main/java/hudson/model/queue/BackFiller.java
+++ b/core/src/main/java/hudson/model/queue/BackFiller.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.StreamSupport;
 
 /**
@@ -110,7 +109,7 @@ public class BackFiller extends LoadPredictor {
 
             // figure out how many executors we need on each computer?
             Map<Computer,Integer> footprint = new HashMap<>();
-            for (Entry<WorkChunk, ExecutorChunk> e : m.toMap().entrySet()) {
+            for (Map.Entry<WorkChunk, ExecutorChunk> e : m.toMap().entrySet()) {
                 Computer c = e.getValue().computer;
                 Integer v = footprint.get(c);
                 if (v==null)    v = 0;
@@ -130,7 +129,7 @@ public class BackFiller extends LoadPredictor {
 
             // now, based on the real predicted loads, figure out the approximation of when we can
             // start executing this guy.
-            for (Entry<Computer, Integer> e : footprint.entrySet()) {
+            for (Map.Entry<Computer, Integer> e : footprint.entrySet()) {
                 Computer computer = e.getKey();
                 Timeline timeline = new Timeline();
                 for (LoadPredictor lp : LoadPredictor.all()) {

--- a/core/src/main/java/hudson/model/queue/MappingWorksheet.java
+++ b/core/src/main/java/hudson/model/queue/MappingWorksheet.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import static java.lang.Math.max;
 
@@ -335,7 +334,7 @@ public class MappingWorksheet {
             long duration = item.task.getEstimatedDuration();
             if (duration > 0) {
                 long now = System.currentTimeMillis();
-                for (Entry<Computer, List<ExecutorSlot>> e : j.entrySet()) {
+                for (Map.Entry<Computer, List<ExecutorSlot>> e : j.entrySet()) {
                     final List<ExecutorSlot> list = e.getValue();
                     final int max = e.getKey().countExecutors();
 

--- a/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -104,7 +103,7 @@ public abstract class AbstractAsyncNodeMonitorDescriptor<T> extends AbstractNode
 
         final Map<Computer,T> data = new HashMap<>();
 
-        for (Entry<Computer, Future<T>> e : futures.entrySet()) {
+        for (Map.Entry<Computer, Future<T>> e : futures.entrySet()) {
             Computer c = e.getKey();
             Future<T> f = futures.get(c);
             data.put(c, null);  // sentinel value

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -33,7 +33,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.logging.Logger;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -56,7 +55,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
         protected Map<Computer, Data> monitor() throws InterruptedException {
             Result<Data> base = monitorDetailed();
             Map<Computer, Data> monitoringData = base.getMonitoringData();
-            for (Entry<Computer, Data> e : monitoringData.entrySet()) {
+            for (Map.Entry<Computer, Data> e : monitoringData.entrySet()) {
                 Computer c = e.getKey();
                 Data d = e.getValue();
                 if (base.getSkipped().contains(c)) {

--- a/core/src/main/java/hudson/scm/ChangeLogAnnotator.java
+++ b/core/src/main/java/hudson/scm/ChangeLogAnnotator.java
@@ -74,7 +74,7 @@ public abstract class ChangeLogAnnotator implements ExtensionPoint {
      *      add additional annotations into this object. If other annotators
      *      are registered, the object may already contain some markups when this
      *      method is invoked. Never null. {@link MarkupText#getText()} on this instance
-     *      will return the same string as {@link Entry#getMsgEscaped()}.
+     *      will return the same string as {@link ChangeLogSet.Entry#getMsgEscaped()}.
      * @since 1.568
      */
     public void annotate(Run<?,?> build, ChangeLogSet.Entry change, MarkupText text) {

--- a/core/src/main/java/hudson/scm/ChangeLogAnnotator.java
+++ b/core/src/main/java/hudson/scm/ChangeLogAnnotator.java
@@ -31,7 +31,6 @@ import hudson.MarkupText;
 import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
-import hudson.scm.ChangeLogSet.Entry;
 import hudson.util.CopyOnWriteList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -78,8 +77,8 @@ public abstract class ChangeLogAnnotator implements ExtensionPoint {
      *      will return the same string as {@link Entry#getMsgEscaped()}.
      * @since 1.568
      */
-    public void annotate(Run<?,?> build, Entry change, MarkupText text) {
-        if (build instanceof AbstractBuild && Util.isOverridden(ChangeLogAnnotator.class, getClass(), "annotate", AbstractBuild.class, Entry.class, MarkupText.class)) {
+    public void annotate(Run<?,?> build, ChangeLogSet.Entry change, MarkupText text) {
+        if (build instanceof AbstractBuild && Util.isOverridden(ChangeLogAnnotator.class, getClass(), "annotate", AbstractBuild.class, ChangeLogSet.Entry.class, MarkupText.class)) {
             annotate((AbstractBuild) build, change, text);
         } else {
             Logger.getLogger(ChangeLogAnnotator.class.getName()).log(Level.WARNING, "You must override the newer overload of annotate from {0}", getClass().getName());
@@ -87,7 +86,7 @@ public abstract class ChangeLogAnnotator implements ExtensionPoint {
     }
 
     @Deprecated
-    public void annotate(AbstractBuild<?,?> build, Entry change, MarkupText text) {
+    public void annotate(AbstractBuild<?,?> build, ChangeLogSet.Entry change, MarkupText text) {
         annotate((Run) build, change, text);
     }
 

--- a/core/src/main/java/hudson/scm/ChangeLogParser.java
+++ b/core/src/main/java/hudson/scm/ChangeLogParser.java
@@ -26,7 +26,6 @@ package hudson.scm;
 import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
-import hudson.scm.ChangeLogSet.Entry;
 import java.io.File;
 import java.io.IOException;
 import org.xml.sax.SAXException;
@@ -44,7 +43,7 @@ public abstract class ChangeLogParser {
     /**
      * @since 1.568
      */
-    public ChangeLogSet<? extends Entry> parse(Run build, RepositoryBrowser<?> browser, File changelogFile) throws IOException, SAXException {
+    public ChangeLogSet<? extends ChangeLogSet.Entry> parse(Run build, RepositoryBrowser<?> browser, File changelogFile) throws IOException, SAXException {
         if (build instanceof AbstractBuild && Util.isOverridden(ChangeLogParser.class, getClass(), "parse", AbstractBuild.class, File.class)) {
             return parse((AbstractBuild) build, changelogFile);
         } else {
@@ -53,7 +52,7 @@ public abstract class ChangeLogParser {
     }
 
     @Deprecated
-    public ChangeLogSet<? extends Entry> parse(AbstractBuild build, File changelogFile) throws IOException, SAXException {
+    public ChangeLogSet<? extends ChangeLogSet.Entry> parse(AbstractBuild build, File changelogFile) throws IOException, SAXException {
         return parse(build, build.getProject().getScm().getEffectiveBrowser(), changelogFile);
     }
 }

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -69,7 +69,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
@@ -429,7 +428,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
         /** Share data structure with other builds, mainly those of the same job. */
         private PackedMap<String,String> compact(Map<String,String> record) {
             Map<String,String> b = new HashMap<>();
-            for (Entry<String,String> e : record.entrySet()) {
+            for (Map.Entry<String,String> e : record.entrySet()) {
                 b.put(e.getKey().intern(), e.getValue().intern());
             }
             return PackedMap.of(b);
@@ -448,7 +447,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
             Jenkins h = Jenkins.get();
 
             Map<String,Fingerprint> m = new TreeMap<>();
-            for (Entry<String, String> r : record.entrySet()) {
+            for (Map.Entry<String, String> r : record.entrySet()) {
                 try {
                     Fingerprint fp = h._getFingerprint(r.getValue());
                     if(fp!=null)

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.BitSet;
 import java.util.Properties;
-import java.util.Map.Entry;
 import java.io.Serializable;
 import java.io.File;
 import java.io.IOException;
@@ -170,7 +169,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      * @since 1.114
      */
     public ArgumentListBuilder addKeyValuePairs(String prefix, Map<String,String> props) {
-        for (Entry<String,String> e : props.entrySet())
+        for (Map.Entry<String,String> e : props.entrySet())
             addKeyValuePair(prefix, e.getKey(), e.getValue(), false);
         return this;
     }
@@ -188,7 +187,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      * @since 1.378
      */
     public ArgumentListBuilder addKeyValuePairs(String prefix, Map<String,String> props, Set<String> propsToMask) {
-        for (Entry<String,String> e : props.entrySet()) {
+        for (Map.Entry<String,String> e : props.entrySet()) {
             addKeyValuePair(prefix, e.getKey(), e.getValue(), (propsToMask != null) && propsToMask.contains(e.getKey()));
         }
         return this;
@@ -230,7 +229,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
 
         properties = Util.replaceMacro(properties, propertiesGeneratingResolver(vr));
 
-        for (Entry<Object,Object> entry : Util.loadProperties(properties).entrySet()) {
+        for (Map.Entry<Object,Object> entry : Util.loadProperties(properties).entrySet()) {
             addKeyValuePair(prefix, (String)entry.getKey(), entry.getValue().toString(), (propsToMask != null) && propsToMask.contains(entry.getKey()));
         }
         return this;

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -65,7 +65,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
@@ -344,7 +343,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 return false;
 
             SortedMap<String,String> envs = getEnvironmentVariables();
-            for (Entry<String,String> e : modelEnvVar.entrySet()) {
+            for (Map.Entry<String,String> e : modelEnvVar.entrySet()) {
                 String v = envs.get(e.getKey());
                 if(v==null || !v.equals(e.getValue()))
                     return false;   // no match
@@ -650,7 +649,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 return false;
 
             SortedMap<String,String> envs = getEnvironmentVariables2();
-            for (Entry<String,String> e : modelEnvVar.entrySet()) {
+            for (Map.Entry<String,String> e : modelEnvVar.entrySet()) {
                 String v = envs.get(e.getKey());
                 if(v==null || !v.equals(e.getValue()))
                     return false;   // no match
@@ -1895,7 +1894,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         @Deprecated
         public Remote(ProcessTree proxy, Channel ch) {
             this.proxy = ch.export(IProcessTree.class,proxy);
-            for (Entry<Integer,OSProcess> e : proxy.processes.entrySet())
+            for (Map.Entry<Integer,OSProcess> e : proxy.processes.entrySet())
                 processes.put(e.getKey(),new RemoteProcess(e.getValue(),ch));
         }
         
@@ -1903,7 +1902,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             super(vetoersExist);
             
             this.proxy = ch.export(IProcessTree.class,proxy);
-            for (Entry<Integer,OSProcess> e : proxy.processes.entrySet())
+            for (Map.Entry<Integer,OSProcess> e : proxy.processes.entrySet())
                 processes.put(e.getKey(),new RemoteProcess(e.getValue(),ch));
         }
 

--- a/core/src/main/java/jenkins/PluginSubtypeMarker.java
+++ b/core/src/main/java/jenkins/PluginSubtypeMarker.java
@@ -38,7 +38,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementScanner6;
-import javax.tools.Diagnostic.Kind;
+import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import java.io.IOException;
@@ -69,7 +69,7 @@ public class PluginSubtypeMarker extends AbstractProcessor {
                             try {
                                 write(e);
                             } catch (IOException x) {
-                                processingEnv.getMessager().printMessage(Kind.ERROR, Functions.printThrowable(x), e);
+                                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, Functions.printThrowable(x), e);
                             }
                         }
                     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -286,7 +286,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -4075,7 +4074,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         long endTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(5);
 
         Map<String,Map<String,String>> r = new HashMap<>();
-        for (Entry<String, Future<Map<String, String>>> e : future.entrySet()) {
+        for (Map.Entry<String, Future<Map<String, String>>> e : future.entrySet()) {
             try {
                 r.put(e.getKey(), e.getValue().get(endTime-System.currentTimeMillis(), TimeUnit.MILLISECONDS));
             } catch (Exception x) {

--- a/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
@@ -1,11 +1,11 @@
 package jenkins.model.lazy;
 
-import groovy.util.MapEntry;
 import hudson.util.AdaptedIterator;
 import hudson.util.Iterators;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.lang.reflect.Array;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -392,13 +392,13 @@ class BuildReferenceMapAdapter<R> implements SortedMap<Integer,R> {
         }
 
         private Entry<Integer,BuildReference<R>> _wrap(Entry<Integer,R> e) {
-            return new MapEntry(e.getKey(),wrap(e.getValue()));
+            return new AbstractMap.SimpleEntry<>(e.getKey(),wrap(e.getValue()));
         }
         private Entry<Integer, R> _unwrap(Entry<Integer, BuildReference<R>> e) {
             R v = unwrap(e.getValue());
             if (v==null)
                 return null;
-            return new MapEntry(e.getKey(), v);
+            return new AbstractMap.SimpleEntry<>(e.getKey(), v);
         }
     }
 }

--- a/core/src/main/java/jenkins/model/lazy/LazyLoadRunMapEntrySet.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyLoadRunMapEntrySet.java
@@ -2,10 +2,10 @@ package jenkins.model.lazy;
 
 import jenkins.model.lazy.AbstractLazyLoadRunMap.Direction;
 
-import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Iterator;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -14,19 +14,19 @@ import java.util.Set;
  *
  * @author Kohsuke Kawaguchi
  */
-class LazyLoadRunMapEntrySet<R> extends AbstractSet<Entry<Integer,R>> {
+class LazyLoadRunMapEntrySet<R> extends AbstractSet<Map.Entry<Integer,R>> {
     private final AbstractLazyLoadRunMap<R> owner;
 
     /**
      * Lazily loaded all entries.
      */
-    private Set<Entry<Integer,R>> all;
+    private Set<Map.Entry<Integer,R>> all;
 
     LazyLoadRunMapEntrySet(AbstractLazyLoadRunMap<R> owner) {
         this.owner = owner;
     }
 
-    private synchronized Set<Entry<Integer,R>> all() {
+    private synchronized Set<Map.Entry<Integer,R>> all() {
         if (all==null)
             all = new BuildReferenceMapAdapter<>(owner, owner.all()).entrySet();
         return all;
@@ -48,8 +48,8 @@ class LazyLoadRunMapEntrySet<R> extends AbstractSet<Entry<Integer,R>> {
 
     @Override
     public boolean contains(Object o) {
-        if (o instanceof Entry) {
-            Entry e = (Entry) o;
+        if (o instanceof Map.Entry) {
+            Map.Entry e = (Map.Entry) o;
             Object k = e.getKey();
             if (k instanceof Integer) {
                 return owner.getByNumber((Integer)k).equals(e.getValue());
@@ -59,8 +59,8 @@ class LazyLoadRunMapEntrySet<R> extends AbstractSet<Entry<Integer,R>> {
     }
 
     @Override
-    public Iterator<Entry<Integer,R>> iterator() {
-        return new Iterator<Entry<Integer,R>>() {
+    public Iterator<Map.Entry<Integer,R>> iterator() {
+        return new Iterator<Map.Entry<Integer,R>>() {
             R last = null;
             R next = owner.newestBuild();
 
@@ -70,7 +70,7 @@ class LazyLoadRunMapEntrySet<R> extends AbstractSet<Entry<Integer,R>> {
             }
 
             @Override
-            public Entry<Integer,R> next() {
+            public Map.Entry<Integer,R> next() {
                 last = next;
                 if (last!=null) {
                     next = owner.search(owner.getNumberOf(last)-1, Direction.DESC);
@@ -79,8 +79,8 @@ class LazyLoadRunMapEntrySet<R> extends AbstractSet<Entry<Integer,R>> {
                 return entryOf(last);
             }
 
-            private Entry<Integer, R> entryOf(R r) {
-                return new SimpleImmutableEntry<>(owner.getNumberOf(r), r);
+            private Map.Entry<Integer, R> entryOf(R r) {
+                return new AbstractMap.SimpleImmutableEntry<>(owner.getNumberOf(r), r);
             }
 
             @Override
@@ -103,14 +103,14 @@ class LazyLoadRunMapEntrySet<R> extends AbstractSet<Entry<Integer,R>> {
     }
 
     @Override
-    public boolean add(Entry<Integer, R> integerREntry) {
+    public boolean add(Map.Entry<Integer, R> integerREntry) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean remove(Object o) {
-        if (o instanceof Entry) {
-            Entry e = (Entry) o;
+        if (o instanceof Map.Entry) {
+            Map.Entry e = (Map.Entry) o;
             return owner.removeValue((R)e.getValue());
         }
         return false;

--- a/core/src/main/java/jenkins/security/UserDetailsCache.java
+++ b/core/src/main/java/jenkins/security/UserDetailsCache.java
@@ -24,7 +24,7 @@
 package jenkins.security;
 
 import com.google.common.cache.Cache;
-import static com.google.common.cache.CacheBuilder.newBuilder;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -70,8 +70,8 @@ public final class UserDetailsCache {
                 EXPIRE_AFTER_WRITE_SEC = (int)TimeUnit.MINUTES.toSeconds(2);
             }
         }
-        detailsCache = newBuilder().softValues().expireAfterWrite(EXPIRE_AFTER_WRITE_SEC, TimeUnit.SECONDS).build();
-        existenceCache = newBuilder().softValues().expireAfterWrite(EXPIRE_AFTER_WRITE_SEC, TimeUnit.SECONDS).build();
+        detailsCache = CacheBuilder.newBuilder().softValues().expireAfterWrite(EXPIRE_AFTER_WRITE_SEC, TimeUnit.SECONDS).build();
+        existenceCache = CacheBuilder.newBuilder().softValues().expireAfterWrite(EXPIRE_AFTER_WRITE_SEC, TimeUnit.SECONDS).build();
     }
 
     /**

--- a/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
+++ b/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
@@ -49,7 +49,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Stack;
 
 /**
@@ -151,7 +150,7 @@ public class XStreamDOM {
     private String[] toAttributeList(Map<String, String> attributes) {
         String[] r = new String[attributes.size()*2];
         int i=0;
-        for (Entry<String, String> e : attributes.entrySet()) {
+        for (Map.Entry<String, String> e : attributes.entrySet()) {
             r[i++] = e.getKey();
             r[i++] = e.getValue();
         }

--- a/core/src/test/java/hudson/util/ConsistentHashTest.java
+++ b/core/src/test/java/hudson/util/ConsistentHashTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import hudson.util.CopyOnWriteMap.Hash;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -40,7 +39,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.HashSet;
-import java.util.Map.Entry;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -122,7 +120,7 @@ public class ConsistentHashTest {
         hash.remove(0);
 
         // verify that the mapping remains consistent
-        for (Entry<Integer,Integer> e : before.entrySet()) {
+        for (Map.Entry<Integer,Integer> e : before.entrySet()) {
             int m = hash.lookup(e.getKey());
             assertTrue(e.getValue() == 0 || e.getValue() == m);
         }
@@ -187,7 +185,7 @@ public class ConsistentHashTest {
     @Test
     @Ignore("Helper test for performance, no assertion")
     public void speed() {
-        Map<String,Integer> data = new Hash<>();
+        Map<String,Integer> data = new CopyOnWriteMap.Hash<>();
         for (int i = 0; i < 1000; i++) {
             data.put("node" + i, 100);
         }

--- a/core/src/test/java/hudson/util/PackedMapTest.java
+++ b/core/src/test/java/hudson/util/PackedMapTest.java
@@ -3,7 +3,6 @@ package hudson.util;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.TreeMap;
 
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class PackedMapTest {
         assertEquals("b",p.get("a"));
         assertEquals("d", p.get("c"));
         assertEquals(2, p.size());
-        for (Entry<String,String> e : p.entrySet()) {
+        for (Map.Entry<String,String> e : p.entrySet()) {
             System.out.println(e.getKey()+'='+e.getValue());
         }
 

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.SortedMap;
@@ -329,7 +328,7 @@ public class AbstractLazyLoadRunMapTest {
     @Issue("JENKINS-18065")
     @Test
     public void entrySetIterator() {
-        Iterator<Entry<Integer, Build>> itr = a.entrySet().iterator();
+        Iterator<Map.Entry<Integer, Build>> itr = a.entrySet().iterator();
 
         // iterator, when created fresh, shouldn't force loading everything
         // this involves binary searching, so it can load several.
@@ -337,7 +336,7 @@ public class AbstractLazyLoadRunMapTest {
 
         // check if the first entry is legit
         assertTrue(itr.hasNext());
-        Entry<Integer, Build> e = itr.next();
+        Map.Entry<Integer, Build> e = itr.next();
         assertEquals((Integer)5,e.getKey());
         e.getValue().asserts(5);
 
@@ -388,7 +387,7 @@ public class AbstractLazyLoadRunMapTest {
     @Issue("JENKINS-18065")
     @Test
     public void entrySetContains() {
-        for (Entry<Integer, Build> e : a.entrySet()) {
+        for (Map.Entry<Integer, Build> e : a.entrySet()) {
             assertTrue(a.entrySet().contains(e));
         }
     }

--- a/test/src/test/java/hudson/cli/ComputerStateTest.java
+++ b/test/src/test/java/hudson/cli/ComputerStateTest.java
@@ -38,7 +38,7 @@ import hudson.cli.CLICommandInvoker.Result;
 import hudson.model.Computer;
 import hudson.model.Slave;
 import hudson.slaves.DumbSlave;
-import hudson.slaves.OfflineCause.UserCause;
+import hudson.slaves.OfflineCause;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -101,7 +101,7 @@ public class ComputerStateTest {
         assertThat(result, succeededSilently());
         assertTrue(slave.toComputer().isOffline());
 
-        UserCause cause = (UserCause) slave.toComputer().getOfflineCause();
+        OfflineCause.UserCause cause = (OfflineCause.UserCause) slave.toComputer().getOfflineCause();
         assertThat(cause.toString(), endsWith("Custom cause message"));
         assertThat(cause.getUser(), equalTo(command.user()));
     }
@@ -120,7 +120,7 @@ public class ComputerStateTest {
         assertThat(result, succeededSilently());
         assertTrue(slave.toComputer().isOffline());
 
-        UserCause cause = (UserCause) slave.toComputer().getOfflineCause();
+        OfflineCause.UserCause cause = (OfflineCause.UserCause) slave.toComputer().getOfflineCause();
         assertThat(cause.toString(), endsWith("Custom cause message"));
         assertThat(cause.getUser(), equalTo(command.user()));
     }

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -42,8 +42,6 @@ import hudson.slaves.ComputerListener;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.OfflineCause;
-import hudson.slaves.OfflineCause.ByCLI;
-import hudson.slaves.OfflineCause.UserCause;
 import hudson.util.TagCloud;
 import java.net.HttpURLConnection;
 
@@ -97,13 +95,13 @@ public class NodeTest {
         Node node = j.createOnlineSlave();
         FreeStyleProject project = j.createFreeStyleProject();
         project.setAssignedLabel(j.jenkins.getLabel(node.getDisplayName()));
-        OfflineCause cause = new ByCLI("message");
+        OfflineCause cause = new OfflineCause.ByCLI("message");
         node.setTemporaryOfflineCause(cause);
         for(ComputerListener l : ComputerListener.all()){
             l.onOnline(node.toComputer(), TaskListener.NULL);
         }
         assertEquals("Node should have offline cause which was set.", cause, node.toComputer().getOfflineCause());
-        OfflineCause cause2 = new ByCLI("another message");
+        OfflineCause cause2 = new OfflineCause.ByCLI("another message");
         node.setTemporaryOfflineCause(cause2);
         assertEquals("Node should have original offline cause after setting another.", cause, node.toComputer().getOfflineCause());
     }
@@ -118,7 +116,7 @@ public class NodeTest {
         ACL.impersonate2(someone.impersonate2());
 
         computer.doToggleOffline("original message");
-        cause = (UserCause) computer.getOfflineCause();
+        cause = (OfflineCause.UserCause) computer.getOfflineCause();
         assertTrue(cause.toString(), cause.toString().matches("^.*?Disconnected by someone@somewhere.com : original message"));
         assertEquals(someone, cause.getUser());
 
@@ -126,7 +124,7 @@ public class NodeTest {
         ACL.impersonate2(root.impersonate2());
 
         computer.doChangeOfflineCause("new message");
-        cause = (UserCause) computer.getOfflineCause();
+        cause = (OfflineCause.UserCause) computer.getOfflineCause();
         assertTrue(cause.toString(), cause.toString().matches("^.*?Disconnected by root@localhost : new message"));
         assertEquals(root, cause.getUser());
 
@@ -143,7 +141,7 @@ public class NodeTest {
             computer.doToggleOffline("original message");
         }
 
-        cause = (UserCause) computer.getOfflineCause();
+        cause = (OfflineCause.UserCause) computer.getOfflineCause();
         assertThat(cause.toString(), endsWith("Disconnected by anonymous : original message"));
         assertEquals(User.getUnknown(), cause.getUser());
 
@@ -152,7 +150,7 @@ public class NodeTest {
         try (ACLContext ctxt = ACL.as2(root.impersonate2())) {
             computer.doChangeOfflineCause("new message");
         }
-        cause = (UserCause) computer.getOfflineCause();
+        cause = (OfflineCause.UserCause) computer.getOfflineCause();
         assertThat(cause.toString(), endsWith("Disconnected by root@localhost : new message"));
         assertEquals(root, cause.getUser());
 

--- a/test/src/test/java/hudson/model/SlaveTest.java
+++ b/test/src/test/java/hudson/model/SlaveTest.java
@@ -36,7 +36,6 @@ import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 import hudson.slaves.RetentionStrategy;
 import hudson.util.FormValidation;
-import static hudson.util.FormValidation.Kind.WARNING;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -121,9 +120,9 @@ public class SlaveTest {
         DumbSlave.DescriptorImpl d = j.jenkins.getDescriptorByType(DumbSlave.DescriptorImpl.class);
         assertEquals(FormValidation.ok(), d.doCheckRemoteFS("c:\\"));
         assertEquals(FormValidation.ok(), d.doCheckRemoteFS("/tmp"));
-        assertEquals(WARNING, d.doCheckRemoteFS("relative/path").kind);
-        assertEquals(WARNING, d.doCheckRemoteFS("/net/foo/bar/zot").kind);
-        assertEquals(WARNING, d.doCheckRemoteFS("\\\\machine\\folder\\foo").kind);
+        assertEquals(FormValidation.Kind.WARNING, d.doCheckRemoteFS("relative/path").kind);
+        assertEquals(FormValidation.Kind.WARNING, d.doCheckRemoteFS("/net/foo/bar/zot").kind);
+        assertEquals(FormValidation.Kind.WARNING, d.doCheckRemoteFS("\\\\machine\\folder\\foo").kind);
     }
 
     @Test

--- a/test/src/test/java/hudson/scm/ChangeLogSetTest.java
+++ b/test/src/test/java/hudson/scm/ChangeLogSetTest.java
@@ -6,11 +6,10 @@ import static org.junit.Assert.fail;
 import hudson.Extension;
 import hudson.MarkupText;
 import hudson.model.AbstractBuild;
-import hudson.scm.ChangeLogSet.Entry;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.FakeChangeLogSCM.EntryImpl;
+import org.jvnet.hudson.test.FakeChangeLogSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -22,20 +21,20 @@ public class ChangeLogSetTest {
     @Test
     @Issue("JENKINS-17084")
     public void catchingExceptionDuringAnnotation() {
-        EntryImpl change = new EntryImpl();
+        FakeChangeLogSCM.EntryImpl change = new FakeChangeLogSCM.EntryImpl();
         change.setParent(ChangeLogSet.createEmpty(null)); // otherwise test would actually test only NPE thrown when accessing parent.build
         try {
             change.getMsgAnnotated();
         } catch (Throwable t) {
             fail(t.getMessage());
         }
-        assertEquals((new EntryImpl()).getMsg(), change.getMsg());
+        assertEquals((new FakeChangeLogSCM.EntryImpl()).getMsg(), change.getMsg());
     }
 
     @Extension
     public static final class ThrowExceptionChangeLogAnnotator extends ChangeLogAnnotator {
         @Override
-        public void annotate(AbstractBuild<?,?> build, Entry change, MarkupText text ) {
+        public void annotate(AbstractBuild<?,?> build, ChangeLogSet.Entry change, MarkupText text ) {
             throw new RuntimeException();
         }
     }
@@ -43,7 +42,7 @@ public class ChangeLogSetTest {
     @Extension
     public static final class ThrowErrorChangeLogAnnotator extends ChangeLogAnnotator {
         @Override
-        public void annotate(AbstractBuild<?,?> build, Entry change, MarkupText text ) {
+        public void annotate(AbstractBuild<?,?> build, ChangeLogSet.Entry change, MarkupText text ) {
             throw new Error();
         }
     }

--- a/test/src/test/java/hudson/slaves/EnvironmentVariableNodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/EnvironmentVariableNodePropertyTest.java
@@ -8,7 +8,6 @@ import hudson.model.Node;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
-import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -47,7 +46,7 @@ public class EnvironmentVariableNodePropertyTest {
 	 */
 	@Test
 	public void testSlavePropertyOnSlave() throws Exception {
-		setVariables(slave, new Entry("KEY", "slaveValue"));
+		setVariables(slave, new EnvironmentVariablesNodeProperty.Entry("KEY", "slaveValue"));
 		Map<String, String> envVars = executeBuild(slave);
 		assertEquals("slaveValue", envVars.get("KEY"));
 	}
@@ -59,7 +58,7 @@ public class EnvironmentVariableNodePropertyTest {
 	public void testMasterPropertyOnMaster() throws Exception {
         j.jenkins.getGlobalNodeProperties().replaceBy(
                 Collections.singleton(new EnvironmentVariablesNodeProperty(
-                        new Entry("KEY", "masterValue"))));
+                        new EnvironmentVariablesNodeProperty.Entry("KEY", "masterValue"))));
 
 		Map<String, String> envVars = executeBuild(j.jenkins);
 
@@ -73,8 +72,8 @@ public class EnvironmentVariableNodePropertyTest {
 	public void testSlaveAndMasterPropertyOnSlave() throws Exception {
         j.jenkins.getGlobalNodeProperties().replaceBy(
                 Collections.singleton(new EnvironmentVariablesNodeProperty(
-                        new Entry("KEY", "masterValue"))));
-		setVariables(slave, new Entry("KEY", "slaveValue"));
+                        new EnvironmentVariablesNodeProperty.Entry("KEY", "masterValue"))));
+		setVariables(slave, new EnvironmentVariablesNodeProperty.Entry("KEY", "slaveValue"));
 
 		Map<String, String> envVars = executeBuild(slave);
 
@@ -93,8 +92,8 @@ public class EnvironmentVariableNodePropertyTest {
 				new StringParameterDefinition("KEY", "parameterValue"));
 		project.addProperty(pdp);
 
-		setVariables(j.jenkins, new Entry("KEY", "masterValue"));
-		setVariables(slave, new Entry("KEY", "slaveValue"));
+		setVariables(j.jenkins, new EnvironmentVariablesNodeProperty.Entry("KEY", "masterValue"));
+		setVariables(slave, new EnvironmentVariablesNodeProperty.Entry("KEY", "slaveValue"));
 
 		Map<String, String> envVars = executeBuild(slave);
 
@@ -105,7 +104,7 @@ public class EnvironmentVariableNodePropertyTest {
 	public void testVariableResolving() throws Exception {
         j.jenkins.getGlobalNodeProperties().replaceBy(
                 Collections.singleton(new EnvironmentVariablesNodeProperty(
-                        new Entry("KEY1", "value"), new Entry("KEY2", "$KEY1"))));
+                        new EnvironmentVariablesNodeProperty.Entry("KEY1", "value"), new EnvironmentVariablesNodeProperty.Entry("KEY2", "$KEY1"))));
 		Map<String,String> envVars = executeBuild(j.jenkins);
 		assertEquals("value", envVars.get("KEY1"));
 		assertEquals("value", envVars.get("KEY2"));
@@ -115,7 +114,7 @@ public class EnvironmentVariableNodePropertyTest {
 	public void testFormRoundTripForMaster() throws Exception {
         j.jenkins.getGlobalNodeProperties().replaceBy(
                 Collections.singleton(new EnvironmentVariablesNodeProperty(
-                        new Entry("KEY", "value"))));
+                        new EnvironmentVariablesNodeProperty.Entry("KEY", "value"))));
 		
 		WebClient webClient = j.createWebClient();
 		HtmlPage page = webClient.getPage(j.jenkins, "configure");
@@ -131,7 +130,7 @@ public class EnvironmentVariableNodePropertyTest {
 
 	@Test
 	public void testFormRoundTripForSlave() throws Exception {
-		setVariables(slave, new Entry("KEY", "value"));
+		setVariables(slave, new EnvironmentVariablesNodeProperty.Entry("KEY", "value"));
 		
 		WebClient webClient = j.createWebClient();
 		HtmlPage page = webClient.getPage(slave, "configure");
@@ -155,7 +154,7 @@ public class EnvironmentVariableNodePropertyTest {
 
 	// ////////////////////// helper methods /////////////////////////////////
 
-	private void setVariables(Node node, Entry... entries) throws IOException {
+	private void setVariables(Node node, EnvironmentVariablesNodeProperty.Entry... entries) throws IOException {
 		node.getNodeProperties().replaceBy(
 				Collections.singleton(new EnvironmentVariablesNodeProperty(
 						entries)));

--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -39,9 +39,7 @@ import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
-import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
 import hudson.tasks.Maven.MavenInstallation;
-import hudson.tasks.Maven.MavenInstallation.DescriptorImpl;
 import hudson.tasks.Maven.MavenInstaller;
 import hudson.tools.InstallSourceProperty;
 import hudson.tools.ToolProperty;
@@ -119,7 +117,7 @@ public class MavenTest {
         j.jenkins.getJDKs().add(varJDK);
         j.jenkins.getNodeProperties().replaceBy(
                 Collections.singleton(new EnvironmentVariablesNodeProperty(
-                        new Entry("VAR_MAVEN", mavenVar), new Entry("VAR_JAVA",
+                        new EnvironmentVariablesNodeProperty.Entry("VAR_MAVEN", mavenVar), new EnvironmentVariablesNodeProperty.Entry("VAR_JAVA",
                                 javaVar))));
 
         FreeStyleProject project = j.createFreeStyleProject();
@@ -184,7 +182,7 @@ public class MavenTest {
     }
 
     private void verify() throws Exception {
-        MavenInstallation[] l = j.get(DescriptorImpl.class).getInstallations();
+        MavenInstallation[] l = j.get(MavenInstallation.DescriptorImpl.class).getInstallations();
         assertEquals(1,l.length);
         j.assertEqualBeans(l[0],new MavenInstallation("myMaven","/tmp/foo", JenkinsRule.NO_PROPERTIES),"name,home");
 
@@ -219,7 +217,7 @@ public class MavenTest {
     public void parametersReferencedFromPropertiesShouldRetainBackslashes() throws Exception {
         final String properties = "global.path=$GLOBAL_PATH\nmy.path=$PATH\\\\Dir";
         final StringParameterDefinition parameter = new StringParameterDefinition("PATH", "C:\\Windows");
-        final Entry envVar = new Entry("GLOBAL_PATH", "D:\\Jenkins");
+        final EnvironmentVariablesNodeProperty.Entry envVar = new EnvironmentVariablesNodeProperty.Entry("GLOBAL_PATH", "D:\\Jenkins");
 
         FreeStyleProject project = j.createFreeStyleProject();
         // This test implements legacy behavior, when Build Variables are injected by default

--- a/test/src/test/java/hudson/triggers/SCMTriggerTest.java
+++ b/test/src/test/java/hudson/triggers/SCMTriggerTest.java
@@ -41,7 +41,6 @@ import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.TaskListener;
-import hudson.model.Cause.UserCause;
 import hudson.scm.NullSCM;
 import hudson.triggers.SCMTrigger.SCMTriggerCause;
 import hudson.triggers.SCMTrigger.BuildAction;
@@ -156,11 +155,11 @@ public class SCMTriggerTest {
         p.addTrigger(t);
 
         // Start one build to block others
-        assertTrue(p.scheduleBuild(new UserCause()));
+        assertTrue(p.scheduleBuild(new Cause.UserCause()));
         buildStarted.block(); // wait for the build to really start
 
         // Schedule a new build, and trigger it many ways while it sits in queue
-        Future<FreeStyleBuild> fb = p.scheduleBuild2(0, new UserCause());
+        Future<FreeStyleBuild> fb = p.scheduleBuild2(0, new Cause.UserCause());
         assertNotNull(fb);
         assertTrue(p.scheduleBuild(new SCMTriggerCause("First poll")));
         assertTrue(p.scheduleBuild(new SCMTriggerCause("Second poll")));

--- a/test/src/test/java/hudson/util/FormFieldValidatorTest.java
+++ b/test/src/test/java/hudson/util/FormFieldValidatorTest.java
@@ -29,7 +29,6 @@ import hudson.model.FreeStyleProject;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
-import hudson.util.FormFieldValidatorTest.BrokenFormValidatorBuilder.DescriptorImpl;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -75,7 +74,7 @@ public class FormFieldValidatorTest {
     @Test
     @Issue("JENKINS-3382")
     public void negative() throws Exception {
-        DescriptorImpl d = new DescriptorImpl();
+        BrokenFormValidatorBuilder.DescriptorImpl d = new BrokenFormValidatorBuilder.DescriptorImpl();
         Publisher.all().add(d);
         try {
             FreeStyleProject p = j.createFreeStyleProject();


### PR DESCRIPTION
The [`BadImport`](https://errorprone.info/bugpattern/BadImport) Error Prone check comes with the following rationale:

>  Importing nested classes/static methods/static fields with commonly-used names can make code harder to read, because it may not be clear from the context exactly which type is being referred to. Qualifying the name with that of the containing class can make the code clearer. 

In this PR I disambiguate any ambiguous imports by qualifying them with the name of the containing class.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).