### PR TITLE
Update `access-modifier` 1.22 → 1.24

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -140,7 +140,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>access-modifier-annotation</artifactId>
-        <version>${access-modifier-annotation.version}</version>
+        <version>${access-modifier.version}</version>
       </dependency>
       <dependency>
         <!--  make sure these old servlet versions are never used by us or by any plugins which end up depending on this version -->

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,7 @@ THE SOFTWARE.
     <findbugs.threshold>High</findbugs.threshold>
     <findbugs.excludeFilterFile>${project.basedir}/../src/findbugs/findbugs-excludes.xml</findbugs.excludeFilterFile>
 
-    <!-- TODO keep these in sync -->
-    <access-modifier-annotation.version>1.22</access-modifier-annotation.version>
-    <access-modifier-checker.version>1.22</access-modifier-checker.version>
+    <access-modifier.version>1.24</access-modifier.version>
     <junit.jupiter.version>5.7.2</junit.jupiter.version>
     <powermock.version>2.0.9</powermock.version>
     <spotless.version>2.12.2</spotless.version>
@@ -329,7 +327,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.kohsuke</groupId>
           <artifactId>access-modifier-checker</artifactId>
-          <version>${access-modifier-checker.version}</version>
+          <version>${access-modifier.version}</version>
         </plugin>
         <plugin>
           <groupId>com.cloudbees</groupId>


### PR DESCRIPTION
Supersedes #5640 + #5641. Picks up https://github.com/jenkinsci/lib-access-modifier/pull/53 + https://github.com/jenkinsci/lib-access-modifier/pull/54. Also see #5639.

### Proposed changelog entries

N/A, developer only

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
