### PR TITLE
[JENKINS-66894] No exception thrown by building disabled project

### DIFF
--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -195,6 +195,11 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
             delay=new TimeDuration(TimeUnit.MILLISECONDS.convert(asJob().getQuietPeriod(), TimeUnit.SECONDS));
         }
 
+        if (asJob().isDisabled())
+        {
+            throw HttpResponses.forwardToPreviousPage();
+        }
+
         if (!asJob().isBuildable()) {
             throw HttpResponses.error(SC_CONFLICT, new IOException(asJob().getFullName() + " is not buildable"));
         }
@@ -231,6 +236,11 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         BuildAuthorizationToken.checkPermission(asJob(), asJob().getAuthToken(), req, rsp);
 
         ParametersDefinitionProperty pp = asJob().getProperty(ParametersDefinitionProperty.class);
+        if (asJob().isDisabled())
+        {
+            throw HttpResponses.forwardToPreviousPage();
+        }
+        
         if (!asJob().isBuildable()) {
             throw HttpResponses.error(SC_CONFLICT, new IOException(asJob().getFullName() + " is not buildable!"));
         }

--- a/test/src/test/java/jenkins/model/ParameterizedJobMixInTest.java
+++ b/test/src/test/java/jenkins/model/ParameterizedJobMixInTest.java
@@ -23,11 +23,14 @@
  */
 package jenkins.model;
 
+
+import com.gargoylesoftware.htmlunit.WebWindow;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import hudson.model.StringParameterDefinition;
 import javax.servlet.http.HttpServletResponse;
+import static org.junit.Assert.assertEquals;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,14 +45,17 @@ public class ParameterizedJobMixInTest {
     
     @Rule
     public JenkinsRule j = new JenkinsRule();
-    
+
     @Test
+    @Issue("JENKINS-66894")
     public void doBuild_shouldFailWhenInvokingDisabledProject() throws Exception {
         final FreeStyleProject project = j.createFreeStyleProject();
         project.doDisable();
         
         final JenkinsRule.WebClient webClient = j.createWebClient();
-        webClient.assertFails(project.getUrl() + "build", HttpServletResponse.SC_CONFLICT);
+        WebWindow page = webClient.getCurrentWindow();
+        webClient.goTo(project.getUrl() + "build");
+        assertEquals(page, webClient.getCurrentWindow());
     }
     
     @Test
@@ -58,9 +64,11 @@ public class ParameterizedJobMixInTest {
         final FreeStyleProject project = j.createFreeStyleProject();
         project.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("FOO", "BAR")));
         project.doDisable();
-        
+
         final JenkinsRule.WebClient webClient = j.createWebClient();
-        webClient.assertFails(project.getUrl() + "buildWithParameters", HttpServletResponse.SC_CONFLICT);
+        WebWindow page = webClient.getCurrentWindow();
+        webClient.goTo(project.getUrl() + "buildWithParameters");
+        assertEquals(page, webClient.getCurrentWindow());
     }
 
     @Test


### PR DESCRIPTION
Check and redirect if project is disabled before throwing exception. See [JENKINS-66894](https://issues.jenkins.io/browse/JENKINS-66894) for full details.

### Proposed changelog entries

* No exception is thrown when attempting to build a disabled project
* Testing for building a disabled project changed accordingly


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

- [x] Appropriate autotests or explanation to why this change has no tests

### Desired reviewers

@mention


### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
