### PR TITLE
Remove duplicate AOP classes in classpath

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,6 +87,11 @@ THE SOFTWARE.
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <exclusions>
+        <exclusion>
+          <!-- Provided by spring-aop via spring-security-web -->
+          <groupId>aopalliance</groupId>
+          <artifactId>aopalliance</artifactId>
+        </exclusion>
         <exclusion> <!-- TODO it seems to want Guava 16; apparently it manages to run against 11 -->
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>


### PR DESCRIPTION
The WAR's `WEB-INF/lib` directory contains both `spring-aop-5.3.7.jar` and `aopalliance-1.0.jar`. The latter contains these files:

```bash
$ jar tf aopalliance-1.0.jar | sort -u
META-INF/
META-INF/MANIFEST.MF
org/
org/aopalliance/
org/aopalliance/aop/
org/aopalliance/aop/Advice.class
org/aopalliance/aop/AspectException.class
org/aopalliance/intercept/
org/aopalliance/intercept/ConstructorInterceptor.class
org/aopalliance/intercept/ConstructorInvocation.class
org/aopalliance/intercept/Interceptor.class
org/aopalliance/intercept/Invocation.class
org/aopalliance/intercept/Joinpoint.class
org/aopalliance/intercept/MethodInterceptor.class
org/aopalliance/intercept/MethodInvocation.class
```

The same classes are included in `spring-aop-5.3.7.jar`:

```bash
$ jar tf spring-aop-5.3.7.jar | grep org.aopalliance | sort -u
org/aopalliance/
org/aopalliance/aop/
org/aopalliance/aop/Advice.class
org/aopalliance/aop/AspectException.class
org/aopalliance/intercept/
org/aopalliance/intercept/ConstructorInterceptor.class
org/aopalliance/intercept/ConstructorInvocation.class
org/aopalliance/intercept/Interceptor.class
org/aopalliance/intercept/Invocation.class
org/aopalliance/intercept/Joinpoint.class
org/aopalliance/intercept/MethodInterceptor.class
org/aopalliance/intercept/MethodInvocation.class
```

It is bad practice to include the same classes twice on the classpath. So which of the two versions should we prefer? `aopalliance-1.0.jar` dates back to March 2004, while the Spring version is much more recent and seems to be [actively maintained](https://github.com/spring-projects/spring-framework/tree/main/spring-aop/src/main/java/org/aopalliance). So in this PR I am excluding `aopalliance-1.0.jar` from the WAR in favor of the Spring versions of the same classes.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
