### PR TITLE
[JENKINS-67099] Make trim labels more selective when we're operating on selected nodes

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2262,7 +2262,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         for (Iterator<Label> itr = labels.values().iterator(); itr.hasNext();) {
             Label l = itr.next();
             if (includedLabels == null || includedLabels.contains(l)) {
-                if (nodeLabels.contains(l) || this.clouds.stream().anyMatch(c -> c.canProvision(l))) {
+                if (nodeLabels.contains(l) || !l.getClouds().isEmpty()) {
                     resetLabel(l);
                 } else {
                     itr.remove();

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2254,7 +2254,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * Reset labels and remove invalid ones for the given nodes.
-     * @param includedLabels the labels taken as reference to update labels. If null, all labels are considered.
+     * @param includedLabels the labels taken as reference to update labels. If {@code null}, all labels are considered.
      */
     private void trimLabels(@CheckForNull Set<LabelAtom> includedLabels) {
         Set<Label> nodeLabels = new HashSet<>(this.getAssignedLabels());
@@ -2263,6 +2263,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             Label l = itr.next();
             if (includedLabels == null || includedLabels.contains(l)) {
                 if (nodeLabels.contains(l) || !l.getClouds().isEmpty()) {
+                    // there is at least one static agent or one cloud that currently claims it can handle the label.
+                    // if the cloud has been removed, or its labels updated such that it can not handle this, this is handle in later calls
+                    // resetLabel will remove the agents, and clouds from the label, and they will be repopulated later.
+                    // not checking `cloud.canProvision()` here prevents a potential call that will only be repeated later
                     resetLabel(l);
                 } else {
                     itr.remove();

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2252,6 +2252,27 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     /**
+     * Reset labels and remove invalid ones for the given nodes.
+     * @param nodes the nodes taken as reference to update labels
+     */
+    void trimLabels(Node... nodes) {
+        Set<LabelAtom> includedLabels = new HashSet<>();
+        for (Node n : nodes) {
+            includedLabels.addAll(n.getAssignedLabels());
+        }
+        Set<Label> nodeLabels = new HashSet<>(this.getAssignedLabels());
+        this.getNodes().forEach(n -> nodeLabels.addAll(n.getAssignedLabels()));
+        for (Iterator<Label> itr = this.labels.values().stream().filter(l -> includedLabels.contains(l)).iterator(); itr.hasNext();) {
+            Label l = itr.next();
+            if (nodeLabels.contains(l) || this.clouds.stream().anyMatch(c -> c.canProvision(l))) {
+                resetLabel(l);
+            } else {
+                itr.remove();
+            }
+        }
+    }
+
+    /**
      * Binds {@link AdministrativeMonitor}s to URL.
      * @param id Monitor ID
      * @return The requested monitor or {@code null} if it does not exist

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2258,7 +2258,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     void trimLabels(Node... nodes) {
         Set<LabelAtom> includedLabels = new HashSet<>();
         for (Node n : nodes) {
-            includedLabels.addAll(n.getAssignedLabels());
+            if (n != null) {
+                includedLabels.addAll(n.getAssignedLabels());
+            }
         }
         Set<Label> nodeLabels = new HashSet<>(this.getAssignedLabels());
         this.getNodes().forEach(n -> nodeLabels.addAll(n.getAssignedLabels()));

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2264,12 +2264,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
         Set<Label> nodeLabels = new HashSet<>(this.getAssignedLabels());
         this.getNodes().forEach(n -> nodeLabels.addAll(n.getAssignedLabels()));
-        for (Iterator<Label> itr = this.labels.values().stream().filter(l -> includedLabels.contains(l)).iterator(); itr.hasNext();) {
+        for (Iterator<Label> itr = this.labels.values().iterator(); itr.hasNext();) {
             Label l = itr.next();
-            if (nodeLabels.contains(l) || this.clouds.stream().anyMatch(c -> c.canProvision(l))) {
-                resetLabel(l);
-            } else {
-                itr.remove();
+            if (includedLabels.contains(l)) {
+                if (nodeLabels.contains(l) || this.clouds.stream().anyMatch(c -> c.canProvision(l))) {
+                    resetLabel(l);
+                } else {
+                    itr.remove();
+                }
             }
         }
     }

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -32,6 +32,7 @@ import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Saveable;
+import hudson.model.labels.LabelAtom;
 import hudson.model.listeners.SaveableListener;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.OfflineCause;
@@ -112,10 +113,12 @@ public class Nodes implements Saveable {
             @Override
             public void run() {
                 Set<String> toRemove = new HashSet<>(Nodes.this.nodes.keySet());
+                Set<LabelAtom> labels = new HashSet<>();
                 for (Node n : nodes) {
                     final String name = n.getNodeName();
                     toRemove.remove(name);
                     Nodes.this.nodes.put(name, n);
+                    labels.addAll(n.getAssignedLabels());
                 }
                 Nodes.this.nodes.keySet().removeAll(toRemove); // directory clean up will be handled by save
                 jenkins.updateComputerList();
@@ -141,7 +144,7 @@ public class Nodes implements Saveable {
             AtomicReference<Node> old = new AtomicReference<>();
             old.set(nodes.put(node.getNodeName(), node));
             jenkins.updateNewComputer(node);
-            jenkins.trimLabels();
+            jenkins.trimLabels(node, oldNode);
             // TODO there is a theoretical race whereby the node instance is updated/removed after lock release
             try {
                 persistNode(node);
@@ -153,7 +156,7 @@ public class Nodes implements Saveable {
                     public void run() {
                         nodes.compute(node.getNodeName(), (ignoredNodeName, ignoredNode) -> oldNode);
                         jenkins.updateComputerList();
-                        jenkins.trimLabels();
+                        jenkins.trimLabels(node, oldNode);
                     }
                 });
                 throw e;
@@ -201,7 +204,7 @@ public class Nodes implements Saveable {
                 @Override
                 public Boolean call() throws Exception {
                     if (node == nodes.get(node.getNodeName())) {
-                        jenkins.trimLabels();
+                        jenkins.trimLabels(node);
                         return true;
                     }
                     return false;
@@ -242,7 +245,7 @@ public class Nodes implements Saveable {
                     Nodes.this.nodes.remove(oldOne.getNodeName());
                     Nodes.this.nodes.put(newOne.getNodeName(), newOne);
                     jenkins.updateComputerList();
-                    jenkins.trimLabels();
+                    jenkins.trimLabels(oldOne, newOne);
                 }
             });
             updateNode(newOne);
@@ -276,7 +279,7 @@ public class Nodes implements Saveable {
                     }
                     if (node == nodes.remove(node.getNodeName())) {
                         jenkins.updateComputerList();
-                        jenkins.trimLabels();
+                        jenkins.trimLabels(node);
                     }
                 }
             });

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -113,12 +113,10 @@ public class Nodes implements Saveable {
             @Override
             public void run() {
                 Set<String> toRemove = new HashSet<>(Nodes.this.nodes.keySet());
-                Set<LabelAtom> labels = new HashSet<>();
                 for (Node n : nodes) {
                     final String name = n.getNodeName();
                     toRemove.remove(name);
                     Nodes.this.nodes.put(name, n);
-                    labels.addAll(n.getAssignedLabels());
                 }
                 Nodes.this.nodes.keySet().removeAll(toRemove); // directory clean up will be handled by save
                 jenkins.updateComputerList();


### PR DESCRIPTION
This follows up #5402 and #5412. We've been noticing some provisioning problems with the new `trimLabels` implementation because it calls `Cloud#canProvision` way more than before.

This is reworking the implementation to only affect labels relevant to affected nodes on local operations (such as `addNode`, `removeNode`), which are being called often when using ephemeral nodes from clouds that come and go in rapid succession.

<!-- Comment 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-67099](https://issues.jenkins-ci.org/browse/JENKINS-67099).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Only apply `trimLabels` operation to affected nodes when adding or removing them. 

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/core

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
