### PR TITLE
Update 2.TODO documentation

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -149,7 +149,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      * accesses a /user/arbitraryName URL.
      * <p>
      * Unfortunately this constitutes a CSRF vulnerability, as malicious users can make admins create arbitrary numbers
-     * of ephemeral user records, so the behavior was changed in Jenkins 2.TODO / 2.32.2.
+     * of ephemeral user records, so the behavior was changed in Jenkins 2.44 / 2.32.2.
      * <p>
      * As some users may be relying on the previous behavior, setting this to true restores the previous behavior. This
      * is not recommended.

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -312,9 +312,9 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
 
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     @Restricted(NoExternalUse.class)
-    @RestrictedSince("TODO")
+    @RestrictedSince("2.289")
     /**
-     * Used to be milliseconds, now is seconds since Jenkins 2.TODO.
+     * Used to be milliseconds, now is seconds since Jenkins 2.289.
      */
     public static /* non-final for Groovy */ long CRON_THRESHOLD = SystemProperties.getLong(Trigger.class.getName() + ".CRON_THRESHOLD", 30L); // Default threshold 30s
 

--- a/core/src/main/java/hudson/util/ChartUtil.java
+++ b/core/src/main/java/hudson/util/ChartUtil.java
@@ -261,7 +261,7 @@ public class ChartUtil {
     }
 
     @Restricted(NoExternalUse.class)
-    @RestrictedSince("2.TODO")
+    @RestrictedSince("2.301")
     public static final double CHEBYSHEV_N = 3;
 
     static {

--- a/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
+++ b/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
@@ -145,7 +145,7 @@ public class ClassLoaderReflectionToolkit {
      * @param name The binary name of the class.
      * @return The resulting {@link Class} object.
      * @throws ClassNotFoundException If the class could not be found.
-     * @since 2.TODO
+     * @since 2.321
      */
     public static @NonNull Class<?> loadClass(ClassLoader cl, String name) throws ClassNotFoundException {
         synchronized (getClassLoadingLock(cl, name)) {

--- a/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
+++ b/core/src/main/java/jenkins/tools/GlobalToolConfiguration.java
@@ -107,7 +107,7 @@ public class GlobalToolConfiguration extends ManagementLink {
     }
 
     @Restricted(NoExternalUse.class)
-    @RestrictedSince("2.TODO")
+    @RestrictedSince("2.301")
     public static final Predicate<Descriptor> FILTER = input -> input.getCategory() instanceof ToolConfigurationCategory;
 
     private static final Logger LOGGER = Logger.getLogger(GlobalToolConfiguration.class.getName());

--- a/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
+++ b/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
@@ -564,6 +564,6 @@ public class XStreamDOM {
     }
 
     @Restricted(NoExternalUse.class)
-    @RestrictedSince("2.TODO")
+    @RestrictedSince("2.301")
     public static final XmlFriendlyReplacer REPLACER = new XmlFriendlyReplacer();
 }

--- a/core/src/main/resources/lib/form/combobox.jelly
+++ b/core/src/main/resources/lib/form/combobox.jelly
@@ -62,7 +62,7 @@ THE SOFTWARE.
     <st:attribute name="checkMethod" use="optional" type="String">
       Specify 'get' (must be lowercase) to change the HTTP method used for the AJAX requests to @checkUrl from a POST to a GET.
       If any other value is specified then requests will use POST.
-      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.TODO.
+      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.285.
     </st:attribute>
   </st:documentation>
   <f:prepareDatabinding/>

--- a/core/src/main/resources/lib/form/number.jelly
+++ b/core/src/main/resources/lib/form/number.jelly
@@ -79,7 +79,7 @@ THE SOFTWARE.
     <st:attribute name="checkMethod" use="optional" type="String">
       Specify 'get' (must be lowercase) to change the HTTP method used for the AJAX requests to @checkUrl from a POST to a GET.
       If any other value is specified then requests will use POST.
-      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.TODO.
+      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.285.
     </st:attribute>
   </st:documentation>
   <f:prepareDatabinding />

--- a/core/src/main/resources/lib/form/select.jelly
+++ b/core/src/main/resources/lib/form/select.jelly
@@ -54,7 +54,7 @@ THE SOFTWARE.
     <st:attribute name="checkMethod" use="optional" type="String">
       Specify 'get' (must be lowercase) to change the HTTP method used for the AJAX requests to @checkUrl from a POST to a GET.
       If any other value is specified then requests will use POST.
-      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.TODO.
+      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.285.
     </st:attribute>
   </st:documentation>
 

--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -58,7 +58,7 @@ THE SOFTWARE.
     <st:attribute name="checkMethod" use="optional" type="String">
       Specify 'get' (must be lowercase) to change the HTTP method used for the AJAX requests to @checkUrl from a POST to a GET.
       If any other value is specified then requests will use POST.
-      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.TODO.
+      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.285.
     </st:attribute>
     <st:attribute name="codemirror-mode">
       Turns this text area into CodeMirror-assisted code editing text area.

--- a/core/src/main/resources/lib/form/textbox.jelly
+++ b/core/src/main/resources/lib/form/textbox.jelly
@@ -72,7 +72,7 @@ THE SOFTWARE.
     <st:attribute name="checkMethod" use="optional" type="String">
       Specify 'get' (must be lowercase) to change the HTTP method used for the AJAX requests to @checkUrl from a POST to a GET.
       If any other value is specified then requests will use POST.
-      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.TODO.
+      The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.285.
     </st:attribute>
     <st:attribute name="autoCompleteDelimChar">
       A single character that can be used as a delimiter for autocompletion. Normal


### PR DESCRIPTION
Replaces 2.TODO documentation with the actual shipped version number.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
