### PR TITLE
Introduce `Queue.Executable.getParentExecutable`

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2084,6 +2084,7 @@ public class Queue extends ResourceController implements Saveable {
          * If {@link #getParent} has a distinct {@link SubTask#getOwnerTask},
          * then it should be the case that {@code getParentExecutable().getParent() == getParent().getOwnerTask()}.
          * @return a <em>distinct</em> executable (never {@code this}, unlike the default of {@link SubTask#getOwnerTask}!); or null if this executable was already at top level
+         * @since TODO, but implementations can already implement this with a lower core dependency.
          */
         default @CheckForNull Executable getParentExecutable() {
             return null;

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2080,6 +2080,16 @@ public class Queue extends ResourceController implements Saveable {
         @NonNull SubTask getParent();
 
         /**
+         * An umbrella executable (such as a {@link Run}) of which this is one part.
+         * If {@link #getParent} has a distinct {@link SubTask#getOwnerTask},
+         * then it should be the case that {@code getParentExecutable().getParent() == getParent().getOwnerTask()}.
+         * @return a <em>distinct</em> executable (unlike the default of {@link SubTask#getOwnerTask}!); or null if this executable was already at top level
+         */
+        default @CheckForNull Executable getParentExecutable() {
+            return null;
+        }
+
+        /**
          * Called by {@link Executor} to perform the task.
          * @throws AsynchronousExecution if you would like to continue without consuming a thread
          */

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2083,7 +2083,7 @@ public class Queue extends ResourceController implements Saveable {
          * An umbrella executable (such as a {@link Run}) of which this is one part.
          * If {@link #getParent} has a distinct {@link SubTask#getOwnerTask},
          * then it should be the case that {@code getParentExecutable().getParent() == getParent().getOwnerTask()}.
-         * @return a <em>distinct</em> executable (unlike the default of {@link SubTask#getOwnerTask}!); or null if this executable was already at top level
+         * @return a <em>distinct</em> executable (never {@code this}, unlike the default of {@link SubTask#getOwnerTask}!); or null if this executable was already at top level
          */
         default @CheckForNull Executable getParentExecutable() {
             return null;


### PR DESCRIPTION
Addresses a longstanding API gap affecting interactions with Pipeline `node` blocks: while you could go from a `PlaceholderTask` to the `WorkflowJob`, and from the `PlaceholderExecutable` to the `PlaceholderTask`, there was no reliable way to find the `WorkflowRun`. https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/170 is the implementation.

### Proposed changelog entries

* N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
