### PR TITLE
Upgrade detached plugins to versions with Guava compatibility fixes

### DIFF
--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -429,6 +429,7 @@ public class AbstractProjectTest {
         tpm.installDetachedPlugin("workflow-step-api");
         tpm.installDetachedPlugin("scm-api");
         tpm.installDetachedPlugin("workflow-api");
+        tpm.installDetachedPlugin("script-security");
         tpm.installDetachedPlugin("junit");
         tpm.installDetachedPlugin("matrix-project");
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -304,28 +304,28 @@ THE SOFTWARE.
                   <!-- dependency of junit -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-api</artifactId>
-                  <version>2.40</version>
+                  <version>2.42</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
-                  <!-- dependency of junit -->
+                  <!-- dependency of junit and workflow-api -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-step-api</artifactId>
-                  <version>2.22</version>
+                  <version>2.23</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of workflow-api -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>scm-api</artifactId>
-                  <version>2.4.1</version>
+                  <version>2.6.5</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
-                  <!-- dependency of junit -->
+                  <!-- dependency of junit and scm-api -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>structs</artifactId>
-                  <version>1.20</version>
+                  <version>1.23</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
To be compatible with recent versions of Guava, [Pipeline: API](https://plugins.jenkins.io/workflow-api/) needs jenkinsci/workflow-api-plugin#135 and [SCM API](https://plugins.jenkins.io/scm-api/) needs jenkinsci/scm-api-plugin#85. The former was released in [2.42](https://github.com/jenkinsci/workflow-api-plugin/releases/tag/workflow-api-2.42), and the latter was released in [2.6.5](https://github.com/jenkinsci/scm-api-plugin/releases/tag/scm-api-2.6.5). In preparation for the Guava upgrade in core, this PR bumps the versions of these detached plugins to those mentioned above. Since `workflow-api` 2.42 depends on `workflow-step-api` 2.23, we update that as well. Since `scm-api` 2.6.5 depends on `structs` 1.23, we update that as well.

### Proposed changelog entries

* Update bundled versions of Pipeline: API, Pipeline: Step API, SCM API, and Structs plugins.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@MarkEWaite and @dheerajodha include links to [Pipeline: API](https://plugins.jenkins.io/workflow-api/), [Pipeline: Step API](https://plugins.jenkins.io/workflow-step-api/), [SCM API](https://plugins.jenkins.io/scm-api), and [Structs](https://plugins.jenkins.io/structs/) plugins in the references section of the changelog


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
