### PR TITLE
Enable `MissingDeprecated` Checkstyle check

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -854,6 +854,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     /**
      * Returns the manifest of a bundled but not-extracted plugin.
+     * @deprecated removed without replacement
      */
     @Deprecated // See https://groups.google.com/d/msg/jenkinsci-dev/kRobm-cxFw8/6V66uhibAwAJ
     public @CheckForNull Manifest getBundledPluginManifest(String shortName) {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -767,6 +767,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     /**
      * Disables this plugin next time Jenkins runs. As it doesn't check anything, it's recommended to use the method
      * {@link #disable(PluginDisableStrategy)}
+     * @deprecated use {@link #disable(PluginDisableStrategy)}
      */
     @Deprecated //see https://issues.jenkins.io/browse/JENKINS-27177
     public void disable() throws IOException {
@@ -1190,6 +1191,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     /**
      * Checks if this plugin is pinned and that's forcing us to use an older version than the bundled one.
+     * @deprecated removed without replacement
      */
     @Deprecated // See https://groups.google.com/d/msg/jenkinsci-dev/kRobm-cxFw8/6V66uhibAwAJ
     public boolean isPinningForcingOldVersion() {

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -105,7 +105,7 @@ public class ListView extends View implements DirectlyModifiableView {
     /**
      * Filter by enabled/disabled status of jobs.
      * Null for no filter, true for enabled-only, false for disabled-only.
-     * Deprecated see {@link StatusFilter}
+     * @deprecated Status filter is now controlled via a {@link ViewJobFilter}, see {@link StatusFilter}
      */
     @Deprecated
     private transient Boolean statusFilter;
@@ -333,7 +333,7 @@ public class ListView extends View implements DirectlyModifiableView {
     /**
      * Filter by enabled/disabled status of jobs.
      * Null for no filter, true for enabled-only, false for disabled-only.
-     * Status filter is now controlled via a JobViewFilter, see {@link StatusFilter}
+     * @deprecated Status filter is now controlled via a {@link ViewJobFilter}, see {@link StatusFilter}
      */
     @Deprecated
     public Boolean getStatusFilter() {
@@ -488,7 +488,7 @@ public class ListView extends View implements DirectlyModifiableView {
     }
 
     /**
-     * Deprecated see, {@link StatusFilter}
+     * @deprecated Status filter is now controlled via a {@link ViewJobFilter}, see {@link StatusFilter}
      */
     @Deprecated
     @DataBoundSetter

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -154,7 +154,7 @@ public abstract class Slave extends Node implements Serializable {
             new DescribableList<>(this);
 
     /**
-     * Removed with no replacement.
+     * @deprecated Removed with no replacement.
      */
     @Deprecated
     private transient String userId;

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -997,6 +997,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
     /**
      * Returns a list of plugins that should be shown in the "available" tab, grouped by category.
      * A plugin with multiple categories will appear multiple times in the list.
+     * @deprecated use {@link #getAvailables()}
      */
     @Deprecated
     public PluginEntry[] getCategorizedAvailables() {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -289,7 +289,7 @@ public class UpdateSite {
 
     /**
      * Let sub-classes of UpdateSite provide their own signature validator.
-     * @param name, the name for the JSON signature Validator object.
+     * @param name the name for the JSON signature Validator object.
      *              if name is null, then the default name will be used,
      *              which is "update site" followed by the update site id
      * @return the signature validator.
@@ -493,7 +493,7 @@ public class UpdateSite {
 
     /**
      * URL which exposes the metadata location in a specific update site.
-     * @param downloadable, the downloadable id of a specific metatadata json (e.g. hudson.tasks.Maven.MavenInstaller.json)
+     * @param downloadable the downloadable id of a specific metatadata json (e.g. hudson.tasks.Maven.MavenInstaller.json)
      * @return the location
      * @since 2.20
      */

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -731,6 +731,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     /**
      * Called by tests in the JTH. Otherwise this shouldn't be called.
      * Even in the tests this usage is questionable.
+     * @deprecated removed without replacement
      */
     @Deprecated
     public static void clear() {

--- a/core/src/main/java/hudson/model/queue/Tasks.java
+++ b/core/src/main/java/hudson/model/queue/Tasks.java
@@ -53,7 +53,7 @@ public class Tasks {
         return t.getSameNodeConstraint();
     }
 
-    /** deprecated call {@link SubTask#getOwnerTask} directly */
+    /** @deprecated call {@link SubTask#getOwnerTask} directly */
     @Deprecated
     public static @NonNull Task getOwnerTaskOf(@NonNull SubTask t) {
         return t.getOwnerTask();

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -92,6 +92,7 @@ public class JNLPLauncher extends ComputerLauncher {
      *                        If {@code null}, {@link RemotingWorkDirSettings#getEnabledDefaults()}
      *                        will be used to enable work directories by default in new agents.
      * @since 2.68
+     * @deprecated use {@link #JNLPLauncher(String, String)} and {@link #setWorkDirSettings(RemotingWorkDirSettings)}
      */
     @Deprecated
     public JNLPLauncher(@CheckForNull String tunnel, @CheckForNull String vmargs, @CheckForNull RemotingWorkDirSettings workDirSettings) {

--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -45,6 +45,7 @@ public class RingBufferLogHandler extends Handler {
     /**
      * This constructor is deprecated. It can't access system properties with {@link jenkins.util.SystemProperties}
      * as it's not legal to use it on remoting agents.
+     * @deprecated use {@link #RingBufferLogHandler(int)}
      */
     @Deprecated
     public RingBufferLogHandler() {

--- a/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
+++ b/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
@@ -72,6 +72,7 @@ public class ClassLoaderReflectionToolkit {
      * @since 1.553
      * @deprecated use {@link #loadClass(ClassLoader, String)}
      */
+    @Deprecated
     public static @CheckForNull Class<?> _findLoadedClass(ClassLoader cl, String name) {
         synchronized (getClassLoadingLock(cl, name)) {
             Class<?> c;
@@ -103,6 +104,7 @@ public class ClassLoaderReflectionToolkit {
      * @since 1.553
      * @deprecated use {@link #loadClass(ClassLoader, String)}
      */
+    @Deprecated
     public static @NonNull Class<?> _findClass(ClassLoader cl, String name) throws ClassNotFoundException {
         synchronized (getClassLoadingLock(cl, name)) {
             if (cl instanceof JenkinsClassLoader) {

--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -58,7 +58,7 @@ public class InstallState implements ExtensionPoint {
      * because it is used for serialized state like "jenkins.install.InstallState$4" 
      * before the change from anonymous class to named class. If you need to add a new InstallState, you can just add a new inner named class but nothing to change in this list.
      * 
-     * @see #readResolve
+     * @deprecated see {@link #readResolve()}
      */
     @Deprecated
     @SuppressWarnings("MismatchedReadAndWriteOfArray")

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4878,6 +4878,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Checks if container uses UTF-8 to decode URLs. See
      * http://wiki.jenkins-ci.org/display/JENKINS/Tomcat#Tomcat-i18n
+     * @deprecated use {@link URICheckEncodingMonitor#doCheckURIEncoding(StaplerRequest)}
      */
     @Restricted(NoExternalUse.class)
     @RestrictedSince("2.37")
@@ -4888,6 +4889,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * Does not check when system default encoding is "ISO-8859-1".
+     * @deprecated use {@link URICheckEncodingMonitor#isCheckEnabled()}
      */
     @Restricted(NoExternalUse.class)
     @RestrictedSince("2.37")

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -658,13 +658,14 @@ public class ApiTokenProperty extends UserProperty {
     }
     
     /**
-     * Only used for legacy API Token generation and change. After that token is revoked, it will be useless.
+     * @deprecated Only used for legacy API Token generation and change. After that token is revoked, it will be useless.
      */
     @Deprecated
     private static final SecureRandom RANDOM = new SecureRandom();
 
     /**
      * We don't want an API key that's too long, so cut the length to 16 (which produces 32-letter MAC code in hexdump)
+     * @deprecated only used for the migration of previous data
      */
     @Deprecated
     @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol.java
@@ -4,9 +4,10 @@ import jenkins.security.HMACConfidentialKey;
 
 /**
  * This class was part of the old JNLP1 protocol, which has been removed.
- * The {@code SLAVE_SECRET} was still used by some plugins. It has been moved to
- * JnlpAgentReceiver as a more suitable location, but this alias retained
+ * The {@link #SLAVE_SECRET} was still used by some plugins. It has been moved to
+ * {@link JnlpAgentReceiver} as a more suitable location, but this alias retained
  * for compatibility. References should be updated to the new location.
+ * @deprecated use {@link JnlpAgentReceiver#SLAVE_SECRET}
  */
 @Deprecated
 public class JnlpSlaveAgentProtocol {

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -95,6 +95,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     /**
      * Legacy constructor used before {@link #threshold} was moved to a {@code @DataBoundSetter}. Kept around for binary
      * compatibility.
+     * @deprecated use {@link #ReverseBuildTrigger(String)} and {@link #setThreshold(Result)}
      */
     @Deprecated
     public ReverseBuildTrigger(String upstreamProjects, Result threshold) {

--- a/pom.xml
+++ b/pom.xml
@@ -435,8 +435,9 @@ THE SOFTWARE.
                   <!--
                     Annotations: https://checkstyle.sourceforge.io/config_annotation.html
                   -->
-                  <module name="MissingOverride" />
                   <module name="AnnotationUseStyle" />
+                  <module name="MissingDeprecated" />
+                  <module name="MissingOverride" />
                   <!--
                     Class Design: https://checkstyle.sourceforge.io/config_design.html
                   -->

--- a/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
@@ -104,7 +104,7 @@ public class DisablePluginCommandTest {
     }
 
     /**
-     * Can disable a plugin with a mandatory dependent plugin before its dependent plugin with <i>all/i> strategy
+     * Can disable a plugin with a mandatory dependent plugin before its dependent plugin with <i>all</i> strategy
      */
     @Test
     @Issue("JENKINS-27177")

--- a/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
@@ -91,7 +91,7 @@ public class OldDataMonitorTest {
 
     /**
      * Note that this doesn't actually run slowly, it just ensures that
-     * the {@link OldDataMonitor#changeListener's onChange()} can complete
+     * the {@link OldDataMonitor#changeListener}'s {@code onChange()} can complete
      * while {@link OldDataMonitor#doDiscard(org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse)}
      * is still running.
      *


### PR DESCRIPTION
Enables the [`MissingDeprecated`](https://checkstyle.sourceforge.io/config_annotation.html#MissingDeprecated) Checkstyle check, which checks that the annotation `@Deprecated` and the Javadoc tag `@deprecated` are both present when either of them is present. Each way of flagging deprecation serves its own purpose. The `@Deprecated` annotation is used for compilers and development tools. The `@deprecated` Javadoc tag is used to document why something is deprecated and what, if any, alternatives exist. In order to properly mark something as deprecated both forms of deprecation should be present.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
