### PR TITLE
Supply a `SlaveComputer` context for both channels associated with a `maven-plugin` build

### DIFF
--- a/core/src/main/java/hudson/slaves/Channels.java
+++ b/core/src/main/java/hudson/slaves/Channels.java
@@ -27,6 +27,7 @@ import hudson.FilePath;
 import hudson.Launcher.LocalLauncher;
 import hudson.Proc;
 import hudson.model.Computer;
+import hudson.model.Executor;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelBuilder;
@@ -108,8 +109,10 @@ public class Channels {
         };
         cb.withHeaderStream(header);
 
+        Executor executor = Executor.currentExecutor();
+        Object context = executor != null ? executor.getOwner() : proc;
         for (ChannelConfigurator cc : ChannelConfigurator.all()) {
-            cc.onChannelBuilding(cb,null);  // TODO: what to pass as a context?
+            cc.onChannelBuilding(cb, context);
         }
 
         return cb.build(in,out);
@@ -145,8 +148,10 @@ public class Channels {
         };
         cb.withHeaderStream(header);
 
+        Executor executor = Executor.currentExecutor();
+        Object context = executor != null ? executor.getOwner() : proc;
         for (ChannelConfigurator cc : ChannelConfigurator.all()) {
-            cc.onChannelBuilding(cb,null);  // TODO: what to pass as a context?
+            cc.onChannelBuilding(cb, context);
         }
 
         return cb.build(proc.getInputStream(),proc.getOutputStream());

--- a/core/src/main/java/jenkins/security/ChannelConfigurator.java
+++ b/core/src/main/java/jenkins/security/ChannelConfigurator.java
@@ -3,9 +3,13 @@ package jenkins.security;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.Proc;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelBuilder;
+import hudson.slaves.Channels;
 import hudson.slaves.SlaveComputer;
+import java.io.OutputStream;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Intercepts the new creation of {@link Channel} and tweak its configuration.
@@ -29,6 +33,8 @@ public abstract class ChannelConfigurator implements ExtensionPoint {
      *      <dl>
      *          <dt>{@link SlaveComputer}
      *          <dd>When a channel is being established to talk to a agent.
+     *          <dt>{@link Proc}
+     *          <dd>When {@link Channels#forProcess(String, ExecutorService, Process, OutputStream)} or overloads are used without a contextual {@link SlaveComputer}.
      *      </dl>
      */
     public void onChannelBuilding(ChannelBuilder builder, @Nullable Object context) {}


### PR DESCRIPTION
Follows up #5880.

### Proposed changelog entries

* N/A, internal

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
