### PR TITLE
[JENKINS-66758] Add localization support for JDK label

### DIFF
--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -174,7 +174,7 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
 
         @Override
         public String getDisplayName() {
-            return Messages.Hudson_JdkDisplayName();
+            return Messages.JDK_DisplayName();
         }
 
         @Override

--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -174,7 +174,7 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
 
         @Override
         public String getDisplayName() {
-            return "JDK"; // TODO I18N
+            return Messages.Hudson_JdkDisplayName();
         }
 
         @Override

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -129,6 +129,7 @@ Hudson.Computer.Caption=Built-In Node
 Hudson.Computer.DisplayName=Built-In Node
 Hudson.ControlCodeNotAllowed=No control code is allowed: {0}
 Hudson.DisplayName=Jenkins
+Hudson.JdkDisplayName=JDK
 Hudson.JobAlreadyExists=A job already exists with the name \u2018{0}\u2019
 Hudson.NoJavaInPath=java is not in your PATH. Maybe you need to <a href="{0}/configure">configure JDKs</a>?
 Hudson.NoName=No name is specified

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -129,7 +129,6 @@ Hudson.Computer.Caption=Built-In Node
 Hudson.Computer.DisplayName=Built-In Node
 Hudson.ControlCodeNotAllowed=No control code is allowed: {0}
 Hudson.DisplayName=Jenkins
-Hudson.JdkDisplayName=JDK
 Hudson.JobAlreadyExists=A job already exists with the name \u2018{0}\u2019
 Hudson.NoJavaInPath=java is not in your PATH. Maybe you need to <a href="{0}/configure">configure JDKs</a>?
 Hudson.NoName=No name is specified
@@ -178,6 +177,7 @@ Item.CONFIGURE.description=Change the configuration of a job.
 Item.READ.description=See a job. (You may deny this permission but allow Discover to force an anonymous user to log in to see the job.)
 Item.RENAME.description=Rename a job.
 ItemGroupMixIn.may_not_copy_as_it_contains_secrets_and_=May not copy {0} as it contains secrets and {1} has {2}/{3} but not /{4}
+JDK.DisplayName=JDK
 Job.AllRecentBuildFailed=All recent builds failed.
 Job.BuildStability=Build stability: {0}
 Job.NOfMFailed={0} out of the last {1} builds failed.


### PR DESCRIPTION
See [JENKINS-66758](https://issues.jenkins-ci.org/browse/JENKINS-66758).

The label for JDK in 'Manage Jenkins' -> 'Global Tool Configuration' was not localised properly and was marked as Todo in code. 
This is my first commit as contributor so I also learn processes, thanks in advance.
No tests was added because the fix solves localization todo-issue.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs


### Desired reviewers

@daniel-beck @Wadeck 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
