### PR TITLE
Include `symbol-annotation` in core BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -289,6 +289,11 @@ THE SOFTWARE.
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>symbol-annotation</artifactId>
+        <version>1.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.sun.mail</groupId>
         <artifactId>jakarta.mail</artifactId>
         <version>1.6.5</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -479,10 +479,9 @@ THE SOFTWARE.
       <groupId>org.jvnet.robust-http-client</groupId>
       <artifactId>robust-http-client</artifactId>
     </dependency>
-    <dependency> <!-- Not included into BOM, plugins should use one from structs-plugin -->
+    <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.1</version>
     </dependency>
 
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -135,8 +135,14 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.24-rc301.b358e327c0ec</version> <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/112 -->
+      <version>1.23</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion> <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/112 -->
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>symbol-annotation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -135,7 +135,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.23</version>
+      <version>1.24-rc301.b358e327c0ec</version> <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/112 -->
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -135,14 +135,8 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.23</version>
+      <version>1.24</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion> <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/112 -->
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>symbol-annotation</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
See [jenkinsci/jenkins#5293 (comment)](https://github.com/jenkinsci/jenkins/pull/5293#issuecomment-780542952). Now that `symbol-annotation` has been [split into its own repository](https://github.com/jenkinsci/lib-symbol-annotation), encourage plugins to use the dependency from Jenkins core rather than the `structs` plugin by adding `symbol-annotation` to the core (not plugin!) BOM. The corresponding change to stop bundling this with `structs` is jenkinsci/structs-plugin#112. Note that I am not upgrading the version of this library yet. I want to wait until jenkinsci/structs-plugin#112 is released and more plugins adopt the new release of structs before I do that in order to avoid unnecessary migration pain.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [X] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
