### PR TITLE
`RingBufferLogHandler.records` could leak records

### DIFF
--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -23,9 +23,10 @@
  */
 package hudson.util;
 
-import java.util.AbstractList;
+import java.lang.ref.SoftReference;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 
@@ -38,9 +39,15 @@ public class RingBufferLogHandler extends Handler {
 
     private static final int DEFAULT_RING_BUFFER_SIZE = Integer.getInteger(RingBufferLogHandler.class.getName() + ".defaultSize", 256);
 
+    private static final class LogRecordRef extends SoftReference<LogRecord> {
+        LogRecordRef(LogRecord referent) {
+            super(referent);
+        }
+    }
+
     private int start = 0;
-    private final LogRecord[] records;
-    private AtomicInteger size = new AtomicInteger(0);
+    private final LogRecordRef[] records;
+    private int size;
 
     /**
      * This constructor is deprecated. It can't access system properties with {@link jenkins.util.SystemProperties}
@@ -53,7 +60,7 @@ public class RingBufferLogHandler extends Handler {
     }
 
     public RingBufferLogHandler(int ringSize) {
-        records = new LogRecord[ringSize];
+        records = new LogRecordRef[ringSize];
     }
 
     /**
@@ -68,17 +75,16 @@ public class RingBufferLogHandler extends Handler {
     @Override
     public synchronized void publish(LogRecord record) {
         int len = records.length;
-        final int tempSize = size.get();
-        records[(start+ tempSize)%len]=record;
-        if(tempSize ==len) {
+        records[(start + size) % len] = new LogRecordRef(record);
+        if (size == len) {
             start = (start+1)%len;
         } else {
-            size.incrementAndGet();
+            size++;
         }
     }
 
     public synchronized void clear() {
-        size.set(0);
+        size = 0;
         start = 0;
     }
 
@@ -88,21 +94,16 @@ public class RingBufferLogHandler extends Handler {
      * <p>
      * New records are always placed early in the list.
      */
-    public List<LogRecord> getView() {
-        return new AbstractList<LogRecord>() {
-            @Override
-            public LogRecord get(int index) {
-                // flip the order
-                synchronized (RingBufferLogHandler.this) {
-                    return records[(start+(size.get()-(index+1)))%records.length];
-                }
+    public synchronized List<LogRecord> getView() {
+        List<LogRecord> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            LogRecord lr = records[(start + i) % records.length].get();
+            if (lr != null) {
+                result.add(lr);
             }
-
-            @Override
-            public int size() {
-                return size.get();
-            }
-        };
+        }
+        Collections.reverse(result);
+        return result;
     }
 
     // noop

--- a/core/src/test/java/hudson/logging/LogRecorderTest.java
+++ b/core/src/test/java/hudson/logging/LogRecorderTest.java
@@ -24,6 +24,8 @@
 
 package hudson.logging;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -113,12 +115,7 @@ public class LogRecorderTest {
         lr.handler.publish(r5);
         lr.handler.publish(r6);
 
-        assertTrue(lr.handler.getView().contains(r1));
-        assertFalse(lr.handler.getView().contains(r2));
-        assertFalse(lr.handler.getView().contains(r3));
-        assertFalse(lr.handler.getView().contains(r4));
-        assertTrue(lr.handler.getView().contains(r5));
-        assertTrue(lr.handler.getView().contains(r6));
+        assertThat(lr.handler.getView(), contains(r6, r5, r1));
     }
 
     private static LogRecord createLogRecord(String logger, Level level, String message) {


### PR DESCRIPTION
As @PierreBtz points out in https://github.com/jenkinsci/support-core-plugin/pull/324#pullrequestreview-823756089, if someone set up a custom logger that recorded messages from Pipeline components, it could temporarily hold on to `GroovyClassLoader`s from completed builds, which is not something we want as these might be quite large; seems preferable to let log messages be dropped under extreme memory pressure conditions. Perhaps it is possible to use `PhantomReference` to replace a record with its formatted equivalent just before collection but this seems like overengineering.

Note that in both the core and plugin cases, it is not exactly correct to hold a list of unformatted `LogRecord`s at all, when they are not going to be immediately written to some log sink. For example code like this

```java
AtomicInteger x = new AtomicInteger();
void doSomething() {
    LOGGER.log(Level.FINE, "running with x={0}", x);
    use(x.incrementAndGet());
}
```

would send messages like

```
running with x=0
running with x=1
running with x=2
```

to a log file, but display

```
running with x=3
running with x=3
running with x=3
```

in a GUI display. Unfortunately there is no way to know for sure if the sub-`INFO` record is going to ever be formatted, so formatting eagerly in `publish` would usually be wasteful just in order to properly handle log messages from code using this antipattern (log record parameters whose `toString` depends on mutable state).

I am also cleaning up some concurrency code that looked dubious in f9995103023c1a25ad5e0718de914d6a3235fc9a and more so in #5772. Since accesses to `start` and `size` are `synchronized`, why use additional constructs? Perhaps this made sense when returning a lazily evaluated list, though I am not convinced its implementation was ever correct. Simpler and clearer to just construct a concrete list of results if and when `getView` is called, which is done for example in https://github.com/jenkinsci/jenkins/blob/71117cc702a8a6b50fadae629ae4006633b00b89/core/src/main/resources/hudson/logging/LogRecorder/index.jelly#L34

### Proposed changelog entries

* Custom log records with large record parameters no longer interfere with garbage collection.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
