### PR TITLE
[JENKINS-65212] Overhaul available plugins search algorithm

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -68,6 +68,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -1521,7 +1522,10 @@ public class UpdateSite {
                 return false;
             }
             // TODO: cache it in a hashset for performance improvements
-            return Arrays.asList(categories).contains(category);
+            return Arrays.stream(categories)
+                    .map(c -> c.toLowerCase(Locale.ROOT))
+                    .collect(Collectors.toSet())
+                    .contains(category.toLowerCase(Locale.ROOT));
         }
 
         /**


### PR DESCRIPTION
See [JENKINS-65212](https://issues.jenkins.io/browse/JENKINS-65212).
See [JENKINS-61497](https://issues.jenkins.io/browse/JENKINS-61497) (not in PR title).

### Description

Refactored the **Available** plugins search algorithm. Before this PR, the filter & sort logic used broad categories like plugin excerpt, which led to too many plugins displayed and a need for ctrl+F. After this PR, the search query is broken down into words, and each word is used to find plugins, mainly by name (ID) & title. If the first word(s) is a category, we show the most popular plugins in the category. Most other searches sort the results alphabetically.

Demo:
![plugins-search-demo](https://user-images.githubusercontent.com/11740869/125205265-66356080-e24f-11eb-86a0-28e4c255d485.gif)

### Proposed changelog entries

* The **Available Plugins** search algorithm now focuses on plugin name (ID) & title while searching. The search results become more specific as more full words from the plugin title are entered. If the query is a category, the most popular plugins in that category are displayed.

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change).
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@timja 
@daniel-beck 
@Wadeck 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
