### PR TITLE
Update at-since Javadoc up to 2.319 (#5936)

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -411,7 +411,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      * plugin</a>. *
      * 
      * @throws Exception if the File could not be inserted into the classpath for some reason.
-     * @since TODO
+     * @since 2.313
      */
     @Restricted(Beta.class)
     public void injectJarsToClasspath(File... jars) throws Exception {

--- a/core/src/main/java/hudson/model/ExecutorListener.java
+++ b/core/src/main/java/hudson/model/ExecutorListener.java
@@ -46,7 +46,7 @@ public interface ExecutorListener extends ExtensionPoint {
      * Called whenever a task is started by an executor.
      * @param executor The executor.
      * @param task The task.
-     * @since TODO
+     * @since 2.318
      */
     default void taskStarted(Executor executor, Queue.Task task) {}
 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2076,7 +2076,7 @@ public class Queue extends ResourceController implements Saveable {
          * If {@link #getParent} has a distinct {@link SubTask#getOwnerTask},
          * then it should be the case that {@code getParentExecutable().getParent() == getParent().getOwnerTask()}.
          * @return a <em>distinct</em> executable (never {@code this}, unlike the default of {@link SubTask#getOwnerTask}!); or null if this executable was already at top level
-         * @since TODO, but implementations can already implement this with a lower core dependency.
+         * @since 2.313, but implementations can already implement this with a lower core dependency.
          */
         default @CheckForNull Executable getParentExecutable() {
             return null;

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -124,7 +124,7 @@ public class XStream2 extends XStream {
     }
 
     /**
-     * @since TODO
+     * @since 2.318
      */
     public XStream2(ReflectionProvider reflectionProvider, HierarchicalStreamDriver driver,
                     ClassLoaderReference classLoaderReference, Mapper mapper, ConverterLookup converterLookup,

--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -37,7 +37,7 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
     }
 
     /**
-     * @since TODO
+     * @since 2.310
      */
     public boolean getAgentToControllerAccessControl() {
         return !rule.getMasterKillSwitch();

--- a/core/src/main/java/jenkins/security/s2m/RunningBuildFilePathFilter.java
+++ b/core/src/main/java/jenkins/security/s2m/RunningBuildFilePathFilter.java
@@ -48,7 +48,7 @@ import java.util.regex.Pattern;
 /**
  * When an agent tries to access build directories on the controller, limit it to those for builds running on that agent.
  *
- * @since TODO
+ * @since 2.319
  */
 @Restricted(NoExternalUse.class)
 public class RunningBuildFilePathFilter extends ReflectiveFilePathFilter {

--- a/essentials.yml
+++ b/essentials.yml
@@ -1,7 +1,7 @@
 ---
 ath:
   useLocalSnapshots: false
-  athRevision: "acceptance-test-harness-1.105"
+  athRevision: "acceptance-test-harness-1.106"
   athImage: "jenkins/ath:1.97-pre"
   tests:
     - '*'


### PR DESCRIPTION
Followup to #5936: Integrate new `@since` Javadoc into 2.319 LTS for better LTS Javadoc.

@cathychan

### Proposed changelog entries

(none, I think we can probably do Javadoc changes without changelog entry even in LTS?)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
