### PR TITLE
Terminology: Warn about use of 'master' in label expression

### DIFF
--- a/core/src/main/java/hudson/model/labels/LabelExpression.java
+++ b/core/src/main/java/hudson/model/labels/LabelExpression.java
@@ -286,6 +286,12 @@ public abstract class LabelExpression extends Label {
         final Jenkins j = Jenkins.get();
         Label l = j.getLabel(expression);
         if (l.isEmpty()) {
+            final LabelAtom masterLabel = LabelAtom.get("master");
+            if (!masterLabel.equals(Jenkins.get().getSelfLabel()) && l.listAtoms().contains(masterLabel) && masterLabel.isEmpty()) {
+                // Show a warning if this expression's lack of nodes and clouds is likely caused by the built-in node name migration.
+                // This can probably be done better (e.g. also when `!l.isEmpty()`), but it's a start.
+                return FormValidation.warningWithMarkup(Messages.LabelExpression_ObsoleteMasterLabel());
+            }
             for (LabelAtom a : l.listAtoms()) {
                 if (a.isEmpty()) {
                     LabelAtom nearest = LabelAtom.findNearest(a.getName());

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -189,6 +189,8 @@ Label.GroupOf=group of {0}
 Label.InvalidLabel=invalid label
 Label.ProvisionedFrom=Provisioned from {0}
 LabelExpression.InvalidBooleanExpression=Invalid boolean expression: {0}
+LabelExpression_ObsoleteMasterLabel=This expression includes the label <tt>master</tt> that is no longer used for the built-in node. Use <tt>built-in</tt> instead. \
+  <a href="https://www.jenkins.io/redirect/built-in-node-migration/" rel="noopener noreferrer" target="_blank">Learn more.</a>
 LabelExpression.LabelLink=<a href="{0}{2}">Label {1}</a> matches {3,choice,0#no nodes|1#1 node|1<{3} nodes}{4,choice,0#|1# and 1 cloud|1< and {4} clouds}. \
   Permissions or other restrictions provided by plugins may further reduce that list.
 LabelExpression.NoMatch=No agent/cloud matches this label expression.


### PR DESCRIPTION
An attempt to make the label change more discoverable to regular users.

This warning currently only shows up when the chosen expression matches no nodes at all. More complex expressions may have unexpected behavior after the migration _without_ a warning appearing on the UI (because they will include nodes, probably even the built-in node in cases involving `!master`), but this should at least cover the most common case(s). We can always iterate later.

### Freestyle Job

> <img width="803" alt="Screenshot 2021-08-19 at 20 05 25" src="https://user-images.githubusercontent.com/1831569/130121861-aa1a5fdf-b85c-404e-a235-b52cdc214421.png">

### Pipeline Snippet Generator

> <img width="724" alt="Screenshot 2021-08-19 at 20 05 40" src="https://user-images.githubusercontent.com/1831569/130121882-e1a9191a-9be4-4cef-81be-fd416a03de39.png">

> <img width="920" alt="Screenshot 2021-08-19 at 20 12 24" src="https://user-images.githubusercontent.com/1831569/130122284-c9ddf4f5-04ba-4fef-95af-a3c5f86629d8.png">

> <img width="874" alt="Screenshot 2021-08-19 at 20 13 28" src="https://user-images.githubusercontent.com/1831569/130122332-07014d55-c49b-4f5d-8cd6-5eb7b9711c3d.png">


### Proposed changelog entries

* Warn about use of `master` in a label expression when that's no longer in use

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
