### PR TITLE
Update at-since up to 2.308

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -1071,7 +1071,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Get list of implied dependencies.
-     * @since TODO
+     * @since 2.296
      */
     @Restricted(NoExternalUse.class)
     public @NonNull Set<String> getImpliedDependents() {

--- a/core/src/main/java/jenkins/agents/AgentComputerUtil.java
+++ b/core/src/main/java/jenkins/agents/AgentComputerUtil.java
@@ -41,7 +41,7 @@ public final class AgentComputerUtil {
      * separate thread on agents, that'll fail.)
      *
      * @return null if the calling thread doesn't have any trace of where its controller is.
-     * @since TODO
+     * @since 2.307
      */
     @CheckForNull
     public static VirtualChannel getChannelToController() {


### PR DESCRIPTION
List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.296
  - https://github.com/jenkinsci/jenkins/commit/4fc0d5a0858dac9617ea099158f5a81393127ca4
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.307
  - https://github.com/jenkinsci/jenkins/commit/96a5526bdb1bad3f553d9a9e7f5987a1e6b11456


### Proposed changelog entries

(too minor)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
