### PR TITLE
Migrate from `RestartableJenkinsRule` to `JenkinsSessionRule`

### DIFF
--- a/test/src/test/java/hudson/model/UserRestartTest.java
+++ b/test/src/test/java/hudson/model/UserRestartTest.java
@@ -29,11 +29,10 @@ import hudson.FilePath;
 import hudson.tasks.Mailer;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runners.model.Statement;
 
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -49,15 +48,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class UserRestartTest {
 
     @Rule
-    public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+    public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
-    @Test public void persistedUsers() throws Exception {
-        rr.then(r -> {
+    @Test public void persistedUsers() throws Throwable {
+        sessions.then(r -> {
             User bob = User.getById("bob", true);
             bob.setFullName("Bob");
             bob.addProperty(new Mailer.UserProperty("bob@nowhere.net"));
         });
-        rr.then(r -> {
+        sessions.then(r -> {
             User bob = User.getById("bob", false);
             assertNotNull(bob);
             assertEquals("Bob", bob.getFullName());
@@ -69,8 +68,8 @@ public class UserRestartTest {
 
     @Issue("JENKINS-45892")
     @Test
-    public void badSerialization() {
-        rr.then(r -> {
+    public void badSerialization() throws Throwable {
+        sessions.then(r -> {
             r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
             FreeStyleProject p = r.createFreeStyleProject("p");
             User u = User.get("pqhacker");
@@ -81,7 +80,7 @@ public class UserRestartTest {
             assertThat(text, not(containsString("<fullName>Pat Q. Hacker</fullName>")));
             assertThat(text, containsString("<id>pqhacker</id>"));
         });
-        rr.then(r -> {
+        sessions.then(r -> {
             FreeStyleProject p = r.jenkins.getItemByFullName("p", FreeStyleProject.class);
             User u = p.getProperty(BadProperty.class).user; // do not inline: call User.get second
             assertEquals(User.get("pqhacker"), u);
@@ -96,47 +95,41 @@ public class UserRestartTest {
 
     @Test
     @Issue("SECURITY-897")
-    public void legacyConfigMoveCannotEscapeUserFolder() {
-        rr.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                rr.j.jenkins.setSecurityRealm(rr.j.createDummySecurityRealm());
-                assertThat(rr.j.jenkins.isUseSecurity(), equalTo(true));
+    public void legacyConfigMoveCannotEscapeUserFolder() throws Throwable {
+        sessions.then(r -> {
+                r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+                assertThat(r.jenkins.isUseSecurity(), equalTo(true));
 
                 // in order to create the folder "users"
                 User.getById("admin", true).save();
 
                 { // attempt with ".."
-                    JenkinsRule.WebClient wc = rr.j.createWebClient()
+                    JenkinsRule.WebClient wc = r.createWebClient()
                             .withThrowExceptionOnFailingStatusCode(false);
 
-                    WebRequest request = new WebRequest(new URL(rr.j.jenkins.getRootUrl() + "whoAmI/api/xml"));
+                    WebRequest request = new WebRequest(new URL(r.jenkins.getRootUrl() + "whoAmI/api/xml"));
                     request.setAdditionalHeader("Authorization", base64("..", "any-password"));
                     wc.getPage(request);
                 }
                 { // attempt with "../users/.."
-                    JenkinsRule.WebClient wc = rr.j.createWebClient()
+                    JenkinsRule.WebClient wc = r.createWebClient()
                             .withThrowExceptionOnFailingStatusCode(false);
 
-                    WebRequest request = new WebRequest(new URL(rr.j.jenkins.getRootUrl() + "whoAmI/api/xml"));
+                    WebRequest request = new WebRequest(new URL(r.jenkins.getRootUrl() + "whoAmI/api/xml"));
                     request.setAdditionalHeader("Authorization", base64("../users/..", "any-password"));
                     wc.getPage(request);
                 }
 
                 // security is still active
-                assertThat(rr.j.jenkins.isUseSecurity(), equalTo(true));
+                assertThat(r.jenkins.isUseSecurity(), equalTo(true));
                 // but, the config file was moved
-                FilePath rootPath = rr.j.jenkins.getRootPath();
+                FilePath rootPath = r.jenkins.getRootPath();
                 assertThat(rootPath.child("config.xml").exists(), equalTo(true));
-            }
         });
-        rr.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                assertThat(rr.j.jenkins.isUseSecurity(), equalTo(true));
-                FilePath rootPath = rr.j.jenkins.getRootPath();
+        sessions.then(r -> {
+                assertThat(r.jenkins.isUseSecurity(), equalTo(true));
+                FilePath rootPath = r.jenkins.getRootPath();
                 assertThat(rootPath.child("config.xml").exists(), equalTo(true));
-            }
         });
     }
 

--- a/test/src/test/java/jenkins/install/SetupWizardRestartTest.java
+++ b/test/src/test/java/jenkins/install/SetupWizardRestartTest.java
@@ -3,50 +3,39 @@ package jenkins.install;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 import hudson.Main;
-import jenkins.model.Jenkins;
 import org.jvnet.hudson.test.SmokeTest;
 
 @Category(SmokeTest.class)
 public class SetupWizardRestartTest {
     @Rule
-    public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+    public JenkinsSessionRule sessions = new JenkinsSessionRule();
 
     @Issue("JENKINS-47439")
     @Test
-    public void restartKeepsSetupWizardState() {
-        rr.addStep(new Statement() {
-            @Override
-            public void evaluate() throws IOException {
+    public void restartKeepsSetupWizardState() throws Throwable {
+        sessions.then(j -> {
                 // Modify state so that we get into the same conditions as a real start
                 Main.isUnitTest = false;
                 FileUtils.write(InstallUtil.getLastExecVersionFile(), "");
-                Jenkins j = rr.j.getInstance();
                 // Re-evaluate current state based on the new context
                 InstallUtil.proceedToNextStateFrom(InstallState.UNKNOWN);
-                assertEquals("Unexpected install state", InstallState.NEW, j.getInstallState());
-                assertTrue("Expecting setup wizard filter to be up", j.getSetupWizard().hasSetupWizardFilter());
+                assertEquals("Unexpected install state", InstallState.NEW, j.jenkins.getInstallState());
+                assertTrue("Expecting setup wizard filter to be up", j.jenkins.getSetupWizard().hasSetupWizardFilter());
                 InstallUtil.saveLastExecVersion();
-            }
         });
         // Check that the state is retained after a restart
-        rr.addStep(new Statement() {
-            @Override
-            public void evaluate() {
-                Jenkins j = rr.j.getInstance();
-                assertEquals("Unexpected install state", InstallState.NEW, j.getInstallState());
-                assertTrue("Expecting setup wizard filter to be up after restart",  j.getSetupWizard().hasSetupWizardFilter());
-            }
+        sessions.then(j -> {
+                assertEquals("Unexpected install state", InstallState.NEW, j.jenkins.getInstallState());
+                assertTrue("Expecting setup wizard filter to be up after restart",  j.jenkins.getSetupWizard().hasSetupWizardFilter());
         });
     }
 


### PR DESCRIPTION
We seem to be generally preferring `JenkinsSessionRule` to `RestartableJenkinsRule`. The main benefit to `JenkinsSessionRule` is that `#then` runs immediately, so it plays nicely with things like `@After.`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
