### PR TITLE
Improving logging from `AbstractCloudSlave._terminate`

### DIFF
--- a/core/src/main/java/hudson/slaves/AbstractCloudSlave.java
+++ b/core/src/main/java/hudson/slaves/AbstractCloudSlave.java
@@ -28,9 +28,8 @@ import hudson.model.Computer;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Slave;
 import hudson.model.TaskListener;
-import hudson.util.StreamTaskListener;
+import hudson.util.LogTaskListener;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -85,8 +84,7 @@ public abstract class AbstractCloudSlave extends Slave {
             computer.recordTermination();
         }
         try {
-            // TODO: send the output to somewhere real
-            _terminate(new StreamTaskListener(System.out, Charset.defaultCharset()));
+            _terminate(computer instanceof SlaveComputer ? ((SlaveComputer) computer).getListener() : new LogTaskListener(LOGGER, Level.INFO));
         } finally {
             try {
                 Jenkins.get().removeNode(this);

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -215,9 +215,10 @@ public class SlaveComputer extends Computer {
     }
 
     /**
-     * Return the {@link TaskListener} for this SlaveComputer. Never null
+     * Offers a way to write to the log file for this agent.
      * @since 2.9
      */
+    @NonNull
     public TaskListener getListener() {
         return taskListener;
     }


### PR DESCRIPTION
Since inception (f62fff5c0ca5091e9e7bc5945ea3a582ee3db3a4), `AbstractCloudSlave._terminate` implementations were supplied with a `TaskListener` that just streams to stdout of the JVM, something we should never do. (For example, it will not be captured by `support-core`.)

### Proposed changelog entries

* Improve logging for termination of cloud agents.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
