### PR TITLE
Replace usage of `com.google.common.collect.HashMultimap` with native Java equivalent

### DIFF
--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -28,20 +28,21 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import hudson.util.RunList;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import com.google.common.collect.HashMultimap;
 
 import hudson.Extension;
 import hudson.model.Job;
@@ -143,7 +144,7 @@ public class LogRotator extends BuildDiscarder {
     @SuppressWarnings("rawtypes")
     public void perform(Job<?,?> job) throws IOException, InterruptedException {
         //Exceptions thrown by the deletion submethods are collated and reported
-        HashMultimap<Run<?,?>, IOException> exceptionMap = HashMultimap.create();
+        Map<Run<?,?>, Set<IOException>> exceptionMap = new HashMap<>();
         
         LOGGER.log(FINE, "Running the log rotation for {0} with numToKeep={1} daysToKeep={2} artifactNumToKeep={3} artifactDaysToKeep={4}", new Object[] {job, numToKeep, daysToKeep, artifactNumToKeep, artifactDaysToKeep});
         
@@ -164,7 +165,7 @@ public class LogRotator extends BuildDiscarder {
                 }
                 LOGGER.log(FINE, "{0} is to be removed", r);
                 try { r.delete(); }
-                catch (IOException ex) { exceptionMap.put(r, ex); }
+                catch (IOException ex) { exceptionMap.computeIfAbsent(r, key -> new HashSet<>()).add(ex); }
             }
         }
 
@@ -179,7 +180,7 @@ public class LogRotator extends BuildDiscarder {
                 if (!shouldKeepRun(r, lsb, lstb)) {
                     LOGGER.log(FINE, "{0} is to be removed", r);
                     try { r.delete(); }
-                    catch (IOException ex) { exceptionMap.put(r, ex); }
+                    catch (IOException ex) { exceptionMap.computeIfAbsent(r, key -> new HashSet<>()).add(ex); }
                 }
                 r = r.getNextBuild();
             }
@@ -193,7 +194,7 @@ public class LogRotator extends BuildDiscarder {
                 }
                 LOGGER.log(FINE, "{0} is to be purged of artifacts", r);
                 try { r.deleteArtifacts(); }
-                catch (IOException ex) { exceptionMap.put(r, ex); }
+                catch (IOException ex) { exceptionMap.computeIfAbsent(r, key -> new HashSet<>()).add(ex); }
             }
         }
 
@@ -208,7 +209,7 @@ public class LogRotator extends BuildDiscarder {
                 if (!shouldKeepRun(r, lsb, lstb)) {
                     LOGGER.log(FINE, "{0} is to be purged of artifacts", r);
                     try { r.deleteArtifacts(); }
-                    catch (IOException ex) { exceptionMap.put(r, ex); }
+                    catch (IOException ex) { exceptionMap.computeIfAbsent(r, key -> new HashSet<>()).add(ex); }
                 }
                 r = r.getNextBuild();
             }
@@ -220,7 +221,7 @@ public class LogRotator extends BuildDiscarder {
                     "Failed to rotate logs for [%s]",
                     exceptionMap.keySet().stream().map(Object::toString).collect(Collectors.joining(", "))
             );
-            throw new CompositeIOException(msg, new ArrayList<>(exceptionMap.values()));
+            throw new CompositeIOException(msg, exceptionMap.values().stream().flatMap(Collection::stream).collect(Collectors.toList()));
         }
     }
 


### PR DESCRIPTION
This idiom can nowadays be written with native Java functionality without resorting to a third-party library.

To test this, I ran `LogRotatorTest` and put a breakpoint on each call to `r.delete();` in `LogRotator#perform`. Once the breakpoint was hit, I induced a failure by changing the ownership of the relevant files such that they could not be deleted. Then I put another breakpoint on the logic that throws `new CompositeIOException` at the end of the method. After releasing the first breakpoint, I verified that the `IOException` occurs and that the (new) logic to create the `new CompositeIOException` worked as expected.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->


### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
