### PR TITLE
Improve artifact list readability in dark theme

### DIFF
--- a/war/src/main/less/base/yui-compatibility.less
+++ b/war/src/main/less/base/yui-compatibility.less
@@ -110,12 +110,14 @@
 }
 
 /* Overrides for treeview-skin.css */
-
-.ygtvlabel,
-.ygtvlabel:link,
-.ygtvlabel:visited,
-.ygtvlabel:hover {
-  color: inherit;
+.ygtvitem {
+  .ygtvlabel,
+  .ygtvlabel:link,
+  .ygtvlabel:visited,
+  .ygtvlabel:hover {
+    color: inherit;
+    background-color: inherit;
+  }
 }
 
 .ygtvfocus {


### PR DESCRIPTION
Currently the artifact list (for sufficiently many artifacts) looks wrong in dark theme:
<img width="185" alt="artifacts-before" src="https://user-images.githubusercontent.com/1105305/140550510-c6d3bf89-5c0f-405d-912a-b557946bcda1.png">
This PR makes the background transparent
<img width="156" alt="artifacts-after" src="https://user-images.githubusercontent.com/1105305/140550592-faee56cf-25fc-45cb-a9e6-6becb56428df.png">

### Proposed changelog entries

* Improve artifact list readability in dark theme.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [n/a] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [n/a] Appropriate autotests or explanation to why this change has no tests
- [n/a] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@fqueiruga @timja

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
