### PR TITLE
Reduce usages of repackaged ASM 5

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
   <properties>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <stapler.version>1532.vfcf95addcb5f</stapler.version>
+    <stapler.version>1534.v84f9bf0bb6ef</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/225 -->
     <groovy.version>2.4.12</groovy.version>
   </properties>
 
@@ -197,6 +197,11 @@ THE SOFTWARE.
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
         <version>3.1.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.1</version>
       </dependency>
       <dependency>
         <groupId>org.kohsuke</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
   <properties>
     <slf4jVersion>1.7.30</slf4jVersion>
-    <stapler.version>1534.v84f9bf0bb6ef</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/225 -->
+    <stapler.version>1539.v2f05ce93882d</stapler.version>
     <groovy.version>2.4.12</groovy.version>
   </properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,6 +118,10 @@ THE SOFTWARE.
       <artifactId>jnr-posix</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler</artifactId>
       <exclusions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -122,7 +122,7 @@ THE SOFTWARE.
       <artifactId>asm</artifactId>
     </dependency>
     <!--
-      For compatibility only; not included into the BOM for the same reason. Once
+      For compatibility only; not included into the BOM for the same reason. TODO once
       https://github.com/jenkinsci/scm-api-plugin/pull/88 is widely adopted, this
       dependency can be dropped.
     -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -121,6 +121,16 @@ THE SOFTWARE.
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
     </dependency>
+    <!--
+      For compatibility only; not included into the BOM for the same reason. Once
+      https://github.com/jenkinsci/scm-api-plugin/pull/88 is widely adopted, this
+      dependency can be dropped.
+    -->
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>asm5</artifactId>
+      <version>5.0.1</version>
+    </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler</artifactId>

--- a/core/src/main/java/hudson/util/SubClassGenerator.java
+++ b/core/src/main/java/hudson/util/SubClassGenerator.java
@@ -42,6 +42,7 @@ import static org.objectweb.asm.Opcodes.RETURN;
  *
  * @author Kohsuke Kawaguchi
  */
+@Deprecated
 public class SubClassGenerator extends ClassLoader {
     public SubClassGenerator(ClassLoader parent) {
         super(parent);

--- a/core/src/main/java/hudson/util/SubClassGenerator.java
+++ b/core/src/main/java/hudson/util/SubClassGenerator.java
@@ -25,17 +25,17 @@ package hudson.util;
 
 import hudson.PluginManager.UberClassLoader;
 import jenkins.model.Jenkins;
-import org.kohsuke.asm5.ClassWriter;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Type;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 import java.lang.reflect.Constructor;
 
-import static org.kohsuke.asm5.Opcodes.ACC_PUBLIC;
-import static org.kohsuke.asm5.Opcodes.ALOAD;
-import static org.kohsuke.asm5.Opcodes.ILOAD;
-import static org.kohsuke.asm5.Opcodes.INVOKESPECIAL;
-import static org.kohsuke.asm5.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ILOAD;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.RETURN;
 
 /**
  * Generates a new class that just defines constructors into the super types.


### PR DESCRIPTION
A more conservative version of #5524 that allows for a more gentle transition period for users of SCM API (i.e., most Jenkins users). Like that PR, we still pull in the version of Stapler that drops the dependency on the repackaged ASM 5 and also stop consuming the repackaged ASM 5 from Jenkins core. But unlike #5524, we continue to bundle the repackaged ASM 5 as a direct dependency for the benefit of users of older versions of SCM API. This allows for a smoother (albeit more prolonged) transition period. Once jenkinsci/scm-api-plugin#88 is widely adopted, the transition can be completed by removing the repackaged ASM 5 from core. Unlike #5524, I have not written changelog or upgrade entries for this change because there should be no visible impact to users.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
