### PR TITLE
[JENKINS-67075] Strip a possible daemon-injected prefix when restarting the server.

### DIFF
--- a/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/UnixLifecycle.java
@@ -80,8 +80,9 @@ public class UnixLifecycle extends Lifecycle {
             LIBC.fcntl(i, F_SETFD,flags| FD_CLOEXEC);
         }
 
-        // exec to self
+        // exec to self, except for a possible daemon-supplied prefix (JENKINS-67075):
         String exe = args.get(0);
+        exe = exe.replaceFirst("^(.*): /", "/");
         LIBC.execvp(exe, new StringArray(args.toArray(new String[0])));
         throw new IOException("Failed to exec '"+exe+"' "+LIBC.strerror(Native.getLastError()));
     }


### PR DESCRIPTION
At least the Debian packages rely on the `daemon` command to start the
server with appropriate parameters, leveraging the /etc/init.d/jenkins
shell script and the variables set in the /etc/default/jenkins config
file.

The init script calls `/usr/bin/daemon --name=$NAME […]`, with NAME
defaulting to `jenkins`. Starting with daemon 0.7.0-1 (as found in
Debian 11 “Bullseye” and in Ubuntu since Hirsute Hippo), using the
`--name` option results in the specified value's being prepended to
the program being started.

This can be checked with:

    root@jenkins:~# pgrep -f jenkins: -a
    73109 jenkins: /usr/bin/java -Djava.awt.headless=true -jar /usr/share/jenkins/jenkins.war --webroot=/var/cache/jenkins/war --httpPort=8080

    root@jenkins:~# tr '\0' '\n' < /proc/73109/cmdline
    jenkins: /usr/bin/java
    -Djava.awt.headless=true
    -jar
    /usr/share/jenkins/jenkins.war
    --webroot=/var/cache/jenkins/war
    --httpPort=8080

Therefore, detect and remove such a prefix from the first argument
(the executable). Since the daemon's name is configurable, don't
hardcode "jenkins: ", but strip everything until the first slash if
it's preceeded by a colon and a space.

Signed-off-by: Cyril Brulebois <cyril@debamax.com>

See [JENKINS-67075](https://issues.jenkins-ci.org/browse/JENKINS-67075).

### Proposed changelog entries

* Entry 1: JENKINS-67075 Fix server restart on recent Debian and Ubuntu environments.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
- [x] Appropriate autotests or explanation to why this change has no tests

I've written this change on top of my local `stable-2.303` branch (and it can be cherry-picked trivially on top of `master`, which is what I'm submitting here), and tested it by deploying the generated war file instead of the one shipped in the Debian package, then using the `/safeRestart` entry point to make sure the server does restart correctly. I'm not sure it warrants adding tests in the source code tree.

### Desired reviewers


### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).