### PR TITLE
Remove unnecessary differences from upstream `AntClassLoader`

### DIFF
--- a/core/src/main/java/hudson/PluginFirstClassLoader.java
+++ b/core/src/main/java/hudson/PluginFirstClassLoader.java
@@ -23,7 +23,6 @@
  */
 package hudson;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,7 +42,6 @@ import jenkins.util.AntWithFindResourceClassLoader;
  */
 public class PluginFirstClassLoader
     extends AntWithFindResourceClassLoader
-    implements Closeable
 {
 
     public PluginFirstClassLoader() {
@@ -69,13 +67,6 @@ public class PluginFirstClassLoader
     public List<URL> getURLs() 
     {
         return urls;
-    }
-    
-    @Override
-    public void close()
-        throws IOException
-    {
-        cleanup();
     }
 
     @Override

--- a/core/src/main/java/jenkins/util/AntWithFindResourceClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntWithFindResourceClassLoader.java
@@ -1,19 +1,18 @@
 package jenkins.util;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Vector;
 
 /**
  * As of 1.8.0, {@link org.apache.tools.ant.AntClassLoader} doesn't implement {@link #findResource(String)}
  * in any meaningful way, which breaks fast lookup. Implement it properly.
  */
-public class AntWithFindResourceClassLoader extends AntClassLoader implements Closeable {
-    private final ArrayList<File> pathComponents;
+public class AntWithFindResourceClassLoader extends AntClassLoader {
+    private final Vector<File> pathComponents;
 
     public AntWithFindResourceClassLoader(ClassLoader parent, boolean parentFirst) {
         super(parent, parentFirst);
@@ -21,7 +20,7 @@ public class AntWithFindResourceClassLoader extends AntClassLoader implements Cl
         try {
             Field $pathComponents = AntClassLoader.class.getDeclaredField("pathComponents");
             $pathComponents.setAccessible(true);
-            pathComponents = (ArrayList<File>)$pathComponents.get(this);
+            pathComponents = (Vector<File>)$pathComponents.get(this);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new LinkageError(e.getMessage(), e);
         }
@@ -30,11 +29,6 @@ public class AntWithFindResourceClassLoader extends AntClassLoader implements Cl
     public void addPathFiles(Collection<File> paths) throws IOException {
         for (File f : paths)
             addPathFile(f);
-    }
-
-    @Override
-    public void close() throws IOException {
-        cleanup();
     }
 
     @Override


### PR DESCRIPTION
This is the first of a series of changes to unfork `AntClassLoader`, a class which we copied from Ant a long time ago (latest [upstream](https://github.com/apache/ant/blob/cc9d93f49fbd6730e057ec0ad6e2e382f8e3c331/src/main/org/apache/tools/ant/AntClassLoader.java)) and has since become a bit of a maintenance burden. This PR does two things:

- Undo non-substantive refactorings that we've done to the fork that aren't present upstream. These didn't buy us much in terms of functionality, but they increased our maintenance burden by increasing the difference between our fork and upstream. For example, I undid the move from `VectorSet` to `ArrayList` and the change that factored out some duplicate code into a `storeAndConvert` method.
- Apply non-substantive refactorings that upstream has done but which our fork doesn't have. These don't buy us much in terms of functionality, but they decrease our maintenance burden by minimizing the difference between our fork and upstream. This includes Java generic support, implementing `Closeable`, adding the `final` keyword to everything, using the Stream API in a few places, and adding some new Javadocs.

With the above taken care of, it's possible to see clearly what Jenkins-specific changes remain:

- Some `super` calls were added to fix [JENKINS-21579](https://issues.jenkins.io/browse/JENKINS-21579)/[JENKINS-22310](https://issues.jenkins.io/browse/JENKINS-22310).
- A `getUrl` method was factored out for use in `AntWithFindResourceClassLoader`.
- `findResources(String)` was made public for use in `ClassLoaderReflectionToolkit`.
- Missing class telemetry support was added.

Here are the remaining upstream changes that were _not_ applied to this PR because I judged them to be too risky:

- commit 593aff2d2 bz-62952 Make `AntClassLoader` multi-release JAR aware when it deals with `java.util.jar.JarFile`
- commit 189ad7e59 bz-62764 Add a debug log message when we skip invalid path elements from the `AntClassLoader`'s classpath
- commit 008f1c8be Embrace `StringUtils#getStackTrace`
- commit d37df73a8 Register `AntClassLoader` as parallel capabale
- commit 13c01b296 Improve skipping of non-zips

I'll probably backport these onto our copy once we start a new LTS cycle.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
