### PR TITLE
Remove java webstart warning from agent page

### DIFF
--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -37,27 +37,16 @@ THE SOFTWARE.
           ${%Connect agent to Jenkins one of these ways:}
         </p>
         <ul>
-          <j:choose>
-            <j:when test="${it.launcher.javaWebStartSupported}">
-              <li>
-                <p>
-                  <a href="jenkins-agent.jnlp" id="jnlp-link">
-                    <img src="${imagesURL}/webstart.gif" alt="${%launch agent}" />
-                  </a>
-                  ${%Launch agent from browser}
-                </p>
-              </li>
-            </j:when>
-            <j:otherwise>
-              <li>
-                <p>
-                  <a href="https://www.jenkins.io/redirect/java11-java-web-start">
-                    ${%Java Web Start is not available for the JVM version running Jenkins}
-                  </a>
-                </p>
-              </li>
-            </j:otherwise>
-          </j:choose>
+          <j:if test="${it.launcher.javaWebStartSupported}">
+            <li>
+              <p>
+                <a href="jenkins-agent.jnlp" id="jnlp-link">
+                  <img src="${imagesURL}/webstart.gif" alt="${%launch agent}" />
+                </a>
+                ${%Launch agent from browser}
+              </p>
+            </li>
+          </j:if>
           <j:choose>
             <j:when test="${it.ACL.hasPermission(app.ANONYMOUS, it.CONNECT)}">
               <li>

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main_it.properties
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main_it.properties
@@ -26,9 +26,6 @@ configure.link.text=Vai alla schermata di configurazione della sicurezza e \
   modificala
 Connect\ agent\ to\ Jenkins\ one\ of\ these\ ways\:=Connettere l''agente a \
   Jenkins in uno di questi modi:
-Java\ Web\ Start\ is\ not\ available\ for\ the\ JVM\ version\ running\ Jenkins=\
-  Java Web Start non è disponibile per la versione della JVM su cui è in \
-  esecuzione Jenkins.
 launch\ agent=avvia l''agente
 Launch\ agent\ from\ browser=Avvia l''agente dal browser
 Or\ if\ the\ agent\ is\ headless\:=O se l''agente è senza interfaccia grafica:


### PR DESCRIPTION
It was added by @MarkEWaite 3 years ago, the goal of Mark's PR is still accomplished which is hiding the java web start button.

I feel like there's no need to be putting this in java 11 users face these days