### PR TITLE
Consistently use `issues.jenkins.io` for issue links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,10 +152,10 @@ just submit a pull request.
 * [Jenkins Contribution Landing Page](https://www.jenkins.io/participate/)
 * [Jenkins IRC Channel](https://www.jenkins.io/chat/)
 * [Beginners Guide To Contributing](https://wiki.jenkins.io/display/JENKINS/Beginners+Guide+to+Contributing)
-* [List of newbie-friendly issues in the core](https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20core%20AND%20labels%20in%20(newbie-friendly))
+* [List of newbie-friendly issues in the core](https://issues.jenkins.io/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20core%20AND%20labels%20in%20(newbie-friendly))
 
 [Preparing for Plugin Development]: https://www.jenkins.io/doc/developer/tutorial/prepare/
-[newbie friendly issues]: https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20core%20AND%20labels%20in%20(newbie-friendly)
+[newbie friendly issues]: https://issues.jenkins.io/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20core%20AND%20labels%20in%20(newbie-friendly)
 [Participate]: https://www.jenkins.io/participate/
 [building and debugging process here]: https://www.jenkins.io/doc/developer/building/
 [guide]: https://wiki.jenkins.io/display/JENKINS/Starting+and+Accessing+Jenkins

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -714,7 +714,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      * Disables this plugin next time Jenkins runs. As it doesn't check anything, it's recommended to use the method
      * {@link #disable(PluginDisableStrategy)}
      */
-    @Deprecated //see https://issues.jenkins-ci.org/browse/JENKINS-27177
+    @Deprecated //see https://issues.jenkins.io/browse/JENKINS-27177
     public void disable() throws IOException {
         disableWithoutCheck();
     }

--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -510,7 +510,7 @@ public abstract class Proc {
     /**
     * An instance of {@link Proc}, which has an internal workaround for JENKINS-23271.
     * It presumes that the instance of the object is guaranteed to be used after the {@link Proc#join()} call.
-    * See <a href="https://jenkins-ci.org/issue/23271">JENKINS-23271</a>
+    * See <a href="https://issues.jenkins.io/browse/JENKINS-23271">JENKINS-23271</a>
     * @author Oleg Nenashev
     */
     @Restricted(NoExternalUse.class)

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -241,9 +241,9 @@ public class Util {
     @NonNull
     public static String loadFile(@NonNull File logfile, @NonNull Charset charset) throws IOException {
         // Note: Until charset handling is resolved (e.g. by implementing
-        // https://issues.jenkins-ci.org/browse/JENKINS-48923 ), this method
+        // https://issues.jenkins.io/browse/JENKINS-48923 ), this method
         // must be able to handle character encoding errors. As reported at
-        // https://issues.jenkins-ci.org/browse/JENKINS-49112 Run.getLog() calls
+        // https://issues.jenkins.io/browse/JENKINS-49112 Run.getLog() calls
         // loadFile() to fully read the generated log file. This file might
         // contain unmappable and/or malformed byte sequences. We need to make
         // sure that in such cases, no CharacterCodingException is thrown.
@@ -253,7 +253,7 @@ public class Util {
         // from a Charset and the reader returned by Files.newBufferedReader()
         // handle malformed and unmappable byte sequences for the specified
         // encoding; the latter is more picky and will throw an exception.
-        // See: https://issues.jenkins-ci.org/browse/JENKINS-49060?focusedCommentId=325989&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-325989
+        // See: https://issues.jenkins.io/browse/JENKINS-49060?focusedCommentId=325989&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-325989
         try {
             return FileUtils.readFileToString(logfile, charset);
         } catch (FileNotFoundException e) {
@@ -418,7 +418,7 @@ public class Util {
         // by default, the permissions of the created directory are 0700&(~umask)
         // whereas the old approach created a temporary directory with permissions
         // 0777&(~umask).
-        // To avoid permissions problems like https://issues.jenkins-ci.org/browse/JENKINS-48407
+        // To avoid permissions problems like https://issues.jenkins.io/browse/JENKINS-48407
         // we can pass POSIX file permissions as an attribute (see, for example,
         // https://github.com/jenkinsci/jenkins/pull/3161 )
         final Path tempPath;

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -124,7 +124,7 @@ public class WebAppMain implements ServletContextListener {
      * Exposes access from RingBufferLogHandler.DEFAULT_RING_BUFFER_SIZE to WebAppMain.
      * Written for the requirements of JENKINS-50669
      * @return int This returns DEFAULT_RING_BUFFER_SIZE
-     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-50669">JENKINS-50669</a>
+     * @see <a href="https://issues.jenkins.io/browse/JENKINS-50669">JENKINS-50669</a>
      * @since 2.259
      */
     public static int getDefaultRingBufferSize() {

--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -194,7 +194,7 @@ public class FileParameterValue extends ParameterValue {
 
 	/**
 	 * Compares file parameters (existing files will be considered as different).
-	 * @since 1.586 Function has been modified in order to avoid <a href="https://jenkins-ci.org/issue/19017">JENKINS-19017</a> issue (wrong merge of builds in the queue).
+	 * @since 1.586 Function has been modified in order to avoid <a href="https://issues.jenkins.io/browse/JENKINS-19017">JENKINS-19017</a> issue (wrong merge of builds in the queue).
 	 */
 	@Override
 	public boolean equals(Object obj) {

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1257,7 +1257,7 @@ public class Fingerprint implements ModelObject, Saveable {
         FingerprintStorage fileFingerprintStorage = FingerprintStorage.getFileFingerprintStorage();
 
         // Implementations are expected to invoke SaveableListener on their own if relevant
-        // TODO: Consider improving Saveable Listener API: https://issues.jenkins-ci.org/browse/JENKINS-62543
+        // TODO: Consider improving Saveable Listener API: https://issues.jenkins.io/browse/JENKINS-62543
         configuredFingerprintStorage.save(this);
 
         // In the case that external fingerprint storage is configured, there may be some fingerprints in memory that

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -98,7 +98,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
 
     private static final Logger LOGGER = Logger.getLogger(Node.class.getName());
 
-    /** @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-46652">JENKINS-46652</a> */
+    /** @see <a href="https://issues.jenkins.io/browse/JENKINS-46652">JENKINS-46652</a> */
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     public static /* not final */ boolean SKIP_BUILD_CHECK_ON_FLYWEIGHTS = SystemProperties.getBoolean(Node.class.getName() + ".SKIP_BUILD_CHECK_ON_FLYWEIGHTS", true);
 

--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -111,7 +111,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
      * The additional safe parameters should be only those considered safe to override the environment
      * and what is declared in the project config in addition to those specified by the user in
      * {@link #SAFE_PARAMETERS_SYSTEM_PROPERTY_NAME}.
-     * See <a href="https://issues.jenkins-ci.org/browse/SECURITY-170">SECURITY-170</a>
+     * See <a href="https://issues.jenkins.io/browse/SECURITY-170">SECURITY-170</a>
      *
      * @param parameters the parameters
      * @param additionalSafeParameters additional safe parameters

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1683,8 +1683,8 @@ public class Queue extends ResourceController implements Saveable {
                     // of getCauseOfBlockageForItem(p) will become a bottleneck before updateSnapshot() will. Additionally
                     // since the snapshot itself only ever has at most one reference originating outside of the stack
                     // it should remain in the eden space and thus be cheap to GC.
-                    // See https://jenkins-ci.org/issue/27708?focusedCommentId=225819&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-225819
-                    // or https://jenkins-ci.org/issue/27708?focusedCommentId=225906&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-225906
+                    // See https://issues.jenkins.io/browse/JENKINS-27708?focusedCommentId=225819&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-225819
+                    // or https://issues.jenkins.io/browse/JENKINS-27708?focusedCommentId=225906&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-225906
                     // for alternative fixes of this issue.
                     updateSnapshot();
                 }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1613,7 +1613,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      */
     public void delete() throws IOException {
         synchronized (this) {
-            // Avoid concurrent delete. See https://issues.jenkins-ci.org/browse/JENKINS-61687
+            // Avoid concurrent delete. See https://issues.jenkins.io/browse/JENKINS-61687
             if (isPendingDelete) {
                 return;
             }

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -139,7 +139,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      * Unfortunately this infringed some legitimate use cases of creating Jenkins-local users for
      * automation purposes. This escape hatch switch can be enabled to resurrect that behaviour.
      * <p>
-     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-22346">JENKINS-22346</a>.
+     * @see <a href="https://issues.jenkins.io/browse/JENKINS-22346">JENKINS-22346</a>.
      */
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     public static boolean ALLOW_NON_EXISTENT_USER_TO_LOGIN = SystemProperties.getBoolean(User.class.getName() + ".allowNonExistentUserToLogin");

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -267,7 +267,7 @@ public class JNLPLauncher extends ComputerLauncher {
      * This enables using a private address for inbound tcp agents,
      * separate from Jenkins root URL.
      *
-     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-63222">JENKINS-63222</a>
+     * @see <a href="https://issues.jenkins.io/browse/JENKINS-63222">JENKINS-63222</a>
      */
     @Restricted(NoExternalUse.class)
     public static String getInboundAgentUrl() {

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -244,7 +244,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      *
      * @param original Resolution will be delegated to this resolver. Resolved
      *                 values will be escaped afterwards.
-     * @see <a href="https://jenkins-ci.org/issue/10539">JENKINS-10539</a>
+     * @see <a href="https://issues.jenkins.io/browse/JENKINS-10539">JENKINS-10539</a>
      */
     private static VariableResolver<String> propertiesGeneratingResolver(final VariableResolver<String> original) {
 

--- a/core/src/main/java/hudson/util/ClassLoaderSanityThreadFactory.java
+++ b/core/src/main/java/hudson/util/ClassLoaderSanityThreadFactory.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit;
  *   in a context where they would receive a customized {@link Thread#contextClassLoader} that was never meant to be used.
  *
  *  Commonly this is a problem for Groovy use, where this may result in memory leaks.
- *  @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-49206">JENKINS-49206</a>
+ *  @see <a href="https://issues.jenkins.io/browse/JENKINS-49206">JENKINS-49206</a>
  * @since 2.105
  */
 public class ClassLoaderSanityThreadFactory implements ThreadFactory {

--- a/core/src/main/java/hudson/util/FileChannelWriter.java
+++ b/core/src/main/java/hudson/util/FileChannelWriter.java
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
  * <p>The goal using this is to reduce as much as we can the likeliness to see zero-length files be created in place
  * of the original ones.</p>
  *
- * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-34855">JENKINS-34855</a>
+ * @see <a href="https://issues.jenkins.io/browse/JENKINS-34855">JENKINS-34855</a>
  * @see <a href="https://github.com/jenkinsci/jenkins/pull/2548">PR-2548</a>
  */
 @Restricted(NoExternalUse.class)

--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -56,7 +56,7 @@ public class RingBufferLogHandler extends Handler {
 
     /**
      * @return int DEFAULT_RING_BUFFER_SIZE
-     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-50669">JENKINS-50669</a>
+     * @see <a href="https://issues.jenkins.io/browse/JENKINS-50669">JENKINS-50669</a>
      * @since 2.259
      */
     public static int getDefaultRingBufferSize() {

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -145,7 +145,7 @@ public class XStream2 extends XStream {
      * @param nullOut whether to perform this special behavior;
      *                false to use the stock XStream behavior of leaving unmentioned {@code root} fields untouched
      * @see XmlFile#unmarshalNullingOut
-     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-21017">JENKINS-21017</a>
+     * @see <a href="https://issues.jenkins.io/browse/JENKINS-21017">JENKINS-21017</a>
      * @since 2.99
      */
     public Object unmarshal(HierarchicalStreamReader reader, Object root, DataHolder dataHolder, boolean nullOut) {

--- a/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
+++ b/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
@@ -136,7 +136,7 @@ public class FileFingerprintStorage extends FingerprintStorage {
             save(fp, file);
         }
         // TODO(oleg_nenashev): Consider generalizing SaveableListener and invoking it for all storage implementations.
-        //  https://issues.jenkins-ci.org/browse/JENKINS-62543
+        //  https://issues.jenkins.io/browse/JENKINS-62543
         SaveableListener.fireOnChange(fp, getConfigFile(file));
     }
 
@@ -164,7 +164,7 @@ public class FileFingerprintStorage extends FingerprintStorage {
                     w.println("</number>");
                     w.println("  </original>");
                 }
-                // TODO(oleg_nenashev): Consider renaming the field: https://issues.jenkins-ci.org/browse/JENKINS-25808
+                // TODO(oleg_nenashev): Consider renaming the field: https://issues.jenkins.io/browse/JENKINS-25808
                 w.print("  <md5sum>");
                 w.print(fp.getHashString());
                 w.println("</md5sum>");

--- a/core/src/main/java/jenkins/model/item_category/ItemCategory.java
+++ b/core/src/main/java/jenkins/model/item_category/ItemCategory.java
@@ -45,7 +45,7 @@ public abstract class ItemCategory implements ExtensionPoint {
      * This field indicates how much non-default categories are required in
      * order to start showing them in Jenkins.
      * This field is restricted for the internal use only, because all other changes would cause binary compatibility issues.
-     * See <a href="https://jenkins-ci.org/issue/36593">JENKINS-36593</a> for more info.
+     * See <a href="https://issues.jenkins.io/browse/JENKINS-36593">JENKINS-36593</a> for more info.
      */
     @Restricted(NoExternalUse.class)
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -1,7 +1,7 @@
 com.google.common.collect.AbstractListMultimap
 com.google.common.collect.AbstractMultimap
 com.google.common.collect.AbstractSetMultimap
-# Artifactory - https://issues.jenkins-ci.org/browse/JENKINS-48991
+# Artifactory - https://issues.jenkins.io/browse/JENKINS-48991
 com.google.common.collect.ArrayListMultimap
 com.google.common.collect.EmptyImmutableList
 com.google.common.collect.EmptyImmutableSet
@@ -16,7 +16,7 @@ com.google.common.collect.ImmutableMap
 com.google.common.collect.ImmutableSet
 com.google.common.collect.ImmutableSet$SerializedForm
 com.google.common.collect.ImmutableSortedSet
-# https://issues.jenkins-ci.org/browse/JENKINS-48989
+# https://issues.jenkins.io/browse/JENKINS-48989
 com.google.common.collect.Maps$TransformedEntriesMap
 # https://github.com/jenkinsci/sonar-gerrit-plugin
 com.google.common.collect.Multimap

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -169,7 +169,7 @@ Code reviews do NOT pursue the following goals:
 
 == Issue triage
 
-Jenkins core and most of its components use link:https://issues.jenkins-ci.org/[Jenkins Jira] as an issue tracker.
+Jenkins core and most of its components use link:https://issues.jenkins.io/[Jenkins Jira] as an issue tracker.
 This issue tracker is open to all Jenkins users.
 They report defects and requests for enhancements,
 and then component maintainers triage issues and provide feedback to users.
@@ -180,7 +180,7 @@ This section provides some tips and tricks about triaging issues submitted to th
 
 === Issue tracker structure
 
-Jenkins core uses the link:https://issues.jenkins-ci.org/projects/JENKINS[JENKINS] project for issue tracking.
+Jenkins core uses the link:https://issues.jenkins.io/projects/JENKINS[JENKINS] project for issue tracking.
 This project is shared between the Jenkins core components and plugins,
 and the Jenkins core is scattered across multiple components: `core`, `remoting`, `cli`, `winstone-jetty`, etc.
 In addition to it, there is a default `_unsorted` component which is recommended by default for users
@@ -194,9 +194,9 @@ Searching for all Jenkins core issues is not trivial, and we provide Jira filter
   and link:https://www.jenkins.io/changelog-stable/[LTS] releases.
   Such ratings allow users to reference issues they experienced with new Jenkins core releases,
   and it helps to discover regressions in the core causing instability or unexpected plugin failures.
-* link:https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=20742[Jenkins core triage board] -
+* link:https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=20742[Jenkins core triage board] -
   Lists untriaged and recent issues in the Jenkins core and bundled components.
-* link:https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=20340[Core maintainers board] -
+* link:https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=20340[Core maintainers board] -
   Lists unresolved recent regressions, unresolved recent core bugs, and popular new issues.
   This dashboard can be used to discover issues that **might** be related to the recent changes in the Jenkins core.
 
@@ -339,7 +339,7 @@ Merge process can be initiated once a pull request matches the requirements:
   (link:https://github.com/jenkinsci/jenkins/pull/4387[example]).
   This is usually the case when a data migration occurs, a feature has been removed, a significant behavior change is introduced (including when there is a way to opt out),
   or in general when we expect at least a large minority of admins to benefit from knowing about the change, e.g. to apply a new option.
-* If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see link:https://issues.jenkins-ci.org/issues/?filter=12146[this Jira query]).
+* If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see link:https://issues.jenkins.io/issues/?filter=12146[this Jira query]).
 
 ==== Step 2: Is it a good time to merge?
 
@@ -430,7 +430,7 @@ Any Jenkins contributors are welcome to participate in backporting and release c
 
 == Tools
 
-* link:https://issues.jenkins-ci.org/secure/Dashboard.jspa?selectPageId=20340[Core maintainers board] -
+* link:https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=20340[Core maintainers board] -
   Lists unresolved recent regressions, unresolved recent core bugs, and popular new issues.
 * link:https://github.com/jenkinsci/core-pr-tester[Core Pull Request Tester]
 * link:https://github.com/jenkinsci/core-changelog-generator[Core Changelog Generator]

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ THE SOFTWARE.
 
   <issueManagement>
     <system>jira</system>
-    <url>https://issues.jenkins-ci.org/browse/JENKINS/component/15593</url>
+    <url>https://issues.jenkins.io/browse/JENKINS/component/15593</url>
   </issueManagement>
 
   <properties>
@@ -770,7 +770,7 @@ THE SOFTWARE.
     <profile>
       <id>jdk11</id>
       <properties>
-        <!-- TODO: https://issues.jenkins-ci.org/browse/JENKINS-53788 (JDK11 issue on CI) -->
+        <!-- TODO: https://issues.jenkins.io/browse/JENKINS-53788 (JDK11 issue on CI) -->
         <doclint>none</doclint>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <!-- release is needed for reliable cross compilation. It is supported

--- a/war/src/main/webapp/WEB-INF/ibm-web-bnd.xmi
+++ b/war/src/main/webapp/WEB-INF/ibm-web-bnd.xmi
@@ -29,7 +29,7 @@ able to use WebSphere's provided deployment script as-is.
 E.g., on WAS 7.0 and using jython:
 AdminApplication.installWarFile('hudson','/blabla/hudson.war','localhostNode01','server1','hudson')
 
-See https://jenkins-ci.org/issue/3270
+See https://issues.jenkins.io/browse/JENKINS-3270
 -->
 <webappbnd:WebAppBinding
   xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"

--- a/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <!--
   Sun One Java Application Server and Glassfish (as of 2007/4) makes
   old Ant classes visible to the web application classloader, and
-  that causes https://jenkins-ci.org/issue/458
+  that causes https://issues.jenkins.io/browse/JENKINS-458
 
   So change the delegation order to make sure we pick up Ant from
   Hudson. See http://docs.sun.com/app/docs/doc/819-2634/6n4tl5kp3?a=view#abxhy

--- a/war/src/main/webapp/scripts/yui/button/button-debug.js
+++ b/war/src/main/webapp/scripts/yui/button/button-debug.js
@@ -2750,7 +2750,7 @@ version: 2.9.0
                     https://bugzilla.mozilla.org/show_bug.cgi?id=1370630
                     In the mean time, we should not make a redundant call to "submit",
                     because it leads to the form being submitted twice in some cases:
-                    https://issues.jenkins-ci.org/browse/JENKINS-58296
+                    https://issues.jenkins.io/browse/JENKINS-58296
                     TODO: once we know the exact Firefox version which will change this
                     behavior, we should add a "UA.gecko >= XX" condition and call "submit".
                 */


### PR DESCRIPTION
`issues.jenkins-ci.org` seems to be redirecting to `issues.jenkins.io`, but links in the source code were never updated.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
