### PR TITLE
Implement `InterceptingExecutorService` without Guava

### DIFF
--- a/core/src/main/java/jenkins/util/InterceptingExecutorService.java
+++ b/core/src/main/java/jenkins/util/InterceptingExecutorService.java
@@ -1,7 +1,5 @@
 package jenkins.util;
 
-import com.google.common.util.concurrent.ForwardingExecutorService;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -18,7 +16,7 @@ import java.util.concurrent.TimeoutException;
  * @author Kohsuke Kawaguchi
  * @since 1.557
  */
-public abstract class InterceptingExecutorService extends ForwardingExecutorService {
+public abstract class InterceptingExecutorService implements ExecutorService {
     private final ExecutorService base;
 
     public InterceptingExecutorService(ExecutorService base) {
@@ -29,49 +27,78 @@ public abstract class InterceptingExecutorService extends ForwardingExecutorServ
 
     protected abstract <V> Callable<V> wrap(Callable<V> r);
 
-    @Override
     protected ExecutorService delegate() {
         return base;
     }
 
-    @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return super.submit(wrap(task));
+        return delegate().submit(wrap(task));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return super.submit(wrap(task), result);
+        return delegate().submit(wrap(task), result);
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return super.submit(wrap(task));
+        return delegate().submit(wrap(task));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return super.invokeAll(wrap(tasks));
+        return delegate().invokeAll(wrap(tasks));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
-        return super.invokeAll(wrap(tasks), timeout, unit);
+        return delegate().invokeAll(wrap(tasks), timeout, unit);
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return super.invokeAny(wrap(tasks));
+        return delegate().invokeAny(wrap(tasks));
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        return super.invokeAny(wrap(tasks), timeout, unit);
+        return delegate().invokeAny(wrap(tasks), timeout, unit);
     }
 
     @Override
     public void execute(Runnable command) {
-        super.execute(wrap(command));
+        delegate().execute(wrap(command));
+    }
+
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate().awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate().isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate().isTerminated();
+    }
+
+    @Override
+    public void shutdown() {
+        delegate().shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate().shutdownNow();
+    }
+
+    @Override
+    public String toString() {
+        return delegate().toString();
     }
 
     private <T> Collection<Callable<T>> wrap(Collection<? extends Callable<T>> callables) {


### PR DESCRIPTION
Jenkins core defines `jenkins.util.InterceptingExecutorService`, which extends `com.google.common.util.concurrent.ForwardingExecutorService`. This exposes a Guava API in the Jenkins public API, which is a liability. If the Guava API changed, the Jenkins API might also have to change, which could result in incompatibilities. Supporting such an API also implies that Jenkins core must expose Guava to plugins, something we would rather avoid if possible.

This PR is going after the same goal as #5558 but with a different approach. The goal is to remove exposure of Guava in the Jenkins core public API. The approach taken in this PR is to directly implement `ExecutorService` rather than to extend Guava's `ForwardingExecutorService`. Modulo compatibility concerns, this is the simplest option to eliminating the dependency.

From a compatibility perspective this change is a bit risky, as it changes the class hierarchy for these classes:

```
jenkins/util/InterceptingExecutorService
jenkins/security/ImpersonatingExecutorService (extends InterceptingExecutorService)
jenkins/security/SecurityContextExecutorService (extends InterceptingExecutorService)
jenkins/util/ContextResettingExecutorService (extends InterceptingExecutorService)
jenkins/util/InterceptingScheduledExecutorService (extends InterceptingExecutorService)
jenkins/security/ImpersonatingScheduledExecutorService (extends InterceptingScheduledExecutorService)
```

They now no longer extend `ForwardingExecutorService` or `ForwardingObject`, so any attempts to cast to those types would fail. However, I doubt any such casts exist.

Apart from that, I've ensured that all of the same public methods are implemented, so in theory any already compiled plugins invoking methods on these objects should continue to work as before. In practice, I think we'd want to do some sort of testing on this, but I'm not sure exactly how to test this. I'll start by trying to get an incremental build and run it through the BOM tests.

### Proposed changelog entries

Developer: `InterceptingExecutorService` and its subclasses no longer extend `com.google.common.util.concurrent.ForwardingExecutorService` or `com.google.common.collect.ForwardingObject`.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
