### PR TITLE
Fix `CopyOnWriteMapTest` 2 flaky tests

### DIFF
--- a/core/src/test/java/hudson/util/CopyOnWriteMapTest.java
+++ b/core/src/test/java/hudson/util/CopyOnWriteMapTest.java
@@ -49,9 +49,13 @@ public class CopyOnWriteMapTest {
         XStream2 xs = new XStream2();
 
         String out = xs.toXML(td);
-        assertEquals("empty maps", "<hudson.util.CopyOnWriteMapTest_-HashData>"
-                + "<map1/><map2/></hudson.util.CopyOnWriteMapTest_-HashData>",
-                out.replaceAll("\\s+", ""));
+        System.out.println(td.getClass().getName());
+        assertTrue(out.replaceAll("\\s+", "")
+                .equals("<hudson.util.CopyOnWriteMapTest_-HashData>"
+                + "<map1/><map2/></hudson.util.CopyOnWriteMapTest_-HashData>")
+                || out.replaceAll("\\s+", "")
+                .equals("<hudson.util.CopyOnWriteMapTest_-HashData>"
+                + "<map2/><map1/></hudson.util.CopyOnWriteMapTest_-HashData>"));
         HashData td2 = (HashData)xs.fromXML(out);
         assertTrue(td2.map1.isEmpty());
         assertTrue(td2.map2.isEmpty());
@@ -59,11 +63,16 @@ public class CopyOnWriteMapTest {
         td.map1.put("foo1", "bar1");
         td.map2.put("foo2", "bar2");
         out = xs.toXML(td);
-        assertEquals("maps", "<hudson.util.CopyOnWriteMapTest_-HashData><map1>"
+        assertTrue(out.replaceAll("\\s+", "")
+                .equals("<hudson.util.CopyOnWriteMapTest_-HashData><map1>"
                 + "<entry><string>foo1</string><string>bar1</string></entry></map1>"
                 + "<map2><entry><string>foo2</string><string>bar2</string></entry>"
-                + "</map2></hudson.util.CopyOnWriteMapTest_-HashData>",
-                out.replaceAll("\\s+", ""));
+                + "</map2></hudson.util.CopyOnWriteMapTest_-HashData>")
+                || out.replaceAll("\\s+", "")
+                .equals("<hudson.util.CopyOnWriteMapTest_-HashData><map2>"
+                + "<entry><string>foo2</string><string>bar2</string></entry></map2>"
+                + "<map1><entry><string>foo1</string><string>bar1</string></entry>"
+                + "</map1></hudson.util.CopyOnWriteMapTest_-HashData>"));
         td2 = (HashData)xs.fromXML(out);
         assertEquals("bar1", td2.map1.get("foo1"));
         assertEquals("bar2", td2.map2.get("foo2"));
@@ -91,10 +100,12 @@ public class CopyOnWriteMapTest {
         XStream2 xs = new XStream2();
 
         String out = xs.toXML(td);
-        assertEquals("empty maps", "<hudson.util.CopyOnWriteMapTest_-TreeData>"
-                + "<map1/><map2/>"
-                + "</hudson.util.CopyOnWriteMapTest_-TreeData>",
-                out.replaceAll("\\s+", ""));
+        assertTrue(out.replaceAll("\\s+", "")
+                .equals("<hudson.util.CopyOnWriteMapTest_-TreeData>"
+                + "<map1/><map2/></hudson.util.CopyOnWriteMapTest_-TreeData>")
+                || out.replaceAll("\\s+", "")
+                .equals("<hudson.util.CopyOnWriteMapTest_-TreeData>"
+                + "<map2/><map1/></hudson.util.CopyOnWriteMapTest_-TreeData>"));
         TreeData td2 = (TreeData)xs.fromXML(out);
         assertTrue(td2.map1.isEmpty());
         assertTrue(td2.map2.isEmpty());
@@ -103,14 +114,22 @@ public class CopyOnWriteMapTest {
         td.map1.put("foo1", "bar1");
         td.map2.put("foo2", "bar2");
         out = xs.toXML(td);
-        assertEquals("maps", "<hudson.util.CopyOnWriteMapTest_-TreeData><map1>"
+        assertTrue(out.replaceAll(">\\s+<", "><")
+                .equals("<hudson.util.CopyOnWriteMapTest_-TreeData><map1>"
                 + "<comparator class=\"java.lang.String$CaseInsensitiveComparator\"/>"
                 + "<entry><string>foo1</string><string>bar1</string></entry></map1>"
                 + "<map2><comparator class=\"java.lang.String$CaseInsensitiveComparator\""
                 + " reference=\"../../map1/comparator\"/>"
                 + "<entry><string>foo2</string><string>bar2</string></entry></map2>"
-                + "</hudson.util.CopyOnWriteMapTest_-TreeData>",
-                out.replaceAll(">\\s+<", "><"));
+                + "</hudson.util.CopyOnWriteMapTest_-TreeData>")
+                || out.replaceAll(">\\s+<", "><")
+                .equals("<hudson.util.CopyOnWriteMapTest_-TreeData><map2>"
+                + "<comparator class=\"java.lang.String$CaseInsensitiveComparator\"/>"
+                + "<entry><string>foo2</string><string>bar2</string></entry></map2>"
+                + "<map1><comparator class=\"java.lang.String$CaseInsensitiveComparator\""
+                + " reference=\"../../map2/comparator\"/>"
+                + "<entry><string>foo1</string><string>bar1</string></entry></map1>"
+                + "</hudson.util.CopyOnWriteMapTest_-TreeData>"));
         td2 = (TreeData)xs.fromXML(out);
         assertEquals("bar1", td2.map1.get("foo1"));
         assertEquals("bar2", td2.map2.get("foo2"));


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries
* Change reason:
   There are flaky tests when doing the `NonDex` run, which returns non-deterministic results that keeps the tests failing. It passes for normal runs, but fails when running the following command:
`mvn -pl core edu.illinois:nondex-maven-plugin:1.1.2:nondex *TESTNAME* `

* There are two flaky test:
`hudson.util.CopyOnWriteMapTest#hashSerialization`
`hudson.util.CopyOnWriteMapTest#treeSerialization`
And the error is reported as:

```
[ERROR] Failures:
[ERROR]   CopyOnWriteMapTest.hashSerialization:77 maps expected:<...pTest_-HashData><map[1><entry><string>foo1</string><string>bar1</stentry></map1><map2><entry><string>foo2</string><string>bar2</string></entry></map2]></hudson.util.CopyO...> 

but was:<...pTest_-HashData><entry><string>foo2</string><string>bar2</string></entry></map2><map1><entry><string>foo1</string><string>bar1</string></entry></map1]on.util.CopyO...>
``` 

* Cause of flaky:
According to the debug report https://github.com/alany9552/flakyreport/blob/master/testCopyOnWriteMapTest.log , the failing reasons is due to the call of **XStream** library, it produces a nondeterministic results which disorders the arguments.

* What has changed:
I changed the test logic replace `assertEqual()`by `assertTrue()`, thus it tests if the result equals to any possible combination after the non deterministic run, after changing, all the tests passes for both regular run and `NonDex` run.
<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [] (If applicable) Jira issue is well described
- [] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
