### PR TITLE
[JENKINS-67226] Deduplicate RPCRequest oids and proxy objects

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/SlaveToMasterFileCallableUsage.java
+++ b/core/src/main/java/jenkins/telemetry/impl/SlaveToMasterFileCallableUsage.java
@@ -30,6 +30,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 import jenkins.SlaveToMasterFileCallable;
 import jenkins.security.s2m.DefaultFilePathFilter;
 import jenkins.telemetry.Telemetry;
@@ -69,7 +70,13 @@ public class SlaveToMasterFileCallableUsage extends Telemetry {
     }
 
     public synchronized void recordTrace(Throwable trace) {
-        traces.add(Functions.printThrowable(trace).replaceAll("@[a-f0-9]+", "@…"));
+        traces.add(generalize(Functions.printThrowable(trace)));
     }
 
+    protected static String generalize(String trace) {
+        return trace
+                .replaceAll("@[a-f0-9]+", "@…")
+                .replaceAll("]\\([0-9]+\\) created at", "](…) created at")
+                .replaceAll("com[.]sun[.]proxy[.][$]Proxy[0-9]+[.]", Matcher.quoteReplacement("com.sun.proxy.$Proxy…."));
+    }
 }

--- a/core/src/test/java/jenkins/telemetry/impl/SlaveToMasterFileCallableUsageTest.java
+++ b/core/src/test/java/jenkins/telemetry/impl/SlaveToMasterFileCallableUsageTest.java
@@ -1,0 +1,37 @@
+package jenkins.telemetry.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SlaveToMasterFileCallableUsageTest {
+    @Test
+    public void ignoreObjectIdentity() {
+        assertGeneralization("Command UserRequest:hudson.FilePath$CopyTo@… created at", "Command UserRequest:hudson.FilePath$CopyTo@abcdef12 created at");
+
+        assertUnmodified("FilePath$CopyTo-abcdef12 created at");
+        assertUnmodified("abcdef12 created at");
+        assertUnmodified("\tat hudson.FilePath.readToString(FilePath.java:2289)");
+    }
+
+    @Test
+    public void ignoreRPCRequestOid() {
+        assertGeneralization("Command UserRequest:UserRPCRequest:hudson.maven.MavenBuildProxy2.end[](…) created at", "Command UserRequest:UserRPCRequest:hudson.maven.MavenBuildProxy2.end[](16) created at");
+        assertGeneralization("Command UserRequest:UserRPCRequest:hudson.maven.MavenBuildProxy2.end[org.acme.FakeType](…) created at", "Command UserRequest:UserRPCRequest:hudson.maven.MavenBuildProxy2.end[org.acme.FakeType](16) created at");
+    }
+
+    @Test
+    public void ignoreProxyIndex() {
+        assertGeneralization("at com.sun.proxy.$Proxy….end(Unknown Source)", "at com.sun.proxy.$Proxy6.end(Unknown Source)");
+        assertGeneralization("at com.sun.proxy.$Proxy….end(Unknown Source)", "at com.sun.proxy.$Proxy66.end(Unknown Source)");
+        assertGeneralization("at com.sun.proxy.$Proxy….begin(Unknown Source)", "at com.sun.proxy.$Proxy66.begin(Unknown Source)");
+    }
+
+    private static void assertGeneralization(String generalized, String actual) {
+        assertEquals(generalized, SlaveToMasterFileCallableUsage.generalize(actual));
+    }
+
+    private static void assertUnmodified(String actual) {
+        assertEquals(actual, SlaveToMasterFileCallableUsage.generalize(actual));
+    }
+}


### PR DESCRIPTION
See [JENKINS-67226](https://issues.jenkins.io/browse/JENKINS-67226).

This cleans up some causes for duplicate entries in the stack traces for agent-to-controller file access via `FilePath` we're collecting telemetry for.

Upstream sources for the `RPCRequest` string we're changing:

* https://github.com/jenkinsci/remoting/blob/91af15b63ef6431621bbd080be183edb8310f141/src/main/java/hudson/remoting/Command.java#L190
* https://github.com/jenkinsci/remoting/blob/92ecf07540c9e2d8ef3c76f8008afcc8a160e505/src/main/java/hudson/remoting/UserRequest.java#L302
* https://github.com/jenkinsci/remoting/blob/91af15b63ef6431621bbd080be183edb8310f141/src/main/java/hudson/remoting/RemoteInvocationHandler.java#L968-L979

The other looks like this in the stack trace:

```
	at com.sun.proxy.$Proxy5.end(Unknown Source)
```

Probably JVM dependent and referencing a proxy instance by ID? This this should at least cut down some of the hits. We can always amend this.

### Proposed changelog entries

<!-- Can probably be skipped? Unsure, depends on whether it creates problems for folks. -->

* More aggressively deduplicate entries in agent-to-controller file access telemetry introduced in Jenkins 2.322.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
