### PR TITLE
`RingBufferLogHandler.getView` needs to be a live `List` for use from `Jenkins.logRecords`

### DIFF
--- a/test/src/test/java/hudson/logging/LogRecordManagerRealTest.java
+++ b/test/src/test/java/hudson/logging/LogRecordManagerRealTest.java
@@ -1,5 +1,10 @@
 package hudson.logging;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
 import java.util.List;
 import java.util.logging.LogRecord;
 import jenkins.model.Jenkins;
@@ -8,11 +13,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-
 public class LogRecordManagerRealTest {
 
     @Rule
@@ -20,15 +20,11 @@ public class LogRecordManagerRealTest {
 
     @Test
     public void logRecordsArePresentOnController() throws Throwable {
-        rr.then(new LogRecordsArePresent());
+        rr.then(LogRecordManagerRealTest::_logRecordsArePresentOnController);
+    }
+    private static void _logRecordsArePresentOnController(JenkinsRule r) throws Throwable {
+        List<LogRecord> logRecords = Jenkins.logRecords;
+        assertThat(logRecords, is(not(empty())));
     }
 
-    private static class LogRecordsArePresent implements RealJenkinsRule.Step {
-
-        @Override
-        public void run(JenkinsRule r) throws Throwable {
-            List<LogRecord> logRecords = Jenkins.logRecords;
-            assertThat(logRecords, is(not(empty())));
-        }
-    }
 }

--- a/test/src/test/java/hudson/logging/LogRecordManagerRealTest.java
+++ b/test/src/test/java/hudson/logging/LogRecordManagerRealTest.java
@@ -1,0 +1,34 @@
+package hudson.logging;
+
+import java.util.List;
+import java.util.logging.LogRecord;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class LogRecordManagerRealTest {
+
+    @Rule
+    public RealJenkinsRule rr = new RealJenkinsRule();
+
+    @Test
+    public void logRecordsArePresentOnController() throws Throwable {
+        rr.then(new LogRecordsArePresent());
+    }
+
+    private static class LogRecordsArePresent implements RealJenkinsRule.Step {
+
+        @Override
+        public void run(JenkinsRule r) throws Throwable {
+            List<LogRecord> logRecords = Jenkins.logRecords;
+            assertThat(logRecords, is(not(empty())));
+        }
+    }
+}

--- a/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
@@ -1,4 +1,4 @@
-package hudson.logging;
+package jenkins.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -7,20 +7,19 @@ import static org.hamcrest.Matchers.not;
 
 import java.util.List;
 import java.util.logging.LogRecord;
-import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 
-public class LogRecordManagerRealTest {
+public class JenkinsLogRecordsTest {
 
     @Rule
     public RealJenkinsRule rr = new RealJenkinsRule();
 
     @Test
     public void logRecordsArePresentOnController() throws Throwable {
-        rr.then(LogRecordManagerRealTest::_logRecordsArePresentOnController);
+        rr.then(JenkinsLogRecordsTest::_logRecordsArePresentOnController);
     }
     private static void _logRecordsArePresentOnController(JenkinsRule r) throws Throwable {
         List<LogRecord> logRecords = Jenkins.logRecords;

--- a/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
@@ -3,14 +3,19 @@ package jenkins.model;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MemoryAssert;
 import org.jvnet.hudson.test.RealJenkinsRule;
 
 public class JenkinsLogRecordsTest {
@@ -28,6 +33,14 @@ public class JenkinsLogRecordsTest {
         assertThat("Records are displayed in reverse order",
             logRecords.stream().map(LogRecord::getMessage).collect(Collectors.toList()),
             containsInRelativeOrder("Completed initialization", "Started initialization"));
+        LogRecord lr = new LogRecord(Level.INFO, "collect me");
+        Logger.getLogger(Jenkins.class.getName()).log(lr);
+        WeakReference<LogRecord> ref = new WeakReference<>(lr);
+        lr = null;
+        MemoryAssert.assertGC(ref, true);
+        assertThat("Records collected",
+            logRecords.stream().map(LogRecord::getMessage).collect(Collectors.toList()),
+            hasItem("<discarded>"));
     }
 
 }

--- a/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
@@ -34,7 +34,7 @@ public class JenkinsLogRecordsTest {
         assertThat("Records are displayed in reverse order",
             logRecords.stream().map(LogRecord::getMessage).collect(Collectors.toList()),
             containsInRelativeOrder("Completed initialization", "Started initialization"));
-        if (new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("9"))) { // TODO https://github.com/jenkinsci/jenkins-test-harness/pull/358
+        if (new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("9"))) { // TODO https://github.com/jenkinsci/jenkins-test-harness/issues/359
             LogRecord lr = new LogRecord(Level.INFO, "collect me");
             Logger.getLogger(Jenkins.class.getName()).log(lr);
             WeakReference<LogRecord> ref = new WeakReference<>(lr);

--- a/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
@@ -1,12 +1,13 @@
 package jenkins.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.util.List;
 import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -23,7 +24,10 @@ public class JenkinsLogRecordsTest {
     }
     private static void _logRecordsArePresentOnController(JenkinsRule r) throws Throwable {
         List<LogRecord> logRecords = Jenkins.logRecords;
-        assertThat(logRecords, is(not(empty())));
+        assertThat(logRecords, not(empty()));
+        assertThat("Records are displayed in reverse order",
+            logRecords.stream().map(LogRecord::getMessage).collect(Collectors.toList()),
+            containsInRelativeOrder("Completed initialization", "Started initialization"));
     }
 
 }


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/6018#issuecomment-990367907. Supersedes #6042.

### Proposed changelog entries

* Unreleased regression in system log display.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
