### PR TITLE
[JENKINS-66753] Ongoing build disappears from build history

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -87,14 +87,11 @@ THE SOFTWARE.
       </tr>
 
       <st:include page="entries.jelly" it="${page}" />
+
+      <!--The value for `page-next-build` is modified inside of `entries.jelly` on render, so set the attribute-->
+      <!--after that component has been rendered to get the correct value to use in `filter-build-history.js`-->
+      <div id="properties" page-next-build="${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}"/>
     </l:pane>
   </div>
-
-  <script defer="true">
-    // The value for `page-next-build` is modified inside of `entries.jelly` on render, so set the attribute
-    // on element `#buildHistoryPage` after that component has been rendered to get
-    // the correct value to use in `filter-build-history.js`
-    document.getElementById("buildHistoryPage").setAttribute("page-next-build", "${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}");
-  </script>
   <script src="${resURL}/jsbundles/filter-build-history.js" type="text/javascript"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
   </j:parse>
 
   <j:set var="page" value="${it.historyPageFilter}" />
-  <div id="buildHistoryPage" page-ajax="${it.baseUrl}/buildHistory/ajax" page-next-build="${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}" page-entry-newest="${page.newestOnPage}" page-entry-oldest="${page.oldestOnPage}" page-has-up="${page.hasUpPage}" page-has-down="${page.hasDownPage}">
+  <div id="buildHistoryPage" page-ajax="${it.baseUrl}/buildHistory/ajax" page-next-build="${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber - 1}" page-entry-newest="${page.newestOnPage}" page-entry-oldest="${page.oldestOnPage}" page-has-up="${page.hasUpPage}" page-has-down="${page.hasDownPage}">
     <div id="buildHistoryPageNav">
       <div class="buildHistoryPageNav__item buildHistoryPageNav__item--page-one pageOne" title="Page 1 (Newest/Latest Builds)">
         <div class="buildHistoryPageNav__item-page-one-top"></div>

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
   </j:parse>
 
   <j:set var="page" value="${it.historyPageFilter}" />
-  <div id="buildHistoryPage" page-ajax="${it.baseUrl}/buildHistory/ajax" page-next-build="${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber - 1}" page-entry-newest="${page.newestOnPage}" page-entry-oldest="${page.oldestOnPage}" page-has-up="${page.hasUpPage}" page-has-down="${page.hasDownPage}">
+  <div id="buildHistoryPage" page-ajax="${it.baseUrl}/buildHistory/ajax" page-entry-newest="${page.newestOnPage}" page-entry-oldest="${page.oldestOnPage}" page-has-up="${page.hasUpPage}" page-has-down="${page.hasDownPage}">
     <div id="buildHistoryPageNav">
       <div class="buildHistoryPageNav__item buildHistoryPageNav__item--page-one pageOne" title="Page 1 (Newest/Latest Builds)">
         <div class="buildHistoryPageNav__item-page-one-top"></div>
@@ -90,5 +90,10 @@ THE SOFTWARE.
     </l:pane>
   </div>
 
+  <script defer="true">
+    // The value for `page-next-build` is modified inside of `entries.jelly` on render, so set the attribute
+    // on `buildHistoryPage` after that component has been rendered to get the correct value for `filter-build-history.js`
+    document.getElementById("buildHistoryPage").setAttribute("page-next-build", "${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}");
+  </script>
   <script src="${resURL}/jsbundles/filter-build-history.js" type="text/javascript"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -92,7 +92,8 @@ THE SOFTWARE.
 
   <script defer="true">
     // The value for `page-next-build` is modified inside of `entries.jelly` on render, so set the attribute
-    // on `buildHistoryPage` after that component has been rendered to get the correct value for `filter-build-history.js`
+    // on element `#buildHistoryPage` after that component has been rendered to get
+    // the correct value to use in `filter-build-history.js`
     document.getElementById("buildHistoryPage").setAttribute("page-next-build", "${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}");
   </script>
   <script src="${resURL}/jsbundles/filter-build-history.js" type="text/javascript"/>

--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -34,12 +34,7 @@ function updateBuilds() {
                 while (rows.length > 0 && rows[firstBuildRow].classList.contains('transitive')) {
                     Element.remove(rows[firstBuildRow]);
                 }
-
-                console.log("Extraordinary man")
-                console.log(rsp.responseText)
-                console.log(buildHistoryContainer.headers)
-                console.log(rsp.getResponseHeader("n"))
-
+                
                 // insert new rows
                 var div = document.createElement('div');
                 div.innerHTML = rsp.responseText;

--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -4,8 +4,9 @@ const buildHistoryContainer = document.getElementById("buildHistory")
 const pageSearchInputContainer = document.getElementsBySelector('#buildHistory .build-search-row .jenkins-search')[0]
 const pageSearchInput = document.getElementsBySelector('#buildHistory .build-search-row input')[0]
 const buildHistoryPage = document.getElementById("buildHistoryPage")
+const properties = document.getElementById("properties")
 const ajaxUrl = buildHistoryPage.getAttribute("page-ajax")
-const nextBuild = buildHistoryPage.getAttribute("page-next-build")
+const nextBuild = properties.getAttribute("page-next-build")
 const noBuildsBanner = document.getElementById("no-builds")
 
 const sidePanel = $('side-panel');

--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -34,7 +34,7 @@ function updateBuilds() {
                 while (rows.length > 0 && rows[firstBuildRow].classList.contains('transitive')) {
                     Element.remove(rows[firstBuildRow]);
                 }
-                
+
                 // insert new rows
                 var div = document.createElement('div');
                 div.innerHTML = rsp.responseText;

--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -35,6 +35,11 @@ function updateBuilds() {
                     Element.remove(rows[firstBuildRow]);
                 }
 
+                console.log("Extraordinary man")
+                console.log(rsp.responseText)
+                console.log(buildHistoryContainer.headers)
+                console.log(rsp.getResponseHeader("n"))
+
                 // insert new rows
                 var div = document.createElement('div');
                 div.innerHTML = rsp.responseText;
@@ -59,7 +64,7 @@ function updateBuilds() {
                 }
 
                 // next update
-                buildHistoryContainer.headers = ["n",rsp.getResponseHeader("n")];
+                buildHistoryContainer.headers = ["n", rsp.getResponseHeader("n")];
                 checkAllRowCellOverflows();
                 createRefreshTimeout();
             }
@@ -399,9 +404,6 @@ function loadPage(params, focusOnSearch) {
         onSuccess: function(rsp) {
             pageSearchInputContainer.classList.remove("jenkins-search--loading");
             buildHistoryContainer.classList.remove("jenkins-pane--loading");
-
-            console.log(rsp.responseText)
-            console.log(rsp.responseText === "<table class=\"pane\"></table>")
 
             if (rsp.responseText === "<table class=\"pane\"></table>") {
                 noBuildsBanner.style.display = "block"


### PR DESCRIPTION
See JENKINS-66753

### Proposed changelog entries

* Display ongoing build in build history (regression in 2.314).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).

