### PR TITLE
[JENKINS-21224] Cannot use `Listeners.notify` in `ItemListener.fireOnCreated` due to `matrix-auth` tricks

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -220,7 +220,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
         }
         createNewComputerForNode(n, automaticAgentLaunch);
         getQueue().scheduleMaintenance();
-        Listeners.notify(ComputerListener.class, ComputerListener::onConfigurationChange);
+        Listeners.notify(ComputerListener.class, false, ComputerListener::onConfigurationChange);
     }
 
     /**
@@ -273,7 +273,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
             killComputer(c);
         }
         getQueue().scheduleMaintenance();
-        Listeners.notify(ComputerListener.class, ComputerListener::onConfigurationChange);
+        Listeners.notify(ComputerListener.class, false, ComputerListener::onConfigurationChange);
     }
 
 }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -707,9 +707,9 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             statusChangeLock.notifyAll();
         }
         if (temporarilyOffline) {
-            Listeners.notify(ComputerListener.class, l -> l.onTemporarilyOffline(this, cause));
+            Listeners.notify(ComputerListener.class, false, l -> l.onTemporarilyOffline(this, cause));
         } else {
-            Listeners.notify(ComputerListener.class, l -> l.onTemporarilyOnline(this));
+            Listeners.notify(ComputerListener.class, false, l -> l.onTemporarilyOnline(this));
         }
     }
 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2551,7 +2551,7 @@ public class Queue extends ResourceController implements Saveable {
         @Override
         /*package*/ void enter(Queue q) {
             if (q.waitingList.add(this)) {
-                Listeners.notify(QueueListener.class, l -> l.onEnterWaiting(this));
+                Listeners.notify(QueueListener.class, true, l -> l.onEnterWaiting(this));
             }
         }
 
@@ -2559,7 +2559,7 @@ public class Queue extends ResourceController implements Saveable {
         /*package*/ boolean leave(Queue q) {
             boolean r = q.waitingList.remove(this);
             if (r) {
-                Listeners.notify(QueueListener.class, l -> l.onLeaveWaiting(this));
+                Listeners.notify(QueueListener.class, true, l -> l.onLeaveWaiting(this));
             }
             return r;
         }
@@ -2630,7 +2630,7 @@ public class Queue extends ResourceController implements Saveable {
         /*package*/ void enter(Queue q) {
             LOGGER.log(Level.FINE, "{0} is blocked", this);
             blockedProjects.add(this);
-            Listeners.notify(QueueListener.class, l -> l.onEnterBlocked(this));
+            Listeners.notify(QueueListener.class, true, l -> l.onEnterBlocked(this));
         }
 
                     @Override
@@ -2638,7 +2638,7 @@ public class Queue extends ResourceController implements Saveable {
             boolean r = blockedProjects.remove(this);
             if (r) {
                 LOGGER.log(Level.FINE, "{0} no longer blocked", this);
-                Listeners.notify(QueueListener.class, l -> l.onLeaveBlocked(this));
+                Listeners.notify(QueueListener.class, true, l -> l.onLeaveBlocked(this));
             }
             return r;
         }
@@ -2725,7 +2725,7 @@ public class Queue extends ResourceController implements Saveable {
         @Override
         /*package*/ void enter(Queue q) {
             q.buildables.add(this);
-            Listeners.notify(QueueListener.class, l -> l.onEnterBuildable(this));
+            Listeners.notify(QueueListener.class, true, l -> l.onEnterBuildable(this));
         }
 
         @Override
@@ -2733,7 +2733,7 @@ public class Queue extends ResourceController implements Saveable {
             boolean r = q.buildables.remove(this);
             if (r) {
                 LOGGER.log(Level.FINE, "{0} no longer blocked", this);
-                Listeners.notify(QueueListener.class, l -> l.onLeaveBuildable(this));
+                Listeners.notify(QueueListener.class, true, l -> l.onLeaveBuildable(this));
             }
             return r;
         }
@@ -2789,7 +2789,7 @@ public class Queue extends ResourceController implements Saveable {
         @Override
         void enter(Queue q) {
             q.leftItems.put(getId(),this);
-            Listeners.notify(QueueListener.class, l -> l.onLeft(this));
+            Listeners.notify(QueueListener.class, true, l -> l.onLeft(this));
         }
 
         @Override

--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -203,7 +203,6 @@ public class ItemListener implements ExtensionPoint {
                 l.onCreated(item);
             } catch (Throwable x) {
                 LOGGER.log(Level.WARNING, null, x);
-
             }
         }
         Listeners.notify(ItemListener.class, l -> l.onCreated(item));

--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -172,7 +172,7 @@ public class ItemListener implements ExtensionPoint {
     }
 
     public static void fireOnCopied(final Item src, final Item result) {
-        Listeners.notify(ItemListener.class, l -> l.onCopied(src, result));
+        Listeners.notify(ItemListener.class, false, l -> l.onCopied(src, result));
     }
 
     /**
@@ -197,23 +197,16 @@ public class ItemListener implements ExtensionPoint {
     }
 
     public static void fireOnCreated(final Item item) {
-        // Do not use Listeners.notify here as impls in matrix-auth expect the Authentication to be retained.
-        for (ItemListener l : all()) {
-            try {
-                l.onCreated(item);
-            } catch (Throwable x) {
-                LOGGER.log(Level.WARNING, null, x);
-            }
-        }
+        Listeners.notify(ItemListener.class, false, l -> l.onCreated(item));
     }
 
     public static void fireOnUpdated(final Item item) {
-        Listeners.notify(ItemListener.class, l -> l.onUpdated(item));
+        Listeners.notify(ItemListener.class, false, l -> l.onUpdated(item));
     }
 
     /** @since 1.548 */
     public static void fireOnDeleted(final Item item) {
-        Listeners.notify(ItemListener.class, l -> l.onDeleted(item));
+        Listeners.notify(ItemListener.class, false, l -> l.onDeleted(item));
     }
 
     /**
@@ -234,16 +227,16 @@ public class ItemListener implements ExtensionPoint {
             final String oldName = oldFullName.substring(prefixS);
             final String newName = rootItem.getName();
             assert newName.equals(newFullName.substring(prefixS));
-            Listeners.notify(ItemListener.class, l -> l.onRenamed(rootItem, oldName, newName));
+            Listeners.notify(ItemListener.class, false, l -> l.onRenamed(rootItem, oldName, newName));
         }
-        Listeners.notify(ItemListener.class, l -> l.onLocationChanged(rootItem, oldFullName, newFullName));
+        Listeners.notify(ItemListener.class, false, l -> l.onLocationChanged(rootItem, oldFullName, newFullName));
         if (rootItem instanceof ItemGroup) {
             for (final Item child : Items.allItems2(ACL.SYSTEM2, (ItemGroup)rootItem, Item.class)) {
                 final String childNew = child.getFullName();
                 assert childNew.startsWith(newFullName);
                 assert childNew.charAt(newFullName.length()) == '/';
                 final String childOld = oldFullName + childNew.substring(newFullName.length());
-                Listeners.notify(ItemListener.class, l -> l.onLocationChanged(child, childOld, childNew));
+                Listeners.notify(ItemListener.class, false, l -> l.onLocationChanged(child, childOld, childNew));
             }
         }
     }

--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -197,6 +197,15 @@ public class ItemListener implements ExtensionPoint {
     }
 
     public static void fireOnCreated(final Item item) {
+        // Do not use Listeners.notify here as impls in matrix-auth expect the Authentication to be retained.
+        for (ItemListener l : all()) {
+            try {
+                l.onCreated(item);
+            } catch (Throwable x) {
+                LOGGER.log(Level.WARNING, null, x);
+
+            }
+        }
         Listeners.notify(ItemListener.class, l -> l.onCreated(item));
     }
 

--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -205,7 +205,6 @@ public class ItemListener implements ExtensionPoint {
                 LOGGER.log(Level.WARNING, null, x);
             }
         }
-        Listeners.notify(ItemListener.class, l -> l.onCreated(item));
     }
 
     public static void fireOnUpdated(final Item item) {

--- a/core/src/main/java/hudson/model/listeners/RunListener.java
+++ b/core/src/main/java/hudson/model/listeners/RunListener.java
@@ -201,7 +201,7 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
      * Fires the {@link #onCompleted(Run, TaskListener)} event.
      */
     public static void fireCompleted(Run r, @NonNull TaskListener listener) {
-        Listeners.notify(RunListener.class, l -> {
+        Listeners.notify(RunListener.class, true, l -> {
             if (l.targetType.isInstance(r)) {
                 l.onCompleted(r, listener);
             }
@@ -212,7 +212,7 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
      * Fires the {@link #onInitialize(Run)} event.
      */
     public static void fireInitialize(Run r) {
-        Listeners.notify(RunListener.class, l -> {
+        Listeners.notify(RunListener.class, true, l -> {
             if (l.targetType.isInstance(r)) {
                 l.onInitialize(r);
             }
@@ -224,7 +224,7 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
      * Fires the {@link #onStarted(Run, TaskListener)} event.
      */
     public static void fireStarted(Run r, TaskListener listener) {
-        Listeners.notify(RunListener.class, l -> {
+        Listeners.notify(RunListener.class, true, l -> {
             if (l.targetType.isInstance(r)) {
                 l.onStarted(r, listener);
             }
@@ -238,7 +238,7 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
         if (!Functions.isExtensionsAvailable()) {
             return;
         }
-        Listeners.notify(RunListener.class, l -> {
+        Listeners.notify(RunListener.class, true, l -> {
             if (l.targetType.isInstance(r)) {
                 l.onFinalized(r);
             }
@@ -249,7 +249,7 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
      * Fires the {@link #onDeleted} event.
      */
     public static void fireDeleted(Run r) {
-        Listeners.notify(RunListener.class, l -> {
+        Listeners.notify(RunListener.class, true, l -> {
             if (l.targetType.isInstance(r)) {
                 l.onDeleted(r);
             }

--- a/core/src/main/java/hudson/model/listeners/SCMPollListener.java
+++ b/core/src/main/java/hudson/model/listeners/SCMPollListener.java
@@ -68,15 +68,15 @@ public abstract class SCMPollListener implements ExtensionPoint {
     public void onPollingFailed( AbstractProject<?, ?> project, TaskListener listener, Throwable exception) {}
 
 	public static void fireBeforePolling( AbstractProject<?, ?> project, TaskListener listener ) {
-        Listeners.notify(SCMPollListener.class, l -> l.onBeforePolling(project, listener));
+        Listeners.notify(SCMPollListener.class, true, l -> l.onBeforePolling(project, listener));
     }
 
 	public static void firePollingSuccess( AbstractProject<?, ?> project, TaskListener listener, PollingResult result ) {
-        Listeners.notify(SCMPollListener.class, l -> l.onPollingSuccess(project, listener, result));
+        Listeners.notify(SCMPollListener.class, true, l -> l.onPollingSuccess(project, listener, result));
 	}
 
     public static void firePollingFailed( AbstractProject<?, ?> project, TaskListener listener, Throwable exception ) {
-        Listeners.notify(SCMPollListener.class, l -> l.onPollingFailed(project, listener, exception));
+        Listeners.notify(SCMPollListener.class, true, l -> l.onPollingFailed(project, listener, exception));
    	}
 
 	/**

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -897,7 +897,7 @@ public class SlaveComputer extends Computer {
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "Failed to terminate channel to " + getDisplayName(), e);
             }
-            Listeners.notify(ComputerListener.class, l -> l.onOffline(this, offlineCause));
+            Listeners.notify(ComputerListener.class, true, l -> l.onOffline(this, offlineCause));
         }
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4494,7 +4494,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     // give some time for the browser to load the "reloading" page
                     Thread.sleep(TimeUnit.SECONDS.toMillis(5));
                     LOGGER.info(String.format("Restarting VM as requested by %s", exitUser));
-                    Listeners.notify(RestartListener.class, RestartListener::onRestart);
+                    Listeners.notify(RestartListener.class, true, RestartListener::onRestart);
                     lifecycle.restart();
                 } catch (InterruptedException | InterruptedIOException e) {
                     LOGGER.log(Level.WARNING, "Interrupted while trying to restart Jenkins", e);
@@ -4531,7 +4531,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                         LOGGER.info("Restart in 10 seconds");
                         Thread.sleep(TimeUnit.SECONDS.toMillis(10));
                         LOGGER.info(String.format("Restarting VM as requested by %s",exitUser));
-                        Listeners.notify(RestartListener.class, RestartListener::onRestart);
+                        Listeners.notify(RestartListener.class, true, RestartListener::onRestart);
                         lifecycle.restart();
                     } else {
                         LOGGER.info("Safe-restart mode cancelled");
@@ -4551,7 +4551,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             Computer computer = Jenkins.get().toComputer();
             if (computer == null) return;
             RestartCause cause = new RestartCause();
-            Listeners.notify(ComputerListener.class, l -> l.onOffline(computer, cause));
+            Listeners.notify(ComputerListener.class, true, l -> l.onOffline(computer, cause));
         }
 
         @Override

--- a/core/src/main/java/jenkins/model/NodeListener.java
+++ b/core/src/main/java/jenkins/model/NodeListener.java
@@ -62,7 +62,7 @@ public abstract class NodeListener implements ExtensionPoint {
      * @param node A node being created.
      */
     public static void fireOnCreated(@NonNull Node node) {
-        Listeners.notify(NodeListener.class, l -> l.onCreated(node));
+        Listeners.notify(NodeListener.class, false, l -> l.onCreated(node));
     }
 
     /**
@@ -72,7 +72,7 @@ public abstract class NodeListener implements ExtensionPoint {
      * @param newOne New Configuration.
      */
     public static void fireOnUpdated(@NonNull Node oldOne, @NonNull Node newOne) {
-        Listeners.notify(NodeListener.class, l -> l.onUpdated(oldOne, newOne));
+        Listeners.notify(NodeListener.class, false, l -> l.onUpdated(oldOne, newOne));
     }
 
     /**
@@ -81,7 +81,7 @@ public abstract class NodeListener implements ExtensionPoint {
      * @param node A node being removed.
      */
     public static void fireOnDeleted(@NonNull Node node) {
-        Listeners.notify(NodeListener.class, l -> l.onDeleted(node));
+        Listeners.notify(NodeListener.class, false, l -> l.onDeleted(node));
     }
 
     /**

--- a/core/src/main/java/jenkins/security/seed/UserSeedChangeListener.java
+++ b/core/src/main/java/jenkins/security/seed/UserSeedChangeListener.java
@@ -53,7 +53,7 @@ public abstract class UserSeedChangeListener extends ExtensionPoint {
      * @param user The target user
      */
     public static void fireUserSeedRenewed(@NonNull User user) {
-        Listeners.notify(UserSeedChangeListener.class, l -> l.onUserSeedRenewed(user));
+        Listeners.notify(UserSeedChangeListener.class, true, l -> l.onUserSeedRenewed(user));
     }
 
     private static List<UserSeedChangeListener> all() {

--- a/core/src/main/java/jenkins/util/Listeners.java
+++ b/core/src/main/java/jenkins/util/Listeners.java
@@ -30,6 +30,7 @@ import hudson.security.ACLContext;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.springframework.security.core.Authentication;
 
 /**
  * Utilities for working with listener interfaces.
@@ -42,10 +43,17 @@ public class Listeners {
      * <p>Only suitable for listener methods which do not throw checked or otherwise documented exceptions.
      * @param <L> the type of listener
      * @param listenerType the type of listener
+     * @param asSystem whether to impersonate {@link ACL#SYSTEM2}.
+     *                 For most listener methods, this should be {@code true},
+     *                 so that listener implementations can freely perform various operations without access checks.
+     *                 In some cases, existing listener interfaces were implicitly assumed to pass along user authentication,
+     *                 because they were sometimes triggered by user actions such as configuration changes;
+     *                 this is an antipattern (better to pass an explicit {@link Authentication} argument if relevant).
      * @param notification a listener method, perhaps with arguments
+     * @since TODO
      */
-    public static <L> void notify(Class<L> listenerType, Consumer<L> notification) {
-        try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
+    public static <L> void notify(Class<L> listenerType, boolean asSystem, Consumer<L> notification) {
+        Runnable r = () -> {
             for (L listener : ExtensionList.lookup(listenerType)) {
                 try {
                     notification.accept(listener);
@@ -53,7 +61,22 @@ public class Listeners {
                     Logger.getLogger(listenerType.getName()).log(Level.WARNING, null, x);
                 }
             }
+        };
+        if (asSystem) {
+            try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
+                r.run();
+            }
+        } else {
+            r.run();
         }
+    }
+
+    /**
+     * @deprecated call {@link #notify(Class, boolean, Consumer)}
+     */
+    @Deprecated
+    public static <L> void notify(Class<L> listenerType, Consumer<L> notification) {
+        notify(listenerType, true, notification);
     }
 
     private Listeners() {}


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/6000#discussion_r766087688

### Proposed changelog entries

* Newly created items are again automatically made accessible to their creators to fix a regression in the `matrix-auth` plugin (regression in 2.324).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
