### PR TITLE
Prefer `ArrayList` and `ArrayDeque` to `LinkedList`

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -60,7 +60,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -569,7 +568,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             public <T> void onProvision(ProvisionInvocation<T> provision) {
                 final T instance = provision.provision();
                 if (instance == null) return;
-                List<Method> methods = new LinkedList<>();
+                List<Method> methods = new ArrayList<>();
                 Class c = instance.getClass();
 
                 // find PostConstruct methods in class hierarchy, the one from parent class being first in list

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -71,7 +71,6 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.GregorianCalendar;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -751,7 +750,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * Obtains all the {@link Run}s whose build numbers matches the given {@link RangeSet}.
      */
     public synchronized List<RunT> getBuilds(RangeSet rs) {
-        List<RunT> builds = new LinkedList<>();
+        List<RunT> builds = new ArrayList<>();
 
         for (Range r : rs.getRanges()) {
             for (RunT b = getNearestBuild(r.start); b!=null && b.getNumber()<r.end; b=b.getNextBuild()) {

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -8,10 +8,10 @@ import hudson.slaves.NodeSpecific;
 import net.sf.json.JSONObject;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.net.URL;
 
@@ -177,7 +177,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
          * @return the merged ToolInstallerList wrapped in a JSONObject
          */
         private JSONObject reduce(List<JSONObject> jsonList) {
-            List<ToolInstallerEntry> reducedToolEntries = new LinkedList<>();
+            List<ToolInstallerEntry> reducedToolEntries = new ArrayList<>();
 
             HashSet<String> processedIds = new HashSet<>();
             for (JSONObject jsonToolList : jsonList) {

--- a/core/src/main/java/hudson/util/CharSpool.java
+++ b/core/src/main/java/hudson/util/CharSpool.java
@@ -25,7 +25,7 @@ package hudson.util;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -58,7 +58,7 @@ public final class CharSpool extends Writer {
             return;
 
         if(buf==null)
-            buf = new LinkedList<>();
+            buf = new ArrayList<>();
         buf.add(last);
         last = new char[1024];
         pos = 0;

--- a/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
+++ b/core/src/main/java/jenkins/tasks/SimpleBuildStep.java
@@ -46,8 +46,8 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.DependencyDeclarer;
@@ -194,7 +194,7 @@ public interface SimpleBuildStep extends BuildStep {
         @NonNull
         @Override
         public Collection<? extends Action> createFor(@NonNull Job j) {
-            List<Action> actions = new LinkedList<>();
+            List<Action> actions = new ArrayList<>();
             Run r = j.getLastSuccessfulBuild();
             if (r != null) {
                 for (LastBuildAction a : r.getActions(LastBuildAction.class)) {

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -57,7 +57,6 @@ import hudson.util.FormValidation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -260,7 +259,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
                         if (upstream instanceof AbstractProject && downstream instanceof AbstractProject) {
                             continue; // handled specially
                         }
-                        Collection<ReverseBuildTrigger> triggers = result.computeIfAbsent(upstream, k -> new LinkedList<>());
+                        Collection<ReverseBuildTrigger> triggers = result.computeIfAbsent(upstream, k -> new ArrayList<>());
                         triggers.remove(trigger);
                         triggers.add(trigger);
                     }

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -45,11 +45,11 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -813,7 +813,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
                 return "";
             }
             
-            Deque<String> relativePath = new LinkedList<>();
+            Deque<String> relativePath = new ArrayDeque<>();
             File current = this.f;
             while (current != null && !current.equals(this.root)) {
                 relativePath.addFirst(current.getName());
@@ -1093,7 +1093,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
                 return "";
             }
 
-            LinkedList<String> relativePath = new LinkedList<>();
+            Deque<String> relativePath = new ArrayDeque<>();
             FilePath current = this.f;
             while (current != null && !current.equals(this.root)) {
                 relativePath.addFirst(current.getName());

--- a/core/src/test/java/hudson/model/ParametersActionTest.java
+++ b/core/src/test/java/hudson/model/ParametersActionTest.java
@@ -3,7 +3,8 @@ package hudson.model;
 import hudson.EnvVars;
 import hudson.model.queue.SubTask;
 import hudson.tasks.BuildWrapper;
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -112,7 +113,7 @@ public class ParametersActionTest {
         assertEquals(2, vars.size());   
         parametersAction.createVariableResolver(build);
         
-        LinkedList<BuildWrapper> wrappers = new LinkedList<>();
+        List<BuildWrapper> wrappers = new ArrayList<>();
         parametersAction.createBuildWrappers(build, wrappers);
         assertEquals(0, wrappers.size());
         

--- a/test/src/test/java/jenkins/security/SecurityContextExecutorServiceTest.java
+++ b/test/src/test/java/jenkins/security/SecurityContextExecutorServiceTest.java
@@ -28,8 +28,8 @@ import hudson.security.ACL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -136,7 +136,7 @@ public class SecurityContextExecutorServiceTest {
     @Test
     @PresetData(PresetData.DataSet.NO_ANONYMOUS_READACCESS)
     public void testCallableCollectionAgainstAllContexts() throws Exception {
-        Collection<Callable<SecurityContext>> callables = new LinkedList<>();
+        Collection<Callable<SecurityContext>> callables = new ArrayList<>();
         Callable<SecurityContext> c = new Callable<SecurityContext>() {
             @Override
             public SecurityContext call() throws Exception {


### PR DESCRIPTION
### Problem

Per Error Prone's [`JdkObsolete`](https://errorprone.info/bugpattern/JdkObsolete) check:

> [`LinkedList`](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedList.html) almost never out-performs [`ArrayList`](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html) or [`ArrayDeque`](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayDeque.html). […] People generally choose `LinkedList` because they want fast insertion and removal. However, `LinkedList` has slow traversal, and typically you need to traverse the list to find the place to insert/remove. It turns out that the cost of traversing to a location in a `LinkedList` is approximately 4x the cost of copying an element in an `ArrayList`. Thus, `LinkedList`’s traversal cost dominates and results in poorer performance. [More info](https://stuartmarks.wordpress.com/2015/12/18/some-java-list-benchmarks/)

### Solution

When using `LinkedList` as a list, prefer `ArrayList`. When using `LinkedList` as a stack or queue/deque, prefer `ArrayDeque`.

### Implementation

Per the same article:

> Migration gotcha: `LinkedList` permits `null` elements; `ArrayDeque` rejects them. The documentation for `Deque` strongly discourages users from inserting `null`, even into implementations that permit it. So, if you are using a `LinkedList` for this purpose, you should likely stop, and you will need to stop in order to migrate to `ArrayDeque`.

The only two new usages of `ArrayDeque` I am introducing in this PR are both in `jenkins.util.VirtualFile`. In both cases, I verified that the arguments being passed to `ArrayDeque` methods (`File#getName` or `FilePath#getName`) cannot be `null`.

Note that I did _not_ touch the calls to `new LinkedList<>()` in `jenkins.widgets.HistoryPageFilter` or `hudson.widgets.BuildHistoryWidget`, because I could not easily prove that the lists never contained `null` elements and did not want to risk a regression.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
