### PR TITLE
[JENKINS-60866] Clean up build button column JS

### DIFF
--- a/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
@@ -27,29 +27,22 @@ THE SOFTWARE.
       <td>
           <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
               <j:set var="id" value="${h.generateId()}"/>
-              <a href="${jobBaseUrl}${job.shortUrl}build?delay=0sec">
+              <j:set var="href" value="${jobBaseUrl}${job.shortUrl}build?delay=0sec"/>
+              <a href="${href}">
                   <j:choose>
                       <j:when test="${job.parameterized}">
                           <j:set var="title" value="${%Schedule_a_task_with_parameters(h.getRelativeDisplayNameFrom(job, itemGroup),it.taskNoun(job))}"/>
-                          <j:set var="onclick" value="${null}"/>
                       </j:when>
                       <j:otherwise>
+                          <span class="build-button-column-icon-reference-holder" data-id="${id}" data-url="${href}" data-notification="${%Task_scheduled(it.taskNoun(job))}"/>
                           <j:set var="title" value="${%Schedule_a_task(h.getRelativeDisplayNameFrom(job, itemGroup),it.taskNoun(job))}"/>
-                          <j:set var="onclick" value="return build_${id}(this)"/>
                       </j:otherwise>
                   </j:choose>
                   <j:set var="icon" value="${app.queue.contains(job) ? 'icon-clock-anime' : 'icon-clock'}"/>
                   <l:icon class="${icon} ${subIconSizeClass}"
-                         title="${title}" alt="${title}"
-                         onclick="${onclick}"/>
+                         title="${title}" alt="${title}" id="${id}" />
+                  <st:adjunct includes="hudson.views.BuildButtonColumn.icon"/>
               </a>
-              <script>
-                function build_${id}(img) {
-                  new Ajax.Request(img.parentNode.href);
-                  hoverNotification('${%Task_scheduled(it.taskNoun(job))}', img, -100);
-                  return false;
-                }
-              </script>
           </j:if>
       </td>
 </j:jelly>

--- a/core/src/main/resources/hudson/views/BuildButtonColumn/icon.js
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/icon.js
@@ -1,0 +1,12 @@
+Behaviour.specify(".build-button-column-icon-reference-holder", 'build-button-column', 0, function (e) {
+    var url = e.getAttribute('data-url');
+    var message = e.getAttribute('data-notification')
+    var id = e.getAttribute('data-id');
+    var icon = document.getElementById(id);
+
+    icon.onclick = function(el) {
+        new Ajax.Request(url);
+        hoverNotification(message, this, -100);
+        return false;
+    }
+});

--- a/core/src/main/resources/lib/layout/icon.jelly
+++ b/core/src/main/resources/lib/layout/icon.jelly
@@ -30,11 +30,15 @@ THE SOFTWARE.
       The icon class specification e.g. 'icon-help icon-sm', 'icon-blue icon-md', 'icon-blue-anime icon-xlg'.
     </st:attribute>
 
+    <st:attribute name="id">
+      ID of the icon element. Since TODO.
+    </st:attribute>
+
     <st:attribute name="src">
       Icon source raw URL. Only relevant if the 'class' attribute is NOT specified.
     </st:attribute>
 
-    <st:attribute name="onclick">onclick handler.</st:attribute>
+    <st:attribute name="onclick" deprecated="true">onclick handler. Deprecated; assign an ID and look up the element that way to attach event handlers.</st:attribute>
     <st:attribute name="title">title</st:attribute>
     <st:attribute name="style">style</st:attribute>
     <st:attribute name="tooltip">tooltip</st:attribute>
@@ -66,19 +70,19 @@ THE SOFTWARE.
 
       <span class="build-status-icon__wrapper ${attrs.class}" style="${imgStyle}">
           <span class="build-status-icon__outer">
-            <l:svgIcon href="${rootURL}/images/build-status/build-status-sprite.svg#${outerLayer}" />
+            <l:svgIcon href="${rootURL}/images/build-status/build-status-sprite.svg#${outerLayer}" id="${attrs.id}" />
           </span>
-          <l:svgIcon class="${attrs.class}" href="${iconSrc}"/>
+          <l:svgIcon class="${attrs.class}" href="${iconSrc}" id="${attrs.id}"/>
       </span>
     </j:when>
 
     <j:when test="${iconMetadata.svgSprite and !iconMetadata.buildStatus}">
-      <l:svgIcon class="${attrs.class}" href="${iconSrc}"/>
+      <l:svgIcon class="${attrs.class}" href="${iconSrc}" id="${attrs.id}"/>
     </j:when>
 
     <j:otherwise>
       <img class="${attrs.class}" src="${iconSrc}" style="${imgStyle}" title="${attrs.title}" height="${attrs.height}"
-           alt="${attrs.alt}" width="${attrs.width}" onclick="${attrs.onclick}" tooltip="${attrs.tooltip }"/>
+           alt="${attrs.alt}" width="${attrs.width}" onclick="${attrs.onclick}" tooltip="${attrs.tooltip}" id="${attrs.id}" />
     </j:otherwise>
   </j:choose>
   

--- a/core/src/main/resources/lib/layout/svgIcon.jelly
+++ b/core/src/main/resources/lib/layout/svgIcon.jelly
@@ -12,6 +12,10 @@
             Extra CSS classes passed to the icon. Currently only the 'svg-icon' class is applied by default.
         </st:attribute>
 
+        <st:attribute name="id">
+            ID of the icon element. Since TODO.
+        </st:attribute>
+
         <st:attribute name="href">
             Href of the 'use' tag. Normally path to a sprite plus an icon id
         </st:attribute>
@@ -22,7 +26,7 @@
             Whether the icon can receive keyboard focus. Possible values 'true' or 'false'
         </st:attribute>
 
-        <st:attribute name="onclick">onclick handler.</st:attribute>
+        <st:attribute name="onclick" deprecated="true">onclick handler. Deprecated; assign an ID and look up the element that way to attach event handlers.</st:attribute>
         <st:attribute name="style">style</st:attribute>
         <st:attribute name="tooltip">tooltip</st:attribute>
         <st:attribute name="ariaHidden">aria-hidden</st:attribute>
@@ -34,6 +38,7 @@
          aria-hidden="${attrs.ariaHidden}"
          style="${attrs.style}"
          onclick="${attrs.onclick}"
+         id="${attrs.id}"
          tooltip="${attrs.tooltip != null ? h.xmlEscape(attrs.tooltip) : null}">
 
         <j:choose>


### PR DESCRIPTION
See [JENKINS-60866](https://issues.jenkins-ci.org/browse/JENKINS-60866).

To support cleanup of the build button column, we need to be able to set IDs on icons, so that's being done here. Also deprecate `onclick` for being evil.

It would probably be cleaner to migrate `icon`/`svgIcon` to `MorphTagLibrary` to be able to add `data` attributes on it, but that's a larger change than necessary and it wouldn't get rid of the support element anyway; as `class` must only specify icons and cannot be used to add additional arbitrary class names.

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
