### PR TITLE
Increase timeout for branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ for(j = 0; j < jdks.size(); j++) {
 
                 // Now run the actual build.
                 stage("${buildType} Build / Test") {
-                    timeout(time: 180, unit: 'MINUTES') {
+                    timeout(time: 300, unit: 'MINUTES') {
                         // See below for what this method does - we're passing an arbitrary environment
                         // variable to it so that JAVA_OPTS and MAVEN_OPTS are set correctly.
                         withMavenEnv(["JAVA_OPTS=-Xmx1536m -Xms512m",


### PR DESCRIPTION
We've swapped to using kubernetes agents for building because the ACI agents were too unstable.

The kubernetes agents currently have ~half the compute that ACI did:

before:
4cpu
12gb memory

now:
2cpu
4gb memory

This is resulting in more stable builds at least for bom, but Jenkins core PRs are mostly timing out.
https://ci.jenkins.io/blue/organizations/jenkins/Core%2Fjenkins/detail/PR-5664/5/pipeline/51

Java 11 passed in ~2hr 40, while java 8 timed out at 3hr

@dduportal is looking at autoscaling and increasing the compute available to us so we could add more resources to the pod, but for now I don't see any harm in this?