### PR TITLE
Add a gap between icon and text in build links

### DIFF
--- a/core/src/main/resources/lib/hudson/buildLink.jelly
+++ b/core/src/main/resources/lib/hudson/buildLink.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
 	      </j:when>
 	      <j:otherwise>
 	        <a href="${attrs.href ?: rootURL+'/'+r.url}" class="model-link">
-	          <l:icon alt="${r.iconColor.description}" class="${r.buildStatusIconClassName} icon-sm"/>${jobName_}#<!-- -->${number}</a>
+          <l:icon alt="${r.iconColor.description}" class="${r.buildStatusIconClassName} icon-sm"/><span class="jenkins-icon-adjacent">${jobName_}#<!-- -->${number}</span></a>
 	      </j:otherwise>
 	    </j:choose>
 	  </j:otherwise>

--- a/core/src/main/resources/lib/hudson/buildLink.jelly
+++ b/core/src/main/resources/lib/hudson/buildLink.jelly
@@ -40,21 +40,21 @@ THE SOFTWARE.
   </st:documentation>
   <j:set var="jobName_" value="${h.appendSpaceIfNotNull(jobName)}"/>
   <j:choose>
-	  <j:when test="${job==null}">
-	    ${jobName_}#<!-- -->${number}
-	  </j:when>
-	  <j:otherwise>
-	    <j:set var="r" value="${job.getBuildByNumber(number)}" />
-	    <j:choose>
-	      <j:when test="${r==null}">
-	        <a href="${rootURL}/${job.url}" class="model-link">${jobName}</a>
+    <j:when test="${job==null}">
+      ${jobName_}#<!-- -->${number}
+    </j:when>
+    <j:otherwise>
+      <j:set var="r" value="${job.getBuildByNumber(number)}" />
+      <j:choose>
+        <j:when test="${r==null}">
+          <a href="${rootURL}/${job.url}" class="model-link">${jobName}</a>
           #<!-- -->${number}
-	      </j:when>
-	      <j:otherwise>
-	        <a href="${attrs.href ?: rootURL+'/'+r.url}" class="model-link">
+        </j:when>
+        <j:otherwise>
+          <a href="${attrs.href ?: rootURL+'/'+r.url}" class="model-link">
           <l:icon alt="${r.iconColor.description}" class="${r.buildStatusIconClassName} icon-sm"/><span class="jenkins-icon-adjacent">${jobName_}#<!-- -->${number}</span></a>
-	      </j:otherwise>
-	    </j:choose>
-	  </j:otherwise>
-	</j:choose>
+        </j:otherwise>
+      </j:choose>
+    </j:otherwise>
+  </j:choose>
 </j:jelly>


### PR DESCRIPTION
Followup to https://github.com/jenkinsci/jenkins/pull/5850.
Fixes the missing gaps in https://github.com/jenkinsci/warnings-ng-plugin/pull/1092.

Before:
![Bildschirmfoto 2021-11-05 um 13 32 13](https://user-images.githubusercontent.com/503338/140510652-3ca366e0-59e0-48f5-bbee-b39f170b8ff0.png)


After: 
![Bildschirmfoto 2021-11-05 um 12 48 14](https://user-images.githubusercontent.com/503338/140506686-96ef689a-564f-4c0b-82c8-f7862c6f873e.png)

### Proposed changelog entries

* Add space between icon and project name (or build number) in all links to builds.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
