### PR TITLE
Replaced volatile int with AtomicInt to fix spotbugs 

### DIFF
--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -25,6 +25,7 @@ package hudson.util;
 
 import java.util.AbstractList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 
@@ -39,7 +40,7 @@ public class RingBufferLogHandler extends Handler {
 
     private int start = 0;
     private final LogRecord[] records;
-    private volatile int size = 0;
+    private AtomicInteger size = new AtomicInteger(0);
 
     /**
      * This constructor is deprecated. It can't access system properties with {@link jenkins.util.SystemProperties}
@@ -66,16 +67,16 @@ public class RingBufferLogHandler extends Handler {
     @Override
     public synchronized void publish(LogRecord record) {
         int len = records.length;
-        records[(start+size)%len]=record;
-        if(size==len) {
+        records[(start+size.get())%len]=record;
+        if(size.get()==len) {
             start = (start+1)%len;
         } else {
-            size++;
+            size.incrementAndGet();
         }
     }
 
     public synchronized void clear() {
-        size = 0;
+        size.set(0);
         start = 0;
     }
 
@@ -91,13 +92,13 @@ public class RingBufferLogHandler extends Handler {
             public LogRecord get(int index) {
                 // flip the order
                 synchronized (RingBufferLogHandler.this) {
-                    return records[(start+(size-(index+1)))%records.length];
+                    return records[(start+(size.get()-(index+1)))%records.length];
                 }
             }
 
             @Override
             public int size() {
-                return size;
+                return size.get();
             }
         };
     }

--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -67,8 +67,9 @@ public class RingBufferLogHandler extends Handler {
     @Override
     public synchronized void publish(LogRecord record) {
         int len = records.length;
-        records[(start+size.get())%len]=record;
-        if(size.get()==len) {
+        final int tempSize = size.get();
+        records[(start+ tempSize)%len]=record;
+        if(tempSize ==len) {
             start = (start+1)%len;
         } else {
             size.incrementAndGet();


### PR DESCRIPTION
This is a fix of a spotbugs error [VO_VOLATILE_INCREMENT](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#vo-an-increment-to-a-volatile-field-isn-t-atomic-vo-volatile-increment)

The `private volatine int` has been replaced with an `AtomicInt`

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
