### PR TITLE
Attempt to fix SlaveComputerTest.startupShouldFailOnErrorOnlineListener

### DIFF
--- a/test/src/test/java/hudson/slaves/SlaveComputerTest.java
+++ b/test/src/test/java/hudson/slaves/SlaveComputerTest.java
@@ -156,7 +156,7 @@ public class SlaveComputerTest {
     @TestExtension(value = "startupShouldFailOnErrorOnlineListener")
     public static final class ErrorOnOnlineListener extends ComputerListener {
 
-        static int onOnlineCount = 0;
+        volatile static int onOnlineCount = 0;
 
         @Override
         public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {

--- a/test/src/test/java/hudson/slaves/SlaveComputerTest.java
+++ b/test/src/test/java/hudson/slaves/SlaveComputerTest.java
@@ -156,7 +156,7 @@ public class SlaveComputerTest {
     @TestExtension(value = "startupShouldFailOnErrorOnlineListener")
     public static final class ErrorOnOnlineListener extends ComputerListener {
 
-        volatile static int onOnlineCount = 0;
+        static volatile int onOnlineCount = 0;
 
         @Override
         public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {


### PR DESCRIPTION
Obseverd in an unrealated PR that the test failed.

without doing any detailed digging into the reason for the failure the
onOnlineCount was not volatile and used ina  loop, so its result could
be cached causing the branch to not exit correctly

THis may not fix the issue, but at the same time it will "do no harm"

see https://ci.jenkins.io/job/Core/job/jenkins/job/PR-5713/6/testReport/junit/hudson.slaves/SlaveComputerTest/Linux_jdk8___Linux_Publishing___startupShouldFailOnErrorOnlineListener/

```
Stacktrace
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at hudson.slaves.SlaveComputerTest.startupShouldFailOnErrorOnlineListener(SlaveComputerTest.java:147)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:601)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
Standard Output
=== Starting startupShouldFailOnErrorOnlineListener(hudson.slaves.SlaveComputerTest)
Standard Error
   0.101 [id=159]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:41971/jenkins/
   0.133 [id=172]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.175 [id=172]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.574 [id=171]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.580 [id=174]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.585 [id=174]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.595 [id=172]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.596 [id=172]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.596 [id=172]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.596 [id=172]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.983 [id=172]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   6.188 [id=159]	INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
   6.311 [id=159]	INFO	jenkins.model.Jenkins#cleanUp: Jenkins stopped

```


<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
