### PR TITLE
Only require one approval for minor changes

### DIFF
--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -374,7 +374,7 @@ LTS backporting, if needed, will be handled separately by the release team.
   Security hardening and enhancements go through the standard process.
 * Release Team members are permitted to bypass the review/merge process if and only if a change is needed to unblock the security release.
   Common review process is used otherwise.
-* Only one approval is required for changes with the `skip-changelog` label,
+* Only one approval is required for low-risk small changes with the `skip-changelog` label,
   as long as the approver has write access to the repository.
   Note that the 24-hour waiting period still applies.
 * 24 hours waiting period after adding the `ready-for-merge` label is not required for:

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -375,7 +375,7 @@ LTS backporting, if needed, will be handled separately by the release team.
 * Release Team members are permitted to bypass the review/merge process if and only if a change is needed to unblock the security release.
   Common review process is used otherwise.
 * Only one approval is required for low-risk small changes with the `skip-changelog` label,
-  as long as the approver has write access to the repository.
+  as long as both author and approver have write access to the repository.
   Note that the 24-hour waiting period still applies.
 * 24 hours waiting period after adding the `ready-for-merge` label is not required for:
 //TODO(oleg_nenashev): Define "trivial" better to avoid loopholes

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -374,6 +374,9 @@ LTS backporting, if needed, will be handled separately by the release team.
   Security hardening and enhancements go through the standard process.
 * Release Team members are permitted to bypass the review/merge process if and only if a change is needed to unblock the security release.
   Common review process is used otherwise.
+* Only one approval is required for changes with the `skip-changelog` label,
+  as long as the approver has write access to the repository.
+  Note that the 24-hour waiting period still applies.
 * 24 hours waiting period after adding the `ready-for-merge` label is not required for:
 //TODO(oleg_nenashev): Define "trivial" better to avoid loopholes
 ** changes that do not result in changes to the primary functionality, such as typo fixes in documentation or localization files


### PR DESCRIPTION
Waiting for two reviews for code cleanup PRs has been slowing me down recently. Such PRs with no user-visible changes don't tend to attract very many reviewers, with or without explicit solicitation, nor do the PRs tend to change very much after the second review. Seems to me that we can dispense with the heavyweight process for code cleanup PRs while still maintaining the 24-hour waiting period to allow for objections to be raised.