### PR TITLE
Remove StAX from WAR

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -263,11 +263,6 @@ THE SOFTWARE.
         <artifactId>memory-monitor</artifactId>
         <version>1.9</version>
       </dependency>
-      <dependency><!-- StAX implementation. See JENKINS-2547. -->
-        <groupId>org.codehaus.woodstox</groupId>
-        <artifactId>wstx-asl</artifactId>
-        <version>3.2.9</version>
-      </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -454,6 +454,13 @@ THE SOFTWARE.
     <dependency>
       <groupId>com.sun.xml.txw2</groupId>
       <artifactId>txw2</artifactId>
+      <exclusions>
+        <!-- StAX is now bundled in the JRE -->
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>
@@ -466,10 +473,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>memory-monitor</artifactId>
-    </dependency>
-    <dependency><!-- StAX implementation. See JENKINS-2547. -->
-      <groupId>org.codehaus.woodstox</groupId>
-      <artifactId>wstx-asl</artifactId>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
Recall that the [Java API for XML Processing (JAXP)](https://en.wikipedia.org/wiki/Java_API_for_XML_Processing) has three parsing interfaces:

- the Document Object Model parsing interface (DOM)
- the [Simple API for XML](https://en.wikipedia.org/wiki/Simple_API_for_XML) parsing interface (SAX)
- the [Streaming API for XML](https://en.wikipedia.org/wiki/StAX) parsing interface (StAX)

StAX was distributed as a separate JAR in Java 5, but starting in Java 6 it became part of the JRE. As such, it is no longer necessary for Java applications to distribute it.

Jenkins core ships with not just one but two copies of the StAX API (`stax-api-1.0.1.jar` and `stax-api-1.0-2.jar`), as well as a StAX implementation (`org.codehaus.woodstox:wstx-asl`, added in [JENKINS-2547](https://issues.jenkins.io/browse/JENKINS-2547) in 2008 to resolve an issue running under Java 5). None of these are necessary now that Jenkins requires Java 8. Therefore, I am removing them all in this PR.

I verified with `usage-in-plugins` that no classes from `org.codehaus.woodstox:wstx-asl` are used in any open source or CloudBees proprietary plugins.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
