### PR TITLE
lib/form/RepeatableTest: tables-to-divs

### DIFF
--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/defaultForField.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/defaultForField.jelly
@@ -30,14 +30,14 @@ THE SOFTWARE.
       <j:set var="instance" value="${it}"/>
       <j:set var="descriptor" value="${it.descriptor}"/>
       <f:repeatable field="list" default="${it.defaults}">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="txt" value="${instance.txt}"/>
           </f:entry>
           <f:entry>
             <f:checkbox name="bool" checked="${instance.bool}"/>
           </f:entry>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/defaultForItems.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/defaultForItems.jelly
@@ -28,14 +28,14 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="foo" items="${it.list}" default="${it.defaults}" name="list" minimum="${it.minimum}">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="txt" value="${foo.txt}"/>
           </f:entry>
           <f:entry>
             <f:checkbox name="bool" checked="${foo.bool}"/>
           </f:entry>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testDropdownList.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testDropdownList.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <l:main-panel>
     <form method="post" name="config" action="submitTest">
       <f:repeatable var="fruity" items="${it.list}" name="items">
-        <table>
+        <div>
           <f:dropdownList name="fruit" title="Fruits">
             <j:forEach var="descriptor" items="${it.fruitDescriptors}" varStatus="loop">
               <j:set var="fruit" value="${descriptor==fruity.fruit.descriptor?fruity.fruit:null}"/>
@@ -41,7 +41,7 @@ THE SOFTWARE.
           <f:entry title="Word">
             <f:textbox name="word" value="${fruity.word}"/>
           </f:entry>
-        </table>
+        </div>
       </f:repeatable>
       <f:submit value="submit"/>
     </form>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNested.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNested.jelly
@@ -28,23 +28,23 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="item" items="${it.list}" name="items">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="title" value="${item.title}"/>
           </f:entry>
           <f:nested>
             <f:repeatable var="foo" items="${item.list}" add="Add Foo">
-              <table>
+              <div>
                 <f:entry>
                   <f:textbox name="txt" value="${foo.txt}"/>
                 </f:entry>
                 <f:entry>
                   <f:checkbox name="bool" checked="${foo.bool}"/>
                 </f:entry>
-              </table>
+              </div>
             </f:repeatable>
           </f:nested>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedRadio.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedRadio.jelly
@@ -28,22 +28,22 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="item" items="${it.list}" name="items">
-        <table>
+        <div>
           <f:entry>
             <f:radio name="outer" value="one"/> One
             <f:radio name="outer" value="two"/> Two
           </f:entry>
           <f:nested>
             <f:repeatable var="moo" items="${item.list}" add="Add Moo">
-              <table>
+              <div>
                 <f:entry>
                   <f:radio name="inner" value="inone"/>
                   <f:radio name="inner" value="intwo"/>
                 </f:entry>
-              </table>
+              </div>
             </f:repeatable>
           </f:nested>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedRadioTopButton.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedRadioTopButton.jelly
@@ -28,22 +28,22 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="item" items="${it.list}" name="items" enableTopButton="true">
-        <table>
+        <div>
           <f:entry>
             <f:radio name="outer" value="one"/> One
             <f:radio name="outer" value="two"/> Two
           </f:entry>
           <f:nested>
             <f:repeatable var="moo" items="${item.list}" add="Add Moo" enableTopButton="true">
-              <table>
+              <div>
                 <f:entry>
                   <f:radio name="inner" value="inone"/>
                   <f:radio name="inner" value="intwo"/>
                 </f:entry>
-              </table>
+              </div>
             </f:repeatable>
           </f:nested>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedTopButton.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedTopButton.jelly
@@ -28,23 +28,23 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="item" items="${it.list}" name="items" enableTopButton="true">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="title" value="${item.title}"/>
           </f:entry>
           <f:nested>
             <f:repeatable var="foo" items="${item.list}" add="Add Foo" enableTopButton="true">
-              <table>
+              <div>
                 <f:entry>
                   <f:textbox name="txt" value="${foo.txt}"/>
                 </f:entry>
                 <f:entry>
                   <f:checkbox name="bool" checked="${foo.bool}"/>
                 </f:entry>
-              </table>
+              </div>
             </f:repeatable>
           </f:nested>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedTopButtonInner.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedTopButtonInner.jelly
@@ -28,23 +28,23 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="item" items="${it.list}" name="items" enableTopButton="false">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="title" value="${item.title}"/>
           </f:entry>
           <f:nested>
             <f:repeatable var="foo" items="${item.list}" add="Add Foo" enableTopButton="true">
-              <table>
+              <div>
                 <f:entry>
                   <f:textbox name="txt" value="${foo.txt}"/>
                 </f:entry>
                 <f:entry>
                   <f:checkbox name="bool" checked="${foo.bool}"/>
                 </f:entry>
-              </table>
+              </div>
             </f:repeatable>
           </f:nested>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedTopButtonOuter.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testNestedTopButtonOuter.jelly
@@ -28,23 +28,23 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="item" items="${it.list}" name="items" enableTopButton="true">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="title" value="${item.title}"/>
           </f:entry>
           <f:nested>
             <f:repeatable var="foo" items="${item.list}" add="Add Foo" enableTopButton="false">
-              <table>
+              <div>
                 <f:entry>
                   <f:textbox name="txt" value="${foo.txt}"/>
                 </f:entry>
                 <f:entry>
                   <f:checkbox name="bool" checked="${foo.bool}"/>
                 </f:entry>
-              </table>
+              </div>
             </f:repeatable>
           </f:nested>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testRadioBlock.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testRadioBlock.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="foo" items="${it.list}" name="foos">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="txt" value=""/>
           </f:entry>
@@ -42,7 +42,7 @@ THE SOFTWARE.
               <f:textbox name="b" value=""/>
             </f:entry>
           </f:radioBlock>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testSimple.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testSimple.jelly
@@ -28,14 +28,14 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="foo" items="${it.list}" name="foos" minimum="${it.minimum}">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="txt" value="${foo.txt}"/>
           </f:entry>
           <f:entry>
             <f:checkbox name="bool" checked="${foo.bool}"/>
           </f:entry>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testSimpleWithDeleteButton.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testSimpleWithDeleteButton.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="foo" items="${it.list}" name="foos" minimum="${it.minimum}" enableTopButton="false">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="txt" value="${foo.txt}"/>
           </f:entry>
@@ -38,7 +38,7 @@ THE SOFTWARE.
           <f:entry>
             <f:repeatableDeleteButton />
           </f:entry>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>

--- a/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testSimpleWithDeleteButtonTopButton.jelly
+++ b/test/src/test/resources/lib/form/RepeatableTest/RootActionImpl/testSimpleWithDeleteButtonTopButton.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <l:main-panel>
     <f:form method="post" name="config" action="submitTest">
       <f:repeatable var="foo" items="${it.list}" name="foos" minimum="${it.minimum}" enableTopButton="true">
-        <table>
+        <div>
           <f:entry>
             <f:textbox name="txt" value="${foo.txt}"/>
           </f:entry>
@@ -38,7 +38,7 @@ THE SOFTWARE.
           <f:entry>
             <f:repeatableDeleteButton />
           </f:entry>
-        </table>
+        </div>
       </f:repeatable>
       <f:entry>
         <f:submit value="submit"/>


### PR DESCRIPTION
See #5562 (@basil). This changes fix some `lib.form.RepeatableTest` failures when using a recent HtmlUnit version.
Not sure why they were working with prior HtmlUnit versions and then broke, but anyway, changing some test forms from tables to divs can't hurt, I assume.

This PR does not bump JTH/HtmlUnit, I'll leave that to #5562.