### PR TITLE
Removed superflous throws

### DIFF
--- a/test/src/test/java/hudson/CustomPluginManagerTest.java
+++ b/test/src/test/java/hudson/CustomPluginManagerTest.java
@@ -58,7 +58,7 @@ public class CustomPluginManagerTest {
             private String oldValue;
 
             @Override
-            public void setup(JenkinsRule jenkinsRule, WithCustomLocalPluginManager recipe) throws Exception {
+            public void setup(JenkinsRule jenkinsRule, WithCustomLocalPluginManager recipe) {
                 jenkinsRule.useLocalPluginManager = true;
                 oldValue = System.getProperty(PluginManager.CUSTOM_PLUGIN_MANAGER);
                 System.setProperty(PluginManager.CUSTOM_PLUGIN_MANAGER, recipe.value().getName());

--- a/test/src/test/java/hudson/ExtensionListTest.java
+++ b/test/src/test/java/hudson/ExtensionListTest.java
@@ -46,7 +46,7 @@ public class ExtensionListTest {
 
 
     @Test
-    public void autoDiscovery() throws Exception {
+    public void autoDiscovery() {
         ExtensionList<Animal> list = ExtensionList.lookup(Animal.class);
         assertEquals(2,list.size());
         assertNotNull(list.get(Dog.class));
@@ -55,14 +55,14 @@ public class ExtensionListTest {
 
     @Test
     @WithoutJenkins
-    public void nullJenkinsInstance() throws Exception {
+    public void nullJenkinsInstance() {
         ExtensionList<Animal> list = ExtensionList.lookup(Animal.class);
         assertEquals(0, list.size());
         assertFalse(list.iterator().hasNext());
     }
 
     @Test
-    public void extensionListView() throws Exception {
+    public void extensionListView() {
         // this is how legacy list like UserNameResolver.LIST gets created.
         List<Animal> LIST = ExtensionListView.createList(Animal.class);
 
@@ -117,7 +117,7 @@ public class ExtensionListTest {
      * Verifies that the automated {@link Descriptor} lookup works.
      */
     @Test
-    public void descriptorLookup() throws Exception {
+    public void descriptorLookup() {
         Descriptor<Fish> d = new Sishamo().getDescriptor();
 
         DescriptorExtensionList<Fish,Descriptor<Fish>> list = j.jenkins.getDescriptorList(Fish.class);
@@ -127,7 +127,7 @@ public class ExtensionListTest {
     }
 
     @Test
-    public void fishDiscovery() throws Exception {
+    public void fishDiscovery() {
         // imagine that this is a static instance, like it is in many LIST static field in Hudson.
         DescriptorList<Fish> LIST = new DescriptorList<>(Fish.class);
 
@@ -156,7 +156,7 @@ public class ExtensionListTest {
     }
 
     @Test
-    public void legacyDescriptorList() throws Exception {
+    public void legacyDescriptorList() {
         // created in a legacy fashion without any tie to ExtensionList
         DescriptorList<Fish> LIST = new DescriptorList<>();
 

--- a/test/src/test/java/hudson/LauncherTest.java
+++ b/test/src/test/java/hudson/LauncherTest.java
@@ -254,7 +254,7 @@ public class LauncherTest {
     }
     @FunctionalInterface
     private interface ProcStarterCustomizer {
-        void run(Launcher.ProcStarter ps, OutputStream os1, OutputStream os2, TaskListener os2Listener) throws Exception;
+        void run(Launcher.ProcStarter ps, OutputStream os1, OutputStream os2, TaskListener os2Listener);
     }
     private void assertMultipleStdioCalls(String message, Node node, boolean emitStderr, ProcStarterCustomizer psCustomizer, boolean outputIn2) throws Exception {
         message = node.getDisplayName() + ": " + message;

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -512,7 +512,7 @@ public class PluginManagerTest {
     @Issue("JENKINS-44898")
     @WithPlugin("plugin-first.hpi")
     @Test
-    public void findResourceForPluginFirstClassLoader() throws Exception {
+    public void findResourceForPluginFirstClassLoader() {
         PluginWrapper w = r.jenkins.getPluginManager().getPlugin("plugin-first");
         assertNotNull(w);
 

--- a/test/src/test/java/hudson/ProcStarterTest.java
+++ b/test/src/test/java/hudson/ProcStarterTest.java
@@ -120,7 +120,7 @@ public class ProcStarterTest {
     public static class DecoratedWrapper extends BuildWrapper {
 
         @Override
-        public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
+        public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws Run.RunnerAbortedException {
             final BuildListener l = listener;
             return new DecoratedLauncher(launcher) {
                 @Override
@@ -133,7 +133,7 @@ public class ProcStarterTest {
         }
 
         @Override
-        public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
+        public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) {
             return new Environment() {
             };
         }

--- a/test/src/test/java/hudson/bugs/DateConversionTest.java
+++ b/test/src/test/java/hudson/bugs/DateConversionTest.java
@@ -51,7 +51,7 @@ public class DateConversionTest {
         for(int i=0;i<10;i++) {
             futures.add(es.submit(new Callable<Object>() {
                 @Override
-                public Object call() throws Exception {
+                public Object call() {
                     for( int i=0; i<10000; i++ )
                         dc.fromString("2008-08-26 15:40:14.568 GMT-03:00");
                     return null;

--- a/test/src/test/java/hudson/cli/BuildCommandTest.java
+++ b/test/src/test/java/hudson/cli/BuildCommandTest.java
@@ -96,7 +96,7 @@ public class BuildCommandTest {
         OneShotEvent completed = new OneShotEvent();
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                 started.signal();
                 completed.block();
                 return true;

--- a/test/src/test/java/hudson/cli/CLITest.java
+++ b/test/src/test/java/hudson/cli/CLITest.java
@@ -236,7 +236,7 @@ public class CLITest {
             // Custom written redirect so no traces of Jenkins are present in headers
             return new HttpResponses.HttpResponseException() {
                 @Override
-                public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
+                public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException {
                     rsp.setHeader("Location", url);
                     rsp.setContentType("text/html");
                     rsp.setStatus(HttpURLConnection.HTTP_MOVED_TEMP);

--- a/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
@@ -59,7 +59,7 @@ public class CancelQuietDownCommandTest {
     }
 
     @Test
-    public void cancelQuietDownShouldFailWithoutAdministerPermission() throws Exception {
+    public void cancelQuietDownShouldFailWithoutAdministerPermission() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ)
                 .invoke();
@@ -69,7 +69,7 @@ public class CancelQuietDownCommandTest {
     }
 
     @Test
-    public void cancelQuietDownShouldSuccessOnNoQuietDownedJenkins() throws Exception {
+    public void cancelQuietDownShouldSuccessOnNoQuietDownedJenkins() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
                 .invoke();
@@ -78,7 +78,7 @@ public class CancelQuietDownCommandTest {
     }
 
     @Test
-    public void cancelQuietDownShouldSuccessOnQuietDownedJenkins() throws Exception {
+    public void cancelQuietDownShouldSuccessOnQuietDownedJenkins() {
         j.jenkins.doQuietDown();
         QuietDownCommandTest.assertJenkinsInQuietMode(j);
         final CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/ClearQueueCommandTest.java
+++ b/test/src/test/java/hudson/cli/ClearQueueCommandTest.java
@@ -54,7 +54,7 @@ public class ClearQueueCommandTest {
         command = new CLICommandInvoker(j, "clear-queue");
     }
 
-    @Test public void clearQueueShouldFailWithoutAdministerPermission() throws Exception {
+    @Test public void clearQueueShouldFailWithoutAdministerPermission() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ).invoke();
 
@@ -64,7 +64,7 @@ public class ClearQueueCommandTest {
     }
 
     @Test
-    public void clearQueueShouldSucceedOnEmptyQueue() throws Exception {
+    public void clearQueueShouldSucceedOnEmptyQueue() {
         assertThat(j.jenkins.getQueue().isEmpty(), equalTo(true));
 
         final CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConnectNodeCommandTest.java
@@ -65,7 +65,7 @@ public class ConnectNodeCommandTest {
         assertThat(result.stderr(), not(containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT)));
     }
 
-    @Test public void connectNodeShouldFailIfNodeDoesNotExist() throws Exception {
+    @Test public void connectNodeShouldFailIfNodeDoesNotExist() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CONNECT, Jenkins.READ)
                 .invokeWithArgs("never_created");
@@ -172,7 +172,7 @@ public class ConnectNodeCommandTest {
         assertThat(slave2.toComputer().isOnline(), equalTo(true));
     }
 
-    @Test public void connectNodeShouldSucceedOnMaster() throws Exception {
+    @Test public void connectNodeShouldSucceedOnMaster() {
         final Computer masterComputer = j.jenkins.getComputer("");
 
         CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/ConsoleCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConsoleCommandTest.java
@@ -94,7 +94,7 @@ public class ConsoleCommandTest {
         assertThat(result.stdout(), containsString("echo 1"));	
     }
 
-    @Test public void consoleShouldFailWhenProjectDoesNotExist() throws Exception {
+    @Test public void consoleShouldFailWhenProjectDoesNotExist() {
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)

--- a/test/src/test/java/hudson/cli/CreateNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/CreateNodeCommandTest.java
@@ -55,7 +55,7 @@ public class CreateNodeCommandTest {
         command = new CLICommandInvoker(j, new CreateNodeCommand());
     }
 
-    @Test public void createNodeShouldFailWithoutComputerCreatePermission() throws Exception {
+    @Test public void createNodeShouldFailWithoutComputerCreatePermission() {
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ)
@@ -68,7 +68,7 @@ public class CreateNodeCommandTest {
         assertThat(result, failedWith(6));
     }
 
-    @Test public void createNode() throws Exception {
+    @Test public void createNode() {
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CREATE, Jenkins.READ)
@@ -83,7 +83,7 @@ public class CreateNodeCommandTest {
         assertThat(updated.getNumExecutors(), equalTo(42));
     }
 
-    @Test public void createNodeSpecifyingNameExplicitly() throws Exception {
+    @Test public void createNodeSpecifyingNameExplicitly() {
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CREATE, Jenkins.READ)

--- a/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
@@ -81,7 +81,7 @@ public class DeleteBuildsCommandTest {
         assertThat(result.stderr(), containsString("ERROR: user is missing the Run/Delete permission"));
     }
 
-    @Test public void deleteBuildsShouldFailIfJobDoesNotExist() throws Exception {
+    @Test public void deleteBuildsShouldFailIfJobDoesNotExist() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Item.READ, Run.DELETE)
                 .invokeWithArgs("never_created", "1");

--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -71,7 +71,7 @@ public class DisconnectNodeCommandTest {
     }
 
     @Test
-    public void disconnectNodeShouldFailIfNodeDoesNotExist() throws Exception {
+    public void disconnectNodeShouldFailIfNodeDoesNotExist() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("never_created");

--- a/test/src/test/java/hudson/cli/GetNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/GetNodeCommandTest.java
@@ -83,7 +83,7 @@ public class GetNodeCommandTest {
         assertThat(result, succeeded());
     }
 
-    @Test public void getNodeShouldFailIfNodeDoesNotExist() throws Exception {
+    @Test public void getNodeShouldFailIfNodeDoesNotExist() {
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.EXTENDED_READ, Jenkins.READ)
@@ -97,7 +97,7 @@ public class GetNodeCommandTest {
 
     @Issue("SECURITY-281")
     @Test
-    public void getNodeShouldFailForBuiltInNode() throws Exception {
+    public void getNodeShouldFailForBuiltInNode() {
         CLICommandInvoker.Result result = command.authorizedTo(Computer.EXTENDED_READ, Jenkins.READ).invokeWithArgs("");
         assertThat(result.stderr(), containsString("No such node ''"));
         assertThat(result, failedWith(3));

--- a/test/src/test/java/hudson/cli/GroovyshCommandTest.java
+++ b/test/src/test/java/hudson/cli/GroovyshCommandTest.java
@@ -41,7 +41,7 @@ public class GroovyshCommandTest {
     @Rule public JenkinsRule r = new JenkinsRule();
 
     @Issue("JENKINS-17929")
-    @Test public void authentication() throws Exception {
+    @Test public void authentication() {
         CLICommandInvoker.Result result = new CLICommandInvoker(r, new GroovyshCommand())
             .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
             .withStdin(new StringInputStream("println(jenkins.model.Jenkins.instance.getClass().name)\n:quit\n"))

--- a/test/src/test/java/hudson/cli/HelpCommandTest.java
+++ b/test/src/test/java/hudson/cli/HelpCommandTest.java
@@ -137,7 +137,7 @@ public class HelpCommandTest {
         }
 
         @Override
-        protected int run() throws Exception {
+        protected int run() {
             throw new UnsupportedOperationException();
         }
     }

--- a/test/src/test/java/hudson/cli/InstallPluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/InstallPluginCommandTest.java
@@ -40,7 +40,7 @@ public class InstallPluginCommandTest {
 
     @Issue("JENKINS-41745")
     @Test
-    public void fromStdin() throws Exception {
+    public void fromStdin() {
         assertNull(r.jenkins.getPluginManager().getPlugin("token-macro"));
         assertThat(new CLICommandInvoker(r, "install-plugin").
                 withStdin(InstallPluginCommandTest.class.getResourceAsStream("/plugins/token-macro.hpi")).

--- a/test/src/test/java/hudson/cli/ListPluginsCommandTest.java
+++ b/test/src/test/java/hudson/cli/ListPluginsCommandTest.java
@@ -41,7 +41,7 @@ public class ListPluginsCommandTest {
     public JenkinsRule j = new JenkinsRule();
     
     @Test
-    public void listPluginsExpectedUsage() throws Exception {
+    public void listPluginsExpectedUsage() {
         assertNull(j.jenkins.getPluginManager().getPlugin("token-macro"));
         CLICommandInvoker.Result result = new CLICommandInvoker(j, new ListPluginsCommand())
                 .invoke();
@@ -64,7 +64,7 @@ public class ListPluginsCommandTest {
     
     @Test
     @Issue("SECURITY-771")
-    public void onlyAccessibleForAdmin() throws Exception {
+    public void onlyAccessibleForAdmin() {
         CLICommandInvoker.Result result = new CLICommandInvoker(j, new ListPluginsCommand())
                 .authorizedTo(Jenkins.READ)
                 .invoke();

--- a/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
@@ -76,7 +76,7 @@ public class OfflineNodeCommandTest {
     }
 
     @Test
-    public void offlineNodeShouldFailIfNodeDoesNotExist() throws Exception {
+    public void offlineNodeShouldFailIfNodeDoesNotExist() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("never_created");
@@ -451,7 +451,7 @@ public class OfflineNodeCommandTest {
     }
 
     @Test
-    public void offlineNodeShouldSucceedOnMaster() throws Exception {
+    public void offlineNodeShouldSucceedOnMaster() {
         final Computer masterComputer = Jenkins.get().getComputer("");
 
         final CLICommandInvoker.Result result = command
@@ -465,7 +465,7 @@ public class OfflineNodeCommandTest {
     }
 
     @Test
-    public void offlineNodeShouldSucceedOnMasterWithCause() throws Exception {
+    public void offlineNodeShouldSucceedOnMasterWithCause() {
         final Computer masterComputer = Jenkins.get().getComputer("");
 
         final CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
@@ -78,7 +78,7 @@ public class OnlineNodeCommandTest {
         assertThat(result.stderr(), containsString("ERROR: user is missing the Agent/Connect permission"));
     }
 
-    @Test public void onlineNodeShouldFailIfNodeDoesNotExist() throws Exception {
+    @Test public void onlineNodeShouldFailIfNodeDoesNotExist() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CONNECT, Jenkins.READ)
                 .invokeWithArgs("never_created");
@@ -284,7 +284,7 @@ public class OnlineNodeCommandTest {
         assertThat(slave2.toComputer().isOnline(), equalTo(true));
     }
 
-    @Test public void onlineNodeShouldSucceedOnMaster() throws Exception {
+    @Test public void onlineNodeShouldSucceedOnMaster() {
         final Computer masterComputer = j.jenkins.getComputer("");
 
         CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -72,7 +72,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldFailWithoutAdministerPermission() throws Exception {
+    public void quietDownShouldFailWithoutAdministerPermission() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ)
                 .invoke();
@@ -82,7 +82,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldSuccess() throws Exception {
+    public void quietDownShouldSuccess() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
                 .invoke();
@@ -91,7 +91,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldSuccessWithBlock() throws Exception {
+    public void quietDownShouldSuccessWithBlock() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
                 .invokeWithArgs("-block");
@@ -100,7 +100,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldSuccessWithTimeout() throws Exception {
+    public void quietDownShouldSuccessWithTimeout() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
                 .invokeWithArgs("-timeout", "0");
@@ -109,7 +109,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldSuccessWithReason() throws Exception {
+    public void quietDownShouldSuccessWithReason() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
                 .invokeWithArgs("-reason", TEST_REASON);
@@ -119,7 +119,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldSuccessWithBlockAndTimeout() throws Exception {
+    public void quietDownShouldSuccessWithBlockAndTimeout() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
                 .invokeWithArgs("-block", "-timeout", "0");
@@ -128,7 +128,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldSuccessWithBlockAndTimeoutAndReason() throws Exception {
+    public void quietDownShouldSuccessWithBlockAndTimeoutAndReason() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
                 .invokeWithArgs("-block", "-timeout", "0", "-reason", TEST_REASON);
@@ -138,7 +138,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldFailWithEmptyTimeout() throws Exception {
+    public void quietDownShouldFailWithEmptyTimeout() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
                 .invokeWithArgs("-timeout");
@@ -148,7 +148,7 @@ public class QuietDownCommandTest {
     }
 
     @Test
-    public void quietDownShouldSuccessOnAlreadyQuietDownedJenkins() throws Exception {
+    public void quietDownShouldSuccessOnAlreadyQuietDownedJenkins() {
         j.jenkins.doQuietDown();
         assertJenkinsInQuietMode();
         final CLICommandInvoker.Result result = command

--- a/test/src/test/java/hudson/cli/ReloadConfigurationCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadConfigurationCommandTest.java
@@ -69,7 +69,7 @@ public class ReloadConfigurationCommandTest {
     }
 
     @Test
-    public void reloadConfigurationShouldFailWithoutAdministerPermission() throws Exception {
+    public void reloadConfigurationShouldFailWithoutAdministerPermission() {
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().toAuthenticated());
         final CLICommandInvoker.Result result = command.invoke();
 
@@ -175,7 +175,7 @@ public class ReloadConfigurationCommandTest {
         assertThat(desc.getDefaultSuffix(), equalTo("@newSuffix"));
     }
 
-    private void reloadJenkinsConfigurationViaCliAndWait() throws Exception {
+    private void reloadJenkinsConfigurationViaCliAndWait() {
         final CLICommandInvoker.Result result = command.invoke();
 
         assertThat(result, succeededSilently());

--- a/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
@@ -113,7 +113,7 @@ public class ReloadJobCommandTest {
         assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
     }
 
-    @Test public void reloadJobShouldFailIfJobDoesNotExist() throws Exception {
+    @Test public void reloadJobShouldFailIfJobDoesNotExist() {
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Item.READ, Item.CONFIGURE, Jenkins.READ)

--- a/test/src/test/java/hudson/cli/SetBuildDescriptionCommandTest.java
+++ b/test/src/test/java/hudson/cli/SetBuildDescriptionCommandTest.java
@@ -110,7 +110,7 @@ public class SetBuildDescriptionCommandTest {
         assertThat(build.getDescription(), equalTo(" "));
     }
 
-    @Test public void setBuildDescriptionShouldFailIfJobDoesNotExist() throws Exception {
+    @Test public void setBuildDescriptionShouldFailIfJobDoesNotExist() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Run.UPDATE, Item.READ, Jenkins.READ)
                 .invokeWithArgs("never_created");

--- a/test/src/test/java/hudson/cli/UpdateNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/UpdateNodeCommandTest.java
@@ -88,7 +88,7 @@ public class UpdateNodeCommandTest {
         assertThat(updatedSlave.getNumExecutors(), equalTo(42));
     }
 
-    @Test public void updateNodeShouldFailIfNodeDoesNotExist() throws Exception {
+    @Test public void updateNodeShouldFailIfNodeDoesNotExist() {
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.CONFIGURE, Jenkins.READ)
@@ -103,7 +103,7 @@ public class UpdateNodeCommandTest {
 
     @Issue("SECURITY-281")
     @Test
-    public void updateNodeShouldFailForMaster() throws Exception {
+    public void updateNodeShouldFailForMaster() {
         CLICommandInvoker.Result result = command.authorizedTo(Computer.CONFIGURE, Jenkins.READ).withStdin(Computer.class.getResourceAsStream("node.xml")).invokeWithArgs("");
         assertThat(result.stderr(), containsString("No such node ''"));
         assertThat(result, failedWith(3));

--- a/test/src/test/java/hudson/cli/WaitNodeOfflineCommandTest.java
+++ b/test/src/test/java/hudson/cli/WaitNodeOfflineCommandTest.java
@@ -59,7 +59,7 @@ public class WaitNodeOfflineCommandTest {
     }
 
     @Test
-    public void waitNodeOfflineShouldFailIfNodeDoesNotExist() throws Exception {
+    public void waitNodeOfflineShouldFailIfNodeDoesNotExist() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ)
                 .invokeWithArgs("never_created");

--- a/test/src/test/java/hudson/cli/WaitNodeOnlineCommandTest.java
+++ b/test/src/test/java/hudson/cli/WaitNodeOnlineCommandTest.java
@@ -58,7 +58,7 @@ public class WaitNodeOnlineCommandTest {
     }
 
     @Test
-    public void waitNodeOnlineShouldFailIfNodeDoesNotExist() throws Exception {
+    public void waitNodeOnlineShouldFailIfNodeDoesNotExist() {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ)
                 .invokeWithArgs("never_created");

--- a/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
+++ b/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
@@ -59,7 +59,7 @@ public class ConsoleAnnotatorTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
                 listener.getLogger().println("---");
                 listener.getLogger().println("ooo");
                 listener.getLogger().println("ooo");
@@ -112,7 +112,7 @@ public class ConsoleAnnotatorTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
                 listener.getLogger().print("abc\n");
                 listener.getLogger().print(HyperlinkNote.encodeTo("http://infradna.com/","def")+"\n");
                 return true;
@@ -173,7 +173,7 @@ public class ConsoleAnnotatorTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                 lock.phase(0);
                 // make sure the build is now properly started
                 lock.phase(2);
@@ -336,7 +336,7 @@ public class ConsoleAnnotatorTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
                 listener.getLogger().println("<b>&amp;</b>");
                 return true;
             }
@@ -377,7 +377,7 @@ public class ConsoleAnnotatorTest {
         }
 
         @Override
-        protected PollingResult compareRemoteRevisionWith(AbstractProject project, Launcher launcher, FilePath workspace, TaskListener listener, SCMRevisionState baseline) throws IOException, InterruptedException {
+        protected PollingResult compareRemoteRevisionWith(AbstractProject project, Launcher launcher, FilePath workspace, TaskListener listener, SCMRevisionState baseline) throws IOException {
             listener.annotate(new DollarMark());
             listener.getLogger().println("hello from polling");
             return new PollingResult(Change.NONE);

--- a/test/src/test/java/hudson/console/ConsoleLogFilterTest.java
+++ b/test/src/test/java/hudson/console/ConsoleLogFilterTest.java
@@ -33,12 +33,12 @@ public class ConsoleLogFilterTest {
     @TestExtension
     public static class Impl extends ConsoleLogFilter {
         @Override
-        public OutputStream decorateLogger(Run build, OutputStream logger) throws IOException, InterruptedException {
+        public OutputStream decorateLogger(Run build, OutputStream logger) {
             return logger;
         }
 
         @Override
-        public OutputStream decorateLogger(final Computer c, OutputStream out) throws IOException, InterruptedException {
+        public OutputStream decorateLogger(final Computer c, OutputStream out) {
             return new LineTransformationOutputStream.Delegating(out) {
                 @Override
                 protected void eol(byte[] b, int len) throws IOException {

--- a/test/src/test/java/hudson/console/UrlAnnotatorTest.java
+++ b/test/src/test/java/hudson/console/UrlAnnotatorTest.java
@@ -47,7 +47,7 @@ public class UrlAnnotatorTest {
      * Mark up of URL should consider surrounding markers, if any.
      */
     @Test
-    public void test2() throws Exception {
+    public void test2() {
         MarkupText m = new MarkupText("{abc='http://url/',def='ghi'}");
         new UrlAnnotator().newInstance(null).annotate(null,m);
         String html = m.toString(false);

--- a/test/src/test/java/hudson/diagnosis/TooManyJobsButNoViewTest.java
+++ b/test/src/test/java/hudson/diagnosis/TooManyJobsButNoViewTest.java
@@ -34,7 +34,7 @@ public class TooManyJobsButNoViewTest {
     @Rule public JenkinsRule r = new JenkinsRule();
     private TooManyJobsButNoView mon;
 
-    @Before public void setUp() throws Exception {
+    @Before public void setUp() {
         mon = AdministrativeMonitor.all().get(TooManyJobsButNoView.class);
     }
 

--- a/test/src/test/java/hudson/init/impl/GroovyInitScriptTest.java
+++ b/test/src/test/java/hudson/init/impl/GroovyInitScriptTest.java
@@ -38,7 +38,7 @@ public class GroovyInitScriptTest {
 
     @Issue("JENKINS-17933")
     @LocalData
-    @Test public void errorsHandled() throws Exception {
+    @Test public void errorsHandled() {
         assertEquals("true", System.getProperty("started"));
         /* TODO Jenkins.logRecords empty during a test, and adding a handler to root logger in JenkinsRule.before() does not work:
         assertTrue(log, log.contains("Nonexistent"));

--- a/test/src/test/java/hudson/model/AbortedFreeStyleBuildTest.java
+++ b/test/src/test/java/hudson/model/AbortedFreeStyleBuildTest.java
@@ -3,7 +3,6 @@ package hudson.model;
 import static org.junit.Assert.assertEquals;
 
 import hudson.Launcher;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;

--- a/test/src/test/java/hudson/model/AbortedFreeStyleBuildTest.java
+++ b/test/src/test/java/hudson/model/AbortedFreeStyleBuildTest.java
@@ -36,7 +36,7 @@ public class AbortedFreeStyleBuildTest {
         project.getBuildWrappersList().add(wrapper);
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                 Executor.currentExecutor().interrupt(Result.FAILURE);
                 throw new InterruptedException();
             }
@@ -48,7 +48,7 @@ public class AbortedFreeStyleBuildTest {
 
     private static class AbortingBuilder extends TestBuilder {
         @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
             throw new InterruptedException();
         }
     }

--- a/test/src/test/java/hudson/model/AbstractBuildTest.java
+++ b/test/src/test/java/hudson/model/AbstractBuildTest.java
@@ -101,7 +101,7 @@ public class AbstractBuildTest {
         public static final String ERROR_MESSAGE = "This publisher fails by design";
         
         @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws IOException {
             throw new IOException(ERROR_MESSAGE);
         }
         
@@ -132,7 +132,7 @@ public class AbstractBuildTest {
 
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {
-            @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
                 listener.getLogger().println(out);
                 return true;
             }
@@ -276,7 +276,7 @@ public class AbstractBuildTest {
     }
 
     private static class ThrowBuilder extends Builder {
-        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) {
             throw new NullPointerException();
         }
         @TestExtension("doNotInterruptBuildAbruptlyWhenExceptionThrownFromBuildStep")
@@ -299,7 +299,7 @@ public class AbstractBuildTest {
             }
 
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                 if (build.number == 1) {
                     e1.signal();  // signal that build #1 is in publisher
                 } else if (build.number == 2) {

--- a/test/src/test/java/hudson/model/BuildExecutionTest.java
+++ b/test/src/test/java/hudson/model/BuildExecutionTest.java
@@ -57,7 +57,7 @@ public class BuildExecutionTest {
         @Override public boolean needsToRunAfterFinalized() {
             throw new IllegalStateException("oops");
         }
-        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) {
             return true;
         }
         @Override public BuildStepMonitor getRequiredMonitorService() {

--- a/test/src/test/java/hudson/model/BuildExecutionTest.java
+++ b/test/src/test/java/hudson/model/BuildExecutionTest.java
@@ -31,7 +31,6 @@ import hudson.Launcher;
 import hudson.slaves.WorkspaceList;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -96,7 +96,7 @@ public class CauseTest {
 
 
     @Issue("JENKINS-48467")
-    @Test public void userIdCausePrintTest() throws Exception {
+    @Test public void userIdCausePrintTest() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TaskListener listener = new StreamTaskListener(baos);
 

--- a/test/src/test/java/hudson/model/DependencyGraphTest.java
+++ b/test/src/test/java/hudson/model/DependencyGraphTest.java
@@ -123,7 +123,7 @@ public class DependencyGraphTest {
      */
     @LocalData @Issue("JENKINS-5265")
     @Test
-    public void testItemReadPermission() throws Exception {
+    public void testItemReadPermission() {
         // Rebuild dependency graph as anonymous user:
         j.jenkins.rebuildDependencyGraph();
         try {

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -36,7 +36,6 @@ import hudson.model.Descriptor.PropertyType;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.tasks.Shell;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -58,7 +58,7 @@ public class DescriptorTest {
     public @Rule JenkinsRule rule = new JenkinsRule();
 
     @Issue("JENKINS-12307")
-    @Test public void getItemTypeDescriptorOrDie() throws Exception {
+    @Test public void getItemTypeDescriptorOrDie() {
         Describable<?> instance = new Shell("echo hello");
         Descriptor<?> descriptor = instance.getDescriptor();
         PropertyType propertyType = descriptor.getPropertyType(instance, "command");
@@ -91,7 +91,7 @@ public class DescriptorTest {
         BuilderImpl(String id) {
             this.id = id;
         }
-        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) {
             listener.getLogger().println("running " + getDescriptor().getId());
             return true;
         }
@@ -108,7 +108,7 @@ public class DescriptorTest {
         @Override public String getId() {
             return id;
         }
-        @Override public Builder newInstance(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+        @Override public Builder newInstance(StaplerRequest req, JSONObject formData) {
             return new BuilderImpl(id);
         }
         @Override public boolean isApplicable(Class<? extends AbstractProject> jobType) {
@@ -145,7 +145,7 @@ public class DescriptorTest {
         @DataBoundConstructor public B1(List<D> ds) {
             this.ds = ds;
         }
-        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) {
             listener.getLogger().println(ds);
             return true;
         }
@@ -181,7 +181,7 @@ public class DescriptorTest {
         @Override public String getId() {
             return id;
         }
-        @Override public D3 newInstance(StaplerRequest req, JSONObject formData) throws Descriptor.FormException {
+        @Override public D3 newInstance(StaplerRequest req, JSONObject formData) {
             return new D3(id);
         }
     }
@@ -192,7 +192,7 @@ public class DescriptorTest {
         @DataBoundConstructor public B2(List<D3> ds) {
             this.ds = ds;
         }
-        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        @Override public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener) {
             listener.getLogger().println(ds);
             return true;
         }
@@ -200,7 +200,7 @@ public class DescriptorTest {
     }
 
     @Test
-    public void presentStacktraceFromFormException() throws Exception {
+    public void presentStacktraceFromFormException() {
         NullPointerException cause = new NullPointerException();
         final Descriptor.FormException fe = new Descriptor.FormException("My Message", cause, "fake");
         FailingHttpStatusCodeException ex = assertThrows(FailingHttpStatusCodeException.class, () ->

--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -43,7 +43,7 @@ public class ExecutorTest {
 
         j.jenkins.getQueue().schedule(new QueueTest.TestTask(new AtomicInteger()) {
             @Override
-            public Queue.Executable createExecutable() throws IOException {
+            public Queue.Executable createExecutable() {
                 throw new IllegalStateException("oops");
             }
         }, 0);

--- a/test/src/test/java/hudson/model/FingerprintCleanupThreadTest.java
+++ b/test/src/test/java/hudson/model/FingerprintCleanupThreadTest.java
@@ -86,7 +86,7 @@ public class FingerprintCleanupThreadTest {
     }
 
     @Test
-    public void testGetRecurrencePeriod() throws IOException {
+    public void testGetRecurrencePeriod() {
         FingerprintCleanupThread cleanupThread = new FingerprintCleanupThread();
         assertEquals("Wrong recurrence period.", PeriodicWork.DAY, cleanupThread.getRecurrencePeriod());
     }
@@ -248,7 +248,7 @@ public class FingerprintCleanupThreadTest {
         }
 
         @Override
-        protected Fingerprint loadFingerprint(File fingerprintFile) throws IOException {
+        protected Fingerprint loadFingerprint(File fingerprintFile) {
             return fingerprintToLoad;
         }
 
@@ -288,11 +288,11 @@ public class FingerprintCleanupThreadTest {
 
         private boolean isAlive = true;
 
-        TestFingerprint() throws IOException {
+        TestFingerprint() {
             super(ptr, "foo", Util.fromHexString(Util.getDigestOf("foo")));
         }
 
-        TestFingerprint(boolean isAlive) throws IOException {
+        TestFingerprint(boolean isAlive) {
             super(ptr, "foo", Util.fromHexString(Util.getDigestOf("foo")));
             this.isAlive = isAlive;
         }
@@ -335,7 +335,7 @@ public class FingerprintCleanupThreadTest {
         }
 
         @Override
-        protected Fingerprint getFingerprint(Fingerprint fp) throws IOException {
+        protected Fingerprint getFingerprint(Fingerprint fp) {
             return new Fingerprint(ptr, "foo", Util.fromHexString(Util.getDigestOf("foo")));
         }
 

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -191,7 +191,7 @@ public class HudsonTest {
      */
     @Test
     @Email("http://www.nabble.com/1.286-version-and-description-The-requested-resource-%28%29-is-not--available.-td22233801.html")
-    public void legacyDescriptorLookup() throws Exception {
+    public void legacyDescriptorLookup() {
         Descriptor dummy = new Descriptor(HudsonTest.class) {};
 
         BuildStep.PUBLISHERS.addRecorder(dummy);

--- a/test/src/test/java/hudson/model/ItemGroupMixInTest.java
+++ b/test/src/test/java/hudson/model/ItemGroupMixInTest.java
@@ -69,7 +69,7 @@ public class ItemGroupMixInTest {
 
     @Issue("JENKINS-20951")
     @LocalData
-    @Test public void xmlFileReadCannotResolveClassException() throws Exception {
+    @Test public void xmlFileReadCannotResolveClassException() {
         MockFolder d = r.jenkins.getItemByFullName("d", MockFolder.class);
         assertNotNull(d);
         Collection<TopLevelItem> items = d.getItems();
@@ -121,7 +121,7 @@ public class ItemGroupMixInTest {
   @LocalData
   @Issue("JENKINS-22811")
   @Test
-  public void xmlFileReadExceptionOnLoad() throws Exception {
+  public void xmlFileReadExceptionOnLoad() {
     MockFolder d = r.jenkins.getItemByFullName("d", MockFolder.class);
     assertNotNull(d);
     Collection<TopLevelItem> items = d.getItems();
@@ -230,7 +230,7 @@ public class ItemGroupMixInTest {
 
   @Issue("JENKINS-61956")
   @Test
-  public void createProject_checkGoodName() throws Failure, IOException {
+  public void createProject_checkGoodName() throws Failure {
     final String badName = "calvin@jenkins";
 
     Failure exception = assertThrows(Failure.class, () -> { r.jenkins.createProject(MockFolder.class, badName); });
@@ -239,7 +239,7 @@ public class ItemGroupMixInTest {
 
   @Issue("JENKINS-61956")
   @Test
-  public void createProjectFromXML_checkGoodName() throws Failure, IOException {
+  public void createProjectFromXML_checkGoodName() throws Failure {
     final String badName = "calvin@jenkins";
 
     final String xml = "<?xml version='1.0' encoding='UTF-8'?>\n" +

--- a/test/src/test/java/hudson/model/JobPropertyTest.java
+++ b/test/src/test/java/hudson/model/JobPropertyTest.java
@@ -145,7 +145,7 @@ public class JobPropertyTest {
         InvisibleImpl() {}
 
         @Override
-        public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws FormException {
+        public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) {
             return this;
         }
 

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -265,7 +265,7 @@ public class JobTest {
     }
 
     @LocalData @Issue("JENKINS-6371")
-    @Test public void getArtifactsUpTo() throws Exception {
+    @Test public void getArtifactsUpTo() {
         // There was a bug where intermediate directories were counted,
         // so too few artifacts were returned.
         Run r = j.jenkins.getItemByFullName("testJob", Job.class).getLastCompletedBuild();
@@ -313,7 +313,7 @@ public class JobTest {
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(6, p.getLastSuccessfulBuild().getNumber());
         assertEquals(3, RunLoadCounter.assertMaxLoads(p, 1, new Callable<Integer>() {
-            @Override public Integer call() throws Exception {
+            @Override public Integer call() {
                 return p.getLastFailedBuild().getNumber();
             }
         }).intValue());

--- a/test/src/test/java/hudson/model/ManagementLinkTest.java
+++ b/test/src/test/java/hudson/model/ManagementLinkTest.java
@@ -63,7 +63,7 @@ public class ManagementLinkTest {
     }
 
     @Test @Issue("JENKINS-33683")
-    public void invisibleLinks() throws Exception {
+    public void invisibleLinks() {
         assertNull(j.jenkins.getDynamic("and_fail_trying"));
     }
 

--- a/test/src/test/java/hudson/model/MyViewTest.java
+++ b/test/src/test/java/hudson/model/MyViewTest.java
@@ -97,7 +97,7 @@ public class MyViewTest {
     }
     
     @Test
-    public void testGetItems() throws IOException, InterruptedException{
+    public void testGetItems() throws IOException {
         User user = User.getOrCreateByIdOrFullName("User1");
         GlobalMatrixAuthorizationStrategy auth = new GlobalMatrixAuthorizationStrategy();   
         rule.jenkins.setAuthorizationStrategy(auth);   

--- a/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
+++ b/test/src/test/java/hudson/model/ParametersDefinitionPropertyTest.java
@@ -84,7 +84,7 @@ public class ParametersDefinitionPropertyTest {
         public static class DescriptorImpl extends ParameterDescriptor {
 
             @Override
-            public ParameterDefinition newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            public ParameterDefinition newInstance(StaplerRequest req, JSONObject formData) {
                 return new KrazyParameterDefinition(formData.getString("name"), formData.getString("description"), formData.getString("field").toLowerCase(Locale.ENGLISH));
             }
 

--- a/test/src/test/java/hudson/model/PeriodicWorkTest.java
+++ b/test/src/test/java/hudson/model/PeriodicWorkTest.java
@@ -45,7 +45,7 @@ public class PeriodicWorkTest {
         }
 
         @Override
-        protected void doRun() throws Exception {
+        protected void doRun() {
             doneSignal.countDown();
         }
     }

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -513,7 +513,7 @@ public class ProjectTest {
         upstream.getPublishersList().add(new ArtifactArchiver("change.log"));
         downstream.getPublishersList().add(new Fingerprinter("change.log", false));
         downstream.getBuildersList().add(new TestBuilder() {
-            @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
                 for (Run<?, ?>.Artifact a: upstream.getLastBuild().getArtifacts()) {
                     Util.copyFile(a.getFile(), new File(build.getWorkspace().child(a.getFileName()).getRemote()));
                 }
@@ -828,7 +828,7 @@ public class ProjectTest {
         }
         
         @Override
-        public boolean pollChanges(AbstractProject<?, ?> project, Launcher launcher, FilePath workspace, TaskListener listener) throws IOException, InterruptedException {
+        public boolean pollChanges(AbstractProject<?, ?> project, Launcher launcher, FilePath workspace, TaskListener listener) {
             return hasChange;
         }
                        
@@ -841,7 +841,7 @@ public class ProjectTest {
         }
         
         @Override
-        protected PollingResult compareRemoteRevisionWith(AbstractProject project, Launcher launcher, FilePath workspace, TaskListener listener, SCMRevisionState baseline) throws IOException, InterruptedException {            
+        protected PollingResult compareRemoteRevisionWith(AbstractProject project, Launcher launcher, FilePath workspace, TaskListener listener, SCMRevisionState baseline) {
             if(!hasChange) {
                 return PollingResult.NO_CHANGES;
             }
@@ -853,7 +853,7 @@ public class ProjectTest {
     public static class AlwaysChangedSCM extends NullSCM {
 
         @Override
-        public boolean pollChanges(AbstractProject<?, ?> project, Launcher launcher, FilePath workspace, TaskListener listener) throws IOException, InterruptedException {
+        public boolean pollChanges(AbstractProject<?, ?> project, Launcher launcher, FilePath workspace, TaskListener listener) {
             return true;
         }
         
@@ -863,7 +863,7 @@ public class ProjectTest {
         }
 
         @Override
-        protected PollingResult compareRemoteRevisionWith(AbstractProject project, Launcher launcher, FilePath workspace, TaskListener listener, SCMRevisionState baseline) throws IOException, InterruptedException {
+        protected PollingResult compareRemoteRevisionWith(AbstractProject project, Launcher launcher, FilePath workspace, TaskListener listener, SCMRevisionState baseline) {
             return PollingResult.SIGNIFICANT;
         }
         

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -110,7 +110,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -197,7 +197,7 @@ public class QueueTest {
      */
     @LocalData
     @Test
-    public void recover_from_legacy_list() throws Exception {
+    public void recover_from_legacy_list() {
         Queue q = r.jenkins.getQueue();
 
         // loaded the legacy queue.xml from test LocalData located in
@@ -268,7 +268,7 @@ public class QueueTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                 seq.phase(0);   // first, we let one build going
 
                 seq.phase(2);
@@ -292,7 +292,7 @@ public class QueueTest {
 
     public static final class FileItemPersistenceTestServlet extends HttpServlet {
         private static final long serialVersionUID = 1L;
-        @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             resp.setContentType("text/html");
             resp.getWriter().println(
                     "<html><body><form action='/' method=post name=main enctype='multipart/form-data'>" +
@@ -301,7 +301,7 @@ public class QueueTest {
             );
         }
 
-        @Override protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        @Override protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
             try {
                 ServletFileUpload f = new ServletFileUpload(new DiskFileItemFactory());
                 List<?> v = f.parseRequest(req);
@@ -353,7 +353,7 @@ public class QueueTest {
         // Make build sleep a while so it blocks new builds
         project.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                 buildStarted.signal();
                 buildShouldComplete.block();
                 return true;
@@ -488,7 +488,7 @@ public class QueueTest {
     }
 
     @Issue("JENKINS-41127")
-    @Test public void flyweightTasksUnwantedConcurrency() throws Exception {
+    @Test public void flyweightTasksUnwantedConcurrency() {
         Label label = r.jenkins.getSelfLabel();
         AtomicInteger cnt = new AtomicInteger();
         TestFlyweightTask task1 = new TestFlyweightTask(cnt, label);
@@ -623,7 +623,7 @@ public class QueueTest {
         @Override public String getDisplayName() {return "Test";}
         @Override public ResourceList getResourceList() {return new ResourceList();}
         protected void doRun() {}
-        @Override public Executable createExecutable() throws IOException {
+        @Override public Executable createExecutable() {
             return new Executable() {
                 @Override public SubTask getParent() {return TestTask.this;}
                 @Override public long getEstimatedDuration() {return -1;}
@@ -640,7 +640,7 @@ public class QueueTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                 ev.block();
                 return true;
             }
@@ -665,7 +665,7 @@ public class QueueTest {
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MockQueueItemAuthenticator(Collections.singletonMap(p.getFullName(), alice)));
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
                 assertEquals(alice2, Jenkins.getAuthentication2());
                 return true;
             }
@@ -692,7 +692,7 @@ public class QueueTest {
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MockQueueItemAuthenticator(Collections.singletonMap(p.getFullName(), alice)));
         p.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
                 assertEquals(alice2, Jenkins.getAuthentication2());
                 return true;
             }
@@ -731,7 +731,7 @@ public class QueueTest {
         }
     }
 
-    @Test public void pendingsConsistenceAfterErrorDuringMaintain() throws IOException, ExecutionException, InterruptedException{
+    @Test public void pendingsConsistenceAfterErrorDuringMaintain() throws IOException, InterruptedException{
         FreeStyleProject project1 = r.createFreeStyleProject();
         FreeStyleProject project2 = r.createFreeStyleProject();
         TopLevelItemDescriptor descriptor = new TopLevelItemDescriptor(FreeStyleProject.class){

--- a/test/src/test/java/hudson/model/RunTest.java
+++ b/test/src/test/java/hudson/model/RunTest.java
@@ -220,11 +220,11 @@ public class RunTest  {
     
     public static final class Mgr extends ArtifactManager {
         static final AtomicBoolean deleted = new AtomicBoolean();
-        @Override public boolean delete() throws IOException, InterruptedException {
+        @Override public boolean delete() {
             return !deleted.getAndSet(true);
         }
         @Override public void onLoad(Run<?, ?> build) {}
-        @Override public void archive(FilePath workspace, Launcher launcher, BuildListener listener, Map<String, String> artifacts) throws IOException, InterruptedException {}
+        @Override public void archive(FilePath workspace, Launcher launcher, BuildListener listener, Map<String, String> artifacts) {}
         @Override public VirtualFile root() {
             return VirtualFile.forFile(Jenkins.get().getRootDir()); // irrelevant
         }

--- a/test/src/test/java/hudson/model/SimpleJobTest.java
+++ b/test/src/test/java/hudson/model/SimpleJobTest.java
@@ -68,7 +68,7 @@ public class SimpleJobTest {
     }
     
     @Test
-    public void testGetEstimatedDurationWithNoRuns() throws IOException {
+    public void testGetEstimatedDurationWithNoRuns() {
         
         final SortedMap<Integer, TestBuild> runs = new TreeMap<>();
         
@@ -162,7 +162,7 @@ public class SimpleJobTest {
         }
 
         @Override
-        public int assignBuildNumber() throws IOException {
+        public int assignBuildNumber() {
             return i++;
         }
 

--- a/test/src/test/java/hudson/model/UpdateCenterCustomTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterCustomTest.java
@@ -41,7 +41,7 @@ public class UpdateCenterCustomTest {
     public final JenkinsRule j = new CustomUpdateCenterRule(CustomUpdateCenter.class);
     
     @Test
-    public void shouldStartupWithCustomUpdateCenter() throws Exception {
+    public void shouldStartupWithCustomUpdateCenter() {
         UpdateCenter uc = j.jenkins.getUpdateCenter();
         assertThat("Update Center must be a custom instance", uc, instanceOf(CustomUpdateCenter.class));
     }
@@ -65,7 +65,7 @@ public class UpdateCenterCustomTest {
         }
 
         @Override
-        public void after() throws Exception {
+        public void after() {
             if (_oldValue != null) {
                 System.setProperty(PROPERTY_NAME, _oldValue);
             }

--- a/test/src/test/java/hudson/model/UpdateCenterTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterTest.java
@@ -46,7 +46,7 @@ import org.junit.Test;
  * @author Kohsuke Kawaguchi
  */
 public class UpdateCenterTest {
-    @Test public void data() throws Exception {
+    @Test public void data() {
         try {
             doData("https://updates.jenkins.io/update-center.json?version=build");
             doData("https://updates.jenkins.io/stable/update-center.json?version=build");

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -91,7 +91,7 @@ public class UpdateSiteTest {
         server.addConnector(connector);
         server.setHandler(new AbstractHandler() {
             @Override
-            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
                 if (target.startsWith(RELATIVE_BASE)) {
                     target = target.substring(RELATIVE_BASE.length());
                 }
@@ -158,7 +158,7 @@ public class UpdateSiteTest {
         assertNotNull(us.getPlugin("AdaptivePlugin"));
     }
 
-    @Test public void lackOfDataDoesNotFailWarningsCode() throws Exception {
+    @Test public void lackOfDataDoesNotFailWarningsCode() {
         assertNull("plugin data is not present", j.jenkins.getUpdateCenter().getSite("default").getData());
 
         // nothing breaking?
@@ -205,7 +205,7 @@ public class UpdateSiteTest {
     }
 
     @Issue("JENKINS-31448")
-    @Test public void isLegacyDefault() throws Exception {
+    @Test public void isLegacyDefault() {
         assertFalse("isLegacyDefault should be false with null id",new UpdateSite(null,"url").isLegacyDefault());
         assertFalse("isLegacyDefault should be false when id is not default and url is http://hudson-ci.org/",new UpdateSite("dummy","http://hudson-ci.org/").isLegacyDefault());
         assertTrue("isLegacyDefault should be true when id is default and url is http://hudson-ci.org/",new UpdateSite(UpdateCenter.PREDEFINED_UPDATE_SITE_ID,"http://hudson-ci.org/").isLegacyDefault());

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -46,7 +46,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;

--- a/test/src/test/java/hudson/model/UserIdMigratorTest.java
+++ b/test/src/test/java/hudson/model/UserIdMigratorTest.java
@@ -39,7 +39,7 @@ public class UserIdMigratorTest {
 
     @Test
     @LocalData
-    public void migrateSimpleUser() throws InterruptedException, ReactorException, IOException {
+    public void migrateSimpleUser() {
         String userId = "fred";
         User fred = User.getById(userId, false);
         assertThat(fred.getFullName(), is("Fred Smith"));
@@ -47,7 +47,7 @@ public class UserIdMigratorTest {
 
     @Test
     @LocalData
-    public void migrateMultipleUsers() throws InterruptedException, ReactorException, IOException {
+    public void migrateMultipleUsers() {
         assertThat(User.getAll().size(), is(3));
         User fred = User.getById("fred", false);
         assertThat(fred.getFullName(), is("Fred Smith"));

--- a/test/src/test/java/hudson/model/UserIdMigratorTest.java
+++ b/test/src/test/java/hudson/model/UserIdMigratorTest.java
@@ -26,10 +26,8 @@ package hudson.model;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.reactor.ReactorException;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 

--- a/test/src/test/java/hudson/model/UserTest.java
+++ b/test/src/test/java/hudson/model/UserTest.java
@@ -156,7 +156,7 @@ public class UserTest {
         j.assertAllImageLoadSuccessfully(page);
     }
 
-    @Test public void getAuthorities() throws Exception {
+    @Test public void getAuthorities() {
         JenkinsRule.DummySecurityRealm realm = j.createDummySecurityRealm();
         realm.addGroups("administrator", "admins");
         realm.addGroups("alice", "users");
@@ -585,7 +585,7 @@ public class UserTest {
 
     @Issue("SECURITY-243")
     @Test
-    public void resolveByUnloadedIdThenName() throws Exception {
+    public void resolveByUnloadedIdThenName() {
         j.jenkins.setSecurityRealm(new ExternalSecurityRealm());
         // do *not* call this here: User.get("victim");
         User attacker1 = User.get("attacker1");

--- a/test/src/test/java/hudson/model/ViewPropertyTest.java
+++ b/test/src/test/java/hudson/model/ViewPropertyTest.java
@@ -100,7 +100,7 @@ public class ViewPropertyTest {
         }
 
         @Override
-        public ViewProperty reconfigure(StaplerRequest req, JSONObject form) throws FormException {
+        public ViewProperty reconfigure(StaplerRequest req, JSONObject form) {
             return this;
         }
 

--- a/test/src/test/java/hudson/model/ViewPropertyTest.java
+++ b/test/src/test/java/hudson/model/ViewPropertyTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertSame;
 import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlLabel;
-import hudson.model.Descriptor.FormException;
 import net.sf.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -84,7 +84,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
 import jenkins.security.NotReallyRoleSensitiveCallable;

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -542,7 +542,7 @@ public class ViewTest {
             grant(Item.CREATE).onFolders(d1).to("dev")); // not on root or d2
         ACL.impersonate2(Jenkins.ANONYMOUS2, new NotReallyRoleSensitiveCallable<Void,Exception>() {
             @Override
-            public Void call() throws Exception {
+            public Void call() {
                 try {
                     assertCheckJobName(j.jenkins, "whatever", FormValidation.Kind.OK);
                     fail("should not have been allowed");
@@ -554,7 +554,7 @@ public class ViewTest {
         });
         ACL.impersonate2(User.get("dev").impersonate2(), new NotReallyRoleSensitiveCallable<Void,Exception>() {
             @Override
-            public Void call() throws Exception {
+            public Void call() {
                 try {
                     assertCheckJobName(j.jenkins, "whatever", FormValidation.Kind.OK);
                     fail("should not have been allowed");
@@ -573,7 +573,7 @@ public class ViewTest {
         });
         ACL.impersonate2(User.get("admin").impersonate2(), new NotReallyRoleSensitiveCallable<Void,Exception>() {
             @Override
-            public Void call() throws Exception {
+            public Void call() {
                 assertCheckJobName(j.jenkins, "whatever", FormValidation.Kind.OK);
                 assertCheckJobName(d1, "whatever", FormValidation.Kind.OK);
                 assertCheckJobName(d2, "whatever", FormValidation.Kind.OK);
@@ -629,14 +629,14 @@ public class ViewTest {
     @Test
     @Issue("JENKINS-36908")
     @LocalData
-    public void testAllViewCreatedIfNoPrimary() throws Exception {
+    public void testAllViewCreatedIfNoPrimary() {
         assertNotNull(j.getInstance().getView("All"));
     }
 
     @Test
     @Issue("JENKINS-36908")
     @LocalData
-    public void testAllViewNotCreatedIfPrimary() throws Exception {
+    public void testAllViewNotCreatedIfPrimary() {
         assertNull(j.getInstance().getView("All"));
     }
 
@@ -1067,11 +1067,11 @@ public class ViewTest {
         }
 
         @Override
-        protected void submit(StaplerRequest req) throws IOException, ServletException, Descriptor.FormException {
+        protected void submit(StaplerRequest req) {
         }
 
         @Override
-        public Item doCreateItem(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        public Item doCreateItem(StaplerRequest req, StaplerResponse rsp) {
             return null;
         }
     }

--- a/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
+++ b/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
@@ -210,7 +210,7 @@ public class WorkspaceCleanupThreadTest {
         @Override
         public boolean processWorkspaceBeforeDeletion(
                 Job<?, ?> project, FilePath workspace, Node node
-        ) throws IOException, InterruptedException {
+        ) {
             return answer;
         }
     }
@@ -223,7 +223,7 @@ public class WorkspaceCleanupThreadTest {
             this.time = time;
         }
 
-        @Override public Void invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+        @Override public Void invoke(File f, VirtualChannel channel) {
             Assume.assumeTrue("failed to reset lastModified on " + f, f.setLastModified(time));
             return null;
         }

--- a/test/src/test/java/hudson/model/labels/LabelAtomSecurity1986Test.java
+++ b/test/src/test/java/hudson/model/labels/LabelAtomSecurity1986Test.java
@@ -45,7 +45,7 @@ public class LabelAtomSecurity1986Test {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void nonexisting() throws Exception {
+    public void nonexisting() {
         LabelAtom nonexistent = j.jenkins.getLabelAtom("nonexistent");
         XmlFile configFile = nonexistent.getConfigFile();
         assertFalse(configFile.getFile().exists());
@@ -62,7 +62,7 @@ public class LabelAtomSecurity1986Test {
 
     @Test
     @Issue("SECURITY-1986")
-    public void startsWithDoubleDotSlash() throws Exception {
+    public void startsWithDoubleDotSlash() {
         FailingHttpStatusCodeException e = assertThrows("Should have rejected label.", FailingHttpStatusCodeException.class, () -> j.submit(j.createWebClient().goTo("labelAtom/..%2ffoo/configure").getFormByName("config")));
         assertThat(e.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
         LabelAtom foo = j.jenkins.getLabelAtom("../foo");
@@ -91,7 +91,7 @@ public class LabelAtomSecurity1986Test {
 
     @Test
     @Issue("SECURITY-1986")
-    public void endsWithDoubleDotSlash() throws Exception {
+    public void endsWithDoubleDotSlash() {
         FailingHttpStatusCodeException e = assertThrows("Should have rejected label.", FailingHttpStatusCodeException.class, () -> j.submit(j.createWebClient().goTo("labelAtom/foo..%2f/configure").getFormByName("config")));
         assertThat(e.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
         LabelAtom foo = j.jenkins.getLabelAtom("foo../");
@@ -110,7 +110,7 @@ public class LabelAtomSecurity1986Test {
 
     @Test
     @Issue("SECURITY-1986")
-    public void startsWithDoubleDotBackslash() throws Exception {
+    public void startsWithDoubleDotBackslash() {
         FailingHttpStatusCodeException e = assertThrows("Should have rejected label.", FailingHttpStatusCodeException.class, () -> j.submit(j.createWebClient().goTo("labelAtom/..\\foo/configure").getFormByName("config")));
         assertThat(e.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
         LabelAtom foo = j.jenkins.getLabelAtom("..\\foo");
@@ -120,7 +120,7 @@ public class LabelAtomSecurity1986Test {
 
     @Test
     @Issue("SECURITY-1986")
-    public void endsWithDoubleDotBackslash() throws Exception {
+    public void endsWithDoubleDotBackslash() {
         FailingHttpStatusCodeException e = assertThrows("Should have rejected label.", FailingHttpStatusCodeException.class, () -> j.submit(j.createWebClient().goTo("labelAtom/foo..\\/configure").getFormByName("config")));
         assertThat(e.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
         LabelAtom foo = j.jenkins.getLabelAtom("foo..\\");
@@ -130,7 +130,7 @@ public class LabelAtomSecurity1986Test {
 
     @Test
     @Issue("SECURITY-1986")
-    public void middleDotsSlashes() throws Exception {
+    public void middleDotsSlashes() {
         FailingHttpStatusCodeException e = assertThrows("Should have rejected label.", FailingHttpStatusCodeException.class, () -> j.submit(j.createWebClient().goTo("labelAtom/foo%2f..%2fgoo/configure").getFormByName("config")));
         assertThat(e.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
         LabelAtom foo = j.jenkins.getLabelAtom("foo/../goo");
@@ -140,7 +140,7 @@ public class LabelAtomSecurity1986Test {
 
     @Test
     @Issue("SECURITY-1986")
-    public void middleDotsBackslashes() throws Exception {
+    public void middleDotsBackslashes() {
         FailingHttpStatusCodeException e = assertThrows("Should have rejected label.", FailingHttpStatusCodeException.class, () -> j.submit(j.createWebClient().goTo("labelAtom/foo%\\..\\goo/configure").getFormByName("config")));
         assertThat(e.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
         LabelAtom foo = j.jenkins.getLabelAtom("foo\\..\\");
@@ -167,7 +167,7 @@ public class LabelAtomSecurity1986Test {
 
     @Test
     @Issue("SECURITY-1986")
-    public void startsWithTripleDotBackslash() throws Exception {
+    public void startsWithTripleDotBackslash() {
         FailingHttpStatusCodeException e = assertThrows("Should have rejected label.", FailingHttpStatusCodeException.class, () -> j.submit(j.createWebClient().goTo("labelAtom/...%2ffoo/configure").getFormByName("config")));
         assertThat(e.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
         LabelAtom foo = j.jenkins.getLabelAtom(".../foo");

--- a/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
@@ -43,7 +43,6 @@ import hudson.model.Label;
 import hudson.model.Node.Mode;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.RetentionStrategy;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Set;

--- a/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
@@ -78,7 +78,7 @@ public class LabelExpressionTest {
         FreeStyleProject p1 = j.createFreeStyleProject();
         p1.getBuildersList().add(new TestBuilder() {
             @Override
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                 seq.phase(0); // first, make sure the w32 agent is occupied
                 seq.phase(2);
                 seq.done();
@@ -184,7 +184,7 @@ public class LabelExpressionTest {
     }
 
     @Test
-    public void parserError() throws Exception {
+    public void parserError() {
         parseShouldFail("foo bar");
         parseShouldFail("foo (bar)");
         parseShouldFail("foo(bar)");
@@ -368,7 +368,7 @@ public class LabelExpressionTest {
     }
 
     @Test
-    public void parseLabel() throws Exception {
+    public void parseLabel() {
         Set<LabelAtom> result = Label.parse("one two three");
         String[] expected = {"one", "two", "three"};
 

--- a/test/src/test/java/hudson/model/listeners/ItemListenerTest.java
+++ b/test/src/test/java/hudson/model/listeners/ItemListenerTest.java
@@ -47,7 +47,7 @@ public class ItemListenerTest {
     private StringBuffer events = new StringBuffer();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         ItemListener listener = new ItemListener() {
             @Override public void onCreated(Item item) {
                 events.append('C');
@@ -60,7 +60,7 @@ public class ItemListenerTest {
     }
 
     @Test
-    public void onCreatedViaCLI() throws Exception {
+    public void onCreatedViaCLI() {
         CLICommandInvoker.Result result = new CLICommandInvoker(j, "create-job").
                 withStdin(new ByteArrayInputStream("<project><actions/><builders/><publishers/><buildWrappers/></project>".getBytes())).
                 invokeWithArgs("testJob");

--- a/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
+++ b/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
@@ -10,7 +10,6 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.ResourceList;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;

--- a/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
+++ b/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
@@ -47,7 +47,7 @@ public class BuildKeepsRunningWhenFaultySubTasksTest {
                 private final SubTask outer = this;
 
                 @Override
-                public Queue.Executable createExecutable() throws IOException {
+                public Queue.Executable createExecutable() {
                     return new Queue.Executable() {
                         @Override
                         public SubTask getParent() {

--- a/test/src/test/java/hudson/model/queue/LoadPredictorTest.java
+++ b/test/src/test/java/hudson/model/queue/LoadPredictorTest.java
@@ -93,7 +93,7 @@ public class LoadPredictorTest {
         return new BuildableItem(new WaitingItem(new GregorianCalendar(),t,new ArrayList<>()));
     }
 
-    private JobOffer createMockOffer(Executor e) throws NoSuchFieldException, IllegalAccessException {
+    private JobOffer createMockOffer(Executor e) {
         JobOffer o = mock(JobOffer.class);
         when(o.getExecutor()).thenReturn(e);
         return o;

--- a/test/src/test/java/hudson/model/queue/WideExecutionTest.java
+++ b/test/src/test/java/hudson/model/queue/WideExecutionTest.java
@@ -56,7 +56,7 @@ public class WideExecutionTest {
             return Collections.singleton(new SubTask() {
                 private final SubTask outer = this;
                 @Override
-                public Executable createExecutable() throws IOException {
+                public Executable createExecutable() {
                     return new Executable() {
                         @Override
                         public SubTask getParent() {

--- a/test/src/test/java/hudson/pages/SystemConfigurationTestCase.java
+++ b/test/src/test/java/hudson/pages/SystemConfigurationTestCase.java
@@ -69,7 +69,7 @@ public class SystemConfigurationTestCase {
         private String decoratorId;
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        public boolean configure(StaplerRequest req, JSONObject json) {
             decoratorId = json.getString("decoratorId");
             return true;
         }

--- a/test/src/test/java/hudson/scm/AbstractScmTagActionTest.java
+++ b/test/src/test/java/hudson/scm/AbstractScmTagActionTest.java
@@ -108,7 +108,7 @@ public class AbstractScmTagActionTest {
         }
 
         @Override
-        public void checkout(@NonNull Run<?, ?> build, @NonNull Launcher launcher, @NonNull FilePath workspace, @NonNull TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState baseline) throws IOException, InterruptedException {
+        public void checkout(@NonNull Run<?, ?> build, @NonNull Launcher launcher, @NonNull FilePath workspace, @NonNull TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState baseline) {
             build.addAction(new TooltipTagAction(build, desiredTooltip));
         }
     }

--- a/test/src/test/java/hudson/scm/AbstractScmTagActionTest.java
+++ b/test/src/test/java/hudson/scm/AbstractScmTagActionTest.java
@@ -42,7 +42,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.File;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;

--- a/test/src/test/java/hudson/scm/ScmTest.java
+++ b/test/src/test/java/hudson/scm/ScmTest.java
@@ -36,7 +36,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Node;
 import hudson.model.Result;
 import java.io.File;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;

--- a/test/src/test/java/hudson/scm/ScmTest.java
+++ b/test/src/test/java/hudson/scm/ScmTest.java
@@ -84,7 +84,7 @@ public class ScmTest {
             public boolean checkout(AbstractBuild<?, ?> build,
                     Launcher launcher, FilePath remoteDir,
                     BuildListener listener, File changeLogFile)
-                    throws IOException, InterruptedException {
+                    throws InterruptedException {
                 throw new InterruptedException();
             }
 

--- a/test/src/test/java/hudson/security/AccessDeniedException3Test.java
+++ b/test/src/test/java/hudson/security/AccessDeniedException3Test.java
@@ -51,7 +51,7 @@ public class AccessDeniedException3Test {
 
     @Issue("JENKINS-39402")
     @Test
-    public void youAreInGroupHeaders() throws Exception {
+    public void youAreInGroupHeaders() {
         JenkinsRule.DummySecurityRealm realm = r.createDummySecurityRealm();
         String[] groups = new String[1000];
         for (int i = 0; i < groups.length; i++) {

--- a/test/src/test/java/hudson/security/ExtendedReadPermissionTest.java
+++ b/test/src/test/java/hudson/security/ExtendedReadPermissionTest.java
@@ -46,7 +46,7 @@ public class ExtendedReadPermissionTest {
             grant(Jenkins.READ, Item.READ, Item.EXTENDED_READ).everywhere().to("charlie"));
     }
 
-    private void setPermissionEnabled(boolean enabled) throws Exception {
+    private void setPermissionEnabled(boolean enabled) {
         Item.EXTENDED_READ.setEnabled(enabled);
     }
 

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -513,7 +513,7 @@ public class HudsonPrivateSecurityRealmTest {
     }
 
     @Test
-    public void createAccountWithHashedPasswordRequiresPrefix() throws Exception {
+    public void createAccountWithHashedPasswordRequiresPrefix() {
         HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
         j.jenkins.setSecurityRealm(securityRealm);
         assertThrows(IllegalArgumentException.class, () -> securityRealm.createAccountWithHashedPassword("user_hashed", BCrypt.hashpw("password", BCrypt.gensalt())));

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -34,7 +34,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import hudson.model.Descriptor;
 import hudson.security.captcha.CaptchaSupport;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Calendar;
 import java.util.Collections;

--- a/test/src/test/java/hudson/security/SecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/SecurityRealmTest.java
@@ -85,7 +85,7 @@ public class SecurityRealmTest {
         }
 
         @Override
-        public void generateImage(String id, OutputStream ios) throws IOException {
+        public void generateImage(String id, OutputStream ios) {
         }
     }
 

--- a/test/src/test/java/hudson/slaves/CloudTest.java
+++ b/test/src/test/java/hudson/slaves/CloudTest.java
@@ -35,7 +35,7 @@ public class CloudTest {
     @Rule public JenkinsRule j = new JenkinsRule();
 
     @Test @WithoutJenkins @Issue("JENKINS-37616")
-    public void provisionPermissionShouldBeIndependentFromAdminister() throws Exception {
+    public void provisionPermissionShouldBeIndependentFromAdminister() {
         SidACL acl = new SidACL() {
             @Override protected Boolean hasPermission(Sid p, Permission permission) {
                 return permission == Cloud.PROVISION;
@@ -48,7 +48,7 @@ public class CloudTest {
     }
 
     @Test @Issue("JENKINS-37616")
-    public void ensureProvisionPermissionIsLoadable() throws Exception {
+    public void ensureProvisionPermissionIsLoadable() {
         // Name introduced by JENKINS-37616
         Permission p = Permission.fromId("hudson.model.Computer.Provision");
         assertEquals("Provision", p.name);

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -135,7 +135,7 @@ public class JNLPLauncherTest {
     @Test
     @LocalData
     @Issue("JENKINS-44112")
-    public void testNoWorkDirMigration() throws Exception {
+    public void testNoWorkDirMigration() {
         Computer computer = j.jenkins.getComputer("Foo");
         assertThat(computer, instanceOf(SlaveComputer.class));
         
@@ -152,7 +152,7 @@ public class JNLPLauncherTest {
     @Test
     @Issue("JENKINS-44112")
     @SuppressWarnings("deprecation")
-    public void testDefaults() throws Exception {
+    public void testDefaults() {
         assertTrue("Work directory should be disabled for agents created via old API", new JNLPLauncher().getWorkDirSettings().isDisabled());
     }
 

--- a/test/src/test/java/hudson/slaves/NodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/NodePropertyTest.java
@@ -53,7 +53,7 @@ public class NodePropertyTest {
         boolean reconfigured = false;
 
         @Override
-        public NodeProperty<?> reconfigure(StaplerRequest req, JSONObject form) throws FormException {
+        public NodeProperty<?> reconfigure(StaplerRequest req, JSONObject form) {
             reconfigured = true;
             return this;
         }

--- a/test/src/test/java/hudson/slaves/NodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/NodePropertyTest.java
@@ -10,7 +10,6 @@ import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlLabel;
 import hudson.model.Descriptor;
-import hudson.model.Descriptor.FormException;
 import hudson.model.Slave;
 import java.util.logging.Level;
 import net.sf.json.JSONObject;

--- a/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
+++ b/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
@@ -81,7 +81,7 @@ public class NodeProvisionerTest {
         public Builder createBuilder() {
             return new Builder() {
                 @Override
-                public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                     block();
                     return true;
                 }

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -86,7 +86,7 @@ public class PingThreadTest {
     }
 
     private static final class GetPid extends MasterToSlaveCallable<String, IOException> {
-        @Override public String call() throws IOException {
+        @Override public String call() {
             return ManagementFactory.getRuntimeMXBean().getName().replaceAll("@.*", "");
         }
     }

--- a/test/src/test/java/hudson/slaves/SlaveComputerTest.java
+++ b/test/src/test/java/hudson/slaves/SlaveComputerTest.java
@@ -110,7 +110,7 @@ public class SlaveComputerTest {
         static int onOnlineCount = 0;
 
         @Override
-        public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
+        public void onOnline(Computer c, TaskListener listener) throws IOException {
             if (c instanceof SlaveComputer) {
                 onOnlineCount++;
                 throw new IOException("Something happened (the listener always throws this exception)");
@@ -124,7 +124,7 @@ public class SlaveComputerTest {
         static int onOnlineCount = 0;
 
         @Override
-        public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
+        public void onOnline(Computer c, TaskListener listener) {
             if (c instanceof SlaveComputer) {
                 onOnlineCount++;
                 throw new RuntimeException("Something happened (the listener always throws this exception)");
@@ -158,7 +158,7 @@ public class SlaveComputerTest {
         static volatile int onOnlineCount = 0;
 
         @Override
-        public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
+        public void onOnline(Computer c, TaskListener listener) {
             if (c instanceof SlaveComputer) {
                 onOnlineCount++;
                 throw new IOError(new Exception("Something happened (the listener always throws this exception)"));

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -444,7 +444,7 @@ public class ArtifactArchiverTest {
 
     private static class RemoveReadPermission extends MasterToSlaveFileCallable<Object> {
         @Override
-        public Object invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+        public Object invoke(File f, VirtualChannel channel) throws IOException {
             assertTrue(f.createNewFile());
             assertTrue(f.setReadable(false));
             return null;

--- a/test/src/test/java/hudson/tasks/BatchFileTest.java
+++ b/test/src/test/java/hudson/tasks/BatchFileTest.java
@@ -30,13 +30,13 @@ public class BatchFileTest {
 
     @Issue("JENKINS-7478")
     @Test
-    public void validateBatchFileCommandEOL() throws Exception {
+    public void validateBatchFileCommandEOL() {
         BatchFile obj = new BatchFile("echo A\necho B\recho C");
         rule.assertStringContains(obj.getCommand(), "echo A\r\necho B\r\necho C");
     }
 
     @Test
-    public void validateBatchFileContents() throws Exception {
+    public void validateBatchFileContents() {
         BatchFile obj = new BatchFile("echo A\necho B\recho C");
         rule.assertStringContains(obj.getContents(), "echo A\r\necho B\r\necho C\r\nexit %ERRORLEVEL%");
     }
@@ -51,7 +51,7 @@ public class BatchFileTest {
         }
 
         @Override
-        public Proc onLaunch(ProcStarter p) throws IOException {
+        public Proc onLaunch(ProcStarter p) {
             return new FinishedProc(this.code);
         }
     }
@@ -141,7 +141,7 @@ public class BatchFileTest {
 
     @Issue("JENKINS-23786")
     @Test
-    public void windowsUnstableCodeZeroIsSameAsUnset() throws Exception {
+    public void windowsUnstableCodeZeroIsSameAsUnset() {
         assumeTrue(Functions.isWindows());
 
         /* Creating unstable=0 produces unstable=null */
@@ -151,7 +151,7 @@ public class BatchFileTest {
     @Issue("JENKINS-40894")
     @Test
     @LocalData
-    public void canLoadUnstableReturnFromDisk() throws Exception {
+    public void canLoadUnstableReturnFromDisk() {
         FreeStyleProject p = (FreeStyleProject) rule.jenkins.getItemByFullName("batch");
         BatchFile batchFile = (BatchFile) p.getBuildersList().get(0);
         assertEquals("unstable return", Integer.valueOf(1), batchFile.getUnstableReturn());

--- a/test/src/test/java/hudson/tasks/BatchFileTest.java
+++ b/test/src/test/java/hudson/tasks/BatchFileTest.java
@@ -9,7 +9,6 @@ import hudson.Launcher.ProcStarter;
 import hudson.Proc;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.FakeLauncher;

--- a/test/src/test/java/hudson/tasks/BuildTriggerTest.java
+++ b/test/src/test/java/hudson/tasks/BuildTriggerTest.java
@@ -345,7 +345,7 @@ public class BuildTriggerTest {
         }
 
         @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws IOException {
             FreeStyleBuild success = us.getLastSuccessfulBuild();
             FreeStyleBuild last = us.getLastBuild();
             try {

--- a/test/src/test/java/hudson/tasks/FingerprinterTest.java
+++ b/test/src/test/java/hudson/tasks/FingerprinterTest.java
@@ -98,7 +98,7 @@ public class FingerprinterTest {
     @Rule public JenkinsRule j = new JenkinsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         Fingerprinter.enableFingerprintsInDependencyGraph = true;
     }
     
@@ -122,7 +122,7 @@ public class FingerprinterTest {
 
     private static class FingerprintAddingBuilder extends Builder {
         @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
             build.addAction(new Fingerprinter.FingerprintAction(build, Collections.singletonMap(singleFiles2[0], "fakefingerprint")));
             return true;
         }

--- a/test/src/test/java/hudson/tasks/FingerprinterTest.java
+++ b/test/src/test/java/hudson/tasks/FingerprinterTest.java
@@ -51,7 +51,6 @@ import hudson.model.Result;
 import hudson.util.RunList;
 import hudson.util.StreamTaskListener;
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/test/src/test/java/hudson/tasks/ShellTest.java
+++ b/test/src/test/java/hudson/tasks/ShellTest.java
@@ -36,13 +36,13 @@ public class ShellTest {
     public JenkinsRule rule = new JenkinsRule();
 
     @Test
-    public void validateShellCommandEOL() throws Exception {
+    public void validateShellCommandEOL() {
         Shell obj = new Shell("echo A\r\necho B\recho C");
         rule.assertStringContains(obj.getCommand(), "echo A\necho B\necho C");
     }
 
     @Test
-    public void validateShellContents() throws Exception {
+    public void validateShellContents() {
         Shell obj = new Shell("echo A\r\necho B\recho C");
         rule.assertStringContains(obj.getContents(), "\necho A\necho B\necho C");
     }
@@ -54,7 +54,7 @@ public class ShellTest {
         // TODO: define a FakeLauncher implementation with easymock so that this kind of assertions can be simplified.
         PretendSlave s = rule.createPretendSlave(new FakeLauncher() {
             @Override
-            public Proc onLaunch(ProcStarter p) throws IOException {
+            public Proc onLaunch(ProcStarter p) {
                 // test the command line argument.
                 List<String> cmds = p.cmds();
                 rule.assertStringContains("/bin/sh",cmds.get(0));
@@ -89,7 +89,7 @@ public class ShellTest {
         }
 
         @Override
-        public Proc onLaunch(ProcStarter p) throws IOException {
+        public Proc onLaunch(ProcStarter p) {
             return new FinishedProc(this.code);
         }
     }
@@ -180,7 +180,7 @@ public class ShellTest {
 
     @Issue("JENKINS-23786")
     @Test
-    public void unixUnstableCodeZeroIsSameAsUnset() throws Exception {
+    public void unixUnstableCodeZeroIsSameAsUnset() {
         assumeFalse(Functions.isWindows());
 
         /* Creating unstable=0 produces unstable=null */
@@ -190,7 +190,7 @@ public class ShellTest {
     @Issue("JENKINS-40894")
     @Test
     @LocalData
-    public void canLoadUnstableReturnFromDisk() throws Exception {
+    public void canLoadUnstableReturnFromDisk() {
         FreeStyleProject p = (FreeStyleProject) rule.jenkins.getItemByFullName("test");
         Shell shell = (Shell) p.getBuildersList().get(0);
         assertEquals("unstable return", Integer.valueOf(1), shell.getUnstableReturn());

--- a/test/src/test/java/hudson/tasks/ShellTest.java
+++ b/test/src/test/java/hudson/tasks/ShellTest.java
@@ -12,7 +12,6 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 import org.apache.commons.io.FileUtils;

--- a/test/src/test/java/hudson/tools/BatchCommandInstallerTest.java
+++ b/test/src/test/java/hudson/tools/BatchCommandInstallerTest.java
@@ -15,7 +15,7 @@ public class BatchCommandInstallerTest {
     public JenkinsRule rule = new JenkinsRule();
 
     @Test
-    public void validateBatchCommandInstallerCommandEOL() throws Exception {
+    public void validateBatchCommandInstallerCommandEOL() {
         BatchCommandInstaller obj = new BatchCommandInstaller("", "echo A\necho B\recho C", "");
         rule.assertStringContains(obj.getCommand(), "echo A\r\necho B\r\necho C");
     }

--- a/test/src/test/java/hudson/tools/CommandInstallerTest.java
+++ b/test/src/test/java/hudson/tools/CommandInstallerTest.java
@@ -15,7 +15,7 @@ public class CommandInstallerTest {
     public JenkinsRule rule = new JenkinsRule();
 
     @Test
-    public void validateCommandInstallerCommandEOL() throws Exception {
+    public void validateCommandInstallerCommandEOL() {
         CommandInstaller obj = new CommandInstaller("", "echo A\r\necho B\recho C", "");
         rule.assertStringContains(obj.getCommand(), "echo A\necho B\necho C");
     }

--- a/test/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
+++ b/test/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
@@ -40,7 +40,6 @@ import hudson.tasks.Ant.AntInstallation;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Maven.MavenInstallation;
 import hudson.tasks.Shell;
-import java.io.IOException;
 import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;

--- a/test/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
+++ b/test/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
@@ -107,7 +107,7 @@ public class ToolLocationNodePropertyTest {
         assertEquals("zotfoo", location.getHome());
     }
 
-    private void configureDumpEnvBuilder() throws IOException {
+    private void configureDumpEnvBuilder() {
         if(Functions.isWindows())
             project.getBuildersList().add(new BatchFile("set"));
         else

--- a/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
+++ b/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
@@ -29,7 +29,7 @@ public class SafeTimerTaskTest {
     public LoggerRule loggerRule = new LoggerRule();
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         System.clearProperty(SafeTimerTask.LOGS_ROOT_PATH_PROPERTY);
     }
 
@@ -63,7 +63,7 @@ public class SafeTimerTaskTest {
         }
 
         @Override
-        protected void execute(TaskListener listener) throws IOException, InterruptedException {
+        protected void execute(TaskListener listener) {
             listener.getLogger().println("blah");
         }
 

--- a/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
+++ b/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import hudson.model.AsyncPeriodicWork;
 import hudson.model.TaskListener;
 import java.io.File;
-import java.io.IOException;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;

--- a/test/src/test/java/hudson/util/BootFailureTest.java
+++ b/test/src/test/java/hudson/util/BootFailureTest.java
@@ -46,7 +46,7 @@ public class BootFailureTest {
 
     static class CustomRule extends JenkinsRule {
         @Override
-        public void before() throws Throwable {
+        public void before() {
             env = new TestEnvironment(testDescription);
             env.pin();
             // don't let Jenkins start automatically

--- a/test/src/test/java/hudson/util/LineEndingConversionTest.java
+++ b/test/src/test/java/hudson/util/LineEndingConversionTest.java
@@ -17,12 +17,12 @@ public class LineEndingConversionTest {
 
     @Issue("JENKINS-7478")
     @Test
-    public void validateWindowsEOL() throws Exception {
+    public void validateWindowsEOL() {
         rule.assertStringContains(LineEndingConversion.convertEOL("echo A\necho B\recho C", LineEndingConversion.EOLType.Windows), "echo A\r\necho B\r\necho C");
     }
 
     @Test
-    public void validateUnixEOL() throws Exception {
+    public void validateUnixEOL() {
         rule.assertStringContains(LineEndingConversion.convertEOL("echo A\r\necho B\recho C", LineEndingConversion.EOLType.Unix), "echo A\necho B\necho C");
     }
 }

--- a/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -67,7 +67,7 @@ public class RobustReflectionConverterTest {
 
     @Issue("JENKINS-21024")
     @LocalData
-    @Test public void randomExceptionsReported() throws Exception {
+    @Test public void randomExceptionsReported() {
         FreeStyleProject p = r.jenkins.getItemByFullName("j", FreeStyleProject.class);
         assertNotNull(p);
         assertTrue("There should be no triggers", p.getTriggers().isEmpty());


### PR DESCRIPTION
Removed superflous throws. Just limited on hudson test namespace to somehow limit the scope.

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
