### PR TITLE
Revive support for `URLClassLoader` in `ClassicPluginStrategy`

### DIFF
--- a/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
+++ b/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
@@ -8,7 +8,7 @@ import java.net.URLClassLoader;
 import java.util.Enumeration;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import jenkins.util.AntClassLoader;
+import jenkins.util.JenkinsClassLoader;
 
 /**
  * Reflective access to various {@link ClassLoader} methods which are otherwise {@code protected}.
@@ -46,8 +46,8 @@ public class ClassLoaderReflectionToolkit {
     }
 
     private static Object getClassLoadingLock(ClassLoader cl, String name) {
-        if (cl instanceof AntClassLoader) {
-            return ((AntClassLoader) cl).getClassLoadingLock(name);
+        if (cl instanceof JenkinsClassLoader) {
+            return ((JenkinsClassLoader) cl).getClassLoadingLock(name);
         }
         return invoke(GetClassLoadingLock.GET_CLASS_LOADING_LOCK, RuntimeException.class, cl, name);
     }
@@ -74,8 +74,8 @@ public class ClassLoaderReflectionToolkit {
     public static @CheckForNull Class<?> _findLoadedClass(ClassLoader cl, String name) {
         synchronized (getClassLoadingLock(cl, name)) {
             Class<?> c;
-            if (cl instanceof AntClassLoader) {
-                c = ((AntClassLoader) cl).findLoadedClass2(name);
+            if (cl instanceof JenkinsClassLoader) {
+                c = ((JenkinsClassLoader) cl).findLoadedClass2(name);
             } else {
                 c = (Class) invoke(FindLoadedClass.FIND_LOADED_CLASS, RuntimeException.class, cl, name);
             }
@@ -103,8 +103,8 @@ public class ClassLoaderReflectionToolkit {
      */
     public static @NonNull Class<?> _findClass(ClassLoader cl, String name) throws ClassNotFoundException {
         synchronized (getClassLoadingLock(cl, name)) {
-            if (cl instanceof AntClassLoader) {
-                return ((AntClassLoader) cl).findClass(name);
+            if (cl instanceof JenkinsClassLoader) {
+                return ((JenkinsClassLoader) cl).findClass(name);
             } else {
                 return (Class) invoke(FindClass.FIND_CLASS, ClassNotFoundException.class, cl, name);
             }
@@ -131,8 +131,8 @@ public class ClassLoaderReflectionToolkit {
      */
     public static @CheckForNull URL _findResource(ClassLoader cl, String name) {
         URL url;
-        if (cl instanceof AntClassLoader) {
-            url = ((AntClassLoader) cl).findResource(name);
+        if (cl instanceof JenkinsClassLoader) {
+            url = ((JenkinsClassLoader) cl).findResource(name);
         } else if (cl instanceof URLClassLoader) {
             url = ((URLClassLoader) cl).findResource(name);
         } else {
@@ -161,8 +161,8 @@ public class ClassLoaderReflectionToolkit {
      */
     public static @NonNull Enumeration<URL> _findResources(ClassLoader cl, String name) throws IOException {
         Enumeration<URL> urls;
-        if (cl instanceof AntClassLoader) {
-            urls = ((AntClassLoader) cl).findResources(name);
+        if (cl instanceof JenkinsClassLoader) {
+            urls = ((JenkinsClassLoader) cl).findResources(name);
         } else {
             urls = (Enumeration<URL>) invoke(FindResources.FIND_RESOURCES, IOException.class, cl, name);
         }

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -83,7 +83,7 @@ import java.util.zip.ZipFile;
  *
  */
 @Restricted(NoExternalUse.class)
-public class AntClassLoader extends ClassLoader implements SubBuildListener, Closeable {
+public class AntClassLoader extends ClassLoader implements JenkinsClassLoader, SubBuildListener, Closeable {
 
     private static final FileUtils FILE_UTILS = FileUtils.getFileUtils();
 
@@ -1582,6 +1582,7 @@ public class AntClassLoader extends ClassLoader implements SubBuildListener, Clo
     /**
      * Public version of {@link ClassLoader#findLoadedClass(String)}
      */
+    @Override
     public Class<?> findLoadedClass2(String name) {
         return findLoadedClass(name);
     }

--- a/core/src/main/java/jenkins/util/JenkinsClassLoader.java
+++ b/core/src/main/java/jenkins/util/JenkinsClassLoader.java
@@ -1,0 +1,32 @@
+package jenkins.util;
+
+import jenkins.ClassLoaderReflectionToolkit;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+
+/**
+ * Public versions of various {@link ClassLoader} methods for use in {@link
+ * ClassLoaderReflectionToolkit}.
+ */
+@Restricted(NoExternalUse.class)
+public interface JenkinsClassLoader {
+    /** Public version of {@link ClassLoader#findClass(String)} */
+    Class<?> findClass(String name) throws ClassNotFoundException;
+
+    /** Public version of {@link ClassLoader#findLoadedClass(String)} */
+    Class<?> findLoadedClass2(String name);
+
+    /** Public version of {@link ClassLoader#findResource(String)} */
+    URL findResource(String name);
+
+    /** Public version of {@link ClassLoader#findResources(String)} */
+    Enumeration<URL> findResources(String name) throws IOException;
+
+    /** Public version of {@link ClassLoader#getClassLoadingLock(String)} */
+    Object getClassLoadingLock(String className);
+}

--- a/core/src/main/java/jenkins/util/URLClassLoader2.java
+++ b/core/src/main/java/jenkins/util/URLClassLoader2.java
@@ -1,0 +1,49 @@
+package jenkins.util;
+
+import jenkins.ClassLoaderReflectionToolkit;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * {@link URLClassLoader} with loosened visibility for use with {@link
+ * ClassLoaderReflectionToolkit}.
+ */
+@Restricted(NoExternalUse.class)
+public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoader {
+
+    static {
+        registerAsParallelCapable();
+    }
+
+    public URLClassLoader2(URL[] urls) {
+        super(urls);
+    }
+
+    public URLClassLoader2(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+    }
+
+    @Override
+    public void addURL(URL url) {
+        super.addURL(url);
+    }
+
+    @Override
+    public Class<?> findClass(String name) throws ClassNotFoundException {
+        return super.findClass(name);
+    }
+
+    @Override
+    public Class<?> findLoadedClass2(String name) {
+        return super.findLoadedClass(name);
+    }
+
+    @Override
+    public Object getClassLoadingLock(String className) {
+        return super.getClassLoadingLock(className);
+    }
+}


### PR DESCRIPTION
Once upon a time, Jenkins used to support both `URLClassLoader` and `AntClassLoader`, with `AntClassLoader` being preferred only because the `URLClassLoader` of the time didn't implement `Closeable`, which caused problems with predictable release of JAR file handles. That all changed in commit 47de54d070, which dropped support for `URLClassLoader` in order to introduce the Bytecode Compatibility Transformer. But the Bytecode Compatibility Transformer was removed in #5526, and `URLClassLoader` implements `Closeable` as of Java 7. So can we bring back support for `URLClassLoader`? Sure.

`ClassLoaderReflectionToolkit` needs to access internal `ClassLoader` methods for performance reasons. Kohsuke originally implemented this with reflection, but as of Java 11 this logs reflective access warnings, so Tim had to increase the visibility of some methods instead. The same approach can be done in a `URLClassLoader2` subclass of `URLClassLoader`, with a common `JenkinsClassLoader` interface for the methods required by `ClassLoaderReflectionToolkit`. I've done exactly that in this PR.

It all works great in both Java 11 and Java 8 (tested with `java -jar jenkins.war` and the 143 plugins on my staging server) modulo [this code](https://github.com/jenkinsci/bouncycastle-api-plugin/blob/58a04798909bd90b42a72b6d9a11acce5d0ee87f/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java#L61-L66) in the BouncyCastle API plugin which needed to be patched to work with both `AntClassLoader` and `URLClassLoader2`. Because of the BouncyCastle API plugin issue, `URLClassLoader2` can't be enabled by default yet, so I am leaving `AntClassLoader` as the default for now. Once this PR makes it into an LTS release, I plan to follow up with a patch to BouncyCastle API to add support for `URLClassLoader2`. Then once that is merged, released, and widely adopted, we could make `URLClassLoader2` the default again. While that wouldn't completely eliminate our dependency on `AntClassLoader` (recall that `PluginFirstClassLoader` extends `AntClassLoader`), it would bring us far closer to the mainstream when it comes to class loading and therefore reduce our maintenance burden.

I plan to follow this up with a PR to update the [Jenkins Features Controlled with System Properties](https://www.jenkins.io/doc/book/managing/system-properties/) documentation.

### Proposed changelog entries

Internal: Experimental support for `URLClassLoader` can be enabled by setting `hudson.ClassicPluginStrategy.useAntClassLoader=false`.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
