### PR TITLE
Fix `StopBuildsCommandTest` two flaky tests

### DIFF
--- a/test/src/test/java/jenkins/cli/StopBuildsCommandTest.java
+++ b/test/src/test/java/jenkins/cli/StopBuildsCommandTest.java
@@ -24,8 +24,8 @@
 package jenkins.cli;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import hudson.Functions;

--- a/test/src/test/java/jenkins/cli/StopBuildsCommandTest.java
+++ b/test/src/test/java/jenkins/cli/StopBuildsCommandTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-
 import hudson.Functions;
 import hudson.cli.CLICommand;
 import hudson.cli.CLICommandInvoker;

--- a/test/src/test/java/jenkins/cli/StopBuildsCommandTest.java
+++ b/test/src/test/java/jenkins/cli/StopBuildsCommandTest.java
@@ -24,8 +24,10 @@
 package jenkins.cli;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+
 
 import hudson.Functions;
 import hudson.cli.CLICommand;
@@ -156,11 +158,11 @@ public class StopBuildsCommandTest {
         project.scheduleBuild2(0).waitForStart();
 
         final String stdout = runWith(asList(TEST_JOB_NAME, TEST_JOB_NAME_2)).stdout();
-
-        assertThat(stdout,
-                equalTo("Exception occurred while trying to stop build '#1' for job 'jobName'. " +
-                        "Exception class: AccessDeniedException3, message: anonymous is missing the Job/Cancel permission" + LN +
-                        "Build '#1' stopped for job 'jobName2'" + LN));
+        List<String> testList = Arrays.asList(stdout.split(LN));
+        assertThat(testList,
+                contains("Exception occurred while trying to stop build '#1' for job 'jobName'. " +
+                        "Exception class: AccessDeniedException3, message: anonymous is missing the Job/Cancel permission",
+                        "Build '#1' stopped for job 'jobName2'"));
     }
 
     private CLICommandInvoker.Result runWith(final List<String> jobNames) throws Exception {
@@ -177,9 +179,10 @@ public class StopBuildsCommandTest {
         project2.scheduleBuild2(0).waitForStart();
 
         final String stdout = runWith(inputNames).stdout();
-
-        assertThat(stdout, equalTo("Build '#1' stopped for job 'jobName'" + LN +
-                "Build '#1' stopped for job 'jobName2'" + LN));
+        List<String> testList = Arrays.asList(stdout.split(LN));
+        assertThat(testList,
+                contains("Build '#1' stopped for job 'jobName'",
+                        "Build '#1' stopped for job 'jobName2'"));
 
         waitForLastBuildToStop(project);
         waitForLastBuildToStop(project2);


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Fixing two flaky tests in `StopBuildCommandTest` in `test` module
* Change reason:
   There are flaky tests when doing the `NonDex` run, which returns non-deterministic results that keeps the tests failing. It passes for normal runs, but fails when running the following command:
`mvn -pl core edu.illinois:nondex-maven-plugin:1.1.2:nondex *TESTNAME* `

* There are two flaky test:
`jenkins.cli.StopBuildsCommandTest#shouldStopWorkingBuildsInSeveralJobs`
`jenkins.cli.StopBuildsCommandTest#shouldStopSecondJobEvenIfFirstStopFailed`
And the error is reported as:

```
[ERROR] Failures:
[ERROR]   StopBuildsCommandTest.shouldStopSecondJobEvenIfFirstStopFailed:161
Expected: "Exception occurred while trying to stop build '#1' for job 'jobName'. Exception class: AccessDeniedException3, message: anonymous is missing the Job/Cancel permission\nBuild '#1' stopped for job 'jobName2'\n"
     but: was "Build '#1' stopped for job 'jobName2'\nException occurred while trying to stop build '#1' for job 'jobName'. Exception class: AccessDeniedException3, message: anonymous is missing the Job/Cancel permission\n"

``` 

* Cause of flaky:
These two tests are failed because when calling `runWith()` method, it produces a non deterministic results that fail the test. Since the test is using `assertThat(actual,EuqualTo(expected))`, the result passes for normal run, but will keep failing when running `NonDex` due to the disorder. 

* What has changed:
I changed the test logic by changing comparing actual strings to test if the results contains the expected strings. Since the results are non deterministic, it's hard to pass when comparing if the two strings are equal. So I put the strings produced by `runWith()`, and split by `LN`, then test it contains the expected string. After changings, it passes all of the tests including the `NonDex` run. 
<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [] (If applicable) Jira issue is well described
- [] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
