### PR TITLE
[JENKINS-67188] Deadlock loading `TaskListener` vs. `StreamTaskListener` (#5932)

### DIFF
--- a/core/src/main/java/hudson/model/NullTaskListener.java
+++ b/core/src/main/java/hudson/model/NullTaskListener.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import java.io.PrintStream;
+import org.apache.commons.io.output.NullPrintStream;
+
+/**
+ * @see TaskListener#NULL
+ */
+class NullTaskListener implements TaskListener {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public PrintStream getLogger() {
+        return new NullPrintStream();
+    }
+
+}

--- a/core/src/main/java/hudson/model/TaskListener.java
+++ b/core/src/main/java/hudson/model/TaskListener.java
@@ -27,7 +27,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.console.ConsoleNote;
 import hudson.console.HyperlinkNote;
 import hudson.remoting.Channel;
-import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -155,5 +154,5 @@ public interface TaskListener extends SerializableOnlyOverRemoting {
     /**
      * {@link TaskListener} that discards the output.
      */
-    TaskListener NULL = new StreamTaskListener(new NullStream());
+    TaskListener NULL = new NullTaskListener();
 }


### PR DESCRIPTION
## [JENKINS-67188](https://issues.jenkins-ci.org/browse/JENKINS-67188) Deadlock loading `TaskListener` vs. `StreamTaskListener` (#5932)

See [JENKINS-67188](https://issues.jenkins-ci.org/browse/JENKINS-67188) and the [pull request](https://github.com/jenkinsci/jenkins/pull/5932) that resolves the issue in weekly..

### Proposed changelog entries

* N/A - separately maintained changelog for LTS releases

### Proposed upgrade guidelines

* N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@timja

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
