### PR TITLE
Remove JTidy from core

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -184,11 +184,6 @@ THE SOFTWARE.
         <version>1.5</version>
       </dependency>
       <dependency>
-        <groupId>org.jvnet.hudson</groupId>
-        <artifactId>jtidy</artifactId>
-        <version>4aug2000r7-dev-hudson-1</version>
-      </dependency>
-      <dependency>
         <groupId>org.connectbot.jbcrypt</groupId>
         <artifactId>jbcrypt</artifactId>
         <version>1.0.0</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,16 +74,6 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>crypto-util</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.jvnet.hudson</groupId>
-      <artifactId>jtidy</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>jdom</groupId>
-          <artifactId>jdom</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency><!-- working around MCOMPILER-97 -->
       <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
Jenkins core ships JTidy 4aug2000r7-dev-hudson-1, a fork of JTidy 04aug2000r7-dev. The original 04aug2000r7-dev release was published on August 1, 2001; the fork was published on July 14, 2008. JTidy was forked by Kohsuke in commit 2fcca36d5b as part of the fix for [JENKINS-1680](https://issues.jenkins.io/browse/JENKINS-1680) to resolve an incompatibility with IBM WebSphere 6.1, which itself reached end-of-life on September 30, 2013.

Carrying this ancient fork of an even more ancient dependency does not seem desirable for the Jenkins project. In recent years there have been [efforts to revive the JTidy project on GitHub](https://github.com/jtidy/jtidy), but rather than migrating to this revival project I think it makes more sense to remove the JTidy dependency from core. The dependency is effectively unused throughout the entire Jenkins ecosystem, so there is no strong reason to keep bundling it.

Nothing in Jenkins core itself uses JTidy. Running the classes from the JTidy JAR through `usage-in-plugins` and [searching for usages in sources](https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+%22org.w3c.tidy.Tidy%22), I found only two references in plugins:

- [JDepend](https://plugins.jenkins.io/jdepend/), a plugin with 2,313 installations last released 3 years ago. Although this plugin imported a JTidy class and had a method that used that class, the only caller of that method was commented out. I opened jenkinsci/jdepend-plugin#5 to remove this dead code. Although this plugin is not actively maintained, Oleg has permissions and may be able to help with merging and releasing that PR.
- [NIS notification lamp](https://plugins.jenkins.io/nis-notification-lamp/), a plugin with 5 installations last released 8 years ago. This plugin does actually use JTidy, so it would be better for it to directly depend on JTidy rather than relying on Jenkins core to provide this dependency. I opened jenkinsci/nis-notification-lamp-plugin#5 to explicitly specify this dependency. This plugin is not actively maintained, so the likelihood of a merge and release of that PR are quite low. But with only 5 installations, I do not think we should worry about this.

### Proposed changelog entries

Developer: Remove JTidy dependency from Jenkins core. Plugins that use JTidy functionality, including [NIS notification lamp](https://plugins.jenkins.io/nis-notification-lamp/), must be updated to explicitly declare a dependency on JTidy rather than relying on Jenkins core to provide this library.

### Proposed upgrade guidelines

The JTidy dependency has been removed from Jenkins core. Users of [JDepend](https://plugins.jenkins.io/jdepend/) must upgrade JDepend to the latest version. Other plugins that use JTidy functionality, including [NIS notification lamp](https://plugins.jenkins.io/nis-notification-lamp/), must be updated to explicitly declare a dependency on JTidy rather than relying on Jenkins core to provide this library.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).