### PR TITLE
Bump `json-lib` from 2.4-jenkins-2 to 2.4-jenkins-3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -352,7 +352,7 @@ THE SOFTWARE.
       <dependency><!-- until we get this version through Stapler -->
         <groupId>org.kohsuke.stapler</groupId>
         <artifactId>json-lib</artifactId>
-        <version>2.4-jenkins-2</version>
+        <version>2.4-jenkins-3</version>
       </dependency>
       <!-- Overriding Stapler’s 1.1.3 version to diagnose JENKINS-20618: -->
       <dependency>


### PR DESCRIPTION
stapler/stapler#262 was merged, which means the next release of Stapler will include that PR. When Dependabot proposes that release of Stapler to Jenkins core, a `RequireUpperBoundDeps` error will be triggered for `json-lib`. So we might as well get ahead of the curve by upgrading `json-lib` in Jenkins core now.

@timja was kind enough to post the diff in the Stapler PR: https://github.com/jenkinsci/json-lib/compare/json-lib-2.4-jenkins-2...json-lib-2.4-jenkins-3

In [#5629 (comment)](https://github.com/jenkinsci/jenkins/pull/5629#discussion_r673245763), @daniel-beck made the following observation:

> We need to be extremely careful updating this library given how JSON signature validation works. I struggled with unexpectedly broken JSON serialization results a lot in update-center2.

This level of extreme care does not appear to have been taken in stapler/stapler#262, but it's still not too late to properly test this change. Unfortunately, I'm not sure offhand how to go about such testing. I need to think about this some more, so I am leaving the PR in draft state while I try to determine how this should be tested. If others have concrete and actionable suggestions, I would happily take them, though I don't have any expectations here.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).