### PR TITLE
Fix bug in TextparameterDefinition

### DIFF
--- a/core/src/main/java/hudson/model/TextParameterDefinition.java
+++ b/core/src/main/java/hudson/model/TextParameterDefinition.java
@@ -59,6 +59,11 @@ public class TextParameterDefinition extends StringParameterDefinition {
     }
 
     @Override
+    public StringParameterValue getDefaultParameterValue() {
+        return new TextParameterValue(getName(), getDefaultValue(), getDescription());
+    }
+
+    @Override
     public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
         TextParameterValue value = req.bindJSON(TextParameterValue.class, jo);
         value.setDescription(getDescription());


### PR DESCRIPTION
TextParameterDefinition did not override getDefaultParameterValue() method, instead it relied on the implementation in StringParameterDefinition. In most cases this wasn't a problem, but in some cases, for example when triggering build through
buildWithParameters API without specifying the parameter, then the parameter object would be of the wrong type (StringParameterValue as opposed to TextParameterValue). This causes problems with visualization in parameters view as well as incorrect values (and visualization) when rebuild plugin is used.

JIRA issue: https://issues.jenkins.io/browse/JENKINS-66521

No tests since I consider this a minor bug fix (and there are no existing tests to piggyback on).

### Proposed changelog entries

* Fix wrong parameter type for `Text Parameter` when triggering a build via the `buildWithParameters` API call.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [X] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs


### Desired reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
