### PR TITLE
[JENKINS-66470] Register view-related permission groups and permissions prior to the execution of JCasC

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -32,6 +32,8 @@ import hudson.ExtensionPoint;
 import hudson.Functions;
 import hudson.Indenter;
 import hudson.Util;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.Descriptor.FormException;
 import hudson.model.listeners.ItemListener;
 import hudson.scm.ChangeLogSet;
@@ -1317,6 +1319,15 @@ public abstract class View extends AbstractModelObject implements AccessControll
     public static final Permission DELETE = new Permission(PERMISSIONS,"Delete", Messages._View_DeletePermission_Description(), Permission.DELETE, PermissionScope.ITEM_GROUP);
     public static final Permission CONFIGURE = new Permission(PERMISSIONS,"Configure", Messages._View_ConfigurePermission_Description(), Permission.CONFIGURE, PermissionScope.ITEM_GROUP);
     public static final Permission READ = new Permission(PERMISSIONS,"Read", Messages._View_ReadPermission_Description(), Permission.READ, PermissionScope.ITEM_GROUP);
+
+    @Initializer(before = InitMilestone.SYSTEM_CONFIG_LOADED)
+    public static void registerPermissions() {
+        // Pending JENKINS-17200, ensure that the above permissions have been registered prior to
+        // allowing plugins to adapt the system configuration, which may depend on these permissions
+        // having been registered. Since this method is static and since it follows the above
+        // construction of static permission objects (and therefore their calls to
+        // PermissionGroup#register), there is nothing further to do in this method.
+    }
 
     // to simplify access from Jelly
     public static Permission getItemCreatePermission() {

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -1321,6 +1321,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     public static final Permission READ = new Permission(PERMISSIONS,"Read", Messages._View_ReadPermission_Description(), Permission.READ, PermissionScope.ITEM_GROUP);
 
     @Initializer(before = InitMilestone.SYSTEM_CONFIG_LOADED)
+    @Restricted(DoNotUse.class)
     public static void registerPermissions() {
         // Pending JENKINS-17200, ensure that the above permissions have been registered prior to
         // allowing plugins to adapt the system configuration, which may depend on these permissions


### PR DESCRIPTION
See [JENKINS-66470](https://issues.jenkins.io/browse/JENKINS-66470).

Prior to the removal of `TreeView` in #5603, the registration of view-related permission groups and permissions prior to the execution of JCasC (i.e., before `InitMilestone.SYSTEM_CONFIG_LOADED`) worked more or less by accident: by virtue of `TreeView` happening to have a static method annotated with `@Extension`, which happened to be executed very early (in my tests, because of Git plugin's `GitSCM#onLoaded` method), which happened to load the `TreeView` class, which happened to load the `View` class, which happened to run its static initializers, which happened to register the view-related permission groups and permissions. With the removal of `TreeView`, this is no longer happening, and view-related permission groups and permissions are not being registered prior to `InitMilestone.SYSTEM_CONFIG_LOADED`, causing problems with JCasC configurations that reference these permission groups and permissions.

The long-term fix is described in [JENKINS-17200](https://issues.jenkins.io/browse/JENKINS-17200). This PR restores the status quo by ensuring that view-related permission groups and permissions are registered prior to `InitMilestone.SYSTEM_CONFIG_LOADED` (after which JCasC needs them) by adding a new static method in the `View` class. This new static method is placed after the static construction of the permission group and permission instances, during which these instances are registered. By annotating the method with `@Initializer(before = InitMilestone.SYSTEM_CONFIG_LOADED)`, we ensure that the registration takes place before JCasC starts consuming these permissions. Thus the status quo is restored.

### Testing done

Reproduced the problem as described in jenkinsci/configuration-as-code-plugin#1638; could no longer do so after these changes.

### Proposed changelog entries

* Allow Jenkins to start when the JCasC configuration defines view-related permissions (regression in 2.302).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
