### PR TITLE
[JENKINS-66993] Do not register `AntClassLoader` as parallel-capable

### DIFF
--- a/core/src/main/java/hudson/PluginFirstClassLoader.java
+++ b/core/src/main/java/hudson/PluginFirstClassLoader.java
@@ -42,10 +42,6 @@ import jenkins.util.AntClassLoader;
 public class PluginFirstClassLoader
     extends AntClassLoader
 {
-    static {
-        registerAsParallelCapable();
-    }
-
     public PluginFirstClassLoader() {
         super(null, false);
     }

--- a/core/src/main/java/jenkins/util/AntClassLoader.java
+++ b/core/src/main/java/jenkins/util/AntClassLoader.java
@@ -92,7 +92,6 @@ public class AntClassLoader extends ClassLoader implements JenkinsClassLoader, S
     private static final Object MR_JARFILE_CTOR_RUNTIME_VERSION_VAL;
 
     static {
-        registerAsParallelCapable();
         if (IS_ATLEAST_JAVA9) {
             Class[] ctorArgs = null;
             Object runtimeVersionVal = null;


### PR DESCRIPTION
### Steps to reproduce

See [JENKINS-66993](https://issues.jenkins.io/browse/JENKINS-66993).

1. Start Jenkins with `java -jar jenkins.war`.
1. Go through the wizard and install the suggested plugins.
1. Go to http://127.0.0.1:8080/credentials/store/system/domain/_/ and add a few (e.g., five) username/password credentials. It doesn't matter what they are, as long as there are a few of them.
1. Install the [Slack Notification](https://plugins.jenkins.io/slack/) and [Artifactory](https://plugins.jenkins.io/artifactory/) plugins.
1. Shut down Jenkins.
1. Start Jenkins with `java -jar jenkins.war`.
1. Go to http://127.0.0.1:8080/configure and wait for the page to load.

### Expected results

The page loads without errors.

### Actual results

The credentials portions of the page fail to load and the following is logged:

<details>
<summary>Stack trace</summary>
<pre>
2021-10-27 20:49:27.850+0000 [id=47]    WARNING o.e.j.s.h.ContextHandler$Context#log: Error while serving http://127.0.0.1:8080/descriptorByName/jenkins.plugins.slack.SlackNotifier/fillTokenCredentialIdItems
java.lang.LinkageError: loader jenkins.util.AntClassLoader @3e734cf4 attempted duplicate abstract class definition for com.cloudbees.plugins.credentials.CredentialsNameProvider. (com.cloudbees.plugins.credentials.CredentialsNameProvider is in unnamed module of loader jenkins.util.AntClassLoader @3e734cf4, parent loader 'app')
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at jenkins.util.AntClassLoader.defineClassFromData(AntClassLoader.java:1188)
        at jenkins.util.AntClassLoader.getClassFromStream(AntClassLoader.java:1356)
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1408)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1373)
        at jenkins.ClassLoaderReflectionToolkit._findClass(ClassLoaderReflectionToolkit.java:107)
        at hudson.ClassicPluginStrategy$DependencyClassLoader.findClass(ClassicPluginStrategy.java:646)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at jenkins.util.AntClassLoader.findBaseClass(AntClassLoader.java:1437)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1124)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at jenkins.util.AntClassLoader.defineClassFromData(AntClassLoader.java:1188)
        at jenkins.util.AntClassLoader.getClassFromStream(AntClassLoader.java:1356)
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1408)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1373)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1128)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:398)
        at java.base/sun.reflect.generics.factory.CoreReflectionFactory.makeNamedType(CoreReflectionFactory.java:114)
        at java.base/sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:125)
        at java.base/sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49)
        at java.base/sun.reflect.annotation.AnnotationParser.parseSig(AnnotationParser.java:440)
        at java.base/sun.reflect.annotation.AnnotationParser.parseClassValue(AnnotationParser.java:421)
        at java.base/sun.reflect.annotation.AnnotationParser.parseMemberValue(AnnotationParser.java:350)
        at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:287)
        at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:121)
        at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:73)
        at java.base/java.lang.Class.createAnnotationData(Class.java:3757)
        at java.base/java.lang.Class.annotationData(Class.java:3746)
        at java.base/java.lang.Class.getAnnotation(Class.java:3651)
        at com.cloudbees.plugins.credentials.CredentialsResolver.getResolver(CredentialsResolver.java:124)
        at com.cloudbees.plugins.credentials.CredentialsProvider.listCredentials(CredentialsProvider.java:471)
        at com.cloudbees.plugins.credentials.CredentialsProvider.listCredentials(CredentialsProvider.java:603)
        at com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel.includeMatchingAs(AbstractIdCredentialsListBoxModel.java:476)
        at com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel.includeAs(AbstractIdCredentialsListBoxModel.java:397)
        at jenkins.plugins.slack.SlackNotifier$DescriptorImpl.findTokenCredentialIdItems(SlackNotifier.java:816)
        at jenkins.plugins.slack.SlackNotifier$DescriptorImpl.doFillTokenCredentialIdItems(SlackNotifier.java:802)
        at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:710)
        at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:393)
Caused: java.lang.reflect.InvocationTargetException
        at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:397)
        at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:405)
        at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:208)
        at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:141)
        at org.kohsuke.stapler.MetaClass$11.doDispatch(MetaClass.java:536)
        at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
        at org.kohsuke.stapler.MetaClass$4.doDispatch(MetaClass.java:281)
        at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:694)
        at org.kohsuke.stapler.Stapler.service(Stapler.java:240)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
        at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1626)
        at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:156)
        at jenkins.security.ResourceDomainFilter.doFilter(ResourceDomainFilter.java:80)
        at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:153)
        at jenkins.telemetry.impl.UserLanguages$AcceptLanguageFilter.doFilter(UserLanguages.java:128)
        at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:153)
        at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:159)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:153)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:92)
        at jenkins.security.AcegiSecurityExceptionFilter.doFilter(AcegiSecurityExceptionFilter.java:52)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at hudson.security.UnwrapSecurityExceptionFilter.doFilter(UnwrapSecurityExceptionFilter.java:53)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:121)
        at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:115)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:105)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter.doFilter(RememberMeAuthenticationFilter.java:133)
        at org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter.doFilter(RememberMeAuthenticationFilter.java:92)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:218)
        at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:212)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at jenkins.security.BasicHeaderProcessor.doFilter(BasicHeaderProcessor.java:97)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:110)
        at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:80)
        at hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:62)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:109)
        at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:171)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:51)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:85)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at org.kohsuke.stapler.DiagnosticThreadNameFilter.doFilter(DiagnosticThreadNameFilter.java:30)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at jenkins.security.SuspiciousRequestFilter.doFilter(SuspiciousRequestFilter.java:39)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:548)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:578)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1434)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1349)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.Server.handle(Server.java:516)
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:386)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
        at java.base/java.lang.Thread.run(Thread.java:829)
2021-10-27 20:49:27.856+0000 [id=47]    WARNING h.i.i.InstallUncaughtExceptionHandler#handleException: Caught unhandled exception with ID f8f6d014-1715-4333-a7cd-cbf76a0714f6
java.lang.LinkageError: loader jenkins.util.AntClassLoader @3e734cf4 attempted duplicate abstract class definition for com.cloudbees.plugins.credentials.CredentialsNameProvider. (com.cloudbees.plugins.credentials.CredentialsNameProvider is in unnamed module of loader jenkins.util.AntClassLoader @3e734cf4, parent loader 'app')
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at jenkins.util.AntClassLoader.defineClassFromData(AntClassLoader.java:1188)
        at jenkins.util.AntClassLoader.getClassFromStream(AntClassLoader.java:1356)
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1408)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1373)
        at jenkins.ClassLoaderReflectionToolkit._findClass(ClassLoaderReflectionToolkit.java:107)
        at hudson.ClassicPluginStrategy$DependencyClassLoader.findClass(ClassicPluginStrategy.java:646)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at jenkins.util.AntClassLoader.findBaseClass(AntClassLoader.java:1437)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1124)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at jenkins.util.AntClassLoader.defineClassFromData(AntClassLoader.java:1188)
        at jenkins.util.AntClassLoader.getClassFromStream(AntClassLoader.java:1356)
        at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1408)
        at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1373)
        at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1128)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:398)
        at java.base/sun.reflect.generics.factory.CoreReflectionFactory.makeNamedType(CoreReflectionFactory.java:114)
        at java.base/sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:125)
        at java.base/sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49)
        at java.base/sun.reflect.annotation.AnnotationParser.parseSig(AnnotationParser.java:440)
        at java.base/sun.reflect.annotation.AnnotationParser.parseClassValue(AnnotationParser.java:421)
        at java.base/sun.reflect.annotation.AnnotationParser.parseMemberValue(AnnotationParser.java:350)
        at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:287)
        at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:121)
        at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:73)
        at java.base/java.lang.Class.createAnnotationData(Class.java:3757)
        at java.base/java.lang.Class.annotationData(Class.java:3746)
        at java.base/java.lang.Class.getAnnotation(Class.java:3651)
        at com.cloudbees.plugins.credentials.CredentialsResolver.getResolver(CredentialsResolver.java:124)
        at com.cloudbees.plugins.credentials.CredentialsProvider.listCredentials(CredentialsProvider.java:471)
        at com.cloudbees.plugins.credentials.CredentialsProvider.listCredentials(CredentialsProvider.java:603)
        at com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel.includeMatchingAs(AbstractIdCredentialsListBoxModel.java:476)
        at com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel.includeAs(AbstractIdCredentialsListBoxModel.java:397)
        at jenkins.plugins.slack.SlackNotifier$DescriptorImpl.findTokenCredentialIdItems(SlackNotifier.java:816)
        at jenkins.plugins.slack.SlackNotifier$DescriptorImpl.doFillTokenCredentialIdItems(SlackNotifier.java:802)
        at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:710)
        at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:393)
        at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:405)
        at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:208)
        at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:141)
        at org.kohsuke.stapler.MetaClass$11.doDispatch(MetaClass.java:536)
        at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
Caused: javax.servlet.ServletException
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:816)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
        at org.kohsuke.stapler.MetaClass$4.doDispatch(MetaClass.java:281)
        at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:898)
        at org.kohsuke.stapler.Stapler.invoke(Stapler.java:694)
        at org.kohsuke.stapler.Stapler.service(Stapler.java:240)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
        at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1626)
        at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:156)
        at jenkins.security.ResourceDomainFilter.doFilter(ResourceDomainFilter.java:80)
        at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:153)
        at jenkins.telemetry.impl.UserLanguages$AcceptLanguageFilter.doFilter(UserLanguages.java:128)
        at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:153)
        at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:159)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:153)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:92)
        at jenkins.security.AcegiSecurityExceptionFilter.doFilter(AcegiSecurityExceptionFilter.java:52)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at hudson.security.UnwrapSecurityExceptionFilter.doFilter(UnwrapSecurityExceptionFilter.java:53)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:121)
        at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:115)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:105)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter.doFilter(RememberMeAuthenticationFilter.java:133)
        at org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter.doFilter(RememberMeAuthenticationFilter.java:92)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:218)
        at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:212)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at jenkins.security.BasicHeaderProcessor.doFilter(BasicHeaderProcessor.java:97)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:110)
        at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:80)
        at hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:62)
        at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:97)
        at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:109)
        at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:171)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:51)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:85)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at org.kohsuke.stapler.DiagnosticThreadNameFilter.doFilter(DiagnosticThreadNameFilter.java:30)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at jenkins.security.SuspiciousRequestFilter.doFilter(SuspiciousRequestFilter.java:39)
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:548)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:578)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1434)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1349)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.Server.handle(Server.java:516)
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:386)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
        at java.base/java.lang.Thread.run(Thread.java:829)
</pre>
</details>

### Evaluation

This is a regression introduced in 2.309 by registering `AntClassLoader` as parallel-capable. When the call to `registerAsParallelCapable()` is removed from `jenkins.util.AntClassLoader`, the problem can no longer be reproduced. The problem also cannot be reproduced when using the experimental support for `URLClassLoader2` introduced in 2.310, even though this is registered as parallel-capable.

Note that registering `AntClassLoader` as parallel-capable was [an upstream change](https://github.com/apache/ant/commit/d37df73a8097142c328d54847d66ffc204ef226f) made on September 21, 2016. We suspect the upstream change was made in error, as the implementation is still using `synchronized` methods rather than `getClassLoadingLock`.

### Short-term solution (this PR)

Restore the status quo by no longer registering `AntClassLoader` (or its subclass `PluginFirstClassLoader`) as parallel-capable. With this change, the problem can no longer be reproduced. This is intended to ensure stability for the forthcoming 2.31x LTS release.

### Long-term solution (not this PR)

Once the 2.31x LTS release is shipped, we plan to continue the work to make `URLClassLoader2` the default class loader with the goal of deprecating and eventually deleting usages of `AntClassLoader`. This change requires more testing and is not appropriate for the forthcoming 2.31x LTS release; however, it would be appropriate to land such a change at the beginning of a new LTS cycle once enough users have upgraded to recent versions of the [Bouncy Castle API](https://plugins.jenkins.io/bouncycastle-api/) plugin (a prerequisite for the use of `URLClassLoader2`).

### Proposed changelog entries

* Prevent `LinkageError` during class loading (regression in 2.309).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).