### PR TITLE
Exception tests modernized

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -82,7 +82,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
@@ -566,12 +565,7 @@ public class FilePathTest {
             assertNull(d.validateAntFileMask("d1/d2/**/f.txt"));
             assertNull(d.validateAntFileMask("d1/d2/**/f.txt", 10));
             assertEquals(Messages.FilePath_validateAntFileMask_portionMatchButPreviousNotMatchAndSuggest("**/*.js", "**", "**/*.js"), d.validateAntFileMask("**/*.js", 1000));
-            try {
-                d.validateAntFileMask("**/*.js", 10);
-                fail();
-            } catch (InterruptedException x) {
-                // good
-            }
+            assertThrows(InterruptedException.class, () -> d.validateAntFileMask("**/*.js", 10));
     }
     
     @Issue("JENKINS-5253")

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-
 
 import jenkins.model.Jenkins;
 
@@ -57,17 +56,13 @@ public class ListJobsCommandTest {
     }
 
     @Test
-    public void failForNonexistingName() throws Exception {
+    public void failForNonexistentName() {
 
         when(jenkins.getView("NoSuchViewOrItemGroup")).thenReturn(null);
         when(jenkins.getItemByFullName("NoSuchViewOrItemGroup")).thenReturn(null);
 
-        try {
-            runWith("NoSuchViewOrItemGroup");
-            fail("Exception should be thrown in the previous call.");
-        } catch (IllegalArgumentException e) { // Expected
-            assertThat(e.getMessage(), containsString("No view or item group with the given name 'NoSuchViewOrItemGroup' found."));
-        }
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> runWith("NoSuchViewOrItemGroup"));
+        assertThat(e.getMessage(), containsString("No view or item group with the given name 'NoSuchViewOrItemGroup' found."));
         assertThat(stdout, is(empty()));
     }
 

--- a/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
+++ b/core/src/test/java/hudson/cli/handlers/ViewOptionHandlerTest.java
@@ -25,6 +25,7 @@ package hudson.cli.handlers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -179,22 +180,15 @@ public class ViewOptionHandlerTest {
     }
 
     @Test public void reportViewSpaceNameRequestAsIAE() {
-        try {
-            assertNull(handler.getView(" "));
-            fail("No exception thrown. Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertEquals("No view named   inside view Jenkins", e.getMessage());
-            verifyNoInteractions(setter);
-        }
+        final IllegalArgumentException e = assertThrows("No exception thrown. Expected IllegalArgumentException",
+                IllegalArgumentException.class, () -> assertNull(handler.getView(" ")));
+        assertEquals("No view named   inside view Jenkins", e.getMessage());
+        verifyNoInteractions(setter);
     }
 
     @Test public void reportNullViewAsNPE() {
-        try {
-            handler.getView(null);
-            fail("No exception thrown. Expected NullPointerException");
-        } catch (NullPointerException e) {
-            verifyNoInteractions(setter);
-        }
+        assertThrows(NullPointerException.class, () -> handler.getView(null));
+        verifyNoInteractions(setter);
     }
 
     @Test public void refuseToReadOuterView() throws Exception {

--- a/core/src/test/java/hudson/model/AbstractItemTest.java
+++ b/core/src/test/java/hudson/model/AbstractItemTest.java
@@ -2,7 +2,7 @@ package hudson.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -115,15 +115,11 @@ public class AbstractItemTest {
         NameNotEditableItem item = new NameNotEditableItem(null,"NameNotEditableItem");
 
         //WHEN
-        try {
-            item.renameTo("NewName");
-            fail("An item with isNameEditable false must throw exception when trying to rename it.");
-        } catch (IOException e) {
+        final IOException e = assertThrows("An item with isNameEditable false must throw exception when trying to rename it.",
+                IOException.class, () -> item.renameTo("NewName"));
 
-            //THEN
-            assertEquals("Trying to rename an item that does not support this operation.", e.getMessage());
-            assertEquals("NameNotEditableItem",item.getName());
-        }
+        assertEquals("Trying to rename an item that does not support this operation.", e.getMessage());
+        assertEquals("NameNotEditableItem", item.getName());
     }
 
     @Test
@@ -134,15 +130,10 @@ public class AbstractItemTest {
         NameNotEditableItem item = new NameNotEditableItem(null,"NameNotEditableItem");
 
         //WHEN
-        try {
-            item.doConfirmRename("MyNewName");
-            fail("An item with isNameEditable false must throw exception when trying to call doConfirmRename.");
-        } catch (Failure f) {
-
-            //THEN
-            assertEquals("Trying to rename an item that does not support this operation.", f.getMessage());
-            assertEquals("NameNotEditableItem",item.getName());
-        }
+        final Failure f = assertThrows("An item with isNameEditable false must throw exception when trying to call doConfirmRename.",
+                Failure.class, () -> item.doConfirmRename("MyNewName"));
+        assertEquals("Trying to rename an item that does not support this operation.", f.getMessage());
+        assertEquals("NameNotEditableItem", item.getName());
     }
 
 }

--- a/core/src/test/java/hudson/model/RunParameterValueTest.java
+++ b/core/src/test/java/hudson/model/RunParameterValueTest.java
@@ -27,7 +27,7 @@ package hudson.model;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class RunParameterValueTest {
     
@@ -37,24 +37,11 @@ public class RunParameterValueTest {
         assertEquals("whatever", rpv.getName());
         assertEquals("folder/job", rpv.getJobName());
         assertEquals("57", rpv.getNumber());
-        try {
-            new RunParameterValue("whatever", null);
-            fail();
-        } catch (IllegalArgumentException x) {
-            // good
-        }
-        try {
-            new RunParameterValue("whatever", "invalid");
-            fail();
-        } catch (IllegalArgumentException x) {
-            // good
-        }
-        try {
-            new RunParameterValue("whatever", "invalid", "desc");
-            fail();
-        } catch (IllegalArgumentException x) {
-            // good
-        }
+
+        assertThrows(IllegalArgumentException.class, () -> new RunParameterValue("whatever", null));
+        assertThrows(IllegalArgumentException.class, () -> new RunParameterValue("whatever", "invalid"));
+        assertThrows(IllegalArgumentException.class, () -> new RunParameterValue("whatever", "invalid", "desc"));
+
         rpv = (RunParameterValue) Run.XSTREAM2.fromXML("<hudson.model.RunParameterValue><name>whatever</name><runId>bogus</runId></hudson.model.RunParameterValue>");
         assertEquals("whatever", rpv.getName());
         assertNull(rpv.getJobName());

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -25,8 +25,8 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
 public class AtomicFileWriterTest {
@@ -136,12 +136,7 @@ public class AtomicFileWriterTest {
     @Test
     public void indexOutOfBoundsLeavesOriginalUntouched() throws Exception {
         // Given
-        try {
-            afw.write(expectedContent, 0, expectedContent.length() + 10);
-            fail("exception expected");
-        } catch (IndexOutOfBoundsException e) {
-        }
-
+        assertThrows(IndexOutOfBoundsException.class, () -> afw.write(expectedContent, 0, expectedContent.length() + 10));
         assertEquals(PREVIOUS, FileUtils.readFileToString(af, Charset.defaultCharset()));
     }
     @Test
@@ -152,13 +147,10 @@ public class AtomicFileWriterTest {
         assertTrue(newFile.exists());
         assertFalse(parentExistsAndIsAFile.exists());
 
-        try {
-            new AtomicFileWriter(parentExistsAndIsAFile.toPath(), StandardCharsets.UTF_8);
-            fail("Expected a failure");
-        } catch (IOException e) {
-            assertThat(e.getMessage(),
-                       containsString("exists and is neither a directory nor a symlink to a directory"));
-        }
+        final IOException e = assertThrows(IOException.class,
+                () -> new AtomicFileWriter(parentExistsAndIsAFile.toPath(), StandardCharsets.UTF_8));
+        assertThat(e.getMessage(),
+                   containsString("exists and is neither a directory nor a symlink to a directory"));
     }
 
     @Issue("JENKINS-48407")

--- a/core/src/test/java/hudson/util/ConsistentHashTest.java
+++ b/core/src/test/java/hudson/util/ConsistentHashTest.java
@@ -27,8 +27,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -170,13 +170,11 @@ public class ConsistentHashTest {
             throw exception;
         };
 
-        try {
+        final RuntimeException e = assertThrows(RuntimeException.class, () -> {
             ConsistentHash<String> hash = new ConsistentHash<>(hashFunction);
             hash.add("foo");
-            fail("Didn't use custom hash function");
-        } catch (RuntimeException e) {
-            assertSame(exception, e);
-        }
+        });
+        assertSame(exception, e);
     }
 
     /**

--- a/core/src/test/java/hudson/util/CyclicGraphDetectorTest.java
+++ b/core/src/test/java/hudson/util/CyclicGraphDetectorTest.java
@@ -1,7 +1,7 @@
 package hudson.util;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import hudson.util.CyclicGraphDetector.CycleDetectedException;
 import org.junit.Test;
@@ -61,20 +61,19 @@ public class CyclicGraphDetectorTest {
             }.run(nodes());
         }
 
-        void mustContainCycle(String... members) throws Exception {
-            try {
-                check();
-                fail("Cycle expected");
-            } catch (CycleDetectedException e) {
-                String msg = "Expected cycle of " + Arrays.asList(members) + " but found " + e.cycle;
-                for (String s : members)
-                    assertTrue(msg, e.cycle.contains(s));
+        void mustContainCycle(String... members) {
+            final CycleDetectedException e = assertThrows("Cycle expected",
+                    CycleDetectedException.class, this::check);
+
+            final String msg = "Expected cycle of " + Arrays.asList(members) + " but found " + e.cycle;
+            for (String s : members) {
+                assertTrue(msg, e.cycle.contains(s));
             }
         }
     }
 
     @Test
-    public void cycle1() throws Exception {
+    public void cycle1() {
         new Graph().e("A","B").e("B","C").e("C","A").mustContainCycle("A","B","C");
     }
 
@@ -84,7 +83,7 @@ public class CyclicGraphDetectorTest {
     }
 
     @Test
-    public void cycle3() throws Exception {
+    public void cycle3() {
         new Graph().e("A","B").e("B","C").e("C","D").e("B","E").e("E","D").e("E","A").mustContainCycle("A","B","E");
     }
 }

--- a/core/src/test/java/hudson/util/RetrierTest.java
+++ b/core/src/test/java/hudson/util/RetrierTest.java
@@ -10,11 +10,11 @@ import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class RetrierTest {
-    private static Logger LOG = Logger.getLogger(RetrierTest.class.getName());
+    private static final Logger LOG = Logger.getLogger(RetrierTest.class.getName());
 
     @Test
     public void performedAtThirdAttemptTest() throws Exception {
@@ -306,14 +306,8 @@ public class RetrierTest {
                 .build();
 
         // Begin the process that raises an unexpected exception
-        try {
-            r.start();
-            fail("The process should be exited with an unexpected exception");
-        } catch (IOException e) {
-            String testFailure = Messages.Retrier_ExceptionThrown(ATTEMPTS, ACTION);
-            assertTrue(String.format("The log should contain '%s'", testFailure), handler.getView().stream().anyMatch(m -> m.getMessage().contains(testFailure)));
-        } catch (Exception e) {
-            fail(String.format("Unexpected exception: %s", e));
-        }
+        assertThrows("The process should be exited with an unexpected exception", IOException.class, r::start);
+        String testFailure = Messages.Retrier_ExceptionThrown(ATTEMPTS, ACTION);
+        assertTrue(String.format("The log should contain '%s'", testFailure), handler.getView().stream().anyMatch(m -> m.getMessage().contains(testFailure)));
     }
 }

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -23,9 +23,10 @@
  */
 package hudson.util;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
@@ -60,22 +61,15 @@ public class RobustReflectionConverterTest {
 
     @Test
     public void ifWorkaroundNeeded() {
-        try {
-            read(new XStream());
-            fail();
-        } catch (ConversionException e) {
-            // expected
-            assertTrue(e.getMessage().contains("z"));
-        }
+        final ConversionException e = assertThrows(ConversionException.class, () -> read(new XStream()));
+        assertThat(e.getMessage(), containsString("z"));
     }
 
     @Test
     public void classOwnership() {
-        XStream xs = new XStream2(new XStream2.ClassOwnership() {
-            @Override public String ownerOf(Class<?> clazz) {
-                Owner o = clazz.getAnnotation(Owner.class);
-                return o != null ? o.value() : null;
-            }
+        XStream xs = new XStream2(clazz -> {
+            Owner o = clazz.getAnnotation(Owner.class);
+            return o != null ? o.value() : null;
         });
         String prefix1 = RobustReflectionConverterTest.class.getName() + "_-";
         String prefix2 = RobustReflectionConverterTest.class.getName() + "$";

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -284,11 +284,7 @@ public class XStream2Test {
     @Issue("SECURITY-105")
     @Test
     public void dynamicProxyBlocked() {
-        try {
-            ((Runnable) new XStream2().fromXML("<dynamic-proxy><interface>java.lang.Runnable</interface><handler class='java.beans.EventHandler'><target class='" + Hacked.class.getName() + "'/><action>oops</action></handler></dynamic-proxy>")).run();
-        } catch (XStreamException x) {
-            // good
-        }
+        assertThrows(XStreamException.class, () -> ((Runnable) new XStream2().fromXML("<dynamic-proxy><interface>java.lang.Runnable</interface><handler class='java.beans.EventHandler'><target class='" + Hacked.class.getName() + "'/><action>oops</action></handler></dynamic-proxy>")).run());
         assertFalse("should never have run that", Hacked.tripped);
     }
 
@@ -529,13 +525,8 @@ public class XStream2Test {
 
     @Issue("SECURITY-503")
     @Test
-    public void crashXstream() throws Exception {
-        try {
-            new XStream2().fromXML("<void/>");
-            fail("expected to throw ConversionException, but why are we still alive?");
-        } catch (XStreamException ex) {
-            // pass
-        }
+    public void crashXstream() {
+        assertThrows(XStreamException.class, () -> new XStream2().fromXML("<void/>"));
     }
 
     @Test
@@ -543,12 +534,8 @@ public class XStream2Test {
         assertEquals("not registered, so sorry", "<hudson.util.XStream2Test_-C1/>", Jenkins.XSTREAM2.toXML(new C1()));
         assertEquals("manually registered", "<C-2/>", Jenkins.XSTREAM2.toXML(new C2()));
         assertEquals("manually processed", "<C-3/>", Jenkins.XSTREAM2.toXML(new C3()));
-        try {
-            Jenkins.XSTREAM2.fromXML("<C-4/>");
-            fail("this could never have worked anyway");
-        } catch (CannotResolveClassException x) {
-            // OK
-        }
+        assertThrows(CannotResolveClassException.class, () -> Jenkins.XSTREAM2.fromXML("<C-4/>"));
+
         Jenkins.XSTREAM2.processAnnotations(C5.class);
         assertThat("can deserialize from annotations so long as the processing happened at some point", Jenkins.XSTREAM2.fromXML("<C-5/>"), instanceOf(C5.class));
     }

--- a/core/src/test/java/jenkins/model/RunIdMigratorTest.java
+++ b/core/src/test/java/jenkins/model/RunIdMigratorTest.java
@@ -41,8 +41,8 @@ import org.junit.AfterClass;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 import org.junit.Before;
@@ -207,12 +207,7 @@ public class RunIdMigratorTest {
         File dest = new File(tmp.getRoot(), "dest");
         RunIdMigrator.move(src, dest);
         File dest2 = tmp.newFile();
-        try {
-            RunIdMigrator.move(dest, dest2);
-            fail();
-        } catch (IOException x) {
-            System.err.println("Got expected move exception: " + x);
-        }
+        assertThrows(IOException.class, () -> RunIdMigrator.move(dest, dest2));
     }
 
 }

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -157,13 +158,7 @@ public class AbstractLazyLoadRunMapTest {
     @Test
     public void firstKey() {
         assertEquals(5, a.firstKey().intValue());
-
-        try {
-            b.firstKey();
-            fail();
-        } catch (NoSuchElementException e) {
-            // as expected
-        }
+        assertThrows(NoSuchElementException.class, () -> b.firstKey());
     }
 
     @Issue("JENKINS-26690")

--- a/core/src/test/java/jenkins/util/TimerTest.java
+++ b/core/src/test/java/jenkins/util/TimerTest.java
@@ -78,7 +78,7 @@ public class TimerTest {
                                 startLatch.countDown();
                                 contextClassloaders[j] = Thread.currentThread().getContextClassLoader();
                             } catch (Exception ex) {
-                                throw  new RuntimeException(ex);
+                                throw new RuntimeException(ex);
                             }
                         }
                     }, 0, TimeUnit.SECONDS);

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -61,7 +61,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -104,14 +103,9 @@ public class PathRemoverTest {
         given(attributes.isDirectory()).willReturn(false);
 
         PathRemover remover = PathRemover.newSimpleRemover();
-        try {
-            remover.forceRemoveFile(file.toPath());
-            fail("Should not have been deleted: " + file);
-        } catch (IOException e) {
-            assertThat(calcExceptionHierarchy(e), hasItem(FileSystemException.class));
-            assertThat(e.getMessage(), containsString(filename));
-        }
-
+        final IOException e = assertThrows(IOException.class, () -> remover.forceRemoveFile(file.toPath()));
+        assertThat(calcExceptionHierarchy(e), hasItem(FileSystemException.class));
+        assertThat(e.getMessage(), containsString(filename));
     }
 
     private static List<Class<?>> calcExceptionHierarchy(Throwable t) {
@@ -437,13 +431,12 @@ public class PathRemoverTest {
         for (int i = 0; i < lockedFiles; i++) {
             locker.acquireLock(files[i]);
         }
-        try {
-            PathRemover.newSimpleRemover().forceRemoveRecursive(dir.toPath());
-            fail("Deletion should have failed");
-        } catch (CompositeIOException e) {
-            assertThat(e.getSuppressed(), arrayWithSize(maxExceptions));
-            assertThat(e.getMessage(), endsWith("(Discarded " + (lockedFiles + 1 - maxExceptions) + " additional exceptions)"));
-        }
+
+        final CompositeIOException e = assertThrows(CompositeIOException.class,
+                () -> PathRemover.newSimpleRemover().forceRemoveRecursive(dir.toPath()));
+        assertThat(e.getSuppressed(), arrayWithSize(maxExceptions));
+        assertThat(e.getMessage(), endsWith("(Discarded " + (lockedFiles + 1 - maxExceptions) + " additional exceptions)"));
+
         assertTrue(dir.exists());
         assertThat(dir.listFiles().length, equalTo(lockedFiles));
     }

--- a/core/src/test/java/jenkins/xml/XMLUtilsTest.java
+++ b/core/src/test/java/jenkins/xml/XMLUtilsTest.java
@@ -41,6 +41,8 @@ import javax.xml.xpath.XPathExpressionException;
 
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
 import org.jvnet.hudson.test.Issue;
 import org.xml.sax.SAXException;
 
@@ -117,19 +119,15 @@ public class XMLUtilsTest {
     }
     
     @Test
-    public void testParse_with_XXE() throws IOException {
-        try {
-            final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                    "<!DOCTYPE foo [\n" +
-                    "   <!ELEMENT foo ANY >\n" +
-                    "   <!ENTITY xxe SYSTEM \"http://abc.com/temp/test.jsp\" >]> " +
-                    "<foo>&xxe;</foo>";
+    public void testParse_with_XXE() {
+        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<!DOCTYPE foo [\n" +
+                "   <!ELEMENT foo ANY >\n" +
+                "   <!ENTITY xxe SYSTEM \"http://abc.com/temp/test.jsp\" >]> " +
+                "<foo>&xxe;</foo>";
 
-            StringReader stringReader = new StringReader(xml);
-            XMLUtils.parse(stringReader);
-            Assert.fail("Expecting SAXException for XXE.");
-        } catch (SAXException e) {
-            assertThat(e.getMessage(), containsString("\"http://apache.org/xml/features/disallow-doctype-decl\""));
-        }
+        StringReader stringReader = new StringReader(xml);
+        final SAXException e = assertThrows(SAXException.class, () -> XMLUtils.parse(stringReader));
+        assertThat(e.getMessage(), containsString("\"http://apache.org/xml/features/disallow-doctype-decl\""));
     }    
 }


### PR DESCRIPTION
Some more exception tests modernized.


### Proposed changelog entries

_– none –_

### Proposed upgrade guidelines

_– none –_

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

_– none –_

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
