### PR TITLE
Use update site provided file size for better guessing

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1258,8 +1258,15 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                 // particularly noticeable during 2.0 install when downloading
                 // many plugins
                 con.setReadTimeout(PLUGIN_DOWNLOAD_READ_TIMEOUT);
-                
-                int total = con.getContentLength();
+
+                long total;
+                final long sizeFromMetadata = job.getContentLength();
+                if (sizeFromMetadata == -1) {
+                    // Update site does not advertise a file size, so fall back to download file size, if any
+                    total = con.getContentLength();
+                } else {
+                    total = sizeFromMetadata;
+                }
                 byte[] buf = new byte[8192];
                 int len;
 
@@ -1279,7 +1286,11 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                      CountingInputStream cin = new CountingInputStream(in)) {
                     while ((len = cin.read(buf)) >= 0) {
                         out.write(buf,0,len);
-                        job.status = job.new Installing(total == -1 ? -1 : cin.getCount() * 100 / total);
+                        final int count = cin.getCount();
+                        job.status = job.new Installing(total == -1 ? -1 : ((int) (count * 100 / total)));
+                        if (total != -1 && total < count) {
+                            throw new IOException("Received more data than expected. Expected " + total + " bytes but got " + count + " bytes (so far), aborting download.");
+                        }
                     }
                 } catch (IOException | InvalidPathException e) {
                     throw new IOException("Failed to load "+src+" to "+tmp,e);
@@ -1891,6 +1902,17 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         }
 
         /**
+         * Indicate the expected size of the download as provided in update site
+         * metadata.
+         *
+         * @return the expected size, or -1 if unknown.
+         * @since TODO
+         */
+        public long getContentLength() {
+            return -1;
+        }
+
+        /**
          * Indicates the status or the result of a plugin installation.
          * <p>
          * Instances of this class is immutable.
@@ -2156,6 +2178,12 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         @Override
         public String getDisplayName() {
             return plugin.getDisplayName();
+        }
+
+        @Override
+        public long getContentLength() {
+            final Long size = plugin.getFileSize();
+            return size == null ? -1 : size;
         }
 
         @Override

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -697,6 +697,10 @@ public class UpdateSite {
         @Exported
         public final String url;
 
+        /**
+         * Size of the file in bytes, or {@code null} if unknown.
+         */
+        private final Long size;
 
         // non-private, non-final for test
         @Restricted(NoExternalUse.class)
@@ -722,6 +726,12 @@ public class UpdateSite {
             this.sha1 = Util.fixEmptyAndTrim(o.optString("sha1"));
             this.sha256 = Util.fixEmptyAndTrim(o.optString("sha256"));
             this.sha512 = Util.fixEmptyAndTrim(o.optString("sha512"));
+
+            Long fileSize = null;
+            if (o.has("size")) {
+                fileSize = o.getLong("size");
+            }
+            this.size = fileSize;
 
             String url = o.getString("url");
             if (!URI.create(url).isAbsolute()) {
@@ -783,6 +793,17 @@ public class UpdateSite {
             return new Api(this);
         }
 
+        /**
+         * Size of the file being advertised in bytes, or {@code null} if unspecified/unknown.
+         * @return size of the file if known, {@code null} otherwise.
+         *
+         * @since TODO
+         */
+        // @Exported -- TODO unsure
+        @Restricted(NoExternalUse.class)
+        public Long getFileSize() {
+            return size;
+        }
     }
 
     /**


### PR DESCRIPTION
Update sites may advertise download file sizes (since https://github.com/jenkins-infra/update-center2/pull/500), so make use of that metadata here. This allows estimating download progress even if the file download doesn't provide a total size.

Future enhancements could use the new API to show file sizes in the plugin manager UI.

### Proposed changelog entries

* More reliably estimate plugin download progress.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
