### PR TITLE
[JENKINS-65766] `ClassLoaderReflectionToolkit._findClass` was ignoring `getClassLoadingLock` on `AntClassLoader`

### DIFF
--- a/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
+++ b/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
@@ -103,12 +103,12 @@ public class ClassLoaderReflectionToolkit {
      * @since 1.553
      */
     public static @NonNull Class<?> _findClass(ClassLoader cl, String name) throws ClassNotFoundException {
-        if (cl instanceof AntClassLoader) {
-            return ((AntClassLoader) cl).findClass(name);
-        }
-
         synchronized (getClassLoadingLock(cl, name)) {
-            return (Class) invoke(FindClass.FIND_CLASS, ClassNotFoundException.class, cl, name);
+            if (cl instanceof AntClassLoader) {
+                return ((AntClassLoader) cl).findClass(name);
+            } else {
+                return (Class) invoke(FindClass.FIND_CLASS, ClassNotFoundException.class, cl, name);
+            }
         }
     }
 


### PR DESCRIPTION
An apparent bug from #5110.

### Proposed changelog entries

* A race condition in class loading could result in a `LinkageError`.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
