### PR TITLE
`CycleDetectedException` needs to call `Object#toString()`

### DIFF
--- a/core/src/main/java/hudson/util/CyclicGraphDetector.java
+++ b/core/src/main/java/hudson/util/CyclicGraphDetector.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
+import java.util.stream.Collectors;
 
 /**
  * Traverses a directed graph and if it contains any cycle, throw an exception.
@@ -76,7 +77,7 @@ public abstract class CyclicGraphDetector<N> {
         public final List cycle;
 
         public CycleDetectedException(List cycle) {
-            super("Cycle detected: "+ String.join(" -> ", cycle));
+            super("Cycle detected: " + cycle.stream().map(Object::toString).collect(Collectors.joining(" -> ")));
             this.cycle = cycle;
         }
     }


### PR DESCRIPTION
Amends #5467. Fixes a minor regression introduced by me in 2.292 where `CycleDetectedException` could not be created due to an incompatible type being passed to `String#join`. The solution is to stringify the list before joining its elements.

### Proposed changelog entries

A specific and rarely encountered internal error now again correctly shows details about the cause (regression in 2.292).

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
