### PR TITLE
[JENKINS-66776] Add full name of failed plugin when possible

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -95,7 +95,7 @@ THE SOFTWARE.
                          original="${p.active?'true':'false'}"/>
                 </td>
                 <td class="pane details">
-                  <div>
+                  <div class="plugin-name success-plugin">
                     <a href="${p.url}" target="_blank" rel="noopener noreferrer" class="display-name">
                       ${p.updateInfo.displayName?:p.displayName}
                     </a>
@@ -208,9 +208,18 @@ THE SOFTWARE.
                   <input type="checkbox" disabled="disabled"/>
                 </td>
                 <td class="pane">
-                  <div>
+                  <j:if test="${p.pluginWrapper != null}">
+                    <div class="plugin-name failed-plugin with-plugin-wrapper">
+                      <a href="${p.pluginWrapper.url}" target="_blank" rel="noopener noreferrer" class="display-name">
+                        ${p.pluginWrapper.updateInfo.displayName?:p.pluginWrapper.displayName}
+                      </a>
+                    </div>
+                  </j:if>
+                  <j:if test="${p.pluginWrapper == null}">
+                    <div class="plugin-name failed-plugin no-plugin-wrapper">
                       ${p.name}
-                  </div>
+                    </div>
+                  </j:if>
                   <div class="alert alert-danger">
                     <pre>${p.cause.message}</pre>
                   </div>


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-66776](https://issues.jenkins-ci.org/browse/JENKINS-66776).

When a plugin failed to load, only its artifact ID was displayed. Now, when a plugin failed to load but we have access to the `PluginWrapper`, we are using it to show the DisplayName and the expected URL.

**Testing notes**
The easiest way to test this feature is to run in parallel two instances of Jenkins, one regular without this PR, and one built from this PR.
Then you download any plugin from repo.jenkins.io or build from source and you edit the .hpi file, inside the META-INF/MANIFEST.MF, you change the `Jenkins-Version: xxx` with xxx being a version number greater than the one you are running (like `2.999`). Then you upload manually that plugin to both instances and you will see the difference.

⚠️ Be careful, this does not work if you are running in dev mode, due to [PluginWrapper.java#L1030-L1031](https://github.com/jenkinsci/jenkins/blob/632033d6ada7c04bbc77ae710dc0a4635fdf9baa/core/src/main/java/hudson/PluginWrapper.java#L1030-L1031).

ℹ️ Could be changed to improvement instead of bug without problem from my PoV. As a user it feels as a bug, but the code is "clear" about it being "expected" to not care too much about this case.

<details>

<summary>Screenshot</summary>

### Before
![Screenshot_2021-10-01_170850_001](https://user-images.githubusercontent.com/2662497/135649480-5c11320c-75da-4928-8ca4-e57887bb2c51.png)


### After

![Screenshot_2021-10-01_174328_001](https://user-images.githubusercontent.com/2662497/135649489-cff80048-0348-4bd1-9f9b-bebc57afff3a.png)

</details>

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Display full plugin name and link when a plugin fails to load.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
