### PR TITLE
`AbstractBuild` should implement `getParentExecutable` better

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -251,6 +251,12 @@ public abstract class AbstractBuild<P extends AbstractProject<P,R>,R extends Abs
         return this;
     }
 
+    @Override
+    public Queue.Executable getParentExecutable() {
+        AbstractBuild<?, ?> rootBuild = getRootBuild();
+        return rootBuild != this ? rootBuild : null;
+    }
+
     /**
      * Used to render the side panel "Back to project" link.
      *


### PR DESCRIPTION
Forgotten in #5733.

Note that the reverse operation is still impossible: there is no API encapsulating https://github.com/jenkinsci/maven-plugin/blob/d1469e39773885ff4409c0dd9af89a8907ad1e8e/src/main/java/hudson/maven/MavenModuleSetBuild.java#L483-L505 or https://github.com/jenkinsci/matrix-project-plugin/blob/be0b18bcba0c4089b1ed9482863050de6aa65b32/src/main/java/hudson/matrix/MatrixBuild.java#L242-L256.

### Proposed changelog entries

* N/A, internal

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
