### PR TITLE
Documenting `Computer` REST methods `toggleOffline` & `changeOfflineCause`

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/_api.jelly
+++ b/core/src/main/resources/hudson/model/Computer/_api.jelly
@@ -36,4 +36,12 @@ THE SOFTWARE.
     update the configuration of a node.
   </p>
 
+  <h2>Marking this node temporarily offline</h2>
+  <p>
+      You can POST to <a href="../toggleOffline?offlineMessage=some%20text">this URL</a>
+      to mark this node temporary offline, or bring it back online.
+      Or you can POST to <a href="../changeOfflineCause?offlineMessage=some%20text">this URL</a>
+      to mark this node temporary offline, or adjust the offline cause message if it is already offline.
+  </p>
+
 </j:jelly>


### PR DESCRIPTION
Watching [this Pipeline script](https://slack.engineering/how-a-jenkins-job-broke-our-jenkins-ui/) with horror along with the rest of the world I noticed that although the `offline-node` CLI command is prominent enough, the REST equivalents were not documented (at least inside Jenkins).

Validity of URLs verified interactively on a static inbound agent using the browser (you get the usual prompt to retry a link as a `POST`).

Note that `MasterComputer` overrides this page, so it applies only to agents.

### Proposed changelog entries

* Documenting REST methods to mark an (agent) node temporarily offline and related tasks.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
