### PR TITLE
Remove `libpam4j`

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -264,11 +264,6 @@ THE SOFTWARE.
         <version>5.10.0</version>
       </dependency>
       <dependency>
-        <groupId>org.kohsuke</groupId>
-        <artifactId>libpam4j</artifactId>
-        <version>1.11</version>
-      </dependency>
-      <dependency>
         <groupId>com.sun.solaris</groupId>
         <artifactId>embedded_su4j</artifactId>
         <version>1.1</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -454,10 +454,6 @@ THE SOFTWARE.
       <artifactId>jna</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>libpam4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.sun.solaris</groupId>
       <artifactId>embedded_su4j</artifactId>
     </dependency>

--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -34,7 +34,6 @@ import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.NativeLongByReference;
 import hudson.os.PosixAPI;
 import jnr.posix.POSIX;
-import org.jvnet.libpam.impl.CLibrary.passwd;
 
 /**
  * GNU C library.
@@ -63,8 +62,6 @@ public interface GNUCLibrary extends Library {
     int unsetenv(String name);
     void perror(String msg);
     String strerror(int errno);
-
-    passwd getpwuid(int uid);
 
     int fcntl(int fd, int command);
     int fcntl(int fd, int command, int flags);


### PR DESCRIPTION
`libpam4j` hasn't been updated in three years. We don't need to bundle this library in core. It is only used in core to implement `GNUCLibrary#getpwuid`, which nothing in the ecosystem uses (`pam-auth` itself uses JNR rather than `GNUCLibrary` for `getpwuid()`). The only plugin in the ecosystem that references any `libpam4j` classes according to `usage-in-plugins` is `pam-auth`, which itself bundles `libpam4j`. So even though it is currently getting `libpam4j` from core (by virtue of the Jenkins class loading system, where core classes take precedence over classes in plugins), if we removed `libpam4j` from core it would still work, getting `libpam4j` from the plugin instead. Therefore I conclude it is safe to remove this library and all references from core.

### Proposed changelog entries

Removed: [`libpam4j`](https://github.com/kohsuke/libpam4j), a Java binding for `libpam`, has been removed Jenkins core.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
