### PR TITLE
[JENKINS-66379] upgrade winstone to allow non JKS keystores for https certificates

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -106,7 +106,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>5.20</version>
+      <version>5.21-rc617.2ed70edfb45c</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -106,7 +106,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>5.21-rc617.2ed70edfb45c</version>
+      <version>5.21</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The change uses the JVM default keystore.  This allows jenkins to be
used for TLS termination even when JKS is not the default keystore, or
is not allowed for other restrictions.

If someone has a non default keystore yet is using a keystore here then
this will break on upgrade, however it is unlikely that they would be
having a non default keystore as the normal reason for doing that is due
to a restriction like FIPS-140 and given the keystore we require has a
key using JDK here would be non compliant.

downstream of jenkinsci/winstone#165 https://github.com/jenkinsci/winstone/releases/tag/winstone-5.21
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-66379](https://issues.jenkins-ci.org/browse/JENKINS-66379).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Use the JVM's default keystore type for the Jenkins server when terminating TLS connections within Jenkins (ie. Jenkins is started with the `--httpsPort` argument).
*   * Winstone 5.21 changelog: https://github.com/jenkinsci/winstone/releases/tag/winstone-5.21

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

Users who are using Jenkins to terminate TLS connections (by configuring Jenkins with the `--httpsPort` argument) with the `--httpsKeyStore` argument or the default `winstone.ks` who have configured the JVM to use a default keystore other than JKS will need to convert their keystore to the JVMs default format.
This can be achieved with a command such as 
```shell
mv /path/to/keystore /path/to/keystore.old
keytool -importkeystore -v -srckeystore /path/to/keystore.old -srcstoretype JKS -srcstorepass changeit -destkeystore /path/to/keystore -deststorepass changeit
```
The change only affects the Jenkins server (and JVM) and is only impacted when you are running the Jenkins jar directly and not within the built in container.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
