### PR TITLE
Store plain `ArrayList` for `InterruptedBuildAction.causes`

### DIFF
--- a/core/src/main/java/jenkins/model/InterruptedBuildAction.java
+++ b/core/src/main/java/jenkins/model/InterruptedBuildAction.java
@@ -43,11 +43,11 @@ public class InterruptedBuildAction extends InvisibleAction {
     private final List<CauseOfInterruption> causes;
 
     public InterruptedBuildAction(Collection<? extends CauseOfInterruption> causes) {
-        this.causes = Collections.unmodifiableList(new ArrayList<>(causes));
+        this.causes = new ArrayList<>(causes);
     }
 
     @Exported
     public List<CauseOfInterruption> getCauses() {
-        return causes;
+        return Collections.unmodifiableList(causes);
     }
 }


### PR DESCRIPTION
```xml
<?xml version='1.1' encoding='UTF-8'?>
<flow-build>
  <actions>
    <jenkins.model.InterruptedBuildAction>
      <causes class="java.util.Collections$UnmodifiableRandomAccessList" resolves-to="java.util.Collections$UnmodifiableList">
        <c class="list">
          <org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution_-RemovedNodeCause/>
        </c>
        <list reference="../c"/>
      </causes>
    </jenkins.model.InterruptedBuildAction>
  </actions>
…
```

is ugly. XStream does better with a plain `ArrayList`.

Apparently caused by #5464. 2843f5d4012526eb89bbe8aff08e8ae715a3d421 stored a dubious type from the start, but https://github.com/jenkinsci/jenkins/blob/bea3cef24f885d9a15a387eef1af8c6e46ed6364/core/src/main/java/hudson/util/xstream/ImmutableListConverter.java#L95-L98 made this invisible in the XML form.

### Proposed changelog entries

* Clean up format of interruption causes in `build.xml`.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
