### PR TITLE
[JENKINS-67033] Missing icon in dashboard view (#5919)

### DIFF
--- a/core/src/main/java/jenkins/management/ConfigureLink.java
+++ b/core/src/main/java/jenkins/management/ConfigureLink.java
@@ -39,7 +39,7 @@ public class ConfigureLink extends ManagementLink {
 
     @Override
     public String getIconFileName() {
-        return "gear.png";
+        return "gear2.png";
     }
 
     @Override


### PR DESCRIPTION
## [JENKINS-67033](https://issues.jenkins-ci.org/browse/JENKINS-67033) Missing icon in dashboard view (from #5919)

See [JENKINS-67033](https://issues.jenkins-ci.org/browse/JENKINS-67033) and the original fix that was added to Jenkins 2.322 by [PR-5919](https://github.com/jenkinsci/jenkins/pull/5919).

Co-authored-by: Mark Waite <mark.earl.waite@gmail.com>

(cherry picked from commit 090779fb4e88f8105a1cde0e2eaca725e7b3966d)

### Proposed changelog entries

* N/A - manually curated changelog

### Proposed upgrade guidelines

* N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@timja

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
