### PR TITLE
Exclude two generated classes from spotbugs

### DIFF
--- a/src/findbugs/findbugs-excludes.xml
+++ b/src/findbugs/findbugs-excludes.xml
@@ -23,4 +23,11 @@
     <!--Jenkins handles this issue differently or doesn't care about it.-->
     <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
   </Match>
+  <Match>
+    <Bug pattern="NM_METHOD_NAMING_CONVENTION"/>
+    <Or>
+      <Class name="hudson.tasks.Messages"/>
+      <Class name="hudson.tools.Messages"/>
+    </Or>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Exclude two generated classes from spotbugs to fix errors reported in `Medium` scanning. It reports this for example:

```
public static String CannotBeInstalled(Object arg0, Object arg1, Object arg2) {
        return holder.format("CannotBeInstalled", arg0, arg1, arg2);
}
```
spotbugs reports: 

> Method names should start with a lower case letter
> Methods should be verbs, in mixed case with the first letter lowercase, with the first letter of each internal word capitalized.
> Bug kind and pattern: Nm - NM_METHOD_NAMING_CONVENTION

So I set them to ignore, better might be to rename the methods, but I did not find a way to generate it with a lower case.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
