### PR TITLE
[JENKINS-67227] Integrate remoting 4.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.11.1</remoting.version>
+    <remoting.version>4.11.2</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 


### PR DESCRIPTION
(cherry picked from commit 32f4e1efd039d29fda666abb05c6cbf6c345638a)

Backport of https://github.com/jenkinsci/jenkins/pull/5983 into LTS.