### PR TITLE
Skip symlink tests on Windows

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -478,7 +478,7 @@ public class FilePathTest {
     }
 
     @Test public void copyToWithPermissionSpecialPermissions() throws IOException, InterruptedException {
-        assumeFalse("Test uses POSIX-specific features", Functions.isWindows() || Platform.isDarwin());
+        assumeFalse(Functions.isWindows() || Platform.isDarwin());
         File tmp = temp.getRoot();
         File original = new File(tmp,"original");
         FilePath originalP = new FilePath(channels.french, original.getPath());
@@ -497,7 +497,7 @@ public class FilePathTest {
     }
 
     @Test public void symlinkInTar() throws Exception {
-        assumeFalse("can't test on Windows", Functions.isWindows());
+        assumeFalse(Functions.isWindows());
 
         FilePath tmp = new FilePath(temp.getRoot());
             FilePath in = tmp.child("in");
@@ -805,7 +805,7 @@ public class FilePathTest {
     }
 
     @Test public void deleteRecursiveOnUnix() throws Exception {
-        assumeFalse("Uses Unix-specific features", Functions.isWindows());
+        assumeFalse(Functions.isWindows());
         Path targetDir = temp.newFolder("target").toPath();
         Path targetContents = Files.createFile(targetDir.resolve("contents.txt"));
         Path toDelete = temp.newFolder("toDelete").toPath();
@@ -851,7 +851,7 @@ public class FilePathTest {
 
     @Issue("JENKINS-13128")
     @Test public void copyRecursivePreservesPosixFilePermissions() throws Exception {
-        assumeFalse("windows doesn't support posix file permissions", Functions.isWindows());
+        assumeFalse(Functions.isWindows());
         File src = temp.newFolder("src");
         File dst = temp.newFolder("dst");
         Path sourceFile = Files.createFile(src.toPath().resolve("test-file"));
@@ -932,6 +932,7 @@ public class FilePathTest {
     @Test
     @Issue("SECURITY-904")
     public void isDescendant_regularSymlinks() throws IOException, InterruptedException {
+        assumeFalse(Functions.isWindows());
         //  root
         //      /workspace
         //          /a
@@ -1059,6 +1060,7 @@ public class FilePathTest {
 
     @Issue("SECURITY-904")
     public void isDescendant_throwIfParentDoesNotExist_symlink() throws Exception {
+        assumeFalse(Functions.isWindows());
         FilePath rootFolder = new FilePath(temp.newFolder("root"));
         FilePath aFolder = rootFolder.child("a");
         aFolder.mkdirs();
@@ -1086,6 +1088,7 @@ public class FilePathTest {
     @Test
     @Issue("SECURITY-904")
     public void isDescendant_worksEvenInSymbolicWorkspace() throws Exception {
+        assumeFalse(Functions.isWindows());
         //  root
         //      /w
         //          /_workspace => symlink to ../workspace

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
@@ -39,7 +40,6 @@ import java.io.File;
 import java.nio.charset.Charset;
 import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -52,7 +52,7 @@ public class LauncherTest {
 
     @Issue("JENKINS-4611")
     @Test public void remoteKill() throws Exception {
-        Assume.assumeFalse("Skipping, currently Unix-specific test", Functions.isWindows());
+        assumeFalse(Functions.isWindows());
 
         File tmp = temp.newFile();
 

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.model.TaskListener;
 import hudson.os.WindowsUtil;
@@ -55,7 +57,6 @@ import org.apache.commons.io.FileUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -223,7 +224,7 @@ public class UtilTest {
 
     @Test
     public void testSymlink() throws Exception {
-        Assume.assumeFalse(Functions.isWindows());
+        assumeFalse(Functions.isWindows());
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         StreamTaskListener l = new StreamTaskListener(baos);
@@ -271,7 +272,7 @@ public class UtilTest {
 
     @Test
     public void testIsSymlink() throws IOException, InterruptedException {
-        Assume.assumeFalse(Functions.isWindows());
+        assumeFalse(Functions.isWindows());
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         StreamTaskListener l = new StreamTaskListener(baos);
@@ -301,7 +302,7 @@ public class UtilTest {
 
     @Test
     public void testIsSymlink_onWindows_junction() throws Exception {
-        Assume.assumeTrue("Uses Windows-specific features", Functions.isWindows());
+        assumeTrue("Uses Windows-specific features", Functions.isWindows());
         File targetDir = tmp.newFolder("targetDir");
         File d = tmp.newFolder("dir");
         File junction = WindowsUtil.createJunction(new File(d, "junction"), targetDir);
@@ -311,7 +312,7 @@ public class UtilTest {
     @Test
     @Issue("JENKINS-55448")
     public void testIsSymlink_ParentIsJunction() throws IOException, InterruptedException {
-        Assume.assumeTrue("Uses Windows-specific features", Functions.isWindows());
+        assumeTrue("Uses Windows-specific features", Functions.isWindows());
         File targetDir = tmp.newFolder();
         File file = new File(targetDir, "test-file");
         new FilePath(file).touch(System.currentTimeMillis());
@@ -325,6 +326,7 @@ public class UtilTest {
     @Test
     @Issue("JENKINS-55448")
     public void testIsSymlink_ParentIsSymlink() throws IOException, InterruptedException {
+        assumeFalse(Functions.isWindows());
         File folder = tmp.newFolder();
         File file = new File(folder, "test-file");
         new FilePath(file).touch(System.currentTimeMillis());
@@ -592,6 +594,7 @@ public class UtilTest {
     @Test
     @Issue("SECURITY-904")
     public void resolveSymlinkToFile() throws Exception {
+        assumeFalse(Functions.isWindows());
         //  root
         //      /a
         //          /aa

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -8,9 +8,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Functions;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -73,6 +75,7 @@ public class AtomicFileWriterTest {
 
     @Test
     public void symlinkToDirectory() throws Exception {
+        assumeFalse(Functions.isWindows());
         final File folder = tmp.newFolder();
         final File containingSymlink = tmp.newFolder();
         final Path zeSymlink = Files.createSymbolicLink(Paths.get(containingSymlink.getAbsolutePath(), "ze_symlink"),

--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -24,7 +24,8 @@
 package hudson.util.io;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNoException;
 
 import hudson.FilePath;
 import hudson.Functions;
@@ -38,7 +39,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -53,7 +53,7 @@ public class TarArchiverTest {
      */
     @Issue("JENKINS-9397")
     @Test public void permission() throws Exception {
-        assumeTrue(!Functions.isWindows());
+        assumeFalse(Functions.isWindows());
 
         File tar = File.createTempFile("test","tar");
         File zip = File.createTempFile("test","zip");
@@ -107,13 +107,13 @@ public class TarArchiverTest {
         try {
             assertEquals(0, new LocalLauncher(StreamTaskListener.fromStdout()).launch().cmds(cmds).pwd(dir).join());
         } catch (IOException x) { // perhaps restrict to x.message.contains("Cannot run program")? or "error=2, No such file or directory"?
-            Assume.assumeNoException("failed to run " + Arrays.toString(cmds), x);
+            assumeNoException("failed to run " + Arrays.toString(cmds), x);
         }
     }
 
     @Issue("JENKINS-14922")
     @Test public void brokenSymlinks() throws Exception {
-        assumeTrue(!Functions.isWindows());
+        assumeFalse(Functions.isWindows());
         File dir = tmp.getRoot();
         Util.createSymlink(dir, "nonexistent", "link", TaskListener.NULL);
         new FilePath(dir).tar(new NullStream(), "**");

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -84,7 +84,7 @@ public class VirtualFileTest {
     
     @Issue("SECURITY-162")
     @Test public void outsideSymlinks() throws Exception {
-        assumeFalse("Symlinks don't work well on Windows", Functions.isWindows());
+        assumeFalse(Functions.isWindows());
         File ws = tmp.newFolder("ws");
         FileUtils.write(new File(ws, "safe"), "safe", StandardCharsets.US_ASCII, false);
         Util.createSymlink(ws, "safe", "supported", TaskListener.NULL);
@@ -231,6 +231,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void list_Glob_NoFollowLinks_FilePathVF() throws Exception {
+        assumeFalse(Functions.isWindows());
         prepareFileStructureForIsDescendant(tmp.getRoot());
 
         File root = tmp.getRoot();
@@ -361,7 +362,7 @@ public class VirtualFileTest {
 
     @Issue("JENKINS-26810")
     @Test public void readLink() throws Exception {
-        assumeFalse("Symlinks do not work well on Windows", Functions.isWindows());
+        assumeFalse(Functions.isWindows());
         File root = tmp.getRoot();
         FilePath rootF = new FilePath(root);
         rootF.child("plain").write("", null);
@@ -424,6 +425,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void simpleList_WithSymlink_FileVF() throws Exception {
+        assumeFalse(Functions.isWindows());
         prepareFileStructureForIsDescendant(tmp.getRoot());
 
         File root = tmp.getRoot();
@@ -441,6 +443,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void list_NoFollowLinks_ExternalSymlink_FileVF() throws Exception {
+        assumeFalse(Functions.isWindows());
         prepareFileStructureForIsDescendant(tmp.getRoot());
         File root = tmp.getRoot();
         String symlinkName = "symlink";
@@ -457,6 +460,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void list_NoFollowLinks_ExternalSymlink_FilePathVF() throws Exception {
+        assumeFalse(Functions.isWindows());
         prepareFileStructureForIsDescendant(tmp.getRoot());
         File root = tmp.getRoot();
         String symlinkName = "symlink";
@@ -473,6 +477,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void list_Glob_NoFollowLinks_ExternalSymlink_FilePathVF() throws Exception {
+        assumeFalse(Functions.isWindows());
         prepareFileStructureForIsDescendant(tmp.getRoot());
         File root = tmp.getRoot();
         String symlinkName = "symlink";
@@ -489,6 +494,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void list_Glob_NoFollowLinks_ExternalSymlink_FileVF() throws Exception {
+        assumeFalse(Functions.isWindows());
         prepareFileStructureForIsDescendant(tmp.getRoot());
         File root = tmp.getRoot();
         String symlinkName = "symlink";
@@ -610,6 +616,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void simpleList_WithSymlink_FilePathVF() throws Exception {
+        assumeFalse(Functions.isWindows());
         prepareFileStructureForIsDescendant(tmp.getRoot());
 
         File root = tmp.getRoot();
@@ -669,6 +676,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void simpleList_WithSymlink_AbstractBase() throws Exception {
+        assumeFalse(Functions.isWindows());
         // This test checks the method's behavior in the abstract base class,
         // which has limited behavior.
         prepareFileStructureForIsDescendant(tmp.getRoot());
@@ -688,6 +696,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void list_NoFollowLinks_WithSymlink_AbstractBase() throws Exception {
+        assumeFalse(Functions.isWindows());
         // This test checks the method's behavior in the abstract base class,
         // which generally does nothing.
         prepareFileStructureForIsDescendant(tmp.getRoot());
@@ -763,6 +772,7 @@ public class VirtualFileTest {
 
     @Issue("SECURITY-904")
     @Test public void forFile_isDescendant() throws Exception {
+        assumeFalse(Functions.isWindows());
         this.prepareFileStructureForIsDescendant(tmp.getRoot());
 
         File root = tmp.getRoot();
@@ -779,6 +789,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-904")
     public void forFilePath_isDescendant() throws Exception {
+        assumeFalse(Functions.isWindows());
         this.prepareFileStructureForIsDescendant(tmp.getRoot());
 
         File root = tmp.getRoot();
@@ -851,6 +862,7 @@ public class VirtualFileTest {
     @Test
     @Issue("JENKINS-55050")
     public void forFile_listOnlyDescendants_withoutIllegal() throws Exception {
+        assumeFalse(Functions.isWindows());
         this.prepareFileStructureForIsDescendant(tmp.getRoot());
 
         File root = tmp.getRoot();
@@ -866,6 +878,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-904")
     public void forFilePath_listOnlyDescendants_withoutIllegal() throws Exception {
+        assumeFalse(Functions.isWindows());
         this.prepareFileStructureForIsDescendant(tmp.getRoot());
 
         File root = tmp.getRoot();
@@ -1101,6 +1114,7 @@ public class VirtualFileTest {
     @Test
     @Issue("SECURITY-1452")
     public void testOpenNoFollowLinks_FollowsLink_AbstractBase() throws Exception {
+        assumeFalse(Functions.isWindows());
         // This test checks the method's behavior in the abstract base class,
         // which generally does nothing.
         File ws = tmp.newFolder("ws");
@@ -1423,6 +1437,7 @@ public class VirtualFileTest {
 
     @Test
     public void hasSymlink_True_FilePathVF() throws IOException, InterruptedException {
+        assumeFalse(Functions.isWindows());
         FilePath rootPath = new FilePath(tmp.getRoot());
         FilePath childPath = rootPath.child("child");
         childPath.touch(0);
@@ -1440,6 +1455,7 @@ public class VirtualFileTest {
 
     @Test
     public void hasSymlink_True_FileVF() throws IOException, InterruptedException {
+        assumeFalse(Functions.isWindows());
         FilePath rootPath = new FilePath(tmp.getRoot());
         FilePath childPath = rootPath.child("child");
         childPath.touch(0);

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -147,6 +148,7 @@ public class PathRemoverTest {
 
     @Test
     public void testForceRemoveFile_SymbolicLink() throws IOException {
+        assumeFalse(Functions.isWindows());
         File file = tmp.newFile();
         touchWithFileName(file);
         Path link = Files.createSymbolicLink(tmp.getRoot().toPath().resolve("test-link"), file.toPath());
@@ -177,6 +179,7 @@ public class PathRemoverTest {
     @Test
     @Issue("JENKINS-55448")
     public void testForceRemoveFile_ParentIsSymbolicLink() throws IOException {
+        assumeFalse(Functions.isWindows());
         Path realParent = tmp.newFolder().toPath();
         Path path = realParent.resolve("test-file");
         touchWithFileName(path.toFile());
@@ -359,6 +362,7 @@ public class PathRemoverTest {
 
     @Test
     public void testForceRemoveRecursive_ContainsSymbolicLinks() throws IOException {
+        assumeFalse(Functions.isWindows());
         File folder = tmp.newFolder();
         File d1 = new File(folder, "d1");
         File d1f1 = new File(d1, "d1f1");
@@ -398,6 +402,7 @@ public class PathRemoverTest {
     @Test
     @Issue("JENKINS-55448")
     public void testForceRemoveRecursive_ParentIsSymbolicLink() throws IOException {
+        assumeFalse(Functions.isWindows());
         File folder = tmp.newFolder();
         File d1 = new File(folder, "d1");
         File d1f1 = new File(d1, "d1f1");


### PR DESCRIPTION
With these changes, I can run the smoke tests locally on Windows. Without these changes, they fail with various symlink-related errors.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
