### PR TITLE
Reduce usages of Ant

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1070,7 +1070,7 @@ public class Util {
      */
     public static void copyFile(@NonNull File src, @NonNull File dst) throws BuildException {
         Copy cp = new Copy();
-        cp.setProject(new org.apache.tools.ant.Project());
+        cp.setProject(new Project());
         cp.setTofile(dst);
         cp.setFile(src);
         cp.setOverwrite(true);

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -78,6 +78,7 @@ import jenkins.security.NotReallyRoleSensitiveCallable;
 import jenkins.util.SystemProperties;
 import jenkins.util.xml.XMLUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.types.FileSet;
 import org.kohsuke.accmod.Restricted;
@@ -418,7 +419,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                         // shuts down there might be a new job created under the
                         // old name.
                         Copy cp = new Copy();
-                        cp.setProject(new org.apache.tools.ant.Project());
+                        cp.setProject(new Project());
                         cp.setTodir(newRoot);
                         FileSet src = new FileSet();
                         src.setDir(oldRoot);

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -66,6 +66,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -106,7 +107,6 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.lang.StringUtils;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.kohsuke.accmod.Restricted;
@@ -1401,7 +1401,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
                 throw new Failure("No such view: "+from);
         }
         String xml = Jenkins.XSTREAM.toXML(src);
-        v = createViewFromXML(name, new StringInputStream(xml));
+        v = createViewFromXML(name, new ByteArrayInputStream(xml.getBytes(Charset.defaultCharset())));
         return v;
     }
 

--- a/core/src/main/java/hudson/slaves/ComputerLauncher.java
+++ b/core/src/main/java/hudson/slaves/ComputerLauncher.java
@@ -31,6 +31,7 @@ import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.util.DescriptorList;
 import hudson.util.StreamTaskListener;
+import hudson.util.VersionNumber;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,7 +39,6 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.tools.ant.util.DeweyDecimal;
 
 /**
  * Extension point to allow control over how {@link Computer}s are "launched",
@@ -192,7 +192,7 @@ public abstract class ComputerLauncher extends AbstractDescribableImpl<ComputerL
                 final String versionStr = m.group(1);
                 logger.println(Messages.ComputerLauncher_JavaVersionResult(javaCommand, versionStr));
                 try {
-                    if (new DeweyDecimal(versionStr).isLessThan(new DeweyDecimal("1.8"))) {
+                    if (new VersionNumber(versionStr).isOlderThan(new VersionNumber("1.8"))) {
                         throw new IOException(Messages
                                 .ComputerLauncher_NoJavaFound(line));
                     }

--- a/core/src/main/java/jenkins/security/seed/UserSeedChangeListener.java
+++ b/core/src/main/java/jenkins/security/seed/UserSeedChangeListener.java
@@ -25,12 +25,12 @@ package jenkins.security.seed;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
+import hudson.ExtensionPoint;
 import hudson.model.User;
 import java.util.List;
 import java.util.logging.Logger;
 import jenkins.security.SecurityListener;
 import jenkins.util.Listeners;
-import org.apache.tools.ant.ExtensionPoint;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -39,7 +39,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 //TODO remove restriction on the weekly after the security fix
 @Restricted(NoExternalUse.class)
-public abstract class UserSeedChangeListener extends ExtensionPoint {
+public abstract class UserSeedChangeListener implements ExtensionPoint {
     private static final Logger LOGGER = Logger.getLogger(SecurityListener.class.getName());
 
     /**

--- a/core/src/test/java/hudson/PluginManagerTest.java
+++ b/core/src/test/java/hudson/PluginManagerTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -44,7 +45,6 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
@@ -63,7 +63,7 @@ public class PluginManagerTest {
                 tmp.resolve("output.txt")
         );
         assertEquals("{other=2.0, stuff=1.2}", new LocalPluginManager(output.toFile())
-                .parseRequestedPlugins(new StringInputStream("<root><stuff plugin='stuff@1.0'><more plugin='other@2.0'><things plugin='stuff@1.2'/></more></stuff></root>")).toString());
+                .parseRequestedPlugins(new ByteArrayInputStream("<root><stuff plugin='stuff@1.0'><more plugin='other@2.0'><things plugin='stuff@1.2'/></more></stuff></root>".getBytes())).toString());
     }
 
     @Issue("SECURITY-167")
@@ -82,7 +82,7 @@ public class PluginManagerTest {
 
         PluginManager pluginManager = new LocalPluginManager(Util.createTempDir());
         final IOException ex = assertThrows(IOException.class,
-                () -> pluginManager.parseRequestedPlugins(new StringInputStream(evilXML)),
+                () -> pluginManager.parseRequestedPlugins(new ByteArrayInputStream(evilXML.getBytes())),
                 "XML contains an external entity, but no exception was thrown.");
         assertThat(ex.getCause(), instanceOf(SAXException.class));
         assertThat(ex.getCause().getMessage(), containsString("Refusing to resolve entity with publicId(null) and systemId (file:///)"));

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -44,6 +44,7 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.FormValidation;
 import hudson.util.PersistedList;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -61,7 +62,6 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -243,9 +243,9 @@ public class PluginManagerTest {
         sites.add(site);
         assertEquals(FormValidation.ok(), site.updateDirectly(false).get());
         assertNotNull(site.getData());
-        assertEquals(Collections.emptyList(), r.jenkins.getPluginManager().prevalidateConfig(new StringInputStream("<whatever><runant plugin=\"ant@1.1\"/></whatever>")));
+        assertEquals(Collections.emptyList(), r.jenkins.getPluginManager().prevalidateConfig(new ByteArrayInputStream("<whatever><runant plugin=\"ant@1.1\"/></whatever>".getBytes())));
         assertNull(r.jenkins.getPluginManager().getPlugin("htmlpublisher"));
-        List<Future<UpdateCenterJob>> jobs = r.jenkins.getPluginManager().prevalidateConfig(new StringInputStream("<whatever><htmlpublisher plugin=\"htmlpublisher@0.7\"/></whatever>"));
+        List<Future<UpdateCenterJob>> jobs = r.jenkins.getPluginManager().prevalidateConfig(new ByteArrayInputStream("<whatever><htmlpublisher plugin=\"htmlpublisher@0.7\"/></whatever>".getBytes()));
         assertEquals(1, jobs.size());
         UpdateCenterJob job = jobs.get(0).get(); // blocks for completion
         assertEquals("InstallationJob", job.getType());

--- a/test/src/test/java/hudson/cli/GroovyshCommandTest.java
+++ b/test/src/test/java/hudson/cli/GroovyshCommandTest.java
@@ -29,8 +29,8 @@ import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.io.ByteArrayInputStream;
 import jenkins.model.Jenkins;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -44,7 +44,7 @@ public class GroovyshCommandTest {
     @Test public void authentication() {
         CLICommandInvoker.Result result = new CLICommandInvoker(r, new GroovyshCommand())
             .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
-            .withStdin(new StringInputStream("println(jenkins.model.Jenkins.instance.getClass().name)\n:quit\n"))
+            .withStdin(new ByteArrayInputStream("println(jenkins.model.Jenkins.instance.getClass().name)\n:quit\n".getBytes()))
             .invoke();
         assertThat(result, succeeded());
         assertThat(result, hasNoErrorOutput());

--- a/test/src/test/java/hudson/tasks/EnvVarsInConfigTasksTest.java
+++ b/test/src/test/java/hudson/tasks/EnvVarsInConfigTasksTest.java
@@ -1,7 +1,7 @@
 package hudson.tasks;
 
-
 import hudson.EnvVars;
+import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.JDK;
@@ -9,7 +9,6 @@ import hudson.model.Result;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.DumbSlave;
 import hudson.tasks.Maven.MavenInstallation;
-import org.apache.tools.ant.taskdefs.condition.Os;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -61,7 +60,7 @@ public class EnvVarsInConfigTasksTest {
 	@Test
 	public void testFreeStyleShellOnAgent() throws Exception {
 		FreeStyleProject project = j.createFreeStyleProject();
-		if (Os.isFamily("dos")) {
+		if (Functions.isWindows()) {
 			project.getBuildersList().add(new BatchFile("echo %JAVA_HOME%"));
 		} else {
 			project.getBuildersList().add(new Shell("echo \"$JAVA_HOME\""));

--- a/test/src/test/java/jenkins/install/SetupWizardTest.java
+++ b/test/src/test/java/jenkins/install/SetupWizardTest.java
@@ -34,6 +34,7 @@ import hudson.model.DownloadService;
 import hudson.model.UpdateSite;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.SecurityRealm;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -52,7 +53,6 @@ import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import jenkins.util.JSONSignatureValidator;
 import org.apache.commons.io.FileUtils;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -455,7 +455,7 @@ public class SetupWizardTest {
         protected Set<TrustAnchor> loadTrustAnchors(CertificateFactory cf) throws IOException {
             Set<TrustAnchor> trustAnchors = new HashSet<>();
             try {
-                Certificate certificate = cf.generateCertificate(new StringInputStream(cert));
+                Certificate certificate = cf.generateCertificate(new ByteArrayInputStream(cert.getBytes()));
                 trustAnchors.add(new TrustAnchor((X509Certificate) certificate, null));
             } catch (CertificateException ex) {
                 throw new IOException(ex);

--- a/test/src/test/java/jenkins/model/NodeListenerTest.java
+++ b/test/src/test/java/jenkins/model/NodeListenerTest.java
@@ -14,7 +14,7 @@ import hudson.cli.DeleteNodeCommand;
 import hudson.cli.GetNodeCommand;
 import hudson.cli.UpdateNodeCommand;
 import hudson.model.Node;
-import org.apache.tools.ant.filters.StringInputStream;
+import java.io.ByteArrayInputStream;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,10 +36,10 @@ public class NodeListenerTest {
     public void crud() throws Exception {
         Node agent = j.createSlave();
         String xml = cli(new GetNodeCommand()).invokeWithArgs(agent.getNodeName()).stdout();
-        cli(new UpdateNodeCommand()).withStdin(new StringInputStream(xml)).invokeWithArgs(agent.getNodeName());
+        cli(new UpdateNodeCommand()).withStdin(new ByteArrayInputStream(xml.getBytes())).invokeWithArgs(agent.getNodeName());
         cli(new DeleteNodeCommand()).invokeWithArgs(agent.getNodeName());
 
-        cli(new CreateNodeCommand()).withStdin(new StringInputStream(xml)).invokeWithArgs("replica");
+        cli(new CreateNodeCommand()).withStdin(new ByteArrayInputStream(xml.getBytes())).invokeWithArgs("replica");
         j.jenkins.getComputer("replica").doDoDelete();
 
         verify(mock, times(2)).onCreated(any(Node.class));


### PR DESCRIPTION
Replaces usages of Ant with native Java Platform or Jenkins API functionality.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
