### PR TITLE
Fix agent-to-controller security killswitch UI

### DIFF
--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -29,7 +29,15 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
     }
 
+    @Deprecated
     public boolean getMasterToSlaveAccessControl() {
+        return getAgentToControllerAccessControl();
+    }
+
+    /**
+     * @since TODO
+     */
+    public boolean getAgentToControllerAccessControl() {
         return !rule.getMasterKillSwitch();
     }
 

--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -29,6 +29,9 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
         return GlobalConfigurationCategory.get(GlobalConfigurationCategory.Security.class);
     }
 
+    /**
+     * @deprecated Use {@link #getAgentToControllerAccessControl()} instead
+     */
     @Deprecated
     public boolean getMasterToSlaveAccessControl() {
         return getAgentToControllerAccessControl();


### PR DESCRIPTION
This is a regression introduced by #5425 in 2.307: The form field name was changed but no corresponding getter was added, so it's always disabled. When submitting the form without changing anything, agent-to-controller access control is disabled (and the admin monitor shows up).

### Proposed changelog entries

* The checkbox labeled "Enable Agent → Controller Access Control" in the form "Configure Global Security" would always start out as disabled. Submitting the form without checking it would then cause a configuration change (regression in 2.307).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
