### PR TITLE
[JENKINS-67332] Pull up `Telemetry.buildComponentInformation` for use in `SlaveToMasterFileCallableUsage`

### DIFF
--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -29,10 +29,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.PluginWrapper;
 import hudson.ProxyConfiguration;
 import hudson.model.AsyncPeriodicWork;
 import hudson.model.TaskListener;
 import hudson.model.UsageStatistics;
+import hudson.util.VersionNumber;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -42,6 +44,8 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -149,6 +153,24 @@ public abstract class Telemetry implements ExtensionPoint {
     public boolean isActivePeriod() {
         LocalDate now = LocalDate.now();
         return now.isAfter(getStart()) && now.isBefore(getEnd());
+    }
+
+    /**
+     * Produces a list of Jenkins core and plugin version numbers
+     * to include in telemetry implementations for which this would be relevant.
+     * @return a map in a format suitable for a value of {@link #createContent}
+     * @since TODO
+     */
+    protected final Map<String, String> buildComponentInformation() {
+        Map<String, String> components = new TreeMap<>();
+        VersionNumber core = Jenkins.getVersion();
+        components.put("jenkins-core", core == null ? "" : core.toString());
+        for (PluginWrapper plugin : Jenkins.get().pluginManager.getPlugins()) {
+            if (plugin.isActive()) {
+                components.put(plugin.getShortName(), plugin.getVersion());
+            }
+        }
+        return components;
     }
 
     @Extension

--- a/core/src/main/java/jenkins/telemetry/impl/SlaveToMasterFileCallableUsage.java
+++ b/core/src/main/java/jenkins/telemetry/impl/SlaveToMasterFileCallableUsage.java
@@ -27,8 +27,9 @@ package jenkins.telemetry.impl;
 import hudson.Extension;
 import hudson.Functions;
 import java.time.LocalDate;
-import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import jenkins.SlaveToMasterFileCallable;
@@ -64,7 +65,10 @@ public class SlaveToMasterFileCallableUsage extends Telemetry {
 
     @Override
     public synchronized JSONObject createContent() {
-        JSONObject json = JSONObject.fromObject(Collections.singletonMap("traces", traces));
+        Map<String, Object> info = new TreeMap<>();
+        info.put("traces", traces);
+        info.put("components", buildComponentInformation());
+        JSONObject json = JSONObject.fromObject(info);
         traces.clear();
         return json;
     }

--- a/core/src/main/java/jenkins/telemetry/impl/StaplerDispatches.java
+++ b/core/src/main/java/jenkins/telemetry/impl/StaplerDispatches.java
@@ -25,15 +25,12 @@ package jenkins.telemetry.impl;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.PluginWrapper;
-import hudson.util.VersionNumber;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentSkipListSet;
-import jenkins.model.Jenkins;
 import jenkins.telemetry.Telemetry;
 import net.sf.json.JSONObject;
 import org.kohsuke.MetaInfServices;
@@ -82,19 +79,6 @@ public class StaplerDispatches extends Telemetry {
         Set<String> currentTraces = new TreeSet<>(traces);
         traces.clear();
         return currentTraces;
-    }
-
-    private Object buildComponentInformation() {
-        Map<String, String> components = new TreeMap<>();
-        VersionNumber core = Jenkins.getVersion();
-        components.put("jenkins-core", core == null ? "" : core.toString());
-
-        for (PluginWrapper plugin : Jenkins.get().pluginManager.getPlugins()) {
-            if (plugin.isActive()) {
-                components.put(plugin.getShortName(), plugin.getVersion());
-            }
-        }
-        return components;
     }
 
     @MetaInfServices


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/5890#issuecomment-972876604

We are getting more hits than initially expected from what appear to be long-obsolete plugin versions running on recent weeklies. This telemetry addition should help us confirm that deprecated agent-to-controller file calls are not being made by current versions of plugins.

### Proposed changelog entries

* N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
