### PR TITLE
[JENKINS-21224] Utility `Listeners.notify`

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
 import org.kohsuke.stapler.StaplerFallback;
 import org.kohsuke.stapler.StaplerProxy;
@@ -219,13 +220,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
         }
         createNewComputerForNode(n, automaticAgentLaunch);
         getQueue().scheduleMaintenance();
-        for (ComputerListener cl : ComputerListener.all()) {
-            try {
-                cl.onConfigurationChange();
-            } catch (Throwable t) {
-                LOGGER.log(Level.WARNING, null, t);
-            }
-        }
+        Listeners.notify(ComputerListener.class, ComputerListener::onConfigurationChange);
     }
 
     /**
@@ -278,13 +273,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
             killComputer(c);
         }
         getQueue().scheduleMaintenance();
-        for (ComputerListener cl : ComputerListener.all()) {
-            try {
-                cl.onConfigurationChange();
-            } catch (Throwable t) {
-                LOGGER.log(Level.WARNING, null, t);
-            }
-        }
+        Listeners.notify(ComputerListener.class, ComputerListener::onConfigurationChange);
     }
 
 }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -103,6 +103,7 @@ import jenkins.security.ImpersonatingExecutorService;
 import jenkins.security.MasterToSlaveCallable;
 import jenkins.security.stapler.StaplerDispatchable;
 import jenkins.util.ContextResettingExecutorService;
+import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
 import net.jcip.annotations.GuardedBy;
 import org.apache.commons.lang.StringUtils;
@@ -706,9 +707,10 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         synchronized (statusChangeLock) {
             statusChangeLock.notifyAll();
         }
-        for (ComputerListener cl : ComputerListener.all()) {
-            if (temporarilyOffline)     cl.onTemporarilyOffline(this,cause);
-            else                        cl.onTemporarilyOnline(this);
+        if (temporarilyOffline) {
+            Listeners.notify(ComputerListener.class, l -> l.onTemporarilyOffline(this, cause));
+        } else {
+            Listeners.notify(ComputerListener.class, l -> l.onTemporarilyOnline(this));
         }
     }
 

--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -31,9 +31,9 @@ import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Items;
 import hudson.security.ACL;
-import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.util.Listeners;
 
 /**
  * Receives notifications about CRUD operations of {@link Item}.
@@ -171,23 +171,8 @@ public class ItemListener implements ExtensionPoint {
         return ExtensionList.lookup(ItemListener.class);
     }
 
-    // TODO JENKINS-21224 generalize this to a method perhaps in ExtensionList and use consistently from all listeners
-    private static void forAll(final Consumer<ItemListener> consumer) {
-        for (ItemListener l : all()) {
-            try {
-                consumer.accept(l);
-            } catch (RuntimeException x) {
-                LOGGER.log(Level.WARNING, "failed to send event to listener of " + l.getClass(), x);
-            }
-        }
-    }
-
     public static void fireOnCopied(final Item src, final Item result) {
-        forAll(l -> {
-            if (l != null) {
-                l.onCopied(src, result);
-            }
-        });
+        Listeners.notify(ItemListener.class, l -> l.onCopied(src, result));
     }
 
     /**
@@ -212,28 +197,16 @@ public class ItemListener implements ExtensionPoint {
     }
 
     public static void fireOnCreated(final Item item) {
-        forAll(l -> {
-            if (l != null) {
-                l.onCreated(item);
-            }
-        });
+        Listeners.notify(ItemListener.class, l -> l.onCreated(item));
     }
 
     public static void fireOnUpdated(final Item item) {
-        forAll(l -> {
-            if (l != null) {
-                l.onUpdated(item);
-            }
-        });
+        Listeners.notify(ItemListener.class, l -> l.onUpdated(item));
     }
 
     /** @since 1.548 */
     public static void fireOnDeleted(final Item item) {
-        forAll(l -> {
-            if (l != null) {
-                l.onDeleted(item);
-            }
-        });
+        Listeners.notify(ItemListener.class, l -> l.onDeleted(item));
     }
 
     /**
@@ -254,28 +227,16 @@ public class ItemListener implements ExtensionPoint {
             final String oldName = oldFullName.substring(prefixS);
             final String newName = rootItem.getName();
             assert newName.equals(newFullName.substring(prefixS));
-            forAll(l -> {
-                if (l != null) {
-                    l.onRenamed(rootItem, oldName, newName);
-                }
-            });
+            Listeners.notify(ItemListener.class, l -> l.onRenamed(rootItem, oldName, newName));
         }
-        forAll(l -> {
-            if (l!= null) {
-                l.onLocationChanged(rootItem, oldFullName, newFullName);
-            }
-        });
+        Listeners.notify(ItemListener.class, l -> l.onLocationChanged(rootItem, oldFullName, newFullName));
         if (rootItem instanceof ItemGroup) {
             for (final Item child : Items.allItems2(ACL.SYSTEM2, (ItemGroup)rootItem, Item.class)) {
                 final String childNew = child.getFullName();
                 assert childNew.startsWith(newFullName);
                 assert childNew.charAt(newFullName.length()) == '/';
                 final String childOld = oldFullName + childNew.substring(newFullName.length());
-                forAll(l -> {
-                    if (l != null) {
-                        l.onLocationChanged(child, childOld, childNew);
-                    }
-                });
+                Listeners.notify(ItemListener.class, l -> l.onLocationChanged(child, childOld, childNew));
             }
         }
     }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -85,6 +85,7 @@ import jenkins.slaves.EncryptedSlaveAgentJnlpFile;
 import jenkins.slaves.JnlpAgentReceiver;
 import jenkins.slaves.RemotingVersionInfo;
 import jenkins.slaves.systemInfo.SlaveSystemInfo;
+import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
 import org.jenkinsci.remoting.util.LoggingChannelListener;
 import org.kohsuke.accmod.Restricted;
@@ -895,8 +896,7 @@ public class SlaveComputer extends Computer {
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "Failed to terminate channel to " + getDisplayName(), e);
             }
-            for (ComputerListener cl : ComputerListener.all())
-                cl.onOffline(this, offlineCause);
+            Listeners.notify(ComputerListener.class, l -> l.onOffline(this, offlineCause));
         }
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -277,6 +277,7 @@ import jenkins.security.stapler.StaplerFilteredActionListener;
 import jenkins.security.stapler.TypedFilter;
 import jenkins.slaves.WorkspaceLocator;
 import jenkins.util.JenkinsJVM;
+import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 import jenkins.util.io.FileBoolean;
@@ -4565,9 +4566,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             Computer computer = Jenkins.get().toComputer();
             if (computer == null) return;
             RestartCause cause = new RestartCause();
-            for (ComputerListener listener: ComputerListener.all()) {
-                listener.onOffline(computer, cause);
-            }
+            Listeners.notify(ComputerListener.class, l -> l.onOffline(computer, cause));
         }
 
         @Override

--- a/core/src/main/java/jenkins/util/Listeners.java
+++ b/core/src/main/java/jenkins/util/Listeners.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.util;
+
+import hudson.ExtensionList;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Utilities for working with listener interfaces.
+ * @since TODO
+ */
+public class Listeners {
+
+    /**
+     * Safely send a notification to all listeners of a given type.
+     * <p>Only suitable for listener methods which do not throw checked or otherwise documented exceptions.
+     * @param <L> the type of listener
+     * @param listenerType the type of listener
+     * @param notification a listener method, perhaps with arguments
+     */
+    public static <L> void notify(Class<L> listenerType, Consumer<L> notification) {
+        try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
+            for (L listener : ExtensionList.lookup(listenerType)) {
+                try {
+                    notification.accept(listener);
+                } catch (Throwable x) {
+                    Logger.getLogger(listenerType.getName()).log(Level.WARNING, null, x);
+                }
+            }
+        }
+    }
+
+    private Listeners() {}
+
+}


### PR DESCRIPTION
See [JENKINS-21224](https://issues.jenkins-ci.org/browse/JENKINS-21224). Inspired by [this thread](https://groups.google.com/g/jenkinsci-dev/c/TexBP8-nE30/m/ajREF0JSBgAJ).

### Proposed changelog entries

* Introduced `Listeners.notify` utility method to encourage safe listener notification.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
