### PR TITLE
[JENKINS-60866] Clean up login and signup page JS

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup-adjunct.js
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup-adjunct.js
@@ -1,0 +1,90 @@
+(function(){
+    const togglePasswordType = function(event) {
+        const passwordField = document.getElementById('password1');
+        const showPass = document.getElementById('showPassword');
+        if (showPass.checked) {
+            passwordField.type = 'text';
+        } else {
+            passwordField.type = 'password';
+        }
+    };
+
+    const passwordScore = function(password) {
+        var score = 0;
+        if (!password) {
+            return score
+        }
+        // award every unique letter until 5 repetitions
+        var letters = {};
+        for (var i = 0; i < password.length; i++) {
+            letters[password[i]] = (letters[password[i]] || 0) + 1
+            score += 5.0 / letters[password[i]]
+        }
+
+        // bonus points for mixing it up
+        var variations = {
+            digits: /\d/.test(password),
+            lower: /[a-z]/.test(password),
+            upper: /[A-Z]/.test(password),
+            nonWords: /\W/.test(password)
+        };
+
+        var variationCount = 0;
+        for (var check in variations) {
+            variationCount += variations[check] === true ? 1 : 0;
+        }
+        score += (variationCount - 1) * 10;
+        return parseInt(score);
+    };
+
+    const passwordStrength = function(score) {
+        var dataSource = document.getElementById('passwordStrengthWrapper');
+        if (score > 80) {
+            return dataSource.getAttribute('data-strong');
+        }
+        if (score > 60) {
+            return dataSource.getAttribute('data-moderate');
+        }
+        if (score >= 30) {
+            return dataSource.getAttribute('data-weak');
+            return "${%Weak}";
+        }
+        return dataSource.getAttribute('data-poor');
+    };
+
+    const passwordStrengthColor = function(score) {
+        if (score > 80) {
+            return "#3a7911"
+        }
+        if (score > 60) {
+            return "#c6810e"
+        }
+        if (score >= 30) {
+            return "#de5912"
+        }
+        return "#c4000a"
+    };
+
+    const validatePassword = function() {
+        const password = document.getElementById('password1');
+        if (password) {
+            const passwordStrengthWrapper =
+                    document.getElementById('passwordStrengthWrapper');
+            passwordStrengthWrapper.hidden = false;
+            const score = passwordScore(password.value);
+            const passwordStrengthIndicator = document.getElementById('passwordStrength');
+            passwordStrengthIndicator.innerText = passwordStrength(score);
+            passwordStrengthIndicator.setAttribute('style', 'color: ' +
+                passwordStrengthColor(score));
+            document.getElementById('password2').value = password.value;
+        }
+    };
+
+    document.getElementById('password1').onkeyup = validatePassword;
+    document.getElementById('showPassword').onclick = togglePasswordType;
+
+
+    if (document.getElementById('passwordStrengthWrapper')) {
+        document.getElementById('passwordStrengthWrapper').hidden = true;
+    }
+})();

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
@@ -30,6 +30,7 @@ THE SOFTWARE.
   <l:view xmlns:l="/lib/layout" contentType="text/html;charset=UTF-8">
     <st:setHeader name="Expires" value="0"/>
     <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate"/>
+    <st:setHeader name="Content-Security-Policy" value="default-src 'self';"/>
     <!--
     needed to generate a session if non exists,
     without it we would add ";jsessionid=" to the url which will result in a 404
@@ -145,92 +146,11 @@ THE SOFTWARE.
                                 >
                                     ${%Password}${data.errors.containsKey('password1') ? ' - ' +  data.errors.get('password1') : ''}
                                 </label>
-                                <script type="text/javascript">
-                                    const togglePasswordType = function(event) {
-                                        const passwordField = document.getElementById('password1');
-                                        const showPass = document.getElementById('showPassword');
-                                        if (showPass.checked) {
-                                            passwordField.type = 'text';
-                                        } else {
-                                            passwordField.type = 'password';
-                                        }
-                                    };
-
-                                    const passwordScore = function(password) {
-                                        var score = 0;
-                                        if (!password) {
-                                            return score
-                                        }
-                                        // award every unique letter until 5 repetitions
-                                        var letters = {};
-                                        for (var i = 0; i &lt; password.length; i++) {
-                                            letters[password[i]] = (letters[password[i]] || 0) + 1
-                                            score += 5.0 / letters[password[i]]
-                                        }
-
-                                        // bonus points for mixing it up
-                                        var variations = {
-                                            digits: /\d/.test(password),
-                                            lower: /[a-z]/.test(password),
-                                            upper: /[A-Z]/.test(password),
-                                            nonWords: /\W/.test(password)
-                                        };
-
-                                        var variationCount = 0;
-                                        for (var check in variations) {
-                                            variationCount += variations[check] === true ? 1 : 0;
-                                        }
-                                        score += (variationCount - 1) * 10;
-                                        return parseInt(score);
-                                    };
-
-                                    const passwordStrength = function(score) {
-                                        if (score > 80) {
-                                            return "${%Strong}";
-                                        }
-                                        if (score > 60) {
-                                            return "${%Moderate}";
-                                        }
-                                        if (score >= 30) {
-                                            return "${%Weak}";
-                                        }
-                                        return "${%Poor}";
-                                    };
-
-                                    const passwordStrengthColor = function(score) {
-                                        if (score > 80) {
-                                            return "#3a7911"
-                                        }
-                                        if (score > 60) {
-                                            return "#c6810e"
-                                        }
-                                        if (score >= 30) {
-                                            return "#de5912"
-                                        }
-                                        return "#c4000a"
-                                    };
-
-                                    const validatePassword = function() {
-                                        const password = document.getElementById('password1');
-                                        if (password) {
-                                            const passwordStrengthWrapper =
-                                                    document.getElementById('passwordStrengthWrapper');
-                                            passwordStrengthWrapper.hidden = false;
-                                            const score = passwordScore(password.value);
-                                            const passwordStrengthIndicator = document.getElementById('passwordStrength');
-                                            passwordStrengthIndicator.innerText = passwordStrength(score);
-                                            passwordStrengthIndicator.setAttribute('style', 'color: ' +
-                                                passwordStrengthColor(score));
-                                            document.getElementById('password2').value = password.value;
-                                        }
-                                    }
-                                </script>
                                 <div class="Checkbox Checkbox-small">
                                     <label class="Checkbox-wrapper">
                                         <input
                                             type="checkbox"
                                             id="showPassword"
-                                            onClick="togglePasswordType(this)"
                                             name="remember_me"
                                             tabindex="7"
                                         />
@@ -252,7 +172,6 @@ THE SOFTWARE.
                                 </div>
                             </div>
                             <input
-                                onKeyUp="validatePassword()"
                                 class="${data.errors.containsKey('password1') ? 'danger' : 'normal'}"
                                 value="${data.password1}"
                                 type="password"
@@ -260,13 +179,7 @@ THE SOFTWARE.
                                 name="password1"
                                 id="password1"
                             />
-                            <div id="passwordStrengthWrapper">${%Strength}: <span id="passwordStrength">&#160;</span> </div>
-                            <script type="text/javascript">
-                                if (document.getElementById('passwordStrengthWrapper')) {
-                                    document.getElementById('passwordStrengthWrapper').hidden = true;
-                                }
-                            </script>
-
+                            <div id="passwordStrengthWrapper" data-strong="${%Strong}" data-moderate="${%Moderate}" data-weak="${%Weak}" data-poor="${%Poor}">${%Strength}: <span id="passwordStrength">&#160;</span> </div>
                         </div>
                         <div class="formRow">
                             ${%A strong password is a long password that's unique for every site. Try using a phrase with 5-6 words for the best security.}
@@ -282,14 +195,6 @@ THE SOFTWARE.
                             <f:submit value="${%Create account}"/>
                         </div>
                         <input type="hidden" name="${h.getCrumbRequestField()}" value="${h.getCrumb(request)}"/>
-                        <j:if test="${data.errorField != null}">
-                            <script type="text/javascript">
-                                const errorField = document.getElementById('${data.errorField}');
-                                if(errorField &amp;&amp; errorField.focus) {
-                                    errorField.focus();
-                                }
-                            </script>
-                        </j:if>
                         <div class="footer">
                             <j:forEach var="decorator" items="${simpleDecorators}">
                                 <st:include it="${decorator}" page="simple-footer.jelly" optional="true"/>
@@ -298,6 +203,7 @@ THE SOFTWARE.
                     </form>
                 </div>
             </div>
+            <st:adjunct includes="hudson.security.HudsonPrivateSecurityRealm.signup-adjunct"/>
         </body>
     </html>
   </l:view>

--- a/core/src/main/resources/jenkins/model/Jenkins/login-adjunct.js
+++ b/core/src/main/resources/jenkins/model/Jenkins/login-adjunct.js
@@ -1,0 +1,3 @@
+(function() {
+    document.getElementById('j_username').focus();
+})();

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
   <!-- deactivate all caching -->
   <st:setHeader name="Expires" value="0" />
   <st:setHeader name="Cache-Control" value="no-cache,no-store,must-revalidate" />
+  <st:setHeader name="Content-Security-Policy" value="default-src 'self';"/>
   <!-- needed for cli -->
   <j:if test="${request.servletPath=='/' || request.servletPath==''}">
     ${h.advertiseHeaders(response)}
@@ -106,12 +107,7 @@ THE SOFTWARE.
                 <input type="hidden" name="from" value="${from}" />
                 <div class="submit formRow"><f:submit value="${%signIn}" /></div>
                 <!-- focus the username field -->
-                <script type="text/javascript">
-                  document.getElementById('j_username').focus();
-                  var checkBoxClick = function(event) {
-                    document.getElementById('remember_me').click();
-                  }
-                </script>
+                <st:adjunct includes="jenkins.model.Jenkins.login-adjunct"/>
 
                 <j:if test="${app.security.name()=='SECURED' and !app.disableRememberMe}">
                   <!-- remember me service only available for Spring Security -->


### PR DESCRIPTION
See [JENKINS-60866](https://issues.jenkins-ci.org/browse/JENKINS-60866).

Move inline JS out of signup and login pages.

Additionally, set Content-Security-Policy headers to not allow inline content. This is a potentially breaking change for any `SimplePageDecorator` implementations that add inline JS, but #3380 claimed to improve security, so that seems appropriate. The fix is trivial, just load content from files.

Thoughts?

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
