### PR TITLE
Minor deprecation fixes

### DIFF
--- a/core/src/main/java/hudson/util/BootFailure.java
+++ b/core/src/main/java/hudson/util/BootFailure.java
@@ -10,6 +10,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -62,9 +63,10 @@ public abstract class BootFailure extends ErrorObject {
                 if (f.exists()) {
                     try (BufferedReader failureFileReader = new BufferedReader(new FileReader(f))) {
                         String line;
+                        DateFormat df = DateFormat.getDateInstance();
                         while ((line=failureFileReader.readLine())!=null) {
                             try {
-                                dates.add(new Date(line));
+                                dates.add(df.parse(line));
                             } catch (Exception e) {
                                 // ignore any parse error
                             }

--- a/core/src/main/java/hudson/util/SecretRewriter.java
+++ b/core/src/main/java/hudson/util/SecretRewriter.java
@@ -54,7 +54,7 @@ public class SecretRewriter {
         this();
     }
 
-    private String tryRewrite(String s) throws IOException, InvalidKeyException {
+    private String tryRewrite(String s) throws InvalidKeyException {
         if (s.length()<24)
             return s;   // Encrypting "" in Secret produces 24-letter characters, so this must be the minimum length
         if (!isBase64(s))
@@ -82,7 +82,7 @@ public class SecretRewriter {
 
     public boolean rewrite(File f) throws InvalidKeyException, IOException {
 
-        AtomicFileWriter w = new AtomicFileWriter(f, "UTF-8");
+        AtomicFileWriter w = new AtomicFileWriter(f.toPath(), StandardCharsets.UTF_8);
         try {
             boolean modified = false; // did we actually change anything?
             try (PrintWriter out = new PrintWriter(new BufferedWriter(w));


### PR DESCRIPTION
Minor deprecation fixes:
* `new Date` replaced with `DateFormat`
* use `StandardCharsets.UTF_8`

### Proposed changelog entries

* Internal: N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
