### PR TITLE
Fix `ChainingConstructorIgnoresParameter` Error Prone violation

### DIFF
--- a/core/src/main/java/org/acegisecurity/userdetails/User.java
+++ b/core/src/main/java/org/acegisecurity/userdetails/User.java
@@ -43,7 +43,7 @@ public class User implements UserDetails {
     private GrantedAuthority[] authorities;
 
     public User(String username, String password, boolean enabled, GrantedAuthority[] authorities) {
-        this(username, password, true, true, true, true, authorities);
+        this(username, password, enabled, true, true, true, authorities);
     }
 
     public User(String username, String password, boolean enabled, boolean accountNonExpired, boolean credentialsNonExpired, GrantedAuthority[] authorities) {


### PR DESCRIPTION
Found by Error Prone's [`ChainingConstructorIgnoresParameter`](https://errorprone.info/bugpattern/ChainingConstructorIgnoresParameter) check:

```
[ERROR] src/jenkinsci/jenkins/core/src/main/java/org/acegisecurity/userdetails/User.java:[46,12] error: [ChainingConstructorIgnoresParameter] The called constructor accepts a parameter with the same name and type as one of its caller's parameters, but its caller doesn't pass that parameter to it. It's likely that it was intended to.
```

Indeed, one `org.acegisecurity.userdetails.User` constructor takes an enabled parameter but then delegates to a different constructor, passing `true` for `enabled` rather than the passed-in value of `enabled`.

Note that this PR has no practical impact, because we do not use the `enabled` field to begin with; see [JENKINS-55813](https://issues.jenkins.io/browse/JENKINS-55813). However, it would be good to fix the bug in case we ever did decide to start using this field in the future.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
