### PR TITLE
Adding `@deprecated` messages for `Fingerprinter.recordBuildArtifacts`

### DIFF
--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -124,6 +124,9 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
         this.caseSensitive = caseSensitive;
     }
 
+    /**
+     * @deprecated use {@link #Fingerprinter(String)} and {@link ArtifactArchiver#setFingerprint}
+     */
     @Deprecated
     public Fingerprinter(String targets, boolean recordBuildArtifacts) {
         this(targets);
@@ -160,6 +163,9 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
         return this;
     }
 
+    /**
+     * @deprecated use {@link ArtifactArchiver#isFingerprint}
+     */
     @Deprecated
     public boolean getRecordBuildArtifacts() {
         return recordBuildArtifacts != null && recordBuildArtifacts;


### PR DESCRIPTION
I neglected to do this long ago in f43a450c31d3875e72defa8400c6ada43bfc3ad0 it seems, and today was unable to recall why it was deprecated!

### Proposed changelog entries

* N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
