### PR TITLE
Stabilize `core` test suite

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -719,7 +719,7 @@ THE SOFTWARE.
         <!-- Version specified in grandparent POM -->
         <configuration>
           <forkCount>0.5C</forkCount>
-          <reuseForks>true</reuseForks>
+          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
       <plugin><!-- set main class -->


### PR DESCRIPTION
See #5827 for previous discussion. The introduction of `mockito-inline` possibly destabilized the `core` test suite. Before this PR, running the `core` test suite in a loop typically fails with [`mockito-inline`-related errors](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-5827/) within about a dozen iterations and at most ~50 iterations. With this PR, running the `core` test suite in a loop for over 16 hours (~200 iterations) without any errors.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
