### PR TITLE
Fix `CatchAndPrintStackTrace`, `CatchFail`, and `EmptyCatch` Error Prone violations in tests

### DIFF
--- a/core/src/test/java/hudson/util/SecretUtilTest.java
+++ b/core/src/test/java/hudson/util/SecretUtilTest.java
@@ -11,7 +11,6 @@ public class SecretUtilTest {
     public void decrypt() {
         String data = "{}";
         Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
-        Assert.assertNull(secret);
     }
 
 
@@ -20,7 +19,7 @@ public class SecretUtilTest {
     public void decryptJustSpace() {
         String data = " ";
         Secret secret = Secret.decrypt(data);
-        Assert.assertNull(secret);
+        Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
     }
 
     @Issue("JENKINS-47500")
@@ -28,7 +27,7 @@ public class SecretUtilTest {
     public void decryptWithSpace() {
         String data = "{ }";
         Secret secret = Secret.decrypt(data);
-        Assert.assertNull(secret);
+        Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
     }
 
     @Issue("JENKINS-47500")
@@ -36,6 +35,6 @@ public class SecretUtilTest {
     public void decryptWithSpaces() {
         String data = "{     }";
         Secret secret = Secret.decrypt(data);
-        Assert.assertNull(secret);
+        Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
     }
 }

--- a/core/src/test/java/hudson/util/SecretUtilTest.java
+++ b/core/src/test/java/hudson/util/SecretUtilTest.java
@@ -10,7 +10,7 @@ public class SecretUtilTest {
     @Test
     public void decrypt() {
         String data = "{}";
-        Secret secret = Secret.decrypt(data);
+        Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
         Assert.assertNull(secret);
     }
 

--- a/core/src/test/java/hudson/util/SecretUtilTest.java
+++ b/core/src/test/java/hudson/util/SecretUtilTest.java
@@ -10,14 +10,8 @@ public class SecretUtilTest {
     @Test
     public void decrypt() {
         String data = "{}";
-
-        try {
-            Secret secret = Secret.decrypt(data);
-            Assert.assertNull(secret);
-        } catch (ArrayIndexOutOfBoundsException e) {
-            Assert.fail(data + " shouldn't throw an ArrayIndexOutOfBoundsException but returning null");
-        }
-
+        Secret secret = Secret.decrypt(data);
+        Assert.assertNull(secret);
     }
 
 
@@ -25,41 +19,23 @@ public class SecretUtilTest {
     @Test
     public void decryptJustSpace() {
         String data = " ";
-
-        try {
-            Secret secret = Secret.decrypt(data);
-            Assert.assertNull(secret);
-        } catch (ArrayIndexOutOfBoundsException e) {
-            Assert.fail(data + " shouldn't throw an ArrayIndexOutOfBoundsException but returning null");
-        }
-
+        Secret secret = Secret.decrypt(data);
+        Assert.assertNull(secret);
     }
 
     @Issue("JENKINS-47500")
     @Test
     public void decryptWithSpace() {
         String data = "{ }";
-
-        try {
-            Secret secret = Secret.decrypt(data);
-            Assert.assertNull(secret);
-        } catch (ArrayIndexOutOfBoundsException e) {
-            Assert.fail(data + " shouldn't throw an ArrayIndexOutOfBoundsException but returning null");
-        }
-
+        Secret secret = Secret.decrypt(data);
+        Assert.assertNull(secret);
     }
 
     @Issue("JENKINS-47500")
     @Test
     public void decryptWithSpaces() {
         String data = "{     }";
-
-        try {
-            Secret secret = Secret.decrypt(data);
-            Assert.assertNull(secret);
-        } catch (ArrayIndexOutOfBoundsException e) {
-            Assert.fail(data + " shouldn't throw an ArrayIndexOutOfBoundsException but returning null");
-        }
-
+        Secret secret = Secret.decrypt(data);
+        Assert.assertNull(secret);
     }
 }

--- a/core/src/test/java/hudson/util/SecretUtilTest.java
+++ b/core/src/test/java/hudson/util/SecretUtilTest.java
@@ -10,6 +10,7 @@ public class SecretUtilTest {
     @Test
     public void decrypt() {
         String data = "{}";
+        Secret secret = Secret.decrypt(data);
         Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
     }
 

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -48,7 +48,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -76,8 +75,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 public class VirtualFileTest {
@@ -101,12 +100,7 @@ public class VirtualFileTest {
         VirtualFile hack = root.child("hack");
         assertFalse(hack.isFile());
         assertFalse(hack.exists());
-        try {
-            hack.open();
-            fail();
-        } catch (FileNotFoundException | NoSuchFileException x) {
-            // OK
-        }
+        assertThrows(FileNotFoundException.class, () -> hack.open());
     }
 
     @Issue("JENKINS-26810")
@@ -800,10 +794,7 @@ public class VirtualFileTest {
     }
 
     private void checkCommonAssertionForIsDescendant(VirtualFile virtualRoot, VirtualFile virtualRootChildA, VirtualFile virtualFromA, String absolutePath) throws Exception {
-        try {
-            virtualRootChildA.isDescendant(absolutePath);
-            fail("isDescendant should have refused the absolute path");
-        } catch (IllegalArgumentException e) {}
+        assertThrows("isDescendant should have refused the absolute path", IllegalArgumentException.class, () -> virtualRootChildA.isDescendant(absolutePath));
 
         assertTrue(virtualRootChildA.isDescendant("aa"));
         assertTrue(virtualRootChildA.isDescendant("aa/aa.txt"));
@@ -1134,12 +1125,7 @@ public class VirtualFileTest {
         Util.createSymlink(ws, childString, linkString, TaskListener.NULL);
 
         VirtualFile link = VirtualFile.forFile(ws).child(linkString);
-        try {
-            link.open(true);
-            fail("Should have not followed links.");
-        } catch (IOException ioe) {
-            // expected
-        }
+        assertThrows("Should have not followed links", IOException.class, () -> link.open(true));
     }
 
     @Test
@@ -1153,12 +1139,7 @@ public class VirtualFileTest {
         FileUtils.write(new File(ws, childString), childString);
         File childThroughSymlink = new File(tmp.getRoot(), "/" + symlinkName + "/" + childString);
         VirtualFile child = rootVirtualFile.child(symlinkName).child(childString);
-        try {
-        child.open(true);
-            fail("Should have not followed links.");
-        } catch (IOException ioe) {
-            // expected
-        }
+        assertThrows("Should have not followed links", IOException.class, () -> child.open(true));
     }
 
     @Test
@@ -1171,12 +1152,7 @@ public class VirtualFileTest {
         FileUtils.write(new File(ws, childString), childString);
         VirtualFile rootVirtualPath = VirtualFile.forFilePath(new FilePath(tmp.getRoot()));
         VirtualFile childVirtualPath = rootVirtualPath.child(symlinkName).child(childString);
-        try {
-            childVirtualPath.open(true);
-            fail("Should have not followed links.");
-        } catch (IOException ioe) {
-            // expected
-        }
+        assertThrows("Should have not followed links", IOException.class, () -> childVirtualPath.open(true));
     }
 
     @Test
@@ -1189,12 +1165,7 @@ public class VirtualFileTest {
         Util.createSymlink(ws, childString, linkString, TaskListener.NULL);
 
         VirtualFile link = VirtualFile.forFilePath(new FilePath(ws)).child(linkString);
-        try {
-            link.open(true);
-            fail("Should have not followed links.");
-        } catch (IOException ioe) {
-            // expected
-        }
+        assertThrows("Should have not followed links", IOException.class, () -> link.open(true));
     }
 
     @Test

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -334,7 +334,7 @@ public class QuietDownCommandTest {
         try {
             exec_task.get(2*TIMEOUT, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
-            fail("Blocking call didn't finish after timeout!");
+            throw new AssertionError("Blocking call didn't finish after timeout!", e);
         }
         assertThat(exec_task.isDone(), equalTo(true));
         finish.signal();

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -74,8 +74,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
@@ -176,7 +176,7 @@ public class JobTest {
             }
             catch (InterruptedException e) {}
             catch (IOException e) {
-                fail("Failed to assign build number");
+                throw new AssertionError("Failed to assign build number", e);
             }
             finally {
                 stop.countDown();
@@ -292,14 +292,11 @@ public class JobTest {
     
     @Test public void projectNamingStrategy() throws Exception {
         j.jenkins.setProjectNamingStrategy(new ProjectNamingStrategy.PatternProjectNamingStrategy("DUMMY.*", false));
-        final FreeStyleProject p = j.createFreeStyleProject("DUMMY_project");
-        assertNotNull("no project created", p);
         try {
-            j.createFreeStyleProject("project");
-            fail("should not get here, the project name is not allowed, therefore the creation must fail!");
-        } catch (Failure e) {
-            // OK, expected
-        }finally{
+            final FreeStyleProject p = j.createFreeStyleProject("DUMMY_project");
+            assertNotNull("no project created", p);
+            assertThrows(Failure.class, () -> j.createFreeStyleProject("project"));
+        } finally {
             // set it back to the default naming strategy, otherwise all other tests would fail to create jobs!
             j.jenkins.setProjectNamingStrategy(ProjectNamingStrategy.DEFAULT_NAMING_STRATEGY);
         }

--- a/test/src/test/java/hudson/model/queue/WideExecutionTest.java
+++ b/test/src/test/java/hudson/model/queue/WideExecutionTest.java
@@ -38,6 +38,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -70,7 +71,7 @@ public class WideExecutionTest {
                             try {
                                 b.setDescription("I was here");
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                throw new UncheckedIOException(e);
                             }
                         }
 

--- a/test/src/test/java/hudson/util/XStream2Security383Test.java
+++ b/test/src/test/java/hudson/util/XStream2Security383Test.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 import jenkins.security.ClassFilterImpl;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import org.jvnet.hudson.test.LoggerRule;
 import static org.mockito.Mockito.when;
 
@@ -76,11 +77,7 @@ public class XStream2Security383Test {
 
             FileUtils.write(new File(tempJobDir, "config.xml"), exploitXml, StandardCharsets.UTF_8);
 
-            try {
-                Items.load(j.jenkins, tempJobDir);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            assertThrows(IOException.class, () -> Items.load(j.jenkins, tempJobDir));
             assertFalse("no file should be created here", exploitFile.exists());
         } finally {
             exploitFile.delete();
@@ -109,12 +106,7 @@ public class XStream2Security383Test {
             when(req.getContentType()).thenReturn("application/xml");
             when(req.getParameter("name")).thenReturn("foo");
 
-            try {
-                j.jenkins.doCreateItem(req, rsp);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-
+            assertThrows(IOException.class, () -> j.jenkins.doCreateItem(req, rsp));
             assertFalse("no file should be created here", exploitFile.exists());
         } finally {
             exploitFile.delete();

--- a/test/src/test/java/jenkins/security/stapler/CustomRoutingDecisionProviderTest.java
+++ b/test/src/test/java/jenkins/security/stapler/CustomRoutingDecisionProviderTest.java
@@ -38,6 +38,7 @@ import org.kohsuke.stapler.WebMethod;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -98,7 +99,9 @@ public class CustomRoutingDecisionProviderTest {
         try {
             resp.getWriter().write("ok");
             resp.flushBuffer();
-        } catch (IOException e) {}
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
     
     @Test

--- a/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
+++ b/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
@@ -49,8 +49,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * To check the previous behavior you can use:
@@ -85,26 +85,14 @@ public class DoActionFilterTest extends StaplerAbstractTest {
         try {
             wc.goTo("testAccessModifierUrl/public/value", null);
         } catch (FailingHttpStatusCodeException e) {
-            fail("should have access to a public method");
+            throw new AssertionError("should have access to a public method", e);
         }
-        try {
-            wc.goTo("testAccessModifierUrl/protected/value", null);
-            fail("should not have allowed protected access");
-        } catch (FailingHttpStatusCodeException x) {
-            assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
-        }
-        try {
-            wc.goTo("testAccessModifierUrl/internal/value", null);
-            fail("should not have allowed internal access");
-        } catch (FailingHttpStatusCodeException x) {
-            assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
-        }
-        try {
-            wc.goTo("testAccessModifierUrl/private/value", null);
-            fail("should not have allowed private access");
-        } catch (FailingHttpStatusCodeException x) {
-            assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
-        }
+        FailingHttpStatusCodeException x = assertThrows("should not have allowed protected access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/protected/value", null));
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
+        x = assertThrows("should not have allowed internal access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/internal/value", null));
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
+        x = assertThrows("should not have allowed private access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/private/value", null));
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
     }
     
     //================================= doXxx methods =================================
@@ -369,13 +357,9 @@ public class DoActionFilterTest extends StaplerAbstractTest {
     
     @Test
     public void testAnnotatedMethodOk_annotatedLimitedTo() throws Exception {
-        try {
-            wc.getPage(new URL(j.getURL(), "testNewRulesOk/annotatedLimitedTo/"));
-            fail();
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(500, e.getStatusCode());
-            assertTrue(e.getResponse().getContentAsString().contains("Needs to be in role"));
-        }
+        FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> wc.getPage(new URL(j.getURL(), "testNewRulesOk/annotatedLimitedTo/")));
+        assertEquals(500, e.getStatusCode());
+        assertTrue(e.getResponse().getContentAsString().contains("Needs to be in role"));
     }
     
     @Test

--- a/test/src/test/java/jenkins/security/stapler/StaplerAbstractTest.java
+++ b/test/src/test/java/jenkins/security/stapler/StaplerAbstractTest.java
@@ -40,14 +40,15 @@ import org.kohsuke.stapler.WebMethod;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.awt.Point;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URL;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public abstract class StaplerAbstractTest {
     @ClassRule
@@ -133,7 +134,9 @@ public abstract class StaplerAbstractTest {
         try {
             resp.getWriter().write("ok");
             resp.flushBuffer();
-        } catch (IOException e) {}
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
     
     //================================= testing methods =================================
@@ -170,7 +173,7 @@ public abstract class StaplerAbstractTest {
             assertGetMethodActionRequestWasNotBlocked();
             assertFieldRequestWasNotBlocked();
         } catch (FailingHttpStatusCodeException e) {
-            fail("Url " + url + " should be reachable, received " + e.getMessage() + " (" + e.getStatusCode() + ") instead.");
+            throw new AssertionError("Url " + url + " should be reachable, received " + e.getMessage() + " (" + e.getStatusCode() + ") instead.", e);
         }
     }
     
@@ -190,16 +193,12 @@ public abstract class StaplerAbstractTest {
             Page page = wc.getPage(new URL(j.getURL(), url));
             assertEquals(200, page.getWebResponse().getStatusCode());
         } catch (FailingHttpStatusCodeException e) {
-            fail("Url " + url + " should be reachable, received " + e.getMessage() + " (" + e.getStatusCode() + ") instead.");
+            throw new AssertionError("Url " + url + " should be reachable, received " + e.getMessage() + " (" + e.getStatusCode() + ") instead.", e);
         }
     }
     
     protected void assertNotReachable(String url) throws IOException {
-        try {
-            wc.getPage(new URL(j.getURL(), url));
-            fail("Url " + url + " is reachable but should not be, an not-found error is expected");
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals("Url " + url + " returns an error different from 404", 404, e.getResponse().getStatusCode());
-        }
+        FailingHttpStatusCodeException e = assertThrows("Url " + url + " is reachable but should not be, a not-found error is expected", FailingHttpStatusCodeException.class, () -> wc.getPage(new URL(j.getURL(), url)));
+        assertEquals("Url " + url + " returns an error different from 404", 404, e.getResponse().getStatusCode());
     }
 }


### PR DESCRIPTION
Fixes violations of the [`CatchAndPrintStackTrace`](https://errorprone.info/bugpattern/CatchAndPrintStackTrace), [`CatchFail`](https://errorprone.info/bugpattern/CatchFail), and [`EmptyCatch`](https://errorprone.info/bugpattern/EmptyCatch) Error Prone checks in tests, mostly by using `org.junit.Assert.assertThrows`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).