### PR TITLE
Restricting `InterceptingExecutorService`

### DIFF
--- a/core/src/main/java/jenkins/util/InterceptingExecutorService.java
+++ b/core/src/main/java/jenkins/util/InterceptingExecutorService.java
@@ -21,6 +21,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Kohsuke Kawaguchi
  * @since 1.557
  */
+@Deprecated
 @Restricted(NoExternalUse.class)
 @RestrictedSince("TODO")
 public abstract class InterceptingExecutorService extends ForwardingExecutorService {

--- a/core/src/main/java/jenkins/util/InterceptingExecutorService.java
+++ b/core/src/main/java/jenkins/util/InterceptingExecutorService.java
@@ -2,6 +2,7 @@ package jenkins.util;
 
 import com.google.common.util.concurrent.ForwardingExecutorService;
 
+import hudson.RestrictedSince;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -11,6 +12,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * {@link ExecutorService} that wraps all the tasks that run inside.
@@ -18,7 +21,8 @@ import java.util.concurrent.TimeoutException;
  * @author Kohsuke Kawaguchi
  * @since 1.557
  */
-@Deprecated
+@Restricted(NoExternalUse.class)
+@RestrictedSince("TODO")
 public abstract class InterceptingExecutorService extends ForwardingExecutorService {
     private final ExecutorService base;
 

--- a/core/src/main/java/jenkins/util/InterceptingExecutorService.java
+++ b/core/src/main/java/jenkins/util/InterceptingExecutorService.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeoutException;
  * @author Kohsuke Kawaguchi
  * @since 1.557
  */
+@Deprecated
 public abstract class InterceptingExecutorService extends ForwardingExecutorService {
     private final ExecutorService base;
 


### PR DESCRIPTION
Jenkins core defines `jenkins.util.InterceptingExecutorService`, which extends `com.google.common.util.concurrent.ForwardingExecutorService`. This exposes a Guava API in the Jenkins public API, which is a liability. If the Guava API changed, the Jenkins API might also have to change, which could result in incompatibilities. Supporting such an API also implies that Jenkins core must expose Guava to plugins, something we would rather avoid if possible.

Analyzing usages in both open source and CloudBees proprietary plugins with `usage-in-plugins`, I see that the only usage of this class is in `workflow-cps`. It seems better to move this class to `workflow-cps`. That way `workflow-cps` still gets what it needs, while Jenkins core gets out of the business of exposing Guava classes in its public API.

This PR deprecates `jenkins.util.InterceptingExecutorService` in Jenkins core. Concomitant with this PR, I am inlining `jenkins.util.InterceptingExecutorService` in `workflow-cps` in jenkinsci/workflow-cps-plugin#448. Once jenkinsci/workflow-cps-plugin#448 is widely adopted, I plan to delete `jenkins.util.InterceptingExecutorService` from Jenkins core.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).