### PR TITLE
Automate jenkins.io changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,9 +6,8 @@ name-template: $NEXT_MINOR_VERSION
 tag-template: jenkins-$NEXT_MINOR_VERSION
 
 template: |
-  **Disclaimer**: This is an automatically generated changelog draft for Jenkins weekly releases. 
-  See https://www.jenkins.io/changelog/ for the official changelogs.
-  For `changelog.yaml` drafts see GitHub action artifacts attached to release commits.
+  _This is an automatically generated changelog draft for Jenkins weekly releases.
+  See https://www.jenkins.io/changelog/ for the official changelogs._
 
   $CHANGES
   

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   update_draft_release:
+    if: github.repository_owner == 'jenkinsci'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
@@ -21,6 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   jenkins_io_draft:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'jenkinsci'
     steps:
       - uses: tibdex/github-app-token@v1
         id: generate-token
@@ -37,9 +39,9 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_AUTH: "nobody:${{ steps.generate-token.outputs.token }}"
           GIT_AUTHOR_NAME: jenkins-dependency-updater
-          GIT_AUTHOR_EMAIL: <81680575+jenkins-dependency-updater[bot]@users.noreply.github.com>
-          GIT_COMMITTER_NAME: jenkins-dependency-updater
-          GIT_COMMITTER_EMAIL: <81680575+jenkins-dependency-updater[bot]@users.noreply.github.com>
+          GIT_AUTHOR_EMAIL: <86592549+jenkins-infra-changelog-generator[bot]@users.noreply.github.com>
+          GIT_COMMITTER_NAME: jenkins-infra-changelog-generator
+          GIT_COMMITTER_EMAIL: <86592549+jenkins-infra-changelog-generator[bot]@users.noreply.github.com>
         run: |
-          wget --quiet https://raw.githubusercontent.com/timja/core-changelog-generator/automate-changelog-generation/generate-weekly-changelog.sh
+          wget --quiet https://raw.githubusercontent.com/jenkinsci/core-changelog-generator/master/generate-weekly-changelog.sh
           bash generate-weekly-changelog.sh

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,9 +25,9 @@ jobs:
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ secrets.JENKINS_DEPENDENCY_UPDATER_APP_ID }}
-          private_key: ${{ secrets.JENKINS_DEPENDENCY_UPDATER_PRIVATE_KEY }}
-          repository: timja/jenkins.io
+          app_id: ${{ secrets.JENKINS_CHANGELOG_UPDATER_APP_ID }}
+          private_key: ${{ secrets.JENKINS_CHANGELOG_UPDATER_PRIVATE_KEY }}
+          repository: jenkins-infra/jenkins.io
       - name: Check out
         uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,6 +3,7 @@
 name: Changelog Drafter
 
 on:
+  workflow_dispatch:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
@@ -18,26 +19,27 @@ jobs:
         uses: release-drafter/release-drafter@v5.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Generates a YAML changelog file using https://github.com/jenkinsci/jenkins-core-changelog-generator
-      - name: Generate YAML changelog draft
-        id: jenkins-core-changelog-generator
-        uses: jenkinsci/jenkins-core-changelog-generator@master
-        env:
-          GITHUB_AUTH: github-actions:${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Changelog YAML
-        uses: actions/upload-artifact@v2.2.4
+  jenkins_io_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
         with:
-          name: changelog.yaml
-          path: changelog.yaml
-#TODO(oleg-nenashev): It will not work well with Release Drafter which does not recreated releases. Asset does not get overwritten, and there is no ready-to-go API for overriding assets
-      # Upload YAML to the release draft assets
-#      - name: Upload changelog.yaml to the Release Draft
-#        id: upload-changelog-yaml
-#        uses: actions/upload-release-asset@v1.0.1
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          upload_url: ${{ steps.release-drafter.outputs.upload_url }}
-#          asset_path: ./changelog.yaml
-#          asset_name: changelog.yaml
-#          asset_content_type: text/yaml
+          app_id: ${{ secrets.JENKINS_DEPENDENCY_UPDATER_APP_ID }}
+          private_key: ${{ secrets.JENKINS_DEPENDENCY_UPDATER_PRIVATE_KEY }}
+          repository: timja/jenkins.io
+      - name: Check out
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - name: Publish jenkins.io changelog draft
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_AUTH: "nobody:${{ steps.generate-token.outputs.token }}"
+          GIT_AUTHOR_NAME: jenkins-dependency-updater
+          GIT_AUTHOR_EMAIL: <81680575+jenkins-dependency-updater[bot]@users.noreply.github.com>
+          GIT_COMMITTER_NAME: jenkins-dependency-updater
+          GIT_COMMITTER_EMAIL: <81680575+jenkins-dependency-updater[bot]@users.noreply.github.com>
+        run: |
+          wget --quiet https://raw.githubusercontent.com/timja/core-changelog-generator/automate-changelog-generation/generate-weekly-changelog.sh
+          bash generate-weekly-changelog.sh

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_AUTH: "nobody:${{ steps.generate-token.outputs.token }}"
-          GIT_AUTHOR_NAME: jenkins-dependency-updater
+          GIT_AUTHOR_NAME: jenkins-infra-changelog-generator
           GIT_AUTHOR_EMAIL: <86592549+jenkins-infra-changelog-generator[bot]@users.noreply.github.com>
           GIT_COMMITTER_NAME: jenkins-infra-changelog-generator
           GIT_COMMITTER_EMAIL: <86592549+jenkins-infra-changelog-generator[bot]@users.noreply.github.com>

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,6 +20,19 @@ jobs:
         uses: release-drafter/release-drafter@v5.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Generates a YAML changelog file using https://github.com/jenkinsci/jenkins-core-changelog-generator
+      # used by Oleg N in open graph generator experiment for now
+      - name: Generate YAML changelog draft
+        id: jenkins-core-changelog-generator
+        uses: jenkinsci/jenkins-core-changelog-generator@master
+        env:
+          GITHUB_AUTH: github-actions:${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Changelog YAML
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: changelog.yaml
+          path: changelog.yaml
+
   jenkins_io_draft:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'jenkinsci'


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

Automates generating changelog on every merge to master

It will either keep pushing to a branch (with open PR) or if people have been merging the changes it will create a new PR, (note: manual copyedits will be overridden), the proposed changelog entries themselves should be updated, or copyediting should be done after the release is complete as the script will move on to the next release once the tag exists

This has been end 2 end tested on my fork,

See:
https://github.com/timja/jenkins/runs/2875832053?check_suite_focus=true
https://github.com/timja/jenkins.io/pull/3

Requires:
https://github.com/jenkinsci/core-changelog-generator/pull/14
and
https://issues.jenkins.io/browse/INFRA-2900


### Proposed changelog entries

* Entry 1: Not needed
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
