### PR TITLE
split the index of javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@ THE SOFTWARE.
           <configuration>
             <quiet>true</quiet>
             <doclint>all,-missing</doclint>
+            <splitindex>true</splitindex>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
The [index ](https://javadoc.jenkins.io/index-all.html) takes a long time to load and scroll as it is massive.
This change uses a separate page for each index (a-z 0-9 etc...) rather
than one long page.

See https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDFGBHB for details.

NB: not tested e2e test, just locally with `mvn clean install javadoc:javadoc -DskipTests -Dcheckstyle.skip`, anything that currently directly links to the `index-all.html` page will likely break, but that would seem to be fixable when found. (there are checkstyle issues in `cli` module)

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Developer: [javadoc](https://javadoc.jenkins.io/index-core.html) indexes are now split to allow faster navigation.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
