### PR TITLE
[JENKINS-65195, JENKINS-64347] Fixes to ProcessTree implementation on Darwin

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -28,6 +28,7 @@ import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.NativeLongByReference;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Util;
@@ -1663,18 +1664,17 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 kinfo_proc_ppid_offset = kinfo_proc_ppid_offset_32;
             }
             try {
-                IntByReference ref = new IntByReference(sizeOfInt);
-                IntByReference size = new IntByReference(sizeOfInt);
+                NativeLongByReference size = new NativeLongByReference(new NativeLong(0));
                 Memory m;
                 int nRetry = 0;
                 while(true) {
                     // find out how much memory we need to do this
-                    if(LIBC.sysctl(MIB_PROC_ALL,3, NULL, size, NULL, ref)!=0)
+                    if(LIBC.sysctl(MIB_PROC_ALL,3, NULL, size, NULL, new NativeLong(0))!=0)
                         throw new IOException("Failed to obtain memory requirement: "+LIBC.strerror(Native.getLastError()));
 
                     // now try the real call
-                    m = new Memory(size.getValue());
-                    if(LIBC.sysctl(MIB_PROC_ALL,3, m, size, NULL, ref)!=0) {
+                    m = new Memory(size.getValue().longValue());
+                    if(LIBC.sysctl(MIB_PROC_ALL,3, m, size, NULL, new NativeLong(0))!=0) {
                         if(Native.getLastError()==ENOMEM && nRetry++<16)
                             continue; // retry
                         throw new IOException("Failed to call kern.proc.all: "+LIBC.strerror(Native.getLastError()));
@@ -1682,10 +1682,10 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     break;
                 }
 
-                int count = size.getValue()/sizeOf_kinfo_proc;
+                int count = size.getValue().intValue()/sizeOf_kinfo_proc;
                 LOGGER.fine("Found "+count+" processes");
 
-                for( int base=0; base<size.getValue(); base+=sizeOf_kinfo_proc) {
+                for( int base=0; base<size.getValue().intValue(); base+=sizeOf_kinfo_proc) {
                     int pid = m.getInt(base+ kinfo_proc_pid_offset);
                     int ppid = m.getInt(base+ kinfo_proc_ppid_offset);
 //                    int effective_uid = m.getInt(base+304);
@@ -1740,53 +1740,63 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     arguments = new ArrayList<>();
                     envVars = new EnvVars();
 
-                    IntByReference intByRef = new IntByReference();
-
                     IntByReference argmaxRef = new IntByReference(0);
-                    IntByReference size = new IntByReference(sizeOfInt);
+                    NativeLongByReference size = new NativeLongByReference(new NativeLong(sizeOfInt));
 
                     // for some reason, I was never able to get sysctlbyname work.
 //        if(LIBC.sysctlbyname("kern.argmax", argmaxRef.getPointer(), size, NULL, _)!=0)
-                    if(LIBC.sysctl(new int[]{CTL_KERN,KERN_ARGMAX},2, argmaxRef.getPointer(), size, NULL, intByRef)!=0)
+                    if(LIBC.sysctl(new int[]{CTL_KERN,KERN_ARGMAX},2, argmaxRef.getPointer(), size, NULL, new NativeLong(0))!=0)
                         throw new IOException("Failed to get kern.argmax: "+LIBC.strerror(Native.getLastError()));
 
                     int argmax = argmaxRef.getValue();
 
                     class StringArrayMemory extends Memory {
                         private long offset=0;
+                        private long length=0;
 
                         StringArrayMemory(long l) {
                             super(l);
+                            length = l;
+                        }
+
+                        void setLength(long l) {
+                            length = Math.min(l, size());
                         }
 
                         int readInt() {
+                            if (offset > length - sizeOfInt)
+                                return 0;
                             int r = getInt(offset);
                             offset+=sizeOfInt;
                             return r;
                         }
 
                         byte peek() {
+                            if (offset >= length)
+                                return 0;
                             return getByte(offset);
                         }
 
                         String readString() {
                             ByteArrayOutputStream baos = new ByteArrayOutputStream();
                             byte ch;
-                            while((ch = getByte(offset++))!='\0')
+                            while(offset < length && (ch = getByte(offset++))!='\0')
                                 baos.write(ch);
                             return baos.toString();
                         }
 
                         void skip0() {
                             // skip padding '\0's
-                            while(getByte(offset)=='\0')
+                            while(offset < length && getByte(offset)=='\0')
                                 offset++;
                         }
                     }
                     StringArrayMemory m = new StringArrayMemory(argmax);
-                    size.setValue(argmax);
-                    if(LIBC.sysctl(new int[]{CTL_KERN,KERN_PROCARGS2,pid},3, m, size, NULL, intByRef)!=0)
+                    m.clear();
+                    size.setValue(new NativeLong(argmax));
+                    if(LIBC.sysctl(new int[]{CTL_KERN,KERN_PROCARGS2,pid},3, m, size, NULL, new NativeLong(0))!=0)
                         throw new IOException("Failed to obtain ken.procargs2: "+LIBC.strerror(Native.getLastError()));
+                    m.setLength(size.getValue().longValue());
 
 
                     /*
@@ -1817,8 +1827,10 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                         * | env[n]        |
                         * |---------------|
                         * | 0             |
-                        * |---------------| <-- Beginning of data returned by sysctl()
-                        * | exec_path     |     is here.
+                        * |---------------| <-- Beginning of data returned by sysctl() is here.
+                        * | argc          |
+                        * |---------------|
+                        * | exec_path     |
                         * |:::::::::::::::|
                         * |               |
                         * | String area.  |
@@ -1830,7 +1842,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                         */
 
                     // I find the Darwin source code of the 'ps' command helpful in understanding how it does this:
-                    // see http://www.opensource.apple.com/source/adv_cmds/adv_cmds-147/ps/print.c
+                    // see https://opensource.apple.com/source/adv_cmds/adv_cmds-176/ps/print.c
                     int argc = m.readInt();
                     String args0 = m.readString(); // exec path
                     m.skip0();

--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -31,6 +31,7 @@ import com.sun.jna.Memory;
 import com.sun.jna.NativeLong;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.NativeLongByReference;
 import hudson.os.PosixAPI;
 import jnr.posix.POSIX;
 import org.jvnet.libpam.impl.CLibrary.passwd;
@@ -85,15 +86,26 @@ public interface GNUCLibrary extends Library {
     // see http://www.gnu.org/s/libc/manual/html_node/Renaming-Files.html
     int rename(String oldname, String newname);
 
+    // The following three functions are Darwin-specific. The native "long" and "size_t" types always have
+    // the same size on Darwin, we use NativeLong and NativeLongByReference where the native functions use
+    // "size_t" and "size_t *" respectively. By updating JNA to 5.9.0 and adding a dependency on "jna-platform",
+    // the "com.sun.jna.platform.unix.LibCAPI.size_t" and "com.sun.jna.platform.unix.LIBCAPI.size_t.ByReference"
+    // types could be used instead.
 
     // this is listed in http://developer.apple.com/DOCUMENTATION/Darwin/Reference/ManPages/man3/sysctlbyname.3.html
     // but not in http://www.gnu.org/software/libc/manual/html_node/System-Parameters.html#index-sysctl-3493
     // perhaps it is only supported on BSD?
+    @Deprecated
     int sysctlbyname(String name, Pointer oldp, IntByReference oldlenp, Pointer newp, IntByReference newlen);
+    int sysctlbyname(String name, Pointer oldp, NativeLongByReference oldlenp, Pointer newp, NativeLong newlen);
 
+    @Deprecated
     int sysctl(int[] mib, int nameLen, Pointer oldp, IntByReference oldlenp, Pointer newp, IntByReference newlen);
+    int sysctl(int[] name, int namelen, Pointer oldp, NativeLongByReference oldlenp, Pointer newp, NativeLong newlen);
 
+    @Deprecated
     int sysctlnametomib(String name, Pointer mibp, IntByReference size);
+    int sysctlnametomib(String name, Pointer mibp, NativeLongByReference sizep);
 
     /**
      * Creates a symlink.


### PR DESCRIPTION
See [JENKINS-65195](https://issues.jenkins-ci.org/browse/JENKINS-65195).
See [JENKINS-64347](https://issues.jenkins-ci.org/browse/JENKINS-64347).

### Proposed changelog entries

* JENKINS-65195 Fix incorrect process termination issues when running on macOS.
* JENKINS-64347 Add check to prevent out of bounds memory access on macOS. 

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
