### PR TITLE
Move Ant tests from core

### DIFF
--- a/test/src/test/java/hudson/tasks/EnvVarsInConfigTasksTest.java
+++ b/test/src/test/java/hudson/tasks/EnvVarsInConfigTasksTest.java
@@ -1,7 +1,5 @@
 package hudson.tasks;
 
-import static hudson.tasks._ant.Messages.Ant_ExecutableNotFound;
-import static org.junit.Assert.assertFalse;
 
 import hudson.EnvVars;
 import hudson.model.FreeStyleBuild;
@@ -10,10 +8,8 @@ import hudson.model.JDK;
 import hudson.model.Result;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.DumbSlave;
-import hudson.tasks.Ant.AntInstallation;
 import hudson.tasks.Maven.MavenInstallation;
 import org.apache.tools.ant.taskdefs.condition.Os;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -51,12 +47,6 @@ public class EnvVarsInConfigTasksTest {
 		MavenInstallation varMaven = new MavenInstallation("varMaven",
 				withVariable(defaultMaven.getHome()), JenkinsRule.NO_PROPERTIES);
 		j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(varMaven);
-
-		// Ant with a variable in its path
-        AntInstallation ant = ToolInstallations.configureDefaultAnt(tmp);
-        AntInstallation antInstallation = new AntInstallation("varAnt",
-                withVariable(ant.getHome()),JenkinsRule.NO_PROPERTIES);
-        j.jenkins.getDescriptorByType(Ant.DescriptorImpl.class).setInstallations(antInstallation);
 
 		// create agents
 		EnvVars additionalEnv = new EnvVars(DUMMY_LOCATION_VARNAME, "");
@@ -98,47 +88,6 @@ public class EnvVarsInConfigTasksTest {
 
 		// Check variable was expanded
 		j.assertLogNotContains(DUMMY_LOCATION_VARNAME, build);
-	}
-
-	@Test
-	public void testFreeStyleAntOnAgent() throws Exception {
-		Assume.assumeFalse(
-				"Cannot do testFreeStyleAntOnAgent without ANT_HOME",
-				j.jenkins.getDescriptorByType(Ant.DescriptorImpl.class).getInstallations().length == 0
-		);
-
-		FreeStyleProject project = j.createFreeStyleProject();
-		project.setJDK(j.jenkins.getJDK("varJDK"));
-		project.setScm(new ExtractResourceSCM(getClass().getResource(
-				"/simple-projects.zip")));
-
-		String buildFile = "build.xml${" + DUMMY_LOCATION_VARNAME + "}";
-		// we need additional escapes because bash itself expanding
-		project.getBuildersList().add(
-				new Ant("-Dtest.property=cor${" + DUMMY_LOCATION_VARNAME
-						+ "}rect", "varAnt", "", buildFile, ""));
-
-		// test the regular agent - variable not expanded
-		project.setAssignedLabel(agentRegular.getSelfLabel());
-		FreeStyleBuild build = project.scheduleBuild2(0).get();
-
-		j.assertBuildStatus(Result.FAILURE, build);
-
-		j.assertLogContains(Ant_ExecutableNotFound("varAnt"), build);
-
-		// test the agent with prepared environment
-		project.setAssignedLabel(agentEnv.getSelfLabel());
-		build = project.scheduleBuild2(0).get();
-
-		j.assertBuildStatusSuccess(build);
-
-		// Check variable was expanded
-		j.assertLogContains("Ant home: ", build);
-		j.assertLogContains("Test property: correct", build);
-		assertFalse(JenkinsRule.getLog(build).matches("(?s)^.*Ant home: [^\\n\\r]*"
-				+ DUMMY_LOCATION_VARNAME + ".*$"));
-		assertFalse(JenkinsRule.getLog(build).matches("(?s)^.*Test property: [^\\n\\r]*"
-				+ DUMMY_LOCATION_VARNAME + ".*$"));
 	}
 
 	@Test

--- a/test/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
+++ b/test/src/test/java/hudson/tools/ToolLocationNodePropertyTest.java
@@ -29,26 +29,20 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.EnvVars;
 import hudson.Functions;
-import hudson.model.Build;
 import hudson.model.FreeStyleProject;
 import hudson.model.JDK;
-import hudson.model.Result;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.DumbSlave;
-import hudson.tasks.Ant;
 import hudson.tasks.Ant.AntInstallation;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Maven.MavenInstallation;
 import hudson.tasks.Shell;
-import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-import org.jvnet.hudson.test.SingleFileSCM;
-import org.jvnet.hudson.test.ToolInstallations;
 
 /**
  * This class tests that environment variables from node properties are applied,
@@ -111,28 +105,6 @@ public class ToolLocationNodePropertyTest {
             project.getBuildersList().add(new BatchFile("set"));
         else
             project.getBuildersList().add(new Shell("export"));
-    }
-
-    @Test
-    public void ant() throws Exception {
-        Ant.AntInstallation ant = ToolInstallations.configureDefaultAnt(tmp);
-        String antPath = ant.getHome();
-        Jenkins.get().getDescriptorByType(Ant.DescriptorImpl.class).setInstallations(new AntInstallation("ant", "THIS IS WRONG"));
-
-        project.setScm(new SingleFileSCM("build.xml", "<project name='foo'/>"));
-        project.getBuildersList().add(new Ant("-version", "ant", null,null,null));
-        configureDumpEnvBuilder();
-
-        Build build = project.scheduleBuild2(0).get();
-        j.assertBuildStatus(Result.FAILURE, build);
-
-        ToolLocationNodeProperty property = new ToolLocationNodeProperty(
-                new ToolLocationNodeProperty.ToolLocation(j.jenkins.getDescriptorByType(AntInstallation.DescriptorImpl.class), "ant", antPath));
-        slave.getNodeProperties().add(property);
-
-        build = project.scheduleBuild2(0).get();
-        System.out.println(build.getLog());
-        j.assertBuildStatus(Result.SUCCESS, build);
     }
 
     @Before


### PR DESCRIPTION
Subset of #5972. Corresponds to jenkinsci/ant-plugin#81.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
