### PR TITLE
Bump parent POM from 1.67 to 1.69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.67</version>
+    <version>1.69</version>
     <relativePath />
   </parent>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -95,6 +95,12 @@ THE SOFTWARE.
       <artifactId>jenkins-test-harness-tools</artifactId>
       <version>2.2</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>jenkins-test-harness</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
#6006 but with Enforcer errors fixed. Notably, this pulls in the Maven Enforcer upgrade from jenkinsci/pom#196. The `jenkins-test-harness-tools` dependency in `test/pom.xml` pulls in an ancient version of `jenkins-test-harness`, which in turns pulls in an ancient version of core, which contains some random dependency that has been de-published from Maven Central, which makes the new version of Enforcer blow up. So to avoid this we just exclude `jenkins-test-harness-tools`'s transitive dependency on `jenkins-test-harness`, which we already depend on a recent version of anyway.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
