### PR TITLE
Enable `VariableDeclarationUsageDistance` Checkstyle check

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -950,7 +950,6 @@ public class FilePathTest {
         FilePath workspaceFolder = rootFolder.child("workspace");
         FilePath aFolder = workspaceFolder.child("a");
         FilePath bFolder = workspaceFolder.child("b");
-        FilePath protectedFolder = rootFolder.child("protected");
 
         FilePath regularFile = workspaceFolder.child("regular.txt");
         regularFile.write("regular-file", StandardCharsets.UTF_8.name());
@@ -966,6 +965,7 @@ public class FilePathTest {
         workspaceFolder.child("_nonexistentUp").symlinkTo("../nonexistent", null);
         workspaceFolder.child("_secrettxt").symlinkTo("../protected/secret.txt", null);
 
+        FilePath protectedFolder = rootFolder.child("protected");
         FilePath secretFile = protectedFolder.child("secret.txt");
         secretFile.write("secrets", StandardCharsets.UTF_8.name());
 
@@ -1014,7 +1014,6 @@ public class FilePathTest {
         FilePath workspaceFolder = rootFolder.child("workspace");
         FilePath aFolder = workspaceFolder.child("a");
         FilePath bFolder = workspaceFolder.child("b");
-        FilePath protectedFolder = rootFolder.child("protected");
 
         FilePath regularFile = workspaceFolder.child("regular.txt");
         regularFile.write("regular-file", StandardCharsets.UTF_8.name());
@@ -1028,6 +1027,7 @@ public class FilePathTest {
         createJunction(new File(root, "/workspace/_nonexistentUp"), new File(root, "/nonexistent"));
         createJunction(new File(root, "/workspace/_protected"), new File(root, "/protected"));
 
+        FilePath protectedFolder = rootFolder.child("protected");
         FilePath secretFile = protectedFolder.child("secret.txt");
         secretFile.write("secrets", StandardCharsets.UTF_8.name());
 
@@ -1103,11 +1103,9 @@ public class FilePathTest {
         //      /protected
         //          secret.txt
         FilePath rootFolder = new FilePath(temp.newFolder("root"));
-        FilePath wFolder = rootFolder.child("w");
         FilePath workspaceFolder = rootFolder.child("workspace");
         FilePath aFolder = workspaceFolder.child("a");
         FilePath bFolder = workspaceFolder.child("b");
-        FilePath protectedFolder = rootFolder.child("protected");
 
         FilePath regularFile = workspaceFolder.child("regular.txt");
         regularFile.write("regular-file", StandardCharsets.UTF_8.name());
@@ -1125,10 +1123,12 @@ public class FilePathTest {
         workspaceFolder.child("_secrettxt").symlinkTo("../protected/secret.txt", null);
         workspaceFolder.child("_secrettxt2").symlinkTo("../../protected/secret.txt", null);
 
+        FilePath wFolder = rootFolder.child("w");
         wFolder.mkdirs();
         FilePath symbolicWorkspace = wFolder.child("_w");
         symbolicWorkspace.symlinkTo("../workspace", null);
 
+        FilePath protectedFolder = rootFolder.child("protected");
         FilePath secretFile = protectedFolder.child("secret.txt");
         secretFile.write("secrets", StandardCharsets.UTF_8.name());
 

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -69,12 +69,6 @@ public class RobustReflectionConverterTest {
 
     @Test
     public void classOwnership() {
-        XStream xs = new XStream2(clazz -> {
-            Owner o = clazz.getAnnotation(Owner.class);
-            return o != null ? o.value() : null;
-        });
-        String prefix1 = RobustReflectionConverterTest.class.getName() + "_-";
-        String prefix2 = RobustReflectionConverterTest.class.getName() + "$";
         Enchufla s1 = new Enchufla();
         s1.number = 1;
         s1.direction = "North";
@@ -91,6 +85,12 @@ public class RobustReflectionConverterTest {
         b.steppes = new Steppe[] {s1, s2, s3};
         Projekt p = new Projekt();
         p.bildz = new Bild[] {b};
+        XStream xs = new XStream2(clazz -> {
+            Owner o = clazz.getAnnotation(Owner.class);
+            return o != null ? o.value() : null;
+        });
+        String prefix1 = RobustReflectionConverterTest.class.getName() + "_-";
+        String prefix2 = RobustReflectionConverterTest.class.getName() + "$";
         assertEquals("<Projekt><bildz><Bild><steppes>"
                 + "<Enchufla plugin='p1'><number>1</number><direction>North</direction></Enchufla>"
                 // note no plugin='p2' on <boot/> since that would be redundant; <jacket/> is quiet even though unowned

--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,9 @@ THE SOFTWARE.
                   <module name="UnnecessarySemicolonAfterTypeMemberDeclaration" />
                   <module name="UnnecessarySemicolonInEnumeration" />
                   <module name="UnnecessarySemicolonInTryWithResources" />
+                  <module name="VariableDeclarationUsageDistance">
+                    <property name="allowedDistance" value="10" />
+                  </module>
                   <!--
                     Imports: https://checkstyle.sourceforge.io/config_imports.html
                   -->

--- a/test/src/test/java/hudson/model/AutoCompletionCandidatesTest.java
+++ b/test/src/test/java/hudson/model/AutoCompletionCandidatesTest.java
@@ -25,7 +25,6 @@ public class AutoCompletionCandidatesTest {
         FreeStyleProject foo = j.createFreeStyleProject("foo");
         MatrixProject bar = j.jenkins.createProject(MatrixProject.class, "bar");
         bar.setAxes(new AxisList(new TextAxis("x","1","2","3")));
-        MatrixConfiguration x3 = bar.getItem("x=3");
 
         AutoCompletionCandidates c;
 
@@ -45,6 +44,7 @@ public class AutoCompletionCandidatesTest {
         c = AutoCompletionCandidates.ofJobNames(MatrixConfiguration.class, "bar/", foo, j.jenkins);
         assertContains(c, "bar/x=1", "bar/x=2", "bar/x=3");
 
+        MatrixConfiguration x3 = bar.getItem("x=3");
         c = AutoCompletionCandidates.ofJobNames(Item.class, "", x3, x3.getParent());
         assertContains(c, "x=1", "x=2", "x=3");
 

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -465,7 +465,6 @@ public class ProjectTest {
         FreeStyleProject p = j.createFreeStyleProject("project");
         SCM scm = new NullSCM();
         p.setScm(null);
-        SCM alwaysChange = new AlwaysChangedSCM();
         assertEquals("Project with null scm should have have polling result no change.", PollingResult.Change.NONE, p.poll(TaskListener.NULL).change);
         p.setScm(scm);
         p.disable();
@@ -479,6 +478,7 @@ public class ProjectTest {
         while(p.getLastBuild()==null)
             Thread.sleep(100); //wait until build start
         assertEquals("Project should have polling result no change", PollingResult.Change.NONE, p.poll(TaskListener.NULL).change);
+        SCM alwaysChange = new AlwaysChangedSCM();
         p.setScm(alwaysChange);
         j.buildAndAssertSuccess(p);
         assertEquals("Project should have polling result significant", PollingResult.Change.SIGNIFICANT, p.poll(TaskListener.NULL).change);

--- a/test/src/test/java/hudson/tasks/BuildTriggerTest.java
+++ b/test/src/test/java/hudson/tasks/BuildTriggerTest.java
@@ -223,7 +223,7 @@ public class BuildTriggerTest {
         j.waitUntilNoActivity();
         assertEquals(2, downstream.getLastBuild().number);
         FreeStyleProject simple = j.createFreeStyleProject("simple");
-        FreeStyleBuild b3 = j.buildAndAssertSuccess(simple);
+        j.buildAndAssertSuccess(simple);
         // Finally, in legacy mode we run as SYSTEM:
         grantedPermissions.clear(); // similar behavior but different message if DescriptorImpl removed
         downstream.removeProperty(amp);
@@ -236,7 +236,7 @@ public class BuildTriggerTest {
         j.assertLogContains(downstreamName, b);
         j.waitUntilNoActivity();
         assertEquals(3, downstream.getLastBuild().number);
-        b3 = j.buildAndAssertSuccess(simple);
+        j.buildAndAssertSuccess(simple);
     }
     private void assertDoCheck(org.acegisecurity.Authentication auth, @CheckForNull String expectedError, AbstractProject<?, ?> project, String value) {
         FormValidation result;

--- a/test/src/test/java/hudson/tools/InstallerTranslatorTest.java
+++ b/test/src/test/java/hudson/tools/InstallerTranslatorTest.java
@@ -69,8 +69,6 @@ public class InstallerTranslatorTest {
     @Test public void multipleSlavesAndTools() throws Exception {
         String jdk1Path = Functions.isWindows() ? "C:\\jdk1" : "/opt/jdk1";
         String jdk2Path = Functions.isWindows() ? "C:\\jdk2" : "/opt/jdk2";
-        Node slave1 = r.createSlave();
-        Node slave2 = r.createSlave();
         JDK jdk1 = new JDK("jdk1", null, Collections.singletonList(new InstallSourceProperty(Collections.singletonList(Functions.isWindows() ? new BatchCommandInstaller(null, "echo installed jdk1", jdk1Path) : new CommandInstaller(null, "echo installed jdk1", jdk1Path)))));
         JDK jdk2 = new JDK("jdk2", null, Collections.singletonList(new InstallSourceProperty(Collections.singletonList(Functions.isWindows() ? new BatchCommandInstaller(null, "echo installed jdk2", jdk2Path) : new CommandInstaller(null, "echo installed jdk2", jdk2Path)))));
         r.jenkins.getJDKs().add(jdk1);
@@ -78,7 +76,7 @@ public class InstallerTranslatorTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.setJDK(jdk1);
         p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo %JAVA_HOME%") : new Shell("echo $JAVA_HOME"));
-        p.setAssignedNode(slave1);
+        p.setAssignedNode(r.createSlave());
         FreeStyleBuild b1 = r.buildAndAssertSuccess(p);
         r.assertLogContains("installed jdk1", b1);
         r.assertLogContains(jdk1Path, b1);
@@ -90,7 +88,7 @@ public class InstallerTranslatorTest {
         // An installer is run for every build, and it is up to a CommandInstaller configuration to do any up-to-date check.
         r.assertLogContains("installed jdk2", b3);
         r.assertLogContains(jdk2Path, b3);
-        p.setAssignedNode(slave2);
+        p.setAssignedNode(r.createSlave());
         FreeStyleBuild b4 = r.buildAndAssertSuccess(p);
         r.assertLogContains("installed jdk2", b4);
         r.assertLogContains(jdk2Path, b4);

--- a/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
+++ b/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
@@ -48,10 +48,10 @@ public class BasicHeaderProcessorTest {
         ApiTokenTestHelper.enableLegacyBehavior();
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
-        User foo = User.getById("foo", true);
-        User.getById("bar", true);
 
         wc = j.createWebClient();
+        User foo = User.getById("foo", true);
+        User.getById("bar", true);
 
         // call without authentication
         makeRequestAndVerify("anonymous");

--- a/test/src/test/java/jenkins/security/RedactSecretJsonInErrorMessageSanitizerHtmlTest.java
+++ b/test/src/test/java/jenkins/security/RedactSecretJsonInErrorMessageSanitizerHtmlTest.java
@@ -81,7 +81,6 @@ public class RedactSecretJsonInErrorMessageSanitizerHtmlTest {
         
         String textLevelOne = "plain-2";
         String pwdLevelOneA = "secret-2";
-        String pwdLevelOneB = "pre-set secret"; // set in Jelly
         ((HtmlInput) page.getElementById("text-level-one")).setValueAttribute(textLevelOne);
         ((HtmlInput) page.getElementById("pwd-level-one-a")).setValueAttribute(pwdLevelOneA);
         
@@ -105,6 +104,7 @@ public class RedactSecretJsonInErrorMessageSanitizerHtmlTest {
                 )
         );
         
+        String pwdLevelOneB = "pre-set secret"; // set in Jelly
         JSONObject redactedJson = RedactSecretJsonInErrorMessageSanitizer.INSTANCE.sanitize(rawJson);
         String redactedJsonToString = redactedJson.toString();
         assertThat(redactedJsonToString, containsString(textSimple));

--- a/test/src/test/java/lib/form/PasswordTest.java
+++ b/test/src/test/java/lib/form/PasswordTest.java
@@ -187,7 +187,7 @@ public class PasswordTest {
             assertEquals(p.getConfigFile().asString(), pAdmin.getConfigFile().asString());
 
             // Test case: another user with EXTENDED_READ but not CONFIGURE should not get access even to encrypted secrets.
-            wc.withBasicApiToken(dev);
+            wc.withBasicApiToken(User.getById("dev", false));
             configure = wc.getPage(p, "configure");
             assertThat(xml_regex_pattern.matcher(configure.getWebResponse().getContentAsString()).find(), is(false));
             configXml = wc.goTo(p.getUrl() + "config.xml", "application/xml");


### PR DESCRIPTION
Enable the [`VariableDeclarationUsageDistance`](https://checkstyle.sourceforge.io/config_coding.html#VariableDeclarationUsageDistance) Checkstyle check, which checks the distance between declaration of variable and its first usage. Reducing the scope of variables makes it easier to read and reason about the code. I set this to a fairly liberal value of 10, which caught a few problems in tests but nothing in production code. I feel this should be a good number that won't annoy people but will catch the most egregious violations.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
