### PR TITLE
Clean up usages of `ClassLoaderReflectionToolkit`

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -641,9 +641,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
             if (PluginManager.FAST_LOOKUP) {
                 for (PluginWrapper pw : getTransitiveDependencies()) {
                     try {
-                        Class<?> c = ClassLoaderReflectionToolkit._findLoadedClass(pw.classLoader, name);
-                        if (c!=null)    return c;
-                        return ClassLoaderReflectionToolkit._findClass(pw.classLoader, name);
+                        return ClassLoaderReflectionToolkit.loadClass(pw.classLoader, name);
                     } catch (ClassNotFoundException ignored) {
                         //not found. try next
                     }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2122,15 +2122,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             if (FAST_LOOKUP) {
                 for (PluginWrapper p : activePlugins) {
                     try {
-                        Class<?> c = ClassLoaderReflectionToolkit._findLoadedClass(p.classLoader, name);
-                        if (c != null) {
-                            synchronized (loaded) {
-                                loaded.put(name, c);
-                            }
-                            return c;
-                        }
-                        // calling findClass twice appears to cause LinkageError: duplicate class def
-                        c = ClassLoaderReflectionToolkit._findClass(p.classLoader, name);
+                        Class<?> c = ClassLoaderReflectionToolkit.loadClass(p.classLoader, name);
                         synchronized (loaded) {
                             loaded.put(name, c);
                         }


### PR DESCRIPTION
This PR deduplicates a small bit of code that is found in both `ClassicPluginStrategy` and `PluginManager`. Beside making the code easier to read by removing the duplication, this also makes the code more efficient by avoiding the need to drop and reacquire the lock after the call to `ClassLoader#findLoadedClass(String)` and before the call to `ClassLoader#findClass(String)`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
