### PR TITLE
Bump `jenkins-test-harness` from 1666.vd1360abbfe9e to 1670.v5a5dbf551c41

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -81,7 +81,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>1666.vd1360abbfe9e</version>
+      <version>1670.v5a5dbf551c41</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
There is a new version of `jenkins-test-harness` available, yet @dependabot does not see this:

```
updater | INFO <job_243879467> Checking if org.jenkins-ci.main:jenkins-test-harness 1666.vd1360abbfe9e needs updating
  proxy | 2021/12/13 18:07:41 [110] GET https://repo.jenkins-ci.org:443/public/org/jenkins-ci/jenkins/1.69/jenkins-1.69.pom
  proxy | 2021/12/13 18:07:41 [110] 200 https://repo.jenkins-ci.org:443/public/org/jenkins-ci/jenkins/1.69/jenkins-1.69.pom
  proxy | 2021/12/13 18:07:41 [112] GET https://repo.jenkins-ci.org:443/public/org/jenkins-ci/main/jenkins-test-harness/maven-metadata.xml
  proxy | 2021/12/13 18:07:41 [112] 200 https://repo.jenkins-ci.org:443/public/org/jenkins-ci/main/jenkins-test-harness/maven-metadata.xml
  proxy | 2021/12/13 18:07:41 [114] GET https://repo.maven.apache.org:443/maven2/org/jenkins-ci/main/jenkins-test-harness/maven-metadata.xml
  proxy | 2021/12/13 18:07:41 [114] 404 https://repo.maven.apache.org:443/maven2/org/jenkins-ci/main/jenkins-test-harness/maven-metadata.xml
  proxy | 2021/12/13 18:07:42 [116] HEAD https://repo.jenkins-ci.org:443/public/org/jenkins-ci/main/jenkins-test-harness/1666.vd1360abbfe9e/jenkins-test-harness-1666.vd1360abbfe9e.jar
  proxy | 2021/12/13 18:07:42 [116] 200 https://repo.jenkins-ci.org:443/public/org/jenkins-ci/main/jenkins-test-harness/1666.vd1360abbfe9e/jenkins-test-harness-1666.vd1360abbfe9e.jar
updater | INFO <job_243879467> Latest version is 1666.vd1360abbfe9e
updater | INFO <job_243879467> No update needed for org.jenkins-ci.main:jenkins-test-harness 1666.vd1360abbfe9e
```

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
