### PR TITLE
[JENKINS-61212] Update Tyrus (WebSocket client) to 2.0.1

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client-jdk</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
**Untested** but this may fix [JENKINS-61212](https://issues.jenkins.io/browse/JENKINS-61212) for CLI (not agents!) by picking up https://github.com/eclipse-ee4j/tyrus/pull/707.

### Proposed changelog entries

* WebSocket connections now work when the Jenkins controller is running Java 11 and using self-terminated TLS.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
