### PR TITLE
[JENKINS-66947] Make `ExecutorListener` an extension point

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -613,21 +613,6 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         return new BuildTimelineWidget(getBuilds());
     }
 
-    @Override
-    public void taskAccepted(Executor executor, Queue.Task task) {
-        // dummy implementation
-    }
-
-    @Override
-    public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
-        // dummy implementation
-    }
-
-    @Override
-    public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
-        // dummy implementation
-    }
-
     @Exported
     public boolean isOffline() {
         return temporarilyOffline || getChannel()==null;

--- a/core/src/main/java/hudson/model/ExecutorListener.java
+++ b/core/src/main/java/hudson/model/ExecutorListener.java
@@ -29,7 +29,7 @@ import hudson.slaves.SlaveComputer;
 /**
  * A listener for task related events from executors.
  * A {@link Computer#getRetentionStrategy} or {@link SlaveComputer#getLauncher} may implement this interface.
- * Or you may create an implementation as an extension.
+ * Or you may create an implementation as an extension (since TODO).
 * @author Stephen Connolly
 * @since 1.312
 */
@@ -47,6 +47,7 @@ public interface ExecutorListener extends ExtensionPoint {
      * @param executor The executor.
      * @param task The task.
      * @param executable the executable.
+     * @since TODO
      */
     default void taskStarted(Executor e, Queue.Task task) {}
 

--- a/core/src/main/java/hudson/model/ExecutorListener.java
+++ b/core/src/main/java/hudson/model/ExecutorListener.java
@@ -40,7 +40,15 @@ public interface ExecutorListener extends ExtensionPoint {
      * @param executor The executor.
      * @param task The task.
      */
-    void taskAccepted(Executor executor, Queue.Task task);
+    default void taskAccepted(Executor executor, Queue.Task task) {}
+
+    /**
+     * Called whenever a task is started by an executor.
+     * @param executor The executor.
+     * @param task The task.
+     * @param executable the executable.
+     */
+    default void taskStarted(Executor e, Queue.Task task, Queue.Executable executable) {}
 
     /**
      * Called whenever a task is completed without any problems by an executor.
@@ -48,7 +56,7 @@ public interface ExecutorListener extends ExtensionPoint {
      * @param task The task.
      * @param durationMS The number of milliseconds that the task took to complete.
      */
-    void taskCompleted(Executor executor, Queue.Task task, long durationMS);
+    default void taskCompleted(Executor executor, Queue.Task task, long durationMS) {}
 
     /**
      * Called whenever a task is completed with some problems by an executor.
@@ -57,5 +65,5 @@ public interface ExecutorListener extends ExtensionPoint {
      * @param durationMS The number of milliseconds that the task took to complete.
      * @param problems The exception that was thrown.
      */
-    void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems);
+    default void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {}
 }

--- a/core/src/main/java/hudson/model/ExecutorListener.java
+++ b/core/src/main/java/hudson/model/ExecutorListener.java
@@ -48,7 +48,7 @@ public interface ExecutorListener extends ExtensionPoint {
      * @param task The task.
      * @param executable the executable.
      */
-    default void taskStarted(Executor e, Queue.Task task, Queue.Executable executable) {}
+    default void taskStarted(Executor e, Queue.Task task) {}
 
     /**
      * Called whenever a task is completed without any problems by an executor.

--- a/core/src/main/java/hudson/model/ExecutorListener.java
+++ b/core/src/main/java/hudson/model/ExecutorListener.java
@@ -23,15 +23,17 @@
  */
 package hudson.model;
 
+import hudson.ExtensionPoint;
 import hudson.slaves.SlaveComputer;
 
 /**
  * A listener for task related events from executors.
  * A {@link Computer#getRetentionStrategy} or {@link SlaveComputer#getLauncher} may implement this interface.
+ * Or you may create an implementation as an extension.
 * @author Stephen Connolly
 * @since 1.312
 */
-public interface ExecutorListener {
+public interface ExecutorListener extends ExtensionPoint {
 
     /**
      * Called whenever a task is accepted by an executor.

--- a/core/src/main/java/hudson/model/queue/WorkUnitContext.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnitContext.java
@@ -124,7 +124,11 @@ public final class WorkUnitContext {
             Executor e = Executor.currentExecutor();
             WorkUnit wu = e.getCurrentWorkUnit();
             if (wu.isMainWork()) {
-                future.start.set(e.getCurrentExecutable());
+                Queue.Executable executable = e.getCurrentExecutable();
+                future.start.set(executable);
+                for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
+                    listener.taskStarted(e, task, executable);
+                }
             }
         }
     }

--- a/core/src/main/java/hudson/model/queue/WorkUnitContext.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnitContext.java
@@ -33,6 +33,8 @@ import hudson.model.Queue.Task;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -42,6 +44,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Kohsuke Kawaguchi
  */
 public final class WorkUnitContext {
+
+    private static final Logger LOGGER = Logger.getLogger(WorkUnitContext.class.getName());
 
     public final BuildableItem item;
 
@@ -84,7 +88,11 @@ public final class WorkUnitContext {
                 if (e.getCurrentWorkUnit().isMainWork()) {
                     e.getOwner().taskAccepted(e,task);
                     for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
-                        listener.taskAccepted(e, task);
+                        try {
+                            listener.taskAccepted(e, task);
+                        } catch (RuntimeException x) {
+                            LOGGER.log(Level.WARNING, null, x);
+                        }
                     }
                 }
             }
@@ -126,7 +134,11 @@ public final class WorkUnitContext {
             if (wu.isMainWork()) {
                 future.start.set(e.getCurrentExecutable());
                 for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
-                    listener.taskStarted(e, task);
+                    try {
+                        listener.taskStarted(e, task);
+                    } catch (RuntimeException x) {
+                        LOGGER.log(Level.WARNING, null, x);
+                    }
                 }
             }
         }
@@ -158,13 +170,21 @@ public final class WorkUnitContext {
                     future.set(executable);
                     e.getOwner().taskCompleted(e, task, duration);
                     for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
-                        listener.taskCompleted(e, task, duration);
+                        try {
+                            listener.taskCompleted(e, task, duration);
+                        } catch (RuntimeException x) {
+                            LOGGER.log(Level.WARNING, null, x);
+                        }
                     }
                 } else {
                     future.set(problems);
                     e.getOwner().taskCompletedWithProblems(e, task, duration, problems);
                     for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
-                        listener.taskCompletedWithProblems(e, task, duration, problems);
+                        try {
+                            listener.taskCompletedWithProblems(e, task, duration, problems);
+                        } catch (RuntimeException x) {
+                            LOGGER.log(Level.WARNING, null, x);
+                        }
                     }
                 }
             }

--- a/core/src/main/java/hudson/model/queue/WorkUnitContext.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnitContext.java
@@ -23,8 +23,10 @@
  */
 package hudson.model.queue;
 
+import hudson.ExtensionList;
 import hudson.model.Action;
 import hudson.model.Executor;
+import hudson.model.ExecutorListener;
 import hudson.model.Queue;
 import hudson.model.Queue.BuildableItem;
 import hudson.model.Queue.Task;
@@ -81,6 +83,9 @@ public final class WorkUnitContext {
                 Executor e = Executor.currentExecutor();
                 if (e.getCurrentWorkUnit().isMainWork()) {
                     e.getOwner().taskAccepted(e,task);
+                    for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
+                        listener.taskAccepted(e, task);
+                    }
                 }
             }
         };
@@ -149,9 +154,15 @@ public final class WorkUnitContext {
                 if (problems == null) {
                     future.set(executable);
                     e.getOwner().taskCompleted(e, task, duration);
+                    for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
+                        listener.taskCompleted(e, task, duration);
+                    }
                 } else {
                     future.set(problems);
                     e.getOwner().taskCompletedWithProblems(e, task, duration, problems);
+                    for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
+                        listener.taskCompletedWithProblems(e, task, duration, problems);
+                    }
                 }
             }
         }

--- a/core/src/main/java/hudson/model/queue/WorkUnitContext.java
+++ b/core/src/main/java/hudson/model/queue/WorkUnitContext.java
@@ -124,10 +124,9 @@ public final class WorkUnitContext {
             Executor e = Executor.currentExecutor();
             WorkUnit wu = e.getCurrentWorkUnit();
             if (wu.isMainWork()) {
-                Queue.Executable executable = e.getCurrentExecutable();
-                future.start.set(executable);
+                future.start.set(e.getCurrentExecutable());
                 for (ExecutorListener listener : ExtensionList.lookup(ExecutorListener.class)) {
-                    listener.taskStarted(e, task, executable);
+                    listener.taskStarted(e, task);
                 }
             }
         }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -325,7 +325,6 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
-        super.taskAccepted(executor, task);
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener)launcher).taskAccepted(executor, task);
         }
@@ -339,7 +338,6 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskStarted(Executor executor, Queue.Task task) {
-        super.taskStarted(executor, task);
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener)launcher).taskStarted(executor, task);
         }
@@ -351,7 +349,6 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
-        super.taskCompleted(executor, task, durationMS);
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener)launcher).taskCompleted(executor, task, durationMS);
         }
@@ -363,7 +360,6 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
-        super.taskCompletedWithProblems(executor, task, durationMS, problems);
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener)launcher).taskCompletedWithProblems(executor, task, durationMS, problems);
         }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -338,6 +338,18 @@ public class SlaveComputer extends Computer {
     }
 
     @Override
+    public void taskStarted(Executor executor, Queue.Task task) {
+        super.taskStarted(executor, task);
+        if (launcher instanceof ExecutorListener) {
+            ((ExecutorListener)launcher).taskStarted(executor, task);
+        }
+        RetentionStrategy r = getRetentionStrategy();
+        if (r instanceof ExecutorListener) {
+            ((ExecutorListener) r).taskStarted(executor, task);
+        }
+    }
+
+    @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
         super.taskCompleted(executor, task, durationMS);
         if (launcher instanceof ExecutorListener) {


### PR DESCRIPTION
See [JENKINS-66947](https://issues.jenkins-ci.org/browse/JENKINS-66947).

### Proposed changelog entries

* `ExecutorListener` may now be implemented as a static extension.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
