### PR TITLE
change master to controller

### DIFF
--- a/core/src/main/resources/hudson/tools/Messages.properties
+++ b/core/src/main/resources/hudson/tools/Messages.properties
@@ -30,5 +30,5 @@ ZipExtractionInstaller.bad_connection=Server rejected connection.
 ZipExtractionInstaller.malformed_url=Malformed URL.
 ZipExtractionInstaller.could_not_connect=Could not connect to URL.
 InstallSourceProperty.DescriptorImpl.displayName=Install automatically
-ToolDescriptor.NotADirectory={0} is not a directory on the Jenkins master (but perhaps it exists on some agents)
+ToolDescriptor.NotADirectory={0} is not a directory on the Jenkins controller (but perhaps it exists on some agents)
 CannotBeInstalled=Installer "{0}" cannot be used to install "{1}" on the node "{2}"


### PR DESCRIPTION
Signed-off-by: Darin Pope <darin@planetpope.com>

### Note
There is also another instance of master->controller in core/src/main/resources/hudson/tools/Messages_bg.properties but I'm not sure what the correct translation needs to be.

### Submitter checklist

- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@oleg-nenashev @MarkEWaite 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
