### PR TITLE
[JENKINS-67028] Fix missing project hyperlink in build history

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -47,9 +47,9 @@ THE SOFTWARE.
         <j:if test="${!build.building}">
           <j:set var="linkTitleAttr">${%Took} ${build.durationString}</j:set>
         </j:if>
-        <span tooltip="${linkTitleAttr}">
+        <a class="tip model-link inside build-link" href="${link}" update-parent-class=".build-row" tooltip="${linkTitleAttr}">
           <i:formatDate value="${build.timestamp.time}" type="both" dateStyle="medium" timeStyle="short" /> ${h.getUserTimeZonePostfix()}
-        </span>
+        </a>
         <j:if test="${build.building}">
 	  <j:set target="${it.widget}" property="nextBuildNumberToFetch" value="${build.number}"/>
           <t:buildProgressBar build="${build}"/>


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/JENKINS-67028

![](https://i.imgur.com/K4e0AS8.png)

### Proposed changelog entries

* Fix missing hyperlink in build history (regression in 2.314).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

### Desired reviewers

@MarkEWaite 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
