### PR TITLE
chore: bump ath Docker image to 1.97-pre to fix ATH runs

### DIFF
--- a/essentials.yml
+++ b/essentials.yml
@@ -2,6 +2,6 @@
 ath:
   useLocalSnapshots: false
   athRevision: "acceptance-test-harness-1.96"
-  athImage: "jenkins/ath:acceptance-test-harness-1.80"
+  athImage: "jenkins/ath:1.97-pre"
   categories:
     - org.jenkinsci.test.acceptance.junit.SmokeTest


### PR DESCRIPTION
See [INFRA-3006](https://issues.jenkins.io/browse/INFRA-3006)

This PR fixes the ATH run by using the latest (at the date of these lines) ATH Docker image, built after the merge of https://github.com/jenkinsci/acceptance-test-harness/pull/672

### Proposed changelog entries

N/A (no changes related to Jenkins itself: `skip-changelog`)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- ~[ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)~
  ~* Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade~
- ~[] Appropriate autotests or explanation to why this change has no tests~
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>