### PR TITLE
Lower 'reasonable' number of icons (fix master build)

### DIFF
--- a/core/src/test/java/org/jenkins/ui/icon/IconSetTest.java
+++ b/core/src/test/java/org/jenkins/ui/icon/IconSetTest.java
@@ -14,6 +14,6 @@ public class IconSetTest {
     @Test
     void testIconSetSize() {
         final Map<String, Icon> coreIcons = IconSet.icons.getCoreIcons();
-        assertThat("icons", coreIcons.size(), greaterThanOrEqualTo(371));
+        assertThat("icons", coreIcons.size(), greaterThanOrEqualTo(350));
     }
 }


### PR DESCRIPTION
Test is failing, I think count was lowered in https://github.com/jenkinsci/jenkins/pull/5692

But PRs were batch merged and test failure wasn't caught

https://github.com/jenkinsci/jenkins/pull/5746/checks?check_run_id=3728152427 https://github.com/jenkinsci/jenkins/runs/3728231092