### PR TITLE
Enable `MissingSwitchDefault` Checkstyle check

### DIFF
--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -269,6 +269,9 @@ public class QuotedStringTokenizer
                   else
                       _token.append(c);
                   continue;
+
+              default:
+                  break;
             }
         }
 

--- a/core/src/main/java/hudson/cli/ListChangesCommand.java
+++ b/core/src/main/java/hudson/cli/ListChangesCommand.java
@@ -88,6 +88,8 @@ public class ListChangesCommand extends RunRangeCommand {
                 }
             }
             break;
+        default:
+            throw new AssertionError("Unknown format: " + format);
         }
 
         return 0;

--- a/core/src/main/java/hudson/console/ConsoleAnnotator.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotator.java
@@ -126,9 +126,8 @@ public abstract class ConsoleAnnotator<T> implements Serializable {
         switch (all.size()) {
         case 0:     return null;    // none
         case 1:     return  cast(all.iterator().next()); // just one
+        default:    return new ConsoleAnnotatorAggregator<>(all);
         }
-
-        return new ConsoleAnnotatorAggregator<>(all);
     }
 
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2233,9 +2233,9 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
             case FIXED :
                 return new Summary(false, Messages.Run_Summary_BackToNormal());
                 
+            default:
+                return new Summary(false, Messages.Run_Summary_Unknown());
         }
-        
-        return new Summary(false, Messages.Run_Summary_Unknown());
     }
 
     /**

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -2085,6 +2085,8 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 throw new IOException("Failed to compute SHA-1 of downloaded file, refusing installation");
             case NOT_PROVIDED:
                 throw new IOException("Unable to confirm integrity of downloaded file, refusing installation");
+            default:
+                throw new AssertionError("Unknown verification result: " + result1);
         }
     }
 

--- a/core/src/main/java/hudson/util/jna/RegistryKey.java
+++ b/core/src/main/java/hudson/util/jna/RegistryKey.java
@@ -105,8 +105,10 @@ public class RegistryKey implements AutoCloseable {
 
             case WINERROR.ERROR_SUCCESS:
                 return lpData;
+
+            default:
+                throw new JnaException(r);
             }
-            throw new JnaException(r);
         }
     }
 

--- a/core/src/main/java/jenkins/tasks/filters/impl/RetainVariablesLocalRule.java
+++ b/core/src/main/java/jenkins/tasks/filters/impl/RetainVariablesLocalRule.java
@@ -155,6 +155,8 @@ public class RetainVariablesLocalRule implements EnvVarsFilterLocalRule {
                             variablesRemoved.add(variableName);
                             iterator.remove();
                             break;
+                        default:
+                            throw new AssertionError("Unknown process variables handling: " + processVariablesHandling);
                     }
                 }
             }

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -105,7 +105,9 @@ public class JSONSignatureValidator {
                         LOGGER.log(Level.INFO, "JSON data source '" + name + "' does not provide a SHA-512 content checksum or signature. Looking for SHA-1.");
                         break;
                     case OK:
-                        // fall through
+                        break;
+                    default:
+                        throw new AssertionError("Unknown form validation kind: " + resultSha512.kind);
                 }
             } catch (NoSuchAlgorithmException nsa) {
                 LOGGER.log(Level.WARNING, "Failed to verify potential SHA-512 digest/signature, falling back to SHA-1", nsa);
@@ -127,7 +129,9 @@ public class JSONSignatureValidator {
                         return FormValidation.error("No correct_signature or correct_signature512 entry found in '" + name + "'.");
                     }
                 case OK:
-                    // fall through
+                    break;
+                default:
+                    throw new AssertionError("Unknown form validation kind: " + resultSha1.kind);
             }
 
             if (warning!=null)  return warning;

--- a/core/src/main/java/org/jenkins/ui/icon/IconType.java
+++ b/core/src/main/java/org/jenkins/ui/icon/IconType.java
@@ -54,8 +54,8 @@ public enum IconType {
             case PLUGIN: {
                 return resURL + "/plugin/" + url;
             }
+            default:
+                throw new AssertionError("Unknown icon type: " + this);
         }
-
-        return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,7 @@ THE SOFTWARE.
                   <module name="AvoidNoArgumentSuperConstructorCall" />
                   <module name="CovariantEquals" />
                   <module name="EqualsHashCode" />
+                  <module name="MissingSwitchDefault" />
                   <module name="NoEnumTrailingComma" />
                   <module name="OneStatementPerLine" />
                   <module name="SimplifyBooleanExpression" />


### PR DESCRIPTION
Enables the [`MissingSwitchDefault`](https://checkstyle.sourceforge.io/config_coding.html#MissingSwitchDefault) Checkstyle check, which checks that each `switch` statement has a `default` clause. It is usually a good idea to introduce a default case in every switch statement. Even if the developer is sure that all currently possible cases are covered, this should be expressed in the default branch, e.g. by using an assertion. This way the code is protected against later changes, e.g. introduction of new types in an enumeration type.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
