### PR TITLE
Mark `PluginFirstClassLoader`, `MaskingClassLoader`, and `AntClassLoader` as parallel-capable

### DIFF
--- a/core/src/main/java/hudson/PluginFirstClassLoader.java
+++ b/core/src/main/java/hudson/PluginFirstClassLoader.java
@@ -27,10 +27,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import jenkins.util.AntClassLoader;
 
@@ -43,12 +43,15 @@ import jenkins.util.AntClassLoader;
 public class PluginFirstClassLoader
     extends AntClassLoader
 {
+    static {
+        registerAsParallelCapable();
+    }
 
     public PluginFirstClassLoader() {
         super(null, false);
     }
 
-    private List<URL> urls = new ArrayList<>();
+    private List<URL> urls = new CopyOnWriteArrayList<>();
 
     @Override
     public void addPathFiles( Collection<File> paths )

--- a/core/src/main/java/hudson/util/MaskingClassLoader.java
+++ b/core/src/main/java/hudson/util/MaskingClassLoader.java
@@ -49,6 +49,10 @@ public class MaskingClassLoader extends ClassLoader {
 
     private final List<String> masksResources = new CopyOnWriteArrayList<>();
 
+    static {
+        registerAsParallelCapable();
+    }
+
     public MaskingClassLoader(ClassLoader parent, String... masks) {
         this(parent, Arrays.asList(masks));
     }

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -93,6 +93,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
     private static final Object MR_JARFILE_CTOR_RUNTIME_VERSION_VAL;
 
     static {
+        registerAsParallelCapable();
         if (IS_ATLEAST_JAVA9) {
             Class[] ctorArgs = null;
             Object runtimeVersionVal = null;


### PR DESCRIPTION
Begins the process of marking Jenkins `ClassLoader`s as parallel-capable. `AntClassLoader` was marked as such upstream in [commit d37df73a8](https://github.com/apache/ant/commit/d37df73a8). That commit has been battle-tested since 2016, so I feel confident at this point pulling it into Jenkins. `MaskingClassLoader` was already using `CopyOnWriteArrayList` as its primary data structure, so it seems safe to mark as parallel-capable as well. `PluginFirstClassLoader` extends `AntClassLoader` but used an `ArrayList` as its primary data structure. I converted this to a `CopyOnWriteArrayList` to make it thread-safe.

There are still two remaining `ClassLoader`s in Jenkins core not being addressed by this PR: `DependencyClassLoader` and `UberClassLoader`. Marking those as parallel-capable is a more significant challenge, because not only are they not static classes, but also because the code is a lot more complex and difficult to audit for thread safety. I might look into these in future PRs, but in the meantime this PR gets us closer to the right direction by bringing in the last upstream `AntClassLoader` change that isn't present in our fork.

### Proposed changelog entries

`AntClassLoader` (and its subclass `PluginFirstClassLoader`) and `MaskingClassLoader` register themselves as parallel-capable.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
