### PR TITLE
Fix `XXE_SAXPARSER` SpotBugs violations

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -110,6 +110,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import jenkins.ClassLoaderReflectionToolkit;
@@ -2100,7 +2101,10 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     public Map<String,VersionNumber> parseRequestedPlugins(InputStream configXml) throws IOException {
         final Map<String,VersionNumber> requestedPlugins = new TreeMap<>();
         try {
-            SAXParserFactory.newInstance().newSAXParser().parse(configXml, new DefaultHandler() {
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            spf.newSAXParser().parse(configXml, new DefaultHandler() {
                 @Override public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
                     String plugin = attributes.getValue("plugin");
                     if (plugin == null) {

--- a/core/src/main/java/hudson/XmlFile.java
+++ b/core/src/main/java/hudson/XmlFile.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import org.apache.commons.io.IOUtils;
@@ -320,7 +321,11 @@ public final class XmlFile {
         try (InputStream in = Files.newInputStream(file.toPath())) {
             InputSource input = new InputSource(file.toURI().toASCIIString());
             input.setByteStream(in);
-            JAXP.newSAXParser().parse(input,new DefaultHandler() {
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            spf.setNamespaceAware(true);
+            spf.newSAXParser().parse(input, new DefaultHandler() {
                 private Locator loc;
                 @Override
                 public void setDocumentLocator(Locator locator) {
@@ -372,13 +377,7 @@ public final class XmlFile {
 
     private static final Logger LOGGER = Logger.getLogger(XmlFile.class.getName());
 
-    private static final SAXParserFactory JAXP = SAXParserFactory.newInstance();
-
     private static final HierarchicalStreamDriver DEFAULT_DRIVER = XStream2.getDefaultDriver();
 
     private static final XStream DEFAULT_XSTREAM = new XStream2(DEFAULT_DRIVER);
-
-    static {
-        JAXP.setNamespaceAware(true);
-    }
 }

--- a/core/src/test/java/hudson/PluginManagerTest.java
+++ b/core/src/test/java/hudson/PluginManagerTest.java
@@ -85,7 +85,7 @@ public class PluginManagerTest {
                 () -> pluginManager.parseRequestedPlugins(new ByteArrayInputStream(evilXML.getBytes())),
                 "XML contains an external entity, but no exception was thrown.");
         assertThat(ex.getCause(), instanceOf(SAXException.class));
-        assertThat(ex.getCause().getMessage(), containsString("Refusing to resolve entity with publicId(null) and systemId (file:///)"));
+        assertThat(ex.getCause().getMessage(), containsString("DOCTYPE is disallowed"));
     }
     
     @Test

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -668,13 +668,6 @@
         <Class name="hudson.WebAppMain"/>
       </And>
       <And>
-        <Bug pattern="XXE_SAXPARSER"/>
-        <Or>
-          <Class name="hudson.PluginManager"/>
-          <Class name="hudson.XmlFile"/>
-        </Or>
-      </And>
-      <And>
         <Bug pattern="XXE_XSLT_TRANSFORM_FACTORY"/>
         <Class name="hudson.WebAppMain"/>
       </And>


### PR DESCRIPTION
Picking up where #4779 left off. That PR was almost at the finish line, but a string in a test needed updating. I've updated the string in the test and rebased the changes against tip-of-trunk. Note that there is no actual security problem here as discussed in #4779, but these changes don't hurt and make SpotBugs happy.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
