### PR TITLE
Remove Woodstox from WAR

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -258,11 +258,6 @@ THE SOFTWARE.
         <artifactId>memory-monitor</artifactId>
         <version>1.9</version>
       </dependency>
-      <dependency><!-- StAX implementation. See JENKINS-2547. -->
-        <groupId>org.codehaus.woodstox</groupId>
-        <artifactId>wstx-asl</artifactId>
-        <version>3.2.9</version>
-      </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -470,17 +470,6 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>memory-monitor</artifactId>
     </dependency>
-    <dependency><!-- StAX implementation. See JENKINS-2547. -->
-      <groupId>org.codehaus.woodstox</groupId>
-      <artifactId>wstx-asl</artifactId>
-      <exclusions>
-        <!-- StAX is now bundled in the JRE -->
-        <exclusion>
-          <groupId>stax</groupId>
-          <artifactId>stax-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>


### PR DESCRIPTION
The tasks in [#5604 (comment)](https://github.com/jenkinsci/jenkins/pull/5604#issuecomment-873539241) have been completed, so #5604 can be reverted:

- FasterXML/jackson-dataformat-xml#482 was released in [2.12.4](https://github.com/FasterXML/jackson-dataformat-xml/releases/tag/jackson-dataformat-xml-2.12.4)
- jenkinsci/jackson2-api-plugin#84 was released in [2.12.4](https://github.com/jenkinsci/jackson2-api-plugin/releases/tag/jackson2-api-2.12.4)
- jenkinsci/azure-sdk-plugin#26 was released in [25.vcde945b30f00](https://github.com/jenkinsci/azure-sdk-plugin/releases/tag/25.vcde945b30f00)
- jenkinsci/bom#581 was released in [909.vf028101f1bfa](https://github.com/jenkinsci/bom/releases/tag/909.vf028101f1bfa)
- jenkinsci/azure-sdk-plugin#31 was released in [30.vf3165534d6e8](https://github.com/jenkinsci/azure-sdk-plugin/releases/tag/30.vf3165534d6e8)
- jenkinsci/azure-storage-plugin#196 was released in [359.v09573e5ff73f](https://github.com/jenkinsci/azure-storage-plugin/releases/tag/359.v09573e5ff73f)
- jenkinsci/azure-container-agents-plugin#83 was released in [210.v8071dd1c9f3f](https://github.com/jenkinsci/azure-container-agents-plugin/releases/tag/210.v8071dd1c9f3f)
- jenkinsci/azure-artifact-manager-plugin#23 was released in [93.v9bc4e012ba4d](https://github.com/jenkinsci/azure-artifact-manager-plugin/releases/tag/93.v9bc4e012ba4d)

### Testing done

- Ran `java -jar jenkins.war` and installed the default plugin list and the Azure Storage plugin.
- Started the Azurite storage emulator with `docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite`.
- Went to http://127.0.0.1:8080/credentials/store/system/domain/_/newCredentials and added a new Azure Storage credential with account name, `devstoreaccount1`, account key `Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==`, and URL http://127.0.0.1:10000/devstoreaccount1/.
- Clicked Verify Configuration and confirmed that the "Validation successful" message was printed.

### Proposed changelog entries

Removed: The [Woodstox](https://github.com/FasterXML/woodstox) implementation of the [StAX API](https://en.wikipedia.org/wiki/StAX) has been removed from Jenkins core. Users of the [Azure Artifact Manager](https://plugins.jenkins.io/azure-artifact-manager/), [Azure Container Agents](https://plugins.jenkins.io/azure-container-agents/), [Azure Storage](https://plugins.jenkins.io/windows-azure-storage/), and [Azure SDK API](https://plugins.jenkins.io/azure-sdk/) plugins must upgrade those plugins to the latest versions in lockstep with this core upgrade. Plugins that consume Woodstox should depend on it directly or via the [Jackson 2 API](https://plugins.jenkins.io/jackson2-api/) plugin.

### Proposed upgrade guidelines

The [Woodstox](https://github.com/FasterXML/woodstox) implementation of the [StAX API](https://en.wikipedia.org/wiki/StAX) has been removed from Jenkins core. Users of the [Azure Artifact Manager](https://plugins.jenkins.io/azure-artifact-manager/), [Azure Container Agents](https://plugins.jenkins.io/azure-container-agents/), [Azure Storage](https://plugins.jenkins.io/windows-azure-storage/), and [Azure SDK API](https://plugins.jenkins.io/azure-sdk/) plugins must upgrade those plugins to the latest versions in lockstep with this core upgrade. Plugins that consume Woodstox should depend on it directly or via the [Jackson 2 API](https://plugins.jenkins.io/jackson2-api/) plugin.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
