### PR TITLE
`CallableRejectionConfig` just threw an error rather than persisting anything

### DIFF
--- a/core/src/main/java/jenkins/security/s2m/ConfigFile.java
+++ b/core/src/main/java/jenkins/security/s2m/ConfigFile.java
@@ -94,6 +94,10 @@ abstract class ConfigFile<T,COL extends Collection<T>> extends TextFile {
     }
 
     public synchronized void append(String additional) throws IOException {
+        if (!exists()) {
+            set(additional);
+            return;
+        }
         String s = read();
         if (!s.endsWith("\n"))
             s += "\n";


### PR DESCRIPTION
Noticed during #5880. Would be obsoleted by #5885.

```
WARNING j.s.s2m.CallableRejectionConfig#report: Failed to persist …/secrets/rejected-callables.txt
java.nio.file.NoSuchFileException: …/secrets/rejected-callables.txt
	at …
	at hudson.util.TextFile.read(TextFile.java:72)
Caused: java.io.IOException: Failed to fully read …/secrets/rejected-callables.txt
	at hudson.util.TextFile.read(TextFile.java:77)
	at jenkins.security.s2m.ConfigFile.append(ConfigFile.java:97)
	at jenkins.security.s2m.CallableRejectionConfig.append(CallableRejectionConfig.java:19)
	at jenkins.security.s2m.CallableRejectionConfig.report(CallableRejectionConfig.java:58)
	at jenkins.security.s2m.AdminWhitelistRule.isWhitelisted(AdminWhitelistRule.java:149)
	at jenkins.security.s2m.AdminCallableWhitelist.isWhitelisted(AdminCallableWhitelist.java:29)
	at jenkins.security.s2m.CallableDirectionChecker.isWhitelisted(CallableDirectionChecker.java:72)
	at jenkins.security.s2m.CallableDirectionChecker.check(CallableDirectionChecker.java:58)
	at org.jenkinsci.remoting.RoleChecker.check(RoleChecker.java:46)
	at hudson.remoting.RequiredRoleCheckerWrapper.check(RequiredRoleCheckerWrapper.java:47)
	at hudson.remoting.PingThread$Ping.checkRoles(PingThread.java:167)
	at hudson.remoting.ChannelBuilder$2.userRequest(ChannelBuilder.java:330)
	at …
```

### Proposed changelog entries

* An agent-to-controller security measure failed to persist configuration.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
