### PR TITLE
Restore `wstx-asl-3.2.9.jar` to WAR

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -263,6 +263,11 @@ THE SOFTWARE.
         <artifactId>memory-monitor</artifactId>
         <version>1.9</version>
       </dependency>
+      <dependency><!-- StAX implementation. See JENKINS-2547. -->
+        <groupId>org.codehaus.woodstox</groupId>
+        <artifactId>wstx-asl</artifactId>
+        <version>3.2.9</version>
+      </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -474,6 +474,17 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>memory-monitor</artifactId>
     </dependency>
+    <dependency><!-- StAX implementation. See JENKINS-2547. -->
+      <groupId>org.codehaus.woodstox</groupId>
+      <artifactId>wstx-asl</artifactId>
+      <exclusions>
+        <!-- StAX is now bundled in the JRE -->
+        <exclusion>
+          <groupId>stax</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>


### PR DESCRIPTION
Partial revert of #5559, which removed `stax-api-1.0.1.jar`, `stax-api-1.0-2.jar`, and `wstx-asl-3.2.9.jar` from the WAR under the premise that StAX was now provided by the Java Platform. While removing the first two JARs caused no problems, removing `wstx-asl-3.2.9.jar` (a StAX implementation, in particular the very old Woodstox 3.2.9) was apparently too aggressive and did cause jenkinsci/azure-storage-plugin#194. As a hotfix, restore the working status quo by re-adding `wstx-asl-3.2.9.jar` to the WAR. I verified that this chases away jenkinsci/azure-storage-plugin#194. In the future, it would be good to rationalize our usage of StAX/Jackson/Woodstox across core and the Jackson 2 API plugin and eliminate this old dependency from core. In particular, we shouldn't need to ship Woodstox in core at all, but rather the Jackson 2 API plugin should provide a modern version of `jackson-databind-xml` and Woodstox to all dependent plugins. That is a bit more work and I couldn't complete it in a few hours. In the meantime the regression in core needs to be fixed ASAP.

### Proposed changelog entries

Fix a regression in 2.298 where some plugins (including Azure Storage) could not correctly parse streaming XML output.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
