### PR TITLE
[JEP-233] Upgrade Guava from 11.0.1 to latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,6 @@ updates:
       # will require source code changes to replace javax.mail with jakarta.mail 
       # and some handling for plugins that depend on javax.mail being provided by Jenkins core.
       - dependency-name: "com.sun.mail:jakarta.mail"
-      # needs updates in a number of plugins, see https://github.com/jenkinsci/jenkins/pull/5059 and https://github.com/jenkinsci/bom/pull/392
-      - dependency-name: "com.google.guava:*"
       # this is a banned dependency, we have a hack in our pom to prevent anyone else pulling it in
       - dependency-name: "javax.servlet.servlet-api"
       # needs a jakarta upgrade project, imports changed

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -91,7 +91,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>11.0.1</version>
+        <version>31.0.1-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -95,10 +95,6 @@ THE SOFTWARE.
           <groupId>aopalliance</groupId>
           <artifactId>aopalliance</artifactId>
         </exclusion>
-        <exclusion> <!-- TODO it seems to want Guava 16; apparently it manages to run against 11 -->
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 
@@ -538,9 +534,17 @@ THE SOFTWARE.
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <exclusions>
-        <exclusion> <!-- pick up from SpotBugs Annotations -->
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -119,12 +119,6 @@ THE SOFTWARE.
       <artifactId>antisamy-markup-formatter</artifactId>
       <version>2.4</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion> <!-- TODO it seems to want Guava 27.1; apparently it manages to run against 11.0.1 -->
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Guava Library Upgraded

- Design document: [JEP-233](https://jenkins.io/jep/233)
- Jira epic: [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988)
- [Blog post](https://www.jenkins.io/blog/2021/11/09/guava-upgrade/)
- Open JEP-233 issues: [Jira query](https://issues.jenkins.io/browse/JENKINS-66428?jql=labels%20in%20(JEP-233)%20and%20status%20not%20in%20(resolved%2C%20closed))

### Proposed changelog entries

* Jenkins has upgraded the [Guava](https://guava.dev/) library from [11.0.1](https://github.com/google/guava/releases/tag/v11.0.1) (released on January 9, 2012) to [31.0.1](https://github.com/google/guava/releases/tag/v31.0.1) (released on September 27, 2021). Plugins have already been prepared to support the new version of Guava; use the Plugin Manager to upgrade all plugins before _and_ after upgrading Jenkins.

### Proposed upgrade guidelines

* See the [blog post](https://www.jenkins.io/blog/2021/11/09/guava-upgrade/)

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@jenkinsci/core

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).