### PR TITLE
[JENKINS-67105] Upgrade to 2.320 gives "Failed to deserialize response" error

### DIFF
--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -1,12 +1,15 @@
 com.google.common.collect.AbstractListMultimap
+com.google.common.collect.AbstractMapBasedMultimap
 com.google.common.collect.AbstractMultimap
 com.google.common.collect.AbstractSetMultimap
 # Artifactory - https://issues.jenkins.io/browse/JENKINS-48991
 com.google.common.collect.ArrayListMultimap
+com.google.common.collect.ArrayListMultimapGwtSerializationDependencies
 com.google.common.collect.EmptyImmutableList
 com.google.common.collect.EmptyImmutableSet
 com.google.common.collect.EmptyImmutableSortedSet
 com.google.common.collect.HashMultimap
+com.google.common.collect.HashMultimapGwtSerializationDependencies
 # First hit: https://github.com/jenkinsci/pitmutation-plugin/
 com.google.common.collect.HashMultiset
 com.google.common.collect.ImmutableList

--- a/test/src/test/java/jenkins/security/Jenkins67105Test.java
+++ b/test/src/test/java/jenkins/security/Jenkins67105Test.java
@@ -1,0 +1,69 @@
+package jenkins.security;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.tasks.Builder;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class Jenkins67105Test {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-67105")
+    @Test
+    public void arrayListMultimap() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject();
+        p.setAssignedNode(r.createSlave());
+        p.getBuildersList().add(new GuavaBuilder(new ArrayListMultiMapCallable()));
+        r.buildAndAssertSuccess(p);
+    }
+
+    @Issue("JENKINS-67105")
+    @Test
+    public void hashMultimap() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject();
+        p.setAssignedNode(r.createSlave());
+        p.getBuildersList().add(new GuavaBuilder(new HashMultiMapCallable()));
+        r.buildAndAssertSuccess(p);
+    }
+
+    public static class GuavaBuilder extends Builder {
+        private final MasterToSlaveCallable<?, RuntimeException> callable;
+
+        public GuavaBuilder(MasterToSlaveCallable<?, RuntimeException> callable) {
+            this.callable = callable;
+        }
+
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            listener.getLogger().println("received " + launcher.getChannel().call(callable));
+            return true;
+        }
+    }
+
+    private static class ArrayListMultiMapCallable
+            extends MasterToSlaveCallable<Multimap<?, ?>, RuntimeException> {
+        @Override
+        public Multimap<?, ?> call() throws RuntimeException {
+            return ArrayListMultimap.create();
+        }
+    }
+
+    private static class HashMultiMapCallable
+            extends MasterToSlaveCallable<Multimap<?, ?>, RuntimeException> {
+        @Override
+        public Multimap<?, ?> call() throws RuntimeException {
+            return HashMultimap.create();
+        }
+    }
+}

--- a/test/src/test/java/jenkins/security/Jenkins67105Test.java
+++ b/test/src/test/java/jenkins/security/Jenkins67105Test.java
@@ -23,7 +23,7 @@ public class Jenkins67105Test {
     public void arrayListMultimap() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
         p.setAssignedNode(r.createSlave());
-        p.getBuildersList().add(new GuavaBuilder(new ArrayListMultiMapCallable()));
+        p.getBuildersList().add(new GuavaBuilder(new ArrayListMultimapCallable()));
         r.buildAndAssertSuccess(p);
     }
 
@@ -32,7 +32,7 @@ public class Jenkins67105Test {
     public void hashMultimap() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
         p.setAssignedNode(r.createSlave());
-        p.getBuildersList().add(new GuavaBuilder(new HashMultiMapCallable()));
+        p.getBuildersList().add(new GuavaBuilder(new HashMultimapCallable()));
         r.buildAndAssertSuccess(p);
     }
 
@@ -51,7 +51,7 @@ public class Jenkins67105Test {
         }
     }
 
-    private static class ArrayListMultiMapCallable
+    private static class ArrayListMultimapCallable
             extends MasterToSlaveCallable<Multimap<?, ?>, RuntimeException> {
         @Override
         public Multimap<?, ?> call() throws RuntimeException {
@@ -59,7 +59,7 @@ public class Jenkins67105Test {
         }
     }
 
-    private static class HashMultiMapCallable
+    private static class HashMultimapCallable
             extends MasterToSlaveCallable<Multimap<?, ?>, RuntimeException> {
         @Override
         public Multimap<?, ?> call() throws RuntimeException {


### PR DESCRIPTION
See [JENKINS-67105](https://issues.jenkins.io/browse/JENKINS-67105) and [JENKINS-49000](https://issues.jenkins.io/browse/JENKINS-49000). #5707 upgraded the version of Guava, which added some additional classes to the class hierarchy of `ArrayListMultimap` and `HashMultimap`. This effectively undid #3241, which added all classes in the class hierarchy of `ArrayListMultimap` and `HashMultimap` to `whitelisted-classes.txt` to support the Artifactory plugin. In order to restore the status quo as of #3241, we need to ensure again that `whitelisted-classes.txt` contains all classes in the class hierarchy of `ArrayListMultimap` and `HashMultimap`. As of #5707, this includes three additional classes, which we are adding in this PR.

### Testing done

Wrote a new test that:

- Passes with #5707 reverted and no changes to `core/src/main`
- Fails with no changes to `core/src/main`
- Passes with the changes to `core/src/main` in this PR

### Proposed changelog entries

- Permit additional safe types in agent to controller access control (regression in 2.320).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
