### PR TITLE
[JENKINS-67173] Deprecate `SlaveToMasterFileCallable`, log warning

### DIFF
--- a/core/src/main/java/jenkins/SlaveToMasterFileCallable.java
+++ b/core/src/main/java/jenkins/SlaveToMasterFileCallable.java
@@ -1,18 +1,46 @@
 package jenkins;
 
 import hudson.FilePath.FileCallable;
+import hudson.Main;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.security.Roles;
+import jenkins.util.JenkinsJVM;
 import org.jenkinsci.remoting.RoleChecker;
 
 /**
  * {@link FileCallable}s that can be executed on the master, sent by the agent.
  * Note that any serializable fields must either be defined in your plugin or included in the stock JEP-200 whitelist.
+ * Additionally, this callable can be called with any {@link hudson.FilePath}, it is your responsibility to validate it
+ * in {@link #invoke(java.io.File, hudson.remoting.VirtualChannel)}.
  * @since 1.587 / 1.580.1
+ * @deprecated Use {@link jenkins.security.SlaveToMasterCallable} instead (and only if you really have to), and think
+ * carefully about the <a href="https://www.jenkins.io/doc/developer/security/remoting-callables/">security implications</a>.
+ *
+ * @see jenkins.security.SlaveToMasterCallable
+ * @see org.jenkinsci.remoting.RoleSensitive
  */
+@Deprecated
 public abstract class SlaveToMasterFileCallable<T> implements FileCallable<T> {
+
+    public static final Logger LOGGER = Logger.getLogger(SlaveToMasterFileCallable.class.getName());
+
     @Override
     public void checkRoles(RoleChecker checker) throws SecurityException {
+        warnOnController();
         checker.check(this, Roles.MASTER);
     }
+
+    protected Object readResolve() {
+        warnOnController();
+        return this;
+    }
+
+    private void warnOnController() {
+        if (JenkinsJVM.isJenkinsJVM() && (Main.isUnitTest || Main.isDevelopmentMode)) { // No point in spamming admins who cannot do anything
+            LOGGER.log(Level.WARNING, "SlaveToMasterFileCallable is deprecated. '" + this + "' should be replaced. See https://www.jenkins.io/doc/developer/security/remoting-callables/");
+        }
+    }
+
     private static final long serialVersionUID = 1L;
 }


### PR DESCRIPTION
Start telling people that S2MFCs are bad. There's a reason we need S2MCs (no `File`) for very specific, narrow circumstances, but S2MFCs (and really, most S2MCs) need to go.

Untested.

### Proposed changelog entries

* Deprecate `SlaveToMasterFileCallable`.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
