### PR TITLE
Replaced magic constants in Calender constructors

### DIFF
--- a/core/src/test/java/hudson/scheduler/CronTabDayOfWeekLocaleTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabDayOfWeekLocaleTest.java
@@ -51,7 +51,7 @@ public class CronTabDayOfWeekLocaleTest {
     @Issue("HUDSON-8656") // This is _not_ JENKINS-8656
     public void hudson8656() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 23 * * 1-5"; // execute on weekdays @23:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -59,14 +59,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expectedDate = Calendar.getInstance();
         // Expected next: Monday, Jan 17th 2011, 23:00
-        expectedDate.set(2011, 0, 17, 23, 0, 0);
+        expectedDate.set(2011, Calendar.JANUARY, 17, 23, 0, 0);
         compare(expectedDate, next);
     }
     
     @Test
     public void isSundayAndNextRunIsMonday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 1"; // Mondays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -74,14 +74,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Monday, Jan 17th 2011, 00:00
-        expected.set(2011, 0, 17, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 17, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndPreviousRunIsMonday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 1"; // Mondays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -89,14 +89,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Monday, Jan 10th 2011, 00:00
-        expected.set(2011, 0, 10, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 10, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndNextRunIsTuesday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 2"; // Tuesdays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -104,14 +104,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Tuesday, Jan 18th 2011, 00:00
-        expected.set(2011, 0, 18, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 18, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndPreviousRunIsTuesday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 2"; // Tuesdays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -119,14 +119,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Tuesday, Jan 11th 2011, 00:00
-        expected.set(2011, 0, 11, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 11, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndNextRunIsWednesday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 3"; // Wednesdays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -134,14 +134,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Wednesday, Jan 19th 2011, 00:00
-        expected.set(2011, 0, 19, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 19, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndPreviousRunIsWednesday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 3"; // Wednesdays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -149,14 +149,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Wednesday, Jan 12th 2011, 00:00
-        expected.set(2011, 0, 12, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 12, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndNextRunIsThursday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 4"; // Thursdays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -164,14 +164,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Thursday, Jan 20th 2011, 00:00
-        expected.set(2011, 0, 20, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 20, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndPreviousRunIsThursday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 4"; // Thursdays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -179,14 +179,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Thursday, Jan 13th 2011, 00:00
-        expected.set(2011, 0, 13, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 13, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndNextRunIsFriday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 5"; // Fridays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -194,14 +194,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Friday, Jan 21th 2011, 00:00
-        expected.set(2011, 0, 21, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 21, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndPreviousRunIsFriday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 5"; // Fridays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -209,14 +209,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Friday, Jan 14th 2011, 00:00
-        expected.set(2011, 0, 14, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 14, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndNextRunIsSaturday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 6"; // Saturdays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -224,14 +224,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Saturday, Jan 22th 2011, 00:00
-        expected.set(2011, 0, 22, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 22, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndPreviousRunIsSaturday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 0 * * 6"; // Saturdays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -239,14 +239,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Saturday, Jan 15th 2011, 00:00
-        expected.set(2011, 0, 15, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 15, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndNextRunIsNextSunday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 1, 0, 0); // Sunday, Jan 16th 2011, 01:00
+        cal.set(2011, Calendar.JANUARY, 16, 1, 0, 0); // Sunday, Jan 16th 2011, 01:00
         final String cronStr = "0 0 * * 0"; // Sundays @00:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -254,14 +254,14 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Sunday, Jan 22th 2011, 00:00
-        expected.set(2011, 0, 23, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 23, 0, 0, 0);
         compare(expected, actual);
     }
     
     @Test
     public void isSundayAndPreviousRunIsPreviousSunday() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 1 * * 0"; // Sundays @01:00
         
         final CronTab cron = new CronTab(cronStr);
@@ -269,7 +269,7 @@ public class CronTabDayOfWeekLocaleTest {
         
         final Calendar expected = Calendar.getInstance();
         // Expected next: Sunday, Jan 9th 2011, 01:00
-        expected.set(2011, 0, 9, 1, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 9, 1, 0, 0);
         compare(expected, actual);
     }
 
@@ -277,7 +277,7 @@ public class CronTabDayOfWeekLocaleTest {
     @Issue("JENKINS-12357")
     public void isSundayAndNextRunIsNextSunday7() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 1, 0, 0); // Sunday, Jan 16th 2011, 01:00
+        cal.set(2011, Calendar.JANUARY, 16, 1, 0, 0); // Sunday, Jan 16th 2011, 01:00
         final String cronStr = "0 0 * * 7"; // Sundays(7 not 0) @00:00
 
         final CronTab cron = new CronTab(cronStr);
@@ -285,14 +285,14 @@ public class CronTabDayOfWeekLocaleTest {
 
         final Calendar expected = Calendar.getInstance();
         // Expected next: Sunday, Jan 22th 2011, 00:00
-        expected.set(2011, 0, 23, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 23, 0, 0, 0);
         compare(expected, actual);
     }
 
     @Test
     public void isSundayAndPreviousRunIsPreviousSunday7() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 1 * * 7"; // Sundays(7 not 0) @01:00
 
         final CronTab cron = new CronTab(cronStr);
@@ -300,14 +300,14 @@ public class CronTabDayOfWeekLocaleTest {
 
         final Calendar expected = Calendar.getInstance();
         // Expected next: Sunday, Jan 9th 2011, 01:00
-        expected.set(2011, 0, 9, 1, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 9, 1, 0, 0);
         compare(expected, actual);
     }
 
     @Test
     public void isSaturdayAndNextRunIsSundayAsterisk() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 15, 1, 0, 0); // Saturday, Jan 15th 2011, 01:00
+        cal.set(2011, Calendar.JANUARY, 15, 1, 0, 0); // Saturday, Jan 15th 2011, 01:00
         final String cronStr = "0 0 * * *"; // Everyday @00:00
 
         final CronTab cron = new CronTab(cronStr);
@@ -315,14 +315,14 @@ public class CronTabDayOfWeekLocaleTest {
 
         final Calendar expected = Calendar.getInstance();
         // Expected next: Sunday, Jan 16th 2011, 00:00
-        expected.set(2011, 0, 16, 0, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 16, 0, 0, 0);
         compare(expected, actual);
     }
 
     @Test
     public void isSundayAndPreviousRunIsSaturdayAsterisk() throws Exception {
         final Calendar cal = Calendar.getInstance(locale);
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 23 * * *"; // Everyday @23:00
 
         final CronTab cron = new CronTab(cronStr);
@@ -330,7 +330,7 @@ public class CronTabDayOfWeekLocaleTest {
 
         final Calendar expected = Calendar.getInstance();
         // Expected next: Saturday, Jan 15th 2011, 23:00
-        expected.set(2011, 0, 15, 23, 0, 0);
+        expected.set(2011, Calendar.JANUARY, 15, 23, 0, 0);
         compare(expected, actual);
     }
 

--- a/core/src/test/java/hudson/scheduler/CronTabEventualityTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabEventualityTest.java
@@ -43,7 +43,7 @@ public class CronTabEventualityTest {
     @Test
     @Issue("JENKINS-12388")
     public void testYearlyWillBeEventuallyTriggeredWithinOneYear() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.YEAR, 1);
         checkEventuality(start, "@yearly", limit);
     }
@@ -51,56 +51,56 @@ public class CronTabEventualityTest {
     @Test
     @Issue("JENKINS-12388")
     public void testAnnuallyWillBeEventuallyTriggeredWithinOneYear() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.YEAR, 1);
         checkEventuality(start, "@annually", limit);
     }
 
     @Test
     public void testMonthlyWillBeEventuallyTriggeredWithinOneMonth() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.MONTH, 1);
         checkEventuality(start, "@monthly", limit);
     }
 
     @Test
     public void testWeeklyWillBeEventuallyTriggeredWithinOneWeek() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.WEEK_OF_YEAR, 1);
         checkEventuality(start, "@weekly", limit);
     }
 
     @Test
     public void testDailyWillBeEventuallyTriggeredWithinOneDay() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.DAY_OF_MONTH, 1);
         checkEventuality(start, "@daily", limit);
     }
 
     @Test
     public void testMidnightWillBeEventuallyTriggeredWithinOneDay() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.DAY_OF_MONTH, 1);
         checkEventuality(start, "@midnight", limit);
     }
 
     @Test
     public void testHourlyWillBeEventuallyTriggeredWithinOneHour() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.HOUR, 1);
         checkEventuality(start, "@hourly", limit);
     }
 
     @Test
     public void testFirstDayOfMonthWillBeEventuallyTriggeredWithinOneMonth() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.MONTH, 1);
         checkEventuality(start, "H H 1 * *", limit);
     }
 
     @Test
     public void testFirstSundayOfMonthWillBeEventuallyTriggeredWithinOneMonthAndOneWeek() throws ANTLRException {
-        Calendar start = new GregorianCalendar(2012, 0, 11, 22, 33); // Jan 11th 2012 22:33
+        Calendar start = new GregorianCalendar(2012, Calendar.JANUARY, 11, 22, 33); // Jan 11th 2012 22:33
         Calendar limit = createLimit(start, Calendar.DAY_OF_MONTH, 31+7);
         // If both day of month and day of week are specified:
         //     UNIX: triggered when either matches

--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -56,29 +56,29 @@ public class CronTabTest {
     @Test
     public void testCeil1() throws Exception {
         CronTab x = new CronTab("0,30 * * * *");
-        Calendar c = new GregorianCalendar(2000,2,1,1,10);
-        compare(new GregorianCalendar(2000,2,1,1,30),x.ceil(c));
+        Calendar c = new GregorianCalendar(2000, Calendar.MARCH,1,1,10);
+        compare(new GregorianCalendar(2000, Calendar.MARCH,1,1,30),x.ceil(c));
 
         // roll up test
-        c =     new GregorianCalendar(2000,2,1,1,40);
-        compare(new GregorianCalendar(2000,2,1,2, 0),x.ceil(c));
+        c =     new GregorianCalendar(2000, Calendar.MARCH,1,1,40);
+        compare(new GregorianCalendar(2000, Calendar.MARCH,1,2, 0),x.ceil(c));
     }
 
     @Test
     public void testCeil2() throws Exception {
         // make sure that lower fields are really reset correctly
         CronTab x = new CronTab("15,45 3 * * *");
-        Calendar c = new GregorianCalendar(2000,2,1,2,30);
-        compare(new GregorianCalendar(2000,2,1,3,15),x.ceil(c));
+        Calendar c = new GregorianCalendar(2000, Calendar.MARCH,1,2,30);
+        compare(new GregorianCalendar(2000, Calendar.MARCH,1,3,15),x.ceil(c));
     }
 
     @Test
     public void testCeil3() throws Exception {
         // conflict between DoM and DoW. In this we need to find a day that's the first day of a month and Sunday
         CronTab x = new CronTab("0 0 1 * 0");
-        Calendar c = new GregorianCalendar(2010,0,1,15,55);
+        Calendar c = new GregorianCalendar(2010, Calendar.JANUARY,1,15,55);
         // the first such day in 2010 is Aug 1st
-        compare(new GregorianCalendar(2010,7,1,0,0),x.ceil(c));
+        compare(new GregorianCalendar(2010, Calendar.AUGUST,1,0,0),x.ceil(c));
     }
 
     @Test(timeout = 1000)
@@ -86,9 +86,9 @@ public class CronTabTest {
     public void testCeil3_DoW7() throws Exception {
         // similar to testCeil3, but DoW=7 may stuck in an infinite loop
         CronTab x = new CronTab("0 0 1 * 7");
-        Calendar c = new GregorianCalendar(2010,0,1,15,55);
+        Calendar c = new GregorianCalendar(2010, Calendar.JANUARY,1,15,55);
         // the first such day in 2010 is Aug 1st
-        compare(new GregorianCalendar(2010, 7, 1, 0, 0), x.ceil(c));
+        compare(new GregorianCalendar(2010, Calendar.AUGUST, 1, 0, 0), x.ceil(c));
     }
 
     /**
@@ -98,14 +98,14 @@ public class CronTabTest {
     @Test
     public void testCeil4() throws ANTLRException {
         final Calendar cal = Calendar.getInstance(new Locale("de", "de"));
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 23 * * 1-5"; // execute on weekdays @23:00
 
         final CronTab cron = new CronTab(cronStr);
         final Calendar next = cron.ceil(cal);
 
         final Calendar expectedDate = Calendar.getInstance();
-        expectedDate.set(2011, 0, 17, 23, 0, 0); // Expected next: Monday, Jan 17th 2011, 23:00
+        expectedDate.set(2011, Calendar.JANUARY, 17, 23, 0, 0); // Expected next: Monday, Jan 17th 2011, 23:00
         assertEquals(expectedDate.get(Calendar.HOUR), next.get(Calendar.HOUR));
         assertEquals(expectedDate.get(Calendar.MINUTE), next.get(Calendar.MINUTE));
         assertEquals(expectedDate.get(Calendar.YEAR), next.get(Calendar.YEAR));
@@ -120,14 +120,14 @@ public class CronTabTest {
     @Test
     public void testCeil5() throws ANTLRException {
         final Calendar cal = Calendar.getInstance(new Locale("de", "at"));
-        cal.set(2011, 0, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
+        cal.set(2011, Calendar.JANUARY, 16, 0, 0, 0); // Sunday, Jan 16th 2011, 00:00
         final String cronStr = "0 23 * * 1-5"; // execute on weekdays @23:00
 
         final CronTab cron = new CronTab(cronStr);
         final Calendar next = cron.ceil(cal);
 
         final Calendar expectedDate = Calendar.getInstance();
-        expectedDate.set(2011, 0, 17, 23, 0, 0); // Expected next: Monday, Jan 17th 2011, 23:00
+        expectedDate.set(2011, Calendar.JANUARY, 17, 23, 0, 0); // Expected next: Monday, Jan 17th 2011, 23:00
         assertEquals(expectedDate.get(Calendar.HOUR), next.get(Calendar.HOUR));
         assertEquals(expectedDate.get(Calendar.MINUTE), next.get(Calendar.MINUTE));
         assertEquals(expectedDate.get(Calendar.YEAR), next.get(Calendar.YEAR));
@@ -138,29 +138,29 @@ public class CronTabTest {
     @Test
     public void testFloor1() throws Exception {
         CronTab x = new CronTab("30 * * * *");
-        Calendar c = new GregorianCalendar(2000,2,1,1,40);
-        compare(new GregorianCalendar(2000,2,1,1,30),x.floor(c));
+        Calendar c = new GregorianCalendar(2000, Calendar.MARCH,1,1,40);
+        compare(new GregorianCalendar(2000, Calendar.MARCH,1,1,30),x.floor(c));
 
         // roll down test
-        c =     new GregorianCalendar(2000,2,1,1,10);
-        compare(new GregorianCalendar(2000,2,1,0,30),x.floor(c));
+        c =     new GregorianCalendar(2000, Calendar.MARCH,1,1,10);
+        compare(new GregorianCalendar(2000, Calendar.MARCH,1,0,30),x.floor(c));
     }
 
     @Test
     public void testFloor2() throws Exception {
         // make sure that lower fields are really reset correctly
         CronTab x = new CronTab("15,45 3 * * *");
-        Calendar c = new GregorianCalendar(2000,2,1,4,30);
-        compare(new GregorianCalendar(2000,2,1,3,45),x.floor(c));
+        Calendar c = new GregorianCalendar(2000, Calendar.MARCH,1,4,30);
+        compare(new GregorianCalendar(2000, Calendar.MARCH,1,3,45),x.floor(c));
     }
 
     @Test
     public void testFloor3() throws Exception {
         // conflict between DoM and DoW. In this we need to find a day that's the first day of a month and Sunday in 2010
         CronTab x = new CronTab("0 0 1 * 0");
-        Calendar c = new GregorianCalendar(2011,0,1,15,55);
+        Calendar c = new GregorianCalendar(2011, Calendar.JANUARY,1,15,55);
         // the last such day in 2010 is Aug 1st
-        compare(new GregorianCalendar(2010,7,1,0,0),x.floor(c));
+        compare(new GregorianCalendar(2010, Calendar.AUGUST,1,0,0),x.floor(c));
     }
 
     @Issue("JENKINS-8401")
@@ -168,10 +168,10 @@ public class CronTabTest {
     public void testFloor4() throws Exception {
         // conflict between DoM and DoW. In this we need to find a day that's the first day of a month and Sunday in 2010
         CronTab x = new CronTab("0 0 1 * 0");
-        Calendar c = new GregorianCalendar(2011,0,1,15,55);
+        Calendar c = new GregorianCalendar(2011, Calendar.JANUARY,1,15,55);
         c.setFirstDayOfWeek(MONDAY);
         // the last such day in 2010 is Aug 1st
-        GregorianCalendar answer = new GregorianCalendar(2010, 7, 1, 0, 0);
+        GregorianCalendar answer = new GregorianCalendar(2010, Calendar.AUGUST, 1, 0, 0);
         answer.setFirstDayOfWeek(MONDAY);
         compare(answer,x.floor(c));
     }
@@ -248,31 +248,31 @@ public class CronTabTest {
     }
 
     @Test public void hashedMinute() throws Exception {
-        long t = new GregorianCalendar(2013, 2, 21, 16, 21).getTimeInMillis();
-        compare(new GregorianCalendar(2013, 2, 21, 17, 56), new CronTab("H 17 * * *", Hash.from("stuff")).ceil(t));
-        compare(new GregorianCalendar(2013, 2, 21, 16, 56), new CronTab("H * * * *", Hash.from("stuff")).ceil(t));
-        compare(new GregorianCalendar(2013, 2, 21, 16, 56), new CronTab("@hourly", Hash.from("stuff")).ceil(t));
-        compare(new GregorianCalendar(2013, 2, 21, 17, 20), new CronTab("@hourly", Hash.from("junk")).ceil(t));
-        compare(new GregorianCalendar(2013, 2, 22, 13, 56), new CronTab("H H(12-13) * * *", Hash.from("stuff")).ceil(t));
+        long t = new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 21).getTimeInMillis();
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 17, 56), new CronTab("H 17 * * *", Hash.from("stuff")).ceil(t));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 56), new CronTab("H * * * *", Hash.from("stuff")).ceil(t));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 56), new CronTab("@hourly", Hash.from("stuff")).ceil(t));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 17, 20), new CronTab("@hourly", Hash.from("junk")).ceil(t));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 22, 13, 56), new CronTab("H H(12-13) * * *", Hash.from("stuff")).ceil(t));
     }
 
     @Test public void hashSkips() throws Exception {
-        compare(new GregorianCalendar(2013, 2, 21, 16, 26), new CronTab("H/15 * * * *", Hash.from("stuff")).ceil(new GregorianCalendar(2013, 2, 21, 16, 21)));
-        compare(new GregorianCalendar(2013, 2, 21, 16, 41), new CronTab("H/15 * * * *", Hash.from("stuff")).ceil(new GregorianCalendar(2013, 2, 21, 16, 31)));
-        compare(new GregorianCalendar(2013, 2, 21, 16, 56), new CronTab("H/15 * * * *", Hash.from("stuff")).ceil(new GregorianCalendar(2013, 2, 21, 16, 42)));
-        compare(new GregorianCalendar(2013, 2, 21, 17, 11), new CronTab("H/15 * * * *", Hash.from("stuff")).ceil(new GregorianCalendar(2013, 2, 21, 16, 59)));
-        compare(new GregorianCalendar(2013, 2, 21, 0, 2), new CronTab("H(0-15)/3 * * * *", Hash.from("junk")).ceil(new GregorianCalendar(2013, 2, 21, 0, 0)));
-        compare(new GregorianCalendar(2013, 2, 21, 0, 2), new CronTab("H(0-3)/4 * * * *", Hash.from("junk")).ceil(new GregorianCalendar(2013, 2, 21, 0, 0)));
-        compare(new GregorianCalendar(2013, 2, 21, 1, 2), new CronTab("H(0-3)/4 * * * *", Hash.from("junk")).ceil(new GregorianCalendar(2013, 2, 21, 0, 5)));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 26), new CronTab("H/15 * * * *", Hash.from("stuff")).ceil(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 21)));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 41), new CronTab("H/15 * * * *", Hash.from("stuff")).ceil(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 31)));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 56), new CronTab("H/15 * * * *", Hash.from("stuff")).ceil(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 42)));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 17, 11), new CronTab("H/15 * * * *", Hash.from("stuff")).ceil(new GregorianCalendar(2013, Calendar.MARCH, 21, 16, 59)));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 0, 2), new CronTab("H(0-15)/3 * * * *", Hash.from("junk")).ceil(new GregorianCalendar(2013, Calendar.MARCH, 21, 0, 0)));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 0, 2), new CronTab("H(0-3)/4 * * * *", Hash.from("junk")).ceil(new GregorianCalendar(2013, Calendar.MARCH, 21, 0, 0)));
+        compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 1, 2), new CronTab("H(0-3)/4 * * * *", Hash.from("junk")).ceil(new GregorianCalendar(2013, Calendar.MARCH, 21, 0, 5)));
 
-        assertThrows(ANTLRException.class, () -> compare(new GregorianCalendar(2013, 2, 21, 0, 0), new CronTab("H(0-3)/15 * * * *", Hash.from("junk")).ceil(new GregorianCalendar(2013, 2, 21, 0, 0))));
+        assertThrows(ANTLRException.class, () -> compare(new GregorianCalendar(2013, Calendar.MARCH, 21, 0, 0), new CronTab("H(0-3)/15 * * * *", Hash.from("junk")).ceil(new GregorianCalendar(2013, Calendar.MARCH, 21, 0, 0))));
     }
 
     @Test public void repeatedHash() throws Exception {
         CronTabList tabs = CronTabList.create("H * * * *\nH * * * *", Hash.from("seed"));
         List<Integer> times = new ArrayList<>();
         for (int i = 0; i < 60; i++) {
-            if (tabs.check(new GregorianCalendar(2013, 3, 3, 11, i, 0))) {
+            if (tabs.check(new GregorianCalendar(2013, Calendar.APRIL, 3, 11, i, 0))) {
                 times.add(i);
             }
         }


### PR DESCRIPTION
Replaced magic constants in Calender constructors

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
