### PR TITLE
[JENKINS-66139] Avoid polluting the log if usage stats cannot be sent

### DIFF
--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -74,7 +74,7 @@ import jenkins.util.SystemProperties;
  */
 @Extension
 public class UsageStatistics extends PageDecorator implements PersistentDescriptor {
-    private final static Logger LOG = Logger.getLogger(UsageStatistics.class.getName());
+    private static final Logger LOG = Logger.getLogger(UsageStatistics.class.getName());
     
     private final String keyImage;
 

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -63,6 +63,9 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import com.jcraft.jzlib.GZIPOutputStream;
 import jenkins.util.SystemProperties;
 
@@ -71,6 +74,8 @@ import jenkins.util.SystemProperties;
  */
 @Extension
 public class UsageStatistics extends PageDecorator implements PersistentDescriptor {
+    private final Logger LOG = Logger.getLogger(UsageStatistics.class.getName());
+    
     private final String keyImage;
 
     /**
@@ -122,7 +127,8 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
     }
 
     /**
-     * Gets the encrypted usage stat data to be sent to the Hudson server.
+     * Gets the encrypted usage stat data to be sent to the Hudson server. 
+     * Used exclusively by jelly: resources/hudson/model/UsageStatistics/footer.jelly
      */
     public String getStatData() throws IOException {
         Jenkins j = Jenkins.get();
@@ -190,8 +196,10 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
             }
 
             return new String(Base64.getEncoder().encode(baos.toByteArray()));
-        } catch (GeneralSecurityException e) {
-            throw new Error(e); // impossible
+        } catch (Exception e) { // the exception could be GeneralSecurityException, InvalidParameterException or any other depending on the security provider you have installed
+            LOG.log(Level.INFO, "Usage statistics could not be sent ({0})", e.getMessage());
+            LOG.log(Level.FINE, "Error sending usage statistics", e);
+            return null;
         }
     }
 

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -74,7 +74,7 @@ import jenkins.util.SystemProperties;
  */
 @Extension
 public class UsageStatistics extends PageDecorator implements PersistentDescriptor {
-    private final Logger LOG = Logger.getLogger(UsageStatistics.class.getName());
+    private final static Logger LOG = Logger.getLogger(UsageStatistics.class.getName());
     
     private final String keyImage;
 

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -196,7 +196,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
             }
 
             return new String(Base64.getEncoder().encode(baos.toByteArray()));
-        } catch (Exception e) { // the exception could be GeneralSecurityException, InvalidParameterException or any other depending on the security provider you have installed
+        } catch (Throwable e) { // the exception could be GeneralSecurityException, InvalidParameterException or any other depending on the security provider you have installed
             LOG.log(Level.INFO, "Usage statistics could not be sent ({0})", e.getMessage());
             LOG.log(Level.FINE, "Error sending usage statistics", e);
             return null;

--- a/core/src/main/resources/hudson/model/UsageStatistics/footer.jelly
+++ b/core/src/main/resources/hudson/model/UsageStatistics/footer.jelly
@@ -32,10 +32,13 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${it.due}">
-    <script>
-      Behaviour.addLoadEvent(function() {
-        loadScript("https://usage.jenkins.io/usage-stats.js?${it.statData}");
-      });
-    </script>
+    <j:set var="statData" value="${it.statData}"/>
+    <j:if test="${statData != null}">
+      <script>
+        Behaviour.addLoadEvent(function() {
+          loadScript("https://usage.jenkins.io/usage-stats.js?${statData}");
+        });
+      </script>
+    </j:if>
   </j:if>
 </j:jelly>


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-66139](https://issues.jenkins-ci.org/browse/JENKINS-66139).

Avoid polluting the log when the usage statistics can't be sent. The full stack trace is printed as FINE. The message is printed as INFO because the instance is not compromised, so it's better to avoid disturbing the administrators.

Simple change, no test added. Manually tested:

Usual execution failing to send stats:
```
2021-07-14 15:35:52.544+0000 [id=31]    INFO    hudson.model.UsageStatistics#getStatData: Usage statistics could not be sent (Cipher available for WRAP_MODE and UNWRAP_MODE only)
```

Execution setting the FINE level to the UsageStatistics logger:
```
Jul 14, 2021 5:34:02 PM hudson.model.UsageStatistics getStatData
INFO: Usage statistics could not be sent (Cipher available for WRAP_MODE and UNWRAP_MODE only)
Jul 14, 2021 5:34:02 PM hudson.model.UsageStatistics getStatData
FINE: Error sending usage statistics
java.security.InvalidParameterException: Cipher available for WRAP_MODE and UNWRAP_MODE only
        at org.bouncycastle.jcajce.provider.BaseSingleBlockCipher.engineInit(Unknown Source)
        at org.bouncycastle.jcajce.provider.BaseSingleBlockCipher.engineInit(Unknown Source)
        at javax.crypto.Cipher.implInit(Cipher.java:805)
        at javax.crypto.Cipher.chooseProvider(Cipher.java:867)
        at javax.crypto.Cipher.init(Cipher.java:1252)
        at javax.crypto.Cipher.init(Cipher.java:1189)
        at hudson.model.UsageStatistics.toCipher(UsageStatistics.java:288)
        at hudson.model.UsageStatistics.access$100(UsageStatistics.java:76)
        at hudson.model.UsageStatistics$CombinedCipherOutputStream.<init>(UsageStatistics.java:247)
        at hudson.model.UsageStatistics.getStatData(UsageStatistics.java:192)
...
```

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Avoid polluting the log when usage statistics can not be sent

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
