### PR TITLE
[JENKINS-66563] add a supported API for a plugin to insert jars into its classpath

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -36,6 +36,7 @@ import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import jenkins.security.UpdateSiteWarningsMonitor;
+import jenkins.util.AntClassLoader;
 import jenkins.util.java.JavaUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.LogFactory;
@@ -110,6 +111,7 @@ import static org.apache.commons.io.FilenameUtils.getBaseName;
  */
 @ExportedBean
 public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
+
     /**
      * A plugin won't be loaded unless his declared dependencies are present and match the required minimal version.
      * This can be set to false to disable the version check (legacy behaviour)
@@ -375,6 +377,20 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         We have no good model for plugin metadata from update sites for plugins not being published.
          */
         return !getDeprecations().isEmpty();
+    }
+
+    /**
+     * Inject the specified jar file(s) to the plugins classpath. 
+     * <strong>Warning:</strong> This is advanced usage that you should not need in
+     * 99.9% of all cases, and any jar insertion should happen early into the plugins lifecycle to prevent classloading
+     * issues in dependent plugins.
+     *
+     */
+    public void injectJarsToClassapth(File ...jars) {
+        for (File f : jars) {
+            LOGGER.log(Level.CONFIG, () -> "Inserting " + f + " into " + shortName  + " plugin's classpath");
+            ((AntClassLoader)classLoader).addPathComponent(f);
+        }
     }
 
     @ExportedBean


### PR DESCRIPTION
Required for BouncyCastle plugin so it does not try and expose its
classes when running in a JVM in FIPS mode, but can be other use cases
as yet unknown.


Downstream demonstration PR in BouncyCastle plugin -> jenkinsci/bouncycastle-api-plugin#53
PR that combines and resolves conflicts between this and #5698 -> #5711

Currently WIP pending another PR that merges both this and #5698 and a PR that consumes this incremental in the bouncycastle-api plugin (and a unit test), but reviews of the API signature welcome.

I originally thought this would be best on the `Plugin` class as 
1) it is probably dangerous to allow plugin A to manipluate plugin B's classpath
2) you really want to call this before any other dependant `Plugins` have been `start`ed 

However as `Plugin` is deprecated having this on the `Plugin` class could impact the longevity of the API and also make it harder for any plugin to move away from extending `Plugin`

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-66563](https://issues.jenkins-ci.org/browse/JENKINS-66563).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: expose the ability for a plugin to dynamically insert jars into its classpath.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja @oleg-nenashev @basil 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
