### PR TITLE
Amend #6003

### DIFF
--- a/core/src/main/resources/jenkins/security/stapler/default-whitelist.txt
+++ b/core/src/main/resources/jenkins/security/stapler/default-whitelist.txt
@@ -131,7 +131,7 @@ method hudson.plugins.build_publisher.BuildPublisher$BuildPublisherDescriptor do
 
 
 ###############################################
-# Changes since last successful build Plugin # (sic)
+# Changes since last successful build Plugin  #
 ###############################################
 # Only has an index.jelly view, so needs to be explicit
 class com.cloudbees.jenkins.plugins.changelog.Changes


### PR DESCRIPTION
The original PR #6003 [failed to remove the _sic_ indicator for the deliberate "typo" that just correctly reproduced the plugin name at the time](https://github.com/jenkinsci/jenkins/pull/6003#issuecomment-985396603), and also broke the nice formatting. This PR fixes both.

### Proposed changelog entries



<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
