### PR TITLE
[JENKINS-22566] XML API does not escape/filter invalid characters

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
   <properties>
     <slf4jVersion>1.7.32</slf4jVersion>
-    <stapler.version>1563.v3da2d02f9572</stapler.version>
+    <stapler.version>1566.vd81b422e04d6</stapler.version> <!-- TODO https://github.com/stapler/stapler/pull/248 -->
     <groovy.version>2.4.12</groovy.version>
   </properties>
 

--- a/core/src/main/java/hudson/model/Api.java
+++ b/core/src/main/java/hudson/model/Api.java
@@ -113,6 +113,8 @@ public class Api extends AbstractModelObject {
         }
 
         StringWriter sw = new StringWriter();
+        // The following is needed to ensure that escaped control characters don't result in parsing errors.
+        sw.write("<?xml version=\"1.1\"?>");
 
         // first write to String
         Model p = MODEL_BUILDER.get(bean.getClass());


### PR DESCRIPTION
See [JENKINS-22566](https://issues.jenkins.io/browse/JENKINS-22566) and [Valid characters in XML](https://en.wikipedia.org/wiki/Valid_characters_in_XML). Downstream of stapler/stapler#248. For years now, the XML API has been throwing errors when invalid control characters are produced. This PR fixes that by pulling in the Stapler PR and updating `hudson.model.Api` to use XML 1.1 (where control characters are valid). The rest of this PR just adds/updates test coverage for control characters for all variants of the API.

### Proposed changelog entries

* The XML API now properly escapes control characters.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
