### PR TITLE
Align Guice and ASM dependencies

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -96,8 +96,10 @@ THE SOFTWARE.
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>
-        <artifactId>guice</artifactId>
+        <artifactId>guice-bom</artifactId>
         <version>5.0.1</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- SLF4J used in maven-plugin and core -->

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -39,6 +39,7 @@ THE SOFTWARE.
 
 
   <properties>
+    <asm.version>9.2</asm.version>
     <slf4jVersion>1.7.32</slf4jVersion>
     <stapler.version>1593.v0e838714faae</stapler.version>
     <groovy.version>2.4.12</groovy.version>
@@ -187,6 +188,31 @@ THE SOFTWARE.
         <groupId>org.connectbot.jbcrypt</groupId>
         <artifactId>jbcrypt</artifactId>
         <version>1.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-analysis</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-commons</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-tree</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-util</artifactId>
+        <version>${asm.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,6 +107,26 @@ THE SOFTWARE.
       <artifactId>jnr-posix</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-tree</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler</artifactId>
       <exclusions>


### PR DESCRIPTION
This PR contains two commits, the second of which depends on the first:

- The first commit adds ASM to the core BOM. This is splitting out a portion of #5979 that is ready to push now, as the rest of #5979 is on-hold. Pushing this portion now reduces risk. It is also necessary for the commit that follows it in order to avoid Enforcer warnings.
- The second commit aligns our Guice dependencies by pulling in `guice-bom`. While we currently only ship `guice` (so this has no effect on the WAR), plugins might depend on e.g. `guice-assistedinject` (as does `artifact-manager-s3-plugin`) and get an arbitrarily older version that is incompatible with the version of Guice we ship in core. By including the full `guice-bom` in the core BOM, we ensure that plugins (which pull in a core BOM corresponding to their baseline) pull in a version of e.g. `guice-assistedinject` that aligns with the version of Guice in their core baseline. Note that this is relying on Guice maintaining API compatibility going forward, which is not necessarily a given. We might need to go even further and bundle `guice-assistedinject` into core, but that is a more drastic step. This is a more conservative first step, and if it's good enough then there's no need to go further and bundle more JARs in core (something we'd rather avoid to decrease maintenance burden).

### Proposed changelog entries

Developer: Plugins now have their Guice dependencies aligned with core.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
