### PR TITLE
Remove explicit dependency on ASM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -194,11 +194,6 @@ THE SOFTWARE.
         <version>3.1.7</version>
       </dependency>
       <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm</artifactId>
-        <version>9.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>windows-package-checker</artifactId>
         <version>1.2</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,10 +107,6 @@ THE SOFTWARE.
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-    </dependency>
     <!--
       For compatibility only; not included into the BOM for the same reason. TODO once
       https://github.com/jenkinsci/scm-api-plugin/pull/88 is widely adopted, this


### PR DESCRIPTION
Removing our explicit dependency on ASM from core, since it just ends up creating Dependabot problems as in #5596. Note that this doesn't change the WAR: we still bundle ASM (a transitive dependency of JNR).

For the record, core currently uses ASM both directly (at least until #5566 is merged) and indirectly through JNR (at least until #5606 is merged). Plugins also currently use an ASM provided by core directly (e.g. Token Macro and SCM API) and indirectly through JNR (e.g. File Leak Detector).

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
