### PR TITLE
Remove `jna-posix`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,11 +98,6 @@ THE SOFTWARE.
       <groupId>org.connectbot.jbcrypt</groupId>
       <artifactId>jbcrypt</artifactId>
     </dependency>
-    <dependency> <!-- for compatibility only; all new code should use JNR. Not included into BOM due to the same reason -->
-      <groupId>org.jruby.ext.posix</groupId>
-      <artifactId>jna-posix</artifactId>
-      <version>1.0.3-jenkins-1</version>
-    </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>

--- a/core/src/main/java/hudson/os/PosixAPI.java
+++ b/core/src/main/java/hudson/os/PosixAPI.java
@@ -1,10 +1,5 @@
 package hudson.os;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.PrintStream;
-import java.util.Map;
-import java.util.logging.Logger;
 import jnr.constants.platform.Errno;
 import jnr.posix.POSIX;
 import jnr.posix.POSIXFactory;
@@ -12,7 +7,6 @@ import jnr.posix.util.DefaultPOSIXHandler;
 
 /**
  * POSIX API wrapper.
- * Formerly used the jna-posix library, but this has been superseded by jnr-posix.
  * @author Kohsuke Kawaguchi
  */
 public class PosixAPI {
@@ -30,106 +24,13 @@ public class PosixAPI {
         if (posix == null) {
             posix = POSIXFactory.getPOSIX(new DefaultPOSIXHandler() {
                 @Override public void error(Errno error, String extraData) {
-                    throw new PosixException("native error " + error.description() + " " + extraData, convert(error));
+                    throw new PosixException("native error " + error.description() + " " + extraData);
                 }
                 @Override public void error(Errno error, String methodName, String extraData) {
-                    throw new PosixException("native error calling " + methodName + ": " + error.description() + " " + extraData, convert(error));
-                }
-                private org.jruby.ext.posix.POSIX.ERRORS convert(Errno error) {
-                    try {
-                        return org.jruby.ext.posix.POSIX.ERRORS.valueOf(error.name());
-                    } catch (IllegalArgumentException x) {
-                        return org.jruby.ext.posix.POSIX.ERRORS.EIO; // PosixException.message has real error anyway
-                    }
+                    throw new PosixException("native error calling " + methodName + ": " + error.description() + " " + extraData);
                 }
             }, true);
         }
         return posix;
     }
-
-    /**
-     * @deprecated use {@link #jnr} and {@link POSIX#isNative}
-     */
-    @Deprecated
-    public boolean isNative() {
-        return supportsNative();
-    }
-
-    /**
-     * @deprecated use {@link #jnr} and {@link POSIX#isNative}
-     */
-    @Deprecated
-    public static boolean supportsNative() {
-        return !(jnaPosix instanceof org.jruby.ext.posix.JavaPOSIX);
-    }
-
-    private static org.jruby.ext.posix.POSIX jnaPosix;
-    /** @deprecated Use {@link #jnr} instead. */
-    @Deprecated
-    public static synchronized org.jruby.ext.posix.POSIX get() {
-        if (jnaPosix == null) {
-            jnaPosix = org.jruby.ext.posix.POSIXFactory.getPOSIX(new org.jruby.ext.posix.POSIXHandler() {
-        @Override
-        public void error(org.jruby.ext.posix.POSIX.ERRORS errors, String s) {
-            throw new PosixException(s,errors);
-        }
-
-        @Override
-        public void unimplementedError(String s) {
-            throw new UnsupportedOperationException(s);
-        }
-
-        @Override
-        public void warn(WARNING_ID warning_id, String s, Object... objects) {
-            LOGGER.fine(s);
-        }
-
-        @Override
-        public boolean isVerbose() {
-            return true;
-        }
-
-        @Override
-        public File getCurrentWorkingDirectory() {
-            return new File(".").getAbsoluteFile();
-        }
-
-        @Override
-        public String[] getEnv() {
-            Map<String,String> envs = System.getenv();
-            String[] envp = new String[envs.size()];
-            
-            int i = 0;
-            for (Map.Entry<String,String> e : envs.entrySet()) {
-                envp[i++] = e.getKey()+'+'+e.getValue();
-            }
-            return envp;
-        }
-
-        @Override
-        public InputStream getInputStream() {
-            return System.in;
-        }
-
-        @Override
-        public PrintStream getOutputStream() {
-            return System.out;
-        }
-
-        @Override
-        public int getPID() {
-            // TODO
-            return 0;
-        }
-
-        @Override
-        public PrintStream getErrorStream() {
-            return System.err;
-        }
-    }, true);
-        }
-        return jnaPosix;
-    }
-
-    private static final Logger LOGGER = Logger.getLogger(PosixAPI.class.getName());
 }

--- a/core/src/main/java/hudson/os/PosixException.java
+++ b/core/src/main/java/hudson/os/PosixException.java
@@ -1,28 +1,17 @@
 package hudson.os;
 
-import org.jruby.ext.posix.POSIX.ERRORS;
-
 /**
  * Indicates an error during POSIX API call.
  * @see PosixAPI
  * @author Kohsuke Kawaguchi
  */
 public class PosixException extends RuntimeException {
-    private final ERRORS errors;
 
-    public PosixException(String message, ERRORS errors) {
+    public PosixException(String message) {
         super(message);
-        this.errors = errors;
     }
 
-    /** @deprecated Leaks reference to deprecated jna-posix API. */
-    @Deprecated
-    public ERRORS getErrorCode() {
-        return errors;
-    }
-
-    @Override
-    public String toString() {
-        return super.toString()+" "+errors;
+    public PosixException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/core/src/main/java/hudson/util/IOUtils.java
+++ b/core/src/main/java/hudson/util/IOUtils.java
@@ -141,9 +141,7 @@ public class IOUtils {
                 return Util.permissionsToMode(Files.getPosixFilePermissions(fileToPath(f)));
             }
         } catch (IOException cause) {
-            PosixException e = new PosixException("Unable to get file permissions", null);
-            e.initCause(cause);
-            throw e;
+            throw new PosixException("Unable to get file permissions", cause);
         }
     }
 

--- a/licenseCompleter.groovy
+++ b/licenseCompleter.groovy
@@ -81,13 +81,4 @@ complete {
     match("net.jcip:jcip-annotations") {
         rewriteLicense([],ccby)
     }
-
-    //
-    // Choose from multi-licensed modules
-    //==========================================================================
-
-    match("*:jna-posix") {
-        accept("GNU Lesser General Public License Version 2.1")
-    }
-
 }


### PR DESCRIPTION
`jna-posix` was superseded by `jnr-posix` in Jenkins core in 2013 in commit 2a1d1631bd, but our fork of `org.jruby.ext.posix:jna-posix` (1.0.3-jenkins-1) remains present for backward compatibility. `jna-posix` is not compatible with Java 10+. Carrying this dependency seems undesirable for the Jenkins project in 2021. Isn't it time we moved on?

This PR makes incompatible changes to `PosixException` to remove the exposure of `jna-posix`. I used `usage-in-plugins` to look for usages of `PosixException`. `PosixException` is used in [Copy Artifact](https://plugins.jenkins.io/copyartifact/), [CloudBees Backup Plugin](https://docs.cloudbees.com/docs/release-notes/latest/plugins/infradna-backup-plugin/), and [Operations Center Context Plugin](https://docs.cloudbees.com/docs/release-notes/latest/plugins/operations-center-context-plugin/). But in none of these three cases is the constructor or the `getErrorCode()` method called. They are all just catching `PosixException`. So removing the second argument from the constructor and removing `getErrorCode()` shouldn't break anything.

I also used `usage-in-plugins` to look for usages of classes in the `jna-posix` JAR as well as `hudson.os.PosixAPI#get`, `hudson.os.PosixAPI#isNative`, and `hudson.os.PosixAPI#supportsNative`. Here we go again. `hudson/os/PosixAPI#get()Lorg/jruby/ext/posix/POSIX;` is still used in three ancient plugins:

- [Maven Repository Scheduled Cleanup](https://plugins.jenkins.io/maven-repo-cleaner/), a plugin last released 8 years ago with 3,749 installations. This dependency was already removed in jenkinsci/maven-repo-cleaner-plugin#4, but this change remains unreleased three years later.
- [SICCI for Xcode](https://plugins.jenkins.io/sicci_for_xcode/), a plugin last released 10 years ago with 519 installations. I opened jenkinsci/tmpcleaner-plugin#7 to migrate this plugin from `jna-posix` to `jnr-posix`.
- [java.io.tmpdir cleaner](https://plugins.jenkins.io/tmpcleaner/), a plugin last released 5 years ago with 884 installations. I opened jenkinsci/sicci-for-xcode-plugin#2 to migrate this plugin from `jna-posix` to `jnr-posix`.

I propose we move forward with this removal whether these plugins get released or not. `jna-posix` has been deprecated in Jenkins core for 8 years, and it won't work with Java 11. It's time to move on. Once this PR is merged, I'll file a PR in the Update Center to officially mark these three plugins as deprecated.

### Proposed changelog entries

Developer: Remove `jna-posix` dependency from Jenkins core. Plugins that use `jna-posix` functionality, including [Maven Repository Scheduled Cleanup](https://plugins.jenkins.io/maven-repo-cleaner/), [SICCI for Xcode](https://plugins.jenkins.io/sicci_for_xcode/), and [java.io.tmpdir cleaner](https://plugins.jenkins.io/tmpcleaner/), must be migrated from `jna-posix` to `jnr-posix`.

### Proposed upgrade guidelines

The `jna-posix` dependency has been removed from Jenkins core. Plugins that use `jna-posix` functionality, including [Maven Repository Scheduled Cleanup](https://plugins.jenkins.io/maven-repo-cleaner/), [SICCI for Xcode](https://plugins.jenkins.io/sicci_for_xcode/), and [java.io.tmpdir cleaner](https://plugins.jenkins.io/tmpcleaner/), are no longer supported and must be removed.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
