### PR TITLE
Enable `DefaultComesLast` Checkstyle check

### DIFF
--- a/core/src/main/java/hudson/util/LineEndingConversion.java
+++ b/core/src/main/java/hudson/util/LineEndingConversion.java
@@ -50,15 +50,15 @@ public class LineEndingConversion {
                 // Convert line endings to Windows CR/LF
                 input = input.replace("\n", "\r\n");
                 break;
-            default:
-            case LF:
-            case Unix:
-                // Conversion already completed
-                return input;
             case LFCR:
                 // Convert line endings to LF/CR
                 input = input.replace("\n", "\n\r");
                 break;
+            case LF:
+            case Unix:
+            default:
+                // Conversion already completed
+                return input;
         }
         return input;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,7 @@ THE SOFTWARE.
                   -->
                   <module name="AvoidNoArgumentSuperConstructorCall" />
                   <module name="CovariantEquals" />
+                  <module name="DefaultComesLast" />
                   <module name="EqualsHashCode" />
                   <module name="NoEnumTrailingComma" />
                   <module name="OneStatementPerLine" />


### PR DESCRIPTION
Enables the [`DefaultComesLast`](https://checkstyle.sourceforge.io/config_coding.html#DefaultComesLast) Checkstyle check, which check that the `default` is after all the cases in a `switch` statement. Java allows `default` anywhere within the `switch` statement, but it is more readable if it comes after the last case.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
