### PR TITLE
Add descriptions to administrative monitors

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/description.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/description.properties
+++ b/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = When Jenkins detects a cyclic dependency between plugins (a bug in one or more plugins), this message is shown.

--- a/core/src/main/resources/hudson/PluginManager/PluginDeprecationMonitor/description.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginDeprecationMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/PluginManager/PluginDeprecationMonitor/description.properties
+++ b/core/src/main/resources/hudson/PluginManager/PluginDeprecationMonitor/description.properties
@@ -1,0 +1,2 @@
+blurb = Informs administrators about the deprecation of one or more currently installed plugins. \
+  This is metadata provided by the configured update sites, and the plugin documentation will usually explain why the plugin is deprecated.

--- a/core/src/main/resources/hudson/PluginManager/PluginUpdateMonitor/description.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginUpdateMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/PluginManager/PluginUpdateMonitor/description.properties
+++ b/core/src/main/resources/hudson/PluginManager/PluginUpdateMonitor/description.properties
@@ -1,0 +1,3 @@
+blurb = Informs administrators about a required plugin update. \
+  This is unrelated to plugin updates being available.
+# TODO Is this even used anymore?

--- a/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/description.jelly
+++ b/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/description.properties
+++ b/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/description.properties
@@ -1,0 +1,2 @@
+blurb = If any plugins failed to load, this informs administrators about the problem. \
+  This is a severe problem, as re-saving configuration at this point could result in the loss of configuration data related to unloadable plugins.

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/description.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/description.properties
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = This warning shows up when the available disk space for the Jenkins home directory falls below a certain threshold.

--- a/core/src/main/resources/hudson/diagnosis/NullIdDescriptorMonitor/description.jelly
+++ b/core/src/main/resources/hudson/diagnosis/NullIdDescriptorMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/diagnosis/NullIdDescriptorMonitor/description.properties
+++ b/core/src/main/resources/hudson/diagnosis/NullIdDescriptorMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Informs administrators about a problem with extensions in some legacy plugins.

--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/description.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/description.properties
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/description.properties
@@ -1,0 +1,2 @@
+blurb = When Jenkins configuration files contain unloadable data, this informs administrators about the problem. \
+  A common cause is plugins having been downgraded, or having changed in backwards-incompatible ways.

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/description.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/description.properties
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = If Jenkins is running behind a reverse proxy, this identifies problems with a bad configuration.

--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/description.jelly
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/description.properties
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/description.properties
@@ -1,0 +1,1 @@
+blurb = Recommends the creation of additional views to help categorize jobs if there are none and too many jobs exist.

--- a/core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/description.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/description.properties
+++ b/core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = When a new release of Jenkins has been released, this informs administrators about it.

--- a/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/description.jelly
+++ b/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/description.properties
+++ b/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/description.properties
@@ -1,0 +1,1 @@
+blurb = Whenever a resource monitor marks a node offline, this warning is shown to inform administrators about it.

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/AdministrativeMonitorImpl/description.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/AdministrativeMonitorImpl/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/AdministrativeMonitorImpl/description.properties
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/AdministrativeMonitorImpl/description.properties
@@ -1,0 +1,1 @@
+blurb = If there are more SCM polling activities scheduled than Jenkins can handle in parallel, this informs administrators about the problem and provides diagnostic information.

--- a/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/description.jelly
+++ b/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/description.properties
+++ b/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = This warns administrators that triggers are not firing on schedule, typically because some plugins perform additional actions (like network access) during trigger processing.

--- a/core/src/main/resources/jenkins/diagnosis/HsErrPidList/description.jelly
+++ b/core/src/main/resources/jenkins/diagnosis/HsErrPidList/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnosis/HsErrPidList/description.properties
+++ b/core/src/main/resources/jenkins/diagnosis/HsErrPidList/description.properties
@@ -1,0 +1,1 @@
+blurb = Informs about the presence of JRE crash dumps after an abnormal Jenkins termination, and allows viewing them.

--- a/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/description.properties
+++ b/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Warns about an incomplete initialization, indicating a bug in Jenkins.

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/description.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/description.properties
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/description.properties
@@ -1,0 +1,1 @@
+blurb = Shows a warning when the built-in node has executors despite agents (static or clouds) being configured.

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/description.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/description.properties
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/description.properties
@@ -1,0 +1,1 @@
+blurb = Shows a warning when the built-in node has executors and recommends that agents (static or clouds) are set up.

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/description.properties
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Some Jenkins features require the root URL to be defined, and this warns when it is undefined.

--- a/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/description.properties
+++ b/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Authentication (security realm) and authorization (authorization strategy) should be set up.

--- a/core/src/main/resources/jenkins/diagnostics/URICheckEncodingMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/URICheckEncodingMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/URICheckEncodingMonitor/description.properties
+++ b/core/src/main/resources/jenkins/diagnostics/URICheckEncodingMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = A diagnostic feature warnings administrators about incorrect encoding of URLs, typically with improperly set up reverse proxies or containers.

--- a/core/src/main/resources/jenkins/model/BuiltInNodeMigration/description.jelly
+++ b/core/src/main/resources/jenkins/model/BuiltInNodeMigration/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/model/BuiltInNodeMigration/description.properties
+++ b/core/src/main/resources/jenkins/model/BuiltInNodeMigration/description.properties
@@ -1,0 +1,1 @@
+blurb = When updating Jenkins from before 2.307, this allows administrators to migrate the built-in node name and label.

--- a/core/src/main/resources/jenkins/model/Jenkins/EnforceSlaveAgentPortAdministrativeMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/EnforceSlaveAgentPortAdministrativeMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/EnforceSlaveAgentPortAdministrativeMonitor/description.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/EnforceSlaveAgentPortAdministrativeMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Informs administrators that the TCP agent port is different than its enforced value and will be reset on restart.

--- a/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/description.properties
+++ b/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Recommends Java 11 for running Jenkins if an older version is used.

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/description.properties
+++ b/core/src/main/resources/jenkins/security/QueueItemAuthenticatorMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = If access control for builds is not set up, this shows a warning, explaining the problem.

--- a/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/description.properties
+++ b/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Informs about the need to perform secret re-keying due to <a href="https://www.jenkins.io/redirect/rekey" rel="noopener noreferrer" target="_blank">a security vulnerability</a> that was fixed in 2013.

--- a/core/src/main/resources/jenkins/security/ResourceDomainRecommendation/description.jelly
+++ b/core/src/main/resources/jenkins/security/ResourceDomainRecommendation/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/ResourceDomainRecommendation/description.properties
+++ b/core/src/main/resources/jenkins/security/ResourceDomainRecommendation/description.properties
@@ -1,0 +1,1 @@
+blurb = Informs about the resource root URL option if the <code>Content-Security-Policy</code> HTTP header for user-controlled resources served by Jenkins has been set to a custom value.

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/description.properties
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/description.properties
@@ -1,0 +1,3 @@
+blurb = This warning informs administrators about active security warnings for installed Jenkins core or plugin versions. \
+  Rather than disable this warning entirely (including any future issues), consider disabling specific messages in the global security configuration.
+# TODO Add link

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/description.properties
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Warns administrators about the legacy behavior of automatically generating API tokens for new users.

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/description.properties
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Warns administrators about the legacy behavior of allowing users to generate new legacy API tokens.

--- a/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/description.properties
+++ b/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Warns administrators about the presence of legacy API tokens in the configuration of some users.

--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/description.properties
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/description.properties
@@ -1,0 +1,1 @@
+blurb = Warns about disabled <a href="https://www.jenkins.io/redirect/csrf-protection" rel="noopener noreferrer" target="_blank">CSRF protection</a>.

--- a/core/src/main/resources/jenkins/security/s2m/AdminCallableMonitor/description.jelly
+++ b/core/src/main/resources/jenkins/security/s2m/AdminCallableMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/s2m/AdminCallableMonitor/description.properties
+++ b/core/src/main/resources/jenkins/security/s2m/AdminCallableMonitor/description.properties
@@ -1,0 +1,3 @@
+blurb = An agent attempted to send a message to the controller for execution, but agent-to-controller access control rejected it. \
+  This lets administrators review the message type and approve it.
+# TODO I am fairly sure this never triggers, but https://github.com/jenkinsci/jenkins/pull/5885 will hopefully remove this soon anyway.

--- a/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchWarning/description.jelly
+++ b/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchWarning/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
+    ${%blurb}
+</j:jelly>

--- a/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchWarning/description.properties
+++ b/core/src/main/resources/jenkins/security/s2m/MasterKillSwitchWarning/description.properties
@@ -1,0 +1,1 @@
+blurb = When <a href="https://www.jenkins.io/doc/book/security/controller-isolation/#agent-controller-access-control" rel="noopener noreferrer" target="_blank">agent-to-controller access control</a> is disabled, this warns administrators.


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/5923#pullrequestreview-810988422 reminded me about this feature which I added in #2546 (which has a "before" screenshot) but never made use of.

I still think it's useful to have a short explanation what each admin monitor does in case the display name is not useful enough, so this adds descriptions to all admin monitors in core. Alternatively, we could look into making these `(?)` help instead, which would support a more extensive description. (But this could probably be done later and not even require a rename of these files, being compatible with any external-to-core admin monitors that currently have a description.)

In terms of phrasing, I tried to not use the term "administrative monitor" based on an old conversation I had with Tyler or Jesse (unsure) who said the term is confusing to admins, so a lot of "this" or just no subject at all in the descriptions.

<details>
<summary>Screenshot</summary>

> <img width="665" alt="Screenshot 2021-11-20 at 15 03 02" src="https://user-images.githubusercontent.com/1831569/142729243-a768cefc-f594-4ce6-ab4b-636558d4085f.png">

</details>

One downside is that this drowns out the "Security" labels a bit. Thoughts?

### Proposed changelog entries

* Add descriptions of built-in administrative alerts to the global configuration alert selection page.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
