### PR TITLE
[JENKINS-66854] `AsyncPeriodicWork` should not touch its log file unless it has something to say

### DIFF
--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -113,21 +113,16 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
                 long startTime = System.currentTimeMillis();
                 long stopTime;
 
-                StreamTaskListener l = createListener();
+                AsyncPeriodicWork.LazyTaskListener l = new AsyncPeriodicWork.LazyTaskListener(() -> createListener(), String.format("Started at %tc", new Date(startTime)));
                 try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
-                    l.getLogger().printf("Started at %tc%n", new Date(startTime));
-                        execute(l);
+                    execute(l);
                 } catch (IOException e) {
                     Functions.printStackTrace(e, l.fatalError(e.getMessage()));
                 } catch (InterruptedException e) {
                     Functions.printStackTrace(e, l.fatalError("aborted"));
                 } finally {
                     stopTime = System.currentTimeMillis();
-                    try {
-                        l.getLogger().printf("Finished at %tc. %dms%n", new Date(stopTime), stopTime - startTime);
-                    } finally {
-                        l.closeQuietly();
-                    }
+                    l.close(String.format("Finished at %tc. %dms", new Date(stopTime), stopTime - startTime));
                 }
 
                 logger.log(getNormalLoggingLevel(), "Finished {0}. {1,number} ms",

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -6,8 +6,10 @@ import hudson.security.ACLContext;
 import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import jenkins.model.Jenkins;
@@ -94,9 +96,8 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
                 long startTime = System.currentTimeMillis();
                 long stopTime;
 
-                StreamTaskListener l = createListener();
+                LazyTaskListener l = new LazyTaskListener(() -> createListener(), String.format("Started at %tc", new Date(startTime)));
                 try {
-                    l.getLogger().printf("Started at %tc%n", new Date(startTime));
                     try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
                         execute(l);
                     }
@@ -106,11 +107,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
                     Functions.printStackTrace(e, l.fatalError("aborted"));
                 } finally {
                     stopTime = System.currentTimeMillis();
-                    try {
-                        l.getLogger().printf("Finished at %tc. %dms%n", new Date(stopTime), stopTime - startTime);
-                    } finally {
-                        l.closeQuietly();
-                    }
+                    l.close(String.format("Finished at %tc. %dms", new Date(stopTime), stopTime - startTime));
                 }
 
                 logger.log(getNormalLoggingLevel(), "Finished {0}. {1,number} ms",
@@ -123,6 +120,38 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
             lr.setParameters(new Object[]{name});
             logger.log(lr);
         }
+    }
+
+    static final class LazyTaskListener implements TaskListener {
+
+        private final Supplier<StreamTaskListener> supplier;
+        private final String openingMessage;
+        private StreamTaskListener delegate;
+
+        LazyTaskListener(Supplier<StreamTaskListener> supplier, String openingMessage) {
+            this.supplier = supplier;
+            this.openingMessage = openingMessage;
+        }
+
+        @Override
+        public synchronized PrintStream getLogger() {
+            if (delegate == null) {
+                delegate = supplier.get();
+                delegate.getLogger().println(openingMessage);
+            }
+            return delegate.getLogger();
+        }
+
+        synchronized void close(String closingMessage) {
+            if (delegate != null) {
+                try {
+                    delegate.getLogger().println(closingMessage);
+                } finally {
+                    delegate.closeQuietly();
+                }
+            }
+        }
+
     }
 
     protected StreamTaskListener createListener() {


### PR DESCRIPTION
See [JENKINS-66854](https://issues.jenkins-ci.org/browse/JENKINS-66854).

Note that e.g. `BackgroundGlobalBuildDiscarder` will currently print something every hour if there are any jobs defined. But now `TelemetryReporter` will never create a log file.

Using `RewindableRotatingFileOutputStream` would make sense for frequently-run tasks, but I did not bother with that here.

### Proposed changelog entries

* Reduce the amount of disk writes to `logs/tasks/\*.log` when nothing interesting is happening.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
