### PR TITLE
`Stream`/`Spliterator` support for `RunList`

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1657,7 +1657,7 @@ public abstract class AbstractProject<P extends AbstractProject<P,R>,R extends A
      *
      * For each given build, find the build number range of the given project and put that into the map.
      */
-    private void checkAndRecord(AbstractProject that, TreeMap<Integer, RangeSet> r, Collection<R> builds) {
+    private void checkAndRecord(AbstractProject that, TreeMap<Integer, RangeSet> r, Iterable<R> builds) {
         for (R build : builds) {
             RangeSet rs = build.getDownstreamRelationship(that);
             if(rs==null || rs.isEmpty())

--- a/core/src/main/java/hudson/model/RSS.java
+++ b/core/src/main/java/hudson/model/RSS.java
@@ -52,7 +52,7 @@ public final class RSS {
      * @param adapter
      *      Controls how to render entries to RSS.
      */
-    public static <E> void forwardToRss(String title, String url, Iterable<? extends E> entries, FeedAdapter<E> adapter, StaplerRequest req, HttpServletResponse rsp) throws IOException, ServletException {
+    public static <E> void forwardToRss(String title, String url, Collection<? extends E> entries, FeedAdapter<E> adapter, StaplerRequest req, HttpServletResponse rsp) throws IOException, ServletException {
         req.setAttribute("adapter",adapter);
         req.setAttribute("title",title);
         req.setAttribute("url",url);

--- a/core/src/main/java/hudson/model/RSS.java
+++ b/core/src/main/java/hudson/model/RSS.java
@@ -52,7 +52,7 @@ public final class RSS {
      * @param adapter
      *      Controls how to render entries to RSS.
      */
-    public static <E> void forwardToRss(String title, String url, Collection<? extends E> entries, FeedAdapter<E> adapter, StaplerRequest req, HttpServletResponse rsp) throws IOException, ServletException {
+    public static <E> void forwardToRss(String title, String url, Iterable<? extends E> entries, FeedAdapter<E> adapter, StaplerRequest req, HttpServletResponse rsp) throws IOException, ServletException {
         req.setAttribute("adapter",adapter);
         req.setAttribute("title",title);
         req.setAttribute("url",url);

--- a/core/src/main/java/hudson/util/RunList.java
+++ b/core/src/main/java/hudson/util/RunList.java
@@ -45,7 +45,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 /**
  * {@link List} of {@link Run}s, sorted in the descending date order.
@@ -165,6 +167,20 @@ public class RunList<R extends Run> extends AbstractList<R> {
             r.add(itr.next());
         }
         return r;
+    }
+
+    @Override
+    public Spliterator<R> spliterator() {
+        return base.spliterator();
+    }
+
+    @Override
+    public Stream<R> stream() {
+        if (base instanceof Collection) {
+            return ((Collection) base).stream();
+        } else {
+            return super.stream();
+        }
     }
 
     @Override

--- a/core/src/main/java/hudson/util/RunList.java
+++ b/core/src/main/java/hudson/util/RunList.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * {@link List} of {@link Run}s, sorted in the descending date order.
@@ -172,15 +171,6 @@ public class RunList<R extends Run> extends AbstractList<R> {
     @Override
     public Spliterator<R> spliterator() {
         return base.spliterator();
-    }
-
-    @Override
-    public Stream<R> stream() {
-        if (base instanceof Collection) {
-            return ((Collection) base).stream();
-        } else {
-            return super.stream();
-        }
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -106,8 +106,8 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
     private volatile Index index = new Index();
     private LazyLoadRunMapEntrySet<R> entrySet = new LazyLoadRunMapEntrySet<>(this);
 
-    private transient Set<Integer> keySet;
-    private transient Collection<R> values;
+    private transient volatile Set<Integer> keySet;
+    private transient volatile Collection<R> values;
 
     @Override
     public Set<Integer> keySet() {

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -32,15 +32,22 @@ import hudson.model.Run;
 import hudson.model.RunMap;
 import java.io.File;
 import java.io.IOException;
+import java.util.AbstractCollection;
 import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.TreeMap;
+import java.util.function.IntConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.MemoryReductionUtil;
@@ -98,6 +105,145 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer,R> i
      */
     private volatile Index index = new Index();
     private LazyLoadRunMapEntrySet<R> entrySet = new LazyLoadRunMapEntrySet<>(this);
+
+    private transient Set<Integer> keySet;
+    private transient Collection<R> values;
+
+    @Override
+    public Set<Integer> keySet() {
+        Set<Integer> ks = keySet;
+        if (ks == null) {
+            ks = new AbstractSet<Integer>() {
+                @Override
+                public Iterator<Integer> iterator() {
+                    return new Iterator() {
+                        private final Iterator<Entry<Integer, R>> it = entrySet().iterator();
+
+                        @Override
+                        public boolean hasNext() {
+                            return it.hasNext();
+                        }
+
+                        @Override
+                        public Integer next() {
+                            return it.next().getKey();
+                        }
+
+                        @Override
+                        public void remove() {
+                            it.remove();
+                        }
+                    };
+                }
+
+                @Override
+                public Spliterator<Integer> spliterator() {
+                    return new Spliterators.AbstractIntSpliterator(
+                            Long.MAX_VALUE,
+                            Spliterator.DISTINCT | Spliterator.ORDERED | Spliterator.SORTED) {
+                        private final Iterator<Integer> it = iterator();
+
+                        @Override
+                        public boolean tryAdvance(IntConsumer action) {
+                            if (action == null) {
+                                throw new NullPointerException();
+                            }
+                            if (it.hasNext()) {
+                                action.accept(it.next());
+                                return true;
+                            }
+                            return false;
+                        }
+
+                        @Override
+                        public Comparator<Integer> getComparator() {
+                            return Collections.reverseOrder();
+                        }
+                    };
+                }
+
+                @Override
+                public int size() {
+                    return AbstractLazyLoadRunMap.this.size();
+                }
+
+                @Override
+                public boolean isEmpty() {
+                    return AbstractLazyLoadRunMap.this.isEmpty();
+                }
+
+                @Override
+                public void clear() {
+                    AbstractLazyLoadRunMap.this.clear();
+                }
+
+                @Override
+                public boolean contains(Object k) {
+                    return AbstractLazyLoadRunMap.this.containsKey(k);
+                }
+            };
+            keySet = ks;
+        }
+        return ks;
+    }
+
+    @Override
+    public Collection<R> values() {
+        Collection<R> vals = values;
+        if (vals == null) {
+            vals = new AbstractCollection<R>() {
+                @Override
+                public Iterator<R> iterator() {
+                    return new Iterator<R>() {
+                        private final Iterator<Entry<Integer, R>> it = entrySet().iterator();
+
+                        @Override
+                        public boolean hasNext() {
+                            return it.hasNext();
+                        }
+
+                        @Override
+                        public R next() {
+                            return it.next().getValue();
+                        }
+
+                        @Override
+                        public void remove() {
+                            it.remove();
+                        }
+                    };
+                }
+
+                @Override
+                public Spliterator<R> spliterator() {
+                    return Spliterators.spliteratorUnknownSize(
+                            iterator(), Spliterator.DISTINCT | Spliterator.ORDERED);
+                }
+
+                @Override
+                public int size() {
+                    return AbstractLazyLoadRunMap.this.size();
+                }
+
+                @Override
+                public boolean isEmpty() {
+                    return AbstractLazyLoadRunMap.this.isEmpty();
+                }
+
+                @Override
+                public void clear() {
+                    AbstractLazyLoadRunMap.this.clear();
+                }
+
+                @Override
+                public boolean contains(Object v) {
+                    return AbstractLazyLoadRunMap.this.containsValue(v);
+                }
+            };
+            values = vals;
+        }
+        return vals;
+    }
 
     /**
      * Historical holder for map.

--- a/core/src/main/java/jenkins/model/lazy/LazyLoadRunMapEntrySet.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyLoadRunMapEntrySet.java
@@ -6,6 +6,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import jenkins.model.lazy.AbstractLazyLoadRunMap.Direction;
 
 /**
@@ -89,6 +91,12 @@ class LazyLoadRunMapEntrySet<R> extends AbstractSet<Map.Entry<Integer,R>> {
                 owner.removeValue(last);
             }
         };
+    }
+
+    @Override
+    public Spliterator<Map.Entry<Integer, R>> spliterator() {
+        return Spliterators.spliteratorUnknownSize(
+                iterator(), Spliterator.DISTINCT | Spliterator.ORDERED);
     }
 
     @Override


### PR DESCRIPTION
`RunList`, despite its name, is best used as an `Iterable` rather than a `Collection`, because operations like `Collection#size` trigger eager loading of all build records. Despite this, `RunList#stream` triggers eager loading of all builds, not only because it does not plumb through the corresponding `stream()` and `spliterator()` calls to the underlying `AbstractLazyLoadRunMap`, but also because `AbstractLazyLoadRunMap`'s own `entrySet()`, `keySet()`, and `values()` methods return objects whose `Spliterator`s are sized and therefore incompatible with lazy-loading. This change updates those methods to return `Spliterator`s of unknown size, which do not trigger eager loading. As a bonus, we also update `AbstractLazyLoadRunMap#keySet` so that its return value's `Spliterator` has the `Spliterator.SORTED` characteristic and a corresponding `Comparator` (which is appropriate because `AbstractLazyLoadRunMap` implements `SortedMap`). I have added new tests covering all of this functionality, including verifying lazy-loading behavior with `RunLoadCounter`. The tests fail without the changes to `core/src/main` and pass with them.

### Proposed changelog entries

* Improve performance by lazy loading build records from the run list.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
