### PR TITLE
Display `User.fullName` in `/securityRealm/` for `HudsonPrivateSecurityRealm`

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
           <tr>
             <td><a href="${user.url}/" class="model-link inside"><img src="${h.getUserAvatar(user,'32x32')}" alt="" height="32" width="32" /></a></td>
             <td><a href="${user.url}/">${user.id}</a></td>
-            <td><a href="${user.url}/">${user}</a></td>
+            <td><a href="${user.url}/">${user.fullName}</a></td>
             <td>
               <a href="${user.url}/configure"><l:icon class="icon-gear icon-md" /></a>
               <j:if test="${user.canDelete()}">


### PR DESCRIPTION
**Untested**, just based on https://github.com/jenkinsci/jenkins/pull/4803#issuecomment-973847507.

### Proposed changelog entries

* Display full name, rather than redundantly id, in `/securityRealm/` when using the built-in security realm.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
