### PR TITLE
Javadoc update required for guava upgrade

### DIFF
--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -23,7 +23,6 @@
  */
 package hudson.util;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 
@@ -419,7 +418,9 @@ public class Iterators {
     }
 
     /**
-     * Similar to {@link com.google.common.collect.Iterators#skip} except not {@link Beta}.
+     * Calls {@code next()} on {@code iterator}, either {@code count} times
+     * or until {@code hasNext()} returns {@code false}, whichever comes first.
+     *
      * @param iterator some iterator
      * @param count a nonnegative count
      */


### PR DESCRIPTION
Method was renamed to `advance` so the javadoc reference fails on newer versions, someone has re-styled the method at somepoint anyway from `for` loop to `while` so it's not even the same

Doc taken from guava javadoc that it was copied from

noticed in https://github.com/jenkinsci/jenkins/pull/5646