### PR TITLE
Test stability experiment: `surefire.runOrder=alphabetical`, `test` test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Jenkins is **licensed** under the **[MIT License]**.
 [Mirrors]: http://mirrors.jenkins-ci.org
 [GitHub]: https://github.com/jenkinsci/jenkins
 [website]: https://www.jenkins.io/
+bump

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -720,6 +720,7 @@ THE SOFTWARE.
         <configuration>
           <forkCount>0.5C</forkCount>
           <reuseForks>false</reuseForks>
+          <skipTests>true</skipTests>
         </configuration>
       </plugin>
       <plugin><!-- set main class -->

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,7 @@ THE SOFTWARE.
               <java.awt.headless>true</java.awt.headless>
             </systemPropertyVariables>
             <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
+            <runOrder>alphabetical</runOrder>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Not for review. Running the `test` test suite in a loop with `surefire.runOrder=alphabetical` to ensure that this doesn't introduce new flakiness.