### PR TITLE
Don't enable form element path in unit tests by default

### DIFF
--- a/core/src/main/java/jenkins/formelementpath/FormElementPathPageDecorator.java
+++ b/core/src/main/java/jenkins/formelementpath/FormElementPathPageDecorator.java
@@ -2,7 +2,6 @@ package jenkins.formelementpath;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
-import hudson.Main;
 import hudson.model.PageDecorator;
 import jenkins.util.SystemProperties;
 

--- a/core/src/main/java/jenkins/formelementpath/FormElementPathPageDecorator.java
+++ b/core/src/main/java/jenkins/formelementpath/FormElementPathPageDecorator.java
@@ -10,7 +10,7 @@ import jenkins.util.SystemProperties;
 public class FormElementPathPageDecorator extends PageDecorator {
 
     @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
-    private static /*almost final */ boolean ENABLED = Main.isUnitTest ||
+    private static /*almost final */ boolean ENABLED =
             SystemProperties.getBoolean(FormElementPathPageDecorator.class.getName() + ".enabled");
 
     public boolean isEnabled() {


### PR DESCRIPTION
Reports that HtmlUnit isn't performant enough...

see https://github.com/jenkinsci/bom/pull/746#issuecomment-985172193

Draft till it's validated this fixes it

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).


### Proposed changelog entries

* Developer: Disable form element path in unit tests by default.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
