### PR TITLE
Mark Resource Domain Recommendation monitor as security

### DIFF
--- a/core/src/main/java/jenkins/security/ResourceDomainRecommendation.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRecommendation.java
@@ -80,4 +80,9 @@ public class ResourceDomainRecommendation extends AdministrativeMonitor {
     public Permission getRequiredPermission() {
         return Jenkins.SYSTEM_READ;
     }
+
+    @Override
+    public boolean isSecurity() {
+        return true;
+    }
 }


### PR DESCRIPTION
This monitor identifies a generally unsafe configuration and suggests a better alternative:

> The default Content-Security-Policy is currently overridden using the <code>hudson.model.DirectoryBrowserSupport.CSP</code> system property, which is a potential security issue when browsing untrusted files. \
> As an alternative, you can set up a <strong>resource root URL</strong> that Jenkins will use to serve some static files without adding <code>Content-Security-Policy</code> headers.

That makes it `Security` IMO.

Overlooked in #5015 and #5079.

### Proposed changelog entries

(too minor)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
