### PR TITLE
Winstone 5.18: Update Jetty from 9.4.40.v20210413 to 9.4.41.v20210516

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -105,7 +105,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>5.17</version>
+      <version>5.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -416,7 +416,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.4.40.v20210413</version>
+        <version>9.4.41.v20210516</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
Amends #5532 to also update Winstone from 5.17 to [5.18](https://github.com/jenkinsci/winstone/releases/tag/winstone-5.18), ensuring that the Jetty version remains consistent between Winstone and `jetty-maven-plugin`.

### Proposed changelog entries

* Winstone 5.18: Update Jetty from 9.4.40.v20210413 to 9.4.41.v20210516
    * Winstone 5.18 changelog: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.18
    * Jetty 9.4.41 changelog: https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.41.v20210516

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).