### PR TITLE
Change the word 'number' to 'integer' in number field message

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -670,6 +670,17 @@ function registerMinMaxValidator(e) {
     e = null; // avoid memory leak
 }
 
+
+/**
+ * Prevent user input 'e' or 'E' in <f:number>
+ * @param event Input event
+ */
+function preventInputEe(event) {
+    if (event.which === 69 || event.which === 101) {
+        event.preventDefault();
+    }
+}
+
 /**
  * Wraps a <button> into YUI button.
  *
@@ -960,51 +971,31 @@ function rowvgStartEachRow(recursive,f) {
 
     // validate form values to be an integer
     Behaviour.specify("INPUT.number", "input-number", ++p, function(e) {
-        e.addEventListener('keypress', function (event) {
-            if (event.which === 69 || event.which === 101) { // Prevent user input 'e' or 'E'
-                event.preventDefault();
-            }
-        })
+        e.addEventListener('keypress', preventInputEe)
         registerMinMaxValidator(e);
         registerRegexpValidator(e,/^((\-?\d+)|)$/,"Not an integer");
     });
 
     Behaviour.specify("INPUT.number-required", "input-number-required", ++p, function(e) {
-        e.addEventListener('keypress', function (event) {
-            if (event.which === 69 || event.which === 101) { // Prevent user input 'e' or 'E'
-                event.preventDefault();
-            }
-        })
+        e.addEventListener('keypress', preventInputEe)
         registerMinMaxValidator(e);
         registerRegexpValidator(e,/^\-?(\d+)$/,"Not an integer");
     });
 
     Behaviour.specify("INPUT.non-negative-number-required", "input-non-negative-number-required", ++p, function(e) {
-        e.addEventListener('keypress', function (event) {
-            if (event.which === 69 || event.which === 101) { // Prevent user input 'e' or 'E'
-                event.preventDefault();
-            }
-        })
+        e.addEventListener('keypress', preventInputEe)
         registerMinMaxValidator(e);
-        registerRegexpValidator(e,/^\d+$/,"Not a non-negative number");
+        registerRegexpValidator(e,/^\d+$/,"Not a non-negative integer");
     });
 
     Behaviour.specify("INPUT.positive-number", "input-positive-number", ++p, function(e) {
-        e.addEventListener('keypress', function (event) {
-            if (event.which === 69 || event.which === 101) { // Prevent user input 'e' or 'E'
-                event.preventDefault();
-            }
-        })
+        e.addEventListener('keypress', preventInputEe)
         registerMinMaxValidator(e);
         registerRegexpValidator(e,/^(\d*[1-9]\d*|)$/,"Not a positive integer");
     });
 
     Behaviour.specify("INPUT.positive-number-required", "input-positive-number-required", ++p, function(e) {
-        e.addEventListener('keypress', function (event) {
-            if (event.which === 69 || event.which === 101) { // Prevent user input 'e', 'E', '.'
-                event.preventDefault();
-            }
-        })
+        e.addEventListener('keypress', preventInputEe)
         registerMinMaxValidator(e);
         registerRegexpValidator(e,/^[1-9]\d*$/,"Not a positive integer");
     });


### PR DESCRIPTION
The error messages of number fields are different, some use 'integer', the other use 'number'. For unity, it may be a good idea to change them to the same word 'integer'.

Besides, I deduplicated the code that prevent user to input 'E' or 'e'. See [here](https://github.com/jenkinsci/jenkins/pull/5145#pullrequestreview-560646203).

![image](https://user-images.githubusercontent.com/20413055/120072518-e3a17900-c0c6-11eb-9e91-fb95c542778d.png)


<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Change the word 'number' to 'integer' in the error message under the number field


<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
