### PR TITLE
Bump `bouncycastle-api` from 2.20 to 2.25

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -331,7 +331,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>bouncycastle-api</artifactId>
-                  <version>2.20</version>
+                  <version>2.25</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
We normally avoid upgrading bundled plugins, but there is a good reason to do so in this case. `bouncycastle-api` 2.25 is the first version that supports `URLClassLoader`, which we would eventually like to use as the default class loader in place of `AntClassLoader`. By virtue of https://github.com/jenkinsci/jenkins/blob/c0a03f779c4869398b536fbc80f75b516f7aaaba/core/src/main/java/hudson/PluginManager.java#L755-L761 users of older versions of `bouncycastle-api` will automatically be upgraded to 2.25 upon upgrading Jenkins, which should help accelerate adoption of `bouncycastle-api` 2.25 (and, ultimately, `URLClassLoader` and parallel class loading).

### Testing Done

Installed a release version of Jenkins with the default plugin set, then downgraded `bouncycastle-api` to 2.24. Verified that a stack trace was logged when running with `-Dhudson.ClassicPluginStrategy.useAntClassLoader=false`. Then started Jenkins with the changes from this PR and verified that `bouncycastle-api` was upgraded to 2.25 and no stack trace was logged when running with `-Dhudson.ClassicPluginStrategy.useAntClassLoader=false`.

### Proposed changelog entries

- Update bundled version of Bouncy Castle API plugin from 2.20 to 2.25.  See https://www.bouncycastle.org/releasenotes.html for release notes.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
