### PR TITLE
 Revert "`RingBufferLogHandler.records` could leak records

### DIFF
--- a/core/src/test/java/hudson/logging/LogRecorderTest.java
+++ b/core/src/test/java/hudson/logging/LogRecorderTest.java
@@ -24,8 +24,6 @@
 
 package hudson.logging;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -115,7 +113,12 @@ public class LogRecorderTest {
         lr.handler.publish(r5);
         lr.handler.publish(r6);
 
-        assertThat(lr.handler.getView(), contains(r6, r5, r1));
+        assertTrue(lr.handler.getView().contains(r1));
+        assertFalse(lr.handler.getView().contains(r2));
+        assertFalse(lr.handler.getView().contains(r3));
+        assertFalse(lr.handler.getView().contains(r4));
+        assertTrue(lr.handler.getView().contains(r5));
+        assertTrue(lr.handler.getView().contains(r6));
     }
 
     private static LogRecord createLogRecord(String logger, Level level, String message) {

--- a/test/src/test/java/hudson/logging/LogRecordManagerRealTest.java
+++ b/test/src/test/java/hudson/logging/LogRecordManagerRealTest.java
@@ -1,0 +1,34 @@
+package hudson.logging;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class LogRecordManagerRealTest {
+
+    @Rule
+    public RealJenkinsRule rr = new RealJenkinsRule();
+
+    @Test
+    public void logRecordsArePresentOnController() throws Throwable {
+        rr.then(new LogRecordsArePresent());
+    }
+
+    private static class LogRecordsArePresent implements RealJenkinsRule.Step {
+
+        @Override
+        public void run(JenkinsRule r) throws Throwable {
+            List<LogRecord> logRecords = Jenkins.logRecords;
+            assertThat(logRecords, is(not(empty())));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

See https://github.com/jenkinsci/jenkins/pull/6018#issuecomment-990367907

This change isn't released yet so should get it in ASAP (unless someone can see the issue in the original PR, I don't have time to debug it though)

#6018 broke the controller System log.

Picked up in ATH as it uses the log to check plugins have completed installing.

I wasn't able to reproduce this with `JenkinsRule` but trivially reproduced with `RealJenkinsRule` added a test in https://github.com/jenkinsci/jenkins/commit/da1cc333182eabc430d8277ab0cd6e396f8b24b4 which failed on master and passes after reverting

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
