### PR TITLE
[JENKINS-66105]The appropriate HTTP code in buildWithParameters.

### DIFF
--- a/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
+++ b/core/src/main/java/hudson/model/ParametersDefinitionProperty.java
@@ -27,6 +27,7 @@ package hudson.model;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Queue.WaitingItem;
+import hudson.model.queue.ScheduleResult;
 import java.io.IOException;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import static javax.servlet.http.HttpServletResponse.SC_CREATED;
+import static javax.servlet.http.HttpServletResponse.SC_SEE_OTHER;
 import jenkins.model.Jenkins;
 import jenkins.model.OptionalJobProperty;
 import jenkins.model.ParameterizedJobMixIn;
@@ -187,14 +189,19 @@ public class ParametersDefinitionProperty extends OptionalJobProperty<Job<?, ?>>
         if (delay==null)
             delay=new TimeDuration(TimeUnit.MILLISECONDS.convert(getJob().getQuietPeriod(), TimeUnit.SECONDS));
 
-        Queue.Item item = Jenkins.get().getQueue().schedule2(
-                getJob(), delay.getTimeInSeconds(), new ParametersAction(values), ParameterizedJobMixIn.getBuildCause(getJob(), req)).getItem();
-
+        ScheduleResult scheduleResult = Jenkins.get().getQueue().schedule2(
+                getJob(), delay.getTimeInSeconds(), new ParametersAction(values), ParameterizedJobMixIn.getBuildCause(getJob(), req));
+        Queue.Item item = scheduleResult.getItem();
+        
+        if (item != null && !scheduleResult.isCreated()) {
+            rsp.sendRedirect(SC_SEE_OTHER, req.getContextPath() + '/' + item.getUrl());
+            return;
+        }
         if (item != null) {
             rsp.sendRedirect(SC_CREATED, req.getContextPath() + '/' + item.getUrl());
-        } else {
-            rsp.sendRedirect(".");
+            return;
         }
+        rsp.sendRedirect(".");
     }
 
     /**


### PR DESCRIPTION
In buildWithParameters api, when a new parameter build request is determined to be repeated, HTTP 201 should not be returned here. 409 is generally considered to be more appropriate. But since Jenkins actually merged some foldable actions, I think we should return 303 here.

![image](https://user-images.githubusercontent.com/17956253/125283510-1045e300-e34b-11eb-956e-2521fe2a6227.png)
As shown in the pic above, it is normal for the request of #15 to response http code 201, however, as long as # 15 is still in the queue, no matter how many requests with the same parameters as #15 will be merged, but api still response 201 http code,
this makes it impossible for clients to tell which requests will actually be built.


<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-66105](https://issues.jenkins-ci.org/browse/JENKINS-66105).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, When the **buildWithParameter** API is called, if the requests with the same parameters in the queue are merged, the http response code of the request uses a more appropriate 303(see other) instead of 201(created).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

==== Optimize the http response code of buildWithParameters api

[https://issues.jenkins-ci.org/browse/JENKINS-66105](https://issues.jenkins-ci.org/browse/JENKINS-66105)
In the previous version, when calling the buildWithParameters rest api `{jenkins_root_path}/job/{job_name}/buildWithParameters` of Jenkins, if Jenkins judges that the queue contains requests with the same parameters and merges them, the merged request would also return [HTTP 201](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201), making the client unable to determine which requests were built. 
To solve this problem, in the current version, if the same params request in the queue is merged, [HTTP 303](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303) will be returned, and this is more in line with http semantics.

For example, a job contains a parameter named 'test-key'.
Execute the following http request command:
```shell
curl -XPOST -i -s -d 'test-key=1' 'http://{jenkins_host}/job/{job_name}/buildWithParameters?delay=10sec' | grep 'HTTP\|Location'
echo '------'  
curl -XPOST -i -s -d 'test-key=1' 'http://{jenkins_host}/job/{job_name}/buildWithParameters?delay=10sec' | grep 'HTTP\|Location'
```
Output before the change is rough as follows:
```shell
HTTP/1.1 201
Location: http://{jenkins_host}/queue/item/26/
------
HTTP/1.1 201
Location: http://{jenkins_host}/queue/item/26/
```
After the change:
```shell
HTTP/1.1 201 
Location: http://{jenkins_host}/queue/item/27/
------
HTTP/1.1 303
Location: http://{jenkins_host}/queue/item/27/
```
We can see that the request first created after the change still returns http 201 unaffected, and the http code of merged request return becomes 303.

**Note:** that if you or the request tool you are using has checked the http response code, you must confirm if the new scenario returning 303 affects you, otherwise this could cause some failure.


### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
