### PR TITLE
[JENKINS-66507] Bump XStream from 1.4.17 to 1.4.18

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -303,7 +303,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.17</version>
+        <version>1.4.18</version>
       </dependency>
       <dependency>
         <groupId>net.sf.kxml</groupId>

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -61,8 +61,10 @@ public class RobustReflectionConverterTest {
 
     @Test
     public void ifWorkaroundNeeded() {
-        final ConversionException e = assertThrows(ConversionException.class, () -> read(new XStream()));
-        assertThat(e.getMessage(), containsString("z"));
+        XStream xs = new XStream();
+        xs.allowTypes(new Class[] {Point.class});
+        final ConversionException e = assertThrows(ConversionException.class, () -> read(xs));
+        assertThat(e.getMessage(), containsString("No such field hudson.util.Point.z"));
     }
 
     @Test


### PR DESCRIPTION
Supersedes #5683. Adapts `hudson.util.RobustReflectionConverterTest#ifWorkaroundNeeded` to changes in the XStream framework.

## Proposed changelog entries

* Internal: Upgrade XStream 1.4.17 to 1.4.18
  *  XStream Changelog: http://x-stream.github.io/changes.html
