### PR TITLE
[JENKINS-67372] Restore support for symbolic links in the Jenkins home directory

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -480,7 +480,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
      * Explodes the plugin into a directory, if necessary.
      */
     private static void explode(File archive, File destDir) throws IOException {
-        Files.createDirectories(Util.fileToPath(destDir));
+        Util.createDirectories(Util.fileToPath(destDir));
 
         // timestamp check
         File explodeTime = new File(destDir,".timestamp2");
@@ -549,7 +549,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
             };
             z.setProject(prj);
             z.setTaskType("zip");
-            Files.createDirectories(Util.fileToPath(classesJar.getParentFile()));
+            Util.createDirectories(Util.fileToPath(classesJar.getParentFile()));
             z.setDestFile(classesJar);
             z.add(mapper);
             z.execute();

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -356,7 +356,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
         this.rootDir = rootDir;
         try {
-            Files.createDirectories(rootDir.toPath());
+            Util.createDirectories(rootDir.toPath());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -67,6 +67,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributes;
+import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.DigestInputStream;
@@ -1727,6 +1728,58 @@ public class Util {
         }
     }
     
+    /**
+     * Create a directory by creating all nonexistent parent directories first.
+     *
+     * <p>Unlike {@link Files#createDirectory}, an exception is not thrown
+     * if the directory could not be created because it already exists.
+     * Unlike {@link Files#createDirectories}, an exception is not thrown
+     * if the directory (or one of its parents) is a symbolic link.
+     *
+     * <p>The {@code attrs} parameter contains optional {@link FileAttribute file attributes}
+     * to set atomically when creating the nonexistent directories.
+     * Each file attribute is identified by its {@link FileAttribute#name}.
+     * If more than one attribute of the same name is included in the array,
+     * then all but the last occurrence is ignored.
+     *
+     * <p>If this method fails,
+     * then it may do so after creating some, but not all, of the parent directories.
+     *
+     * @param dir The directory to create.
+     * @param attrs An optional list of file attributes to set atomically
+     *     when creating the directory.
+     * @return The directory.
+     * @throws UnsupportedOperationException If the array contains an attribute
+     *     that cannot be set atomically when creating the directory.
+     * @throws FileAlreadyExistsException If {@code dir} exists but is not a directory.
+     * @throws IOException If an I/O error occurs.
+     * @see Files#createDirectories(Path, FileAttribute[])
+     */
+    @Restricted(NoExternalUse.class)
+    public static Path createDirectories(@NonNull Path dir, FileAttribute<?>... attrs) throws IOException {
+        dir = dir.toAbsolutePath();
+
+        Path parent;
+        for (parent = dir.getParent(); parent != null; parent = parent.getParent()) {
+            if (Files.exists(parent)) {
+                break;
+            }
+        }
+        if (parent == null) {
+            throw new IOException("Unable to determine whether parent directories of " + dir + " exist");
+        }
+
+        Path child = parent;
+        for (Path name : parent.relativize(dir)) {
+            child = child.resolve(name);
+            if (!Files.isDirectory(child)) {
+                Files.createDirectory(child, attrs);
+            }
+        }
+
+        return dir;
+    }
+
     /**
      * Compute the number of calendar days elapsed since the given date.
      * As it's only the calendar days difference that matter, "11.00pm" to "2.00am the day after" returns 1,

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1765,8 +1765,15 @@ public class Util {
                 break;
             }
         }
+
         if (parent == null) {
-            throw new IOException("Unable to determine whether parent directories of " + dir + " exist");
+            try {
+                return Files.createDirectory(dir, attrs);
+            } catch (FileAlreadyExistsException e) {
+                if (!Files.isDirectory(dir)) {
+                    throw e;
+                }
+            }
         }
 
         Path child = parent;

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1767,14 +1767,10 @@ public class Util {
         }
 
         if (parent == null) {
-            try {
+            if (Files.isDirectory(dir)) {
+                return dir;
+            } else {
                 return Files.createDirectory(dir, attrs);
-            } catch (FileAlreadyExistsException e) {
-                if (Files.isDirectory(dir)) {
-                    return dir;
-                } else {
-                    throw e;
-                }
             }
         }
 

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1770,7 +1770,9 @@ public class Util {
             try {
                 return Files.createDirectory(dir, attrs);
             } catch (FileAlreadyExistsException e) {
-                if (!Files.isDirectory(dir)) {
+                if (Files.isDirectory(dir)) {
+                    return dir;
+                } else {
                     throw e;
                 }
             }

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -190,7 +190,7 @@ public class WebAppMain implements ServletContextListener {
             final FileAndDescription describedHomeDir = getHomeDir(event);
             home = describedHomeDir.file.getAbsoluteFile();
             try {
-                Files.createDirectories(home.toPath());
+                Util.createDirectories(home.toPath());
             } catch (IOException | InvalidPathException e) {
                 throw (NoHomeDir)new NoHomeDir(home).initCause(e);
             }

--- a/core/src/main/java/hudson/XmlFile.java
+++ b/core/src/main/java/hudson/XmlFile.java
@@ -252,7 +252,7 @@ public final class XmlFile {
     }
     
     public void mkdirs() throws IOException {
-        Files.createDirectories(Util.fileToPath(file.getParentFile()));
+        Util.createDirectories(Util.fileToPath(file.getParentFile()));
     }
 
     @Override

--- a/core/src/main/java/hudson/init/impl/InitialUserContent.java
+++ b/core/src/main/java/hudson/init/impl/InitialUserContent.java
@@ -43,7 +43,7 @@ public class InitialUserContent {
     public static void init(Jenkins h) throws IOException {
         File userContentDir = new File(h.getRootDir(), "userContent");
         if (!Files.isDirectory(Util.fileToPath(userContentDir))) {
-            Files.createDirectories(Util.fileToPath(userContentDir));
+            Util.createDirectories(Util.fileToPath(userContentDir));
             FileUtils.writeStringToFile(new File(userContentDir,"readme.txt"), Messages.Hudson_USER_CONTENT_README() + "\n");
         }
     }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1678,7 +1678,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
             if (m.matches()) {
                 File newLocation = new File(dir, "logs/slaves/" + m.group(1) + "/slave.log" + Util.fixNull(m.group(2)));
                 try {
-                    Files.createDirectories(newLocation.getParentFile().toPath());
+                    Util.createDirectories(newLocation.getParentFile().toPath());
                     Files.move(f.toPath(), newLocation.toPath(), StandardCopyOption.REPLACE_EXISTING);
                     LOGGER.log(Level.INFO, "Relocated log file {0} to {1}",new Object[] {f.getPath(),newLocation.getPath()});
                 } catch (IOException | InvalidPathException e) {

--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -99,7 +99,7 @@ public abstract class ItemGroupMixIn {
      */
     public static <K,V extends Item> Map<K,V> loadChildren(ItemGroup parent, File modulesDir, Function1<? extends K,? super V> key) {
         try {
-            Files.createDirectories(modulesDir.toPath());
+            Util.createDirectories(modulesDir.toPath());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -273,7 +273,7 @@ public abstract class ItemGroupMixIn {
         final File dir = configXml.getParentFile();
         boolean success = false;
         try {
-            Files.createDirectories(dir.toPath());
+            Util.createDirectories(dir.toPath());
             XMLUtils.safeTransform(new StreamSource(xml), new StreamResult(configXml));
 
             // load it

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -664,7 +664,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         super.renameTo(newName);
         File newBuildDir = getBuildDir();
         if (Files.isDirectory(Util.fileToPath(oldBuildDir)) && !Files.isDirectory(Util.fileToPath(newBuildDir))) {
-            Files.createDirectories(Util.fileToPath(newBuildDir.getParentFile()));
+            Util.createDirectories(Util.fileToPath(newBuildDir.getParentFile()));
             Files.move(Util.fileToPath(oldBuildDir), Util.fileToPath(newBuildDir));
         }
     }

--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -27,6 +27,7 @@ import static java.util.logging.Level.FINEST;
 import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.ASC;
 import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.DESC;
 
+import hudson.Util;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -195,7 +196,7 @@ public final class RunMap<R extends Run<?,R>> extends AbstractLazyLoadRunMap<R> 
             proposeNewNumber(r.getNumber());
         }
         try {
-            Files.createDirectories(rootDir.toPath());
+            Util.createDirectories(rootDir.toPath());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/core/src/main/java/hudson/util/TextFile.java
+++ b/core/src/main/java/hudson/util/TextFile.java
@@ -96,7 +96,7 @@ public class TextFile {
      * Overwrites the file by the given string.
      */
     public void write(String text) throws IOException {
-        Files.createDirectories(Util.fileToPath(file.getParentFile()));
+        Util.createDirectories(Util.fileToPath(file.getParentFile()));
         try (AtomicFileWriter w = new AtomicFileWriter(file)) {
             try {
                 w.write(text);

--- a/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
+++ b/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
@@ -147,7 +147,7 @@ public class FileFingerprintStorage extends FingerprintStorage {
      */
     public static void save(Fingerprint fp, File file) throws IOException {
         if (fp.getPersistedFacets().isEmpty()) {
-            Files.createDirectories(Util.fileToPath(file.getParentFile()));
+            Util.createDirectories(Util.fileToPath(file.getParentFile()));
             // JENKINS-16301: fast path for the common case.
             AtomicFileWriter afw = new AtomicFileWriter(file);
             try (PrintWriter w = new PrintWriter(new BufferedWriter(afw))) {

--- a/core/src/main/java/jenkins/management/AsynchronousAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/management/AsynchronousAdministrativeMonitor.java
@@ -3,6 +3,7 @@ package jenkins.management;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Functions;
+import hudson.Util;
 import hudson.console.AnnotatedLargeText;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.TaskListener;
@@ -13,7 +14,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -60,7 +60,7 @@ public abstract class AsynchronousAdministrativeMonitor extends AdministrativeMo
     protected File getLogFile() {
         File base = getBaseDir();
         try {
-            Files.createDirectories(base.toPath());
+            Util.createDirectories(base.toPath());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/core/src/main/java/jenkins/util/io/FileBoolean.java
+++ b/core/src/main/java/jenkins/util/io/FileBoolean.java
@@ -1,5 +1,6 @@
 package jenkins.util.io;
 
+import hudson.Util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -59,7 +60,7 @@ public class FileBoolean {
 
     public void on() {
         try {
-            Files.createDirectories(file.getParentFile().toPath());
+            Util.createDirectories(file.getParentFile().toPath());
             Files.newOutputStream(file.toPath()).close();
             get();  // update state
         } catch (IOException | InvalidPathException e) {

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -662,7 +662,11 @@ public class UtilTest {
         assertEquals(a.resolve("new4"), Util.createDirectories(b.resolve("new4")).toRealPath());
         assertEquals(a1.resolve("new5"), Util.createDirectories(b.resolve("a1").resolve("new5")).toRealPath());
         assertEquals(a1.resolve("new6"), Util.createDirectories(b.resolve("a2").resolve("new6")).toRealPath());
+    }
 
+    @Test
+    @Issue("JENKINS-67372")
+    public void createDirectoriesInRoot() throws Exception {
         Path newDirInRoot = Paths.get("/new-dir-in-root");
         Path newSymlinkInRoot = Paths.get("/new-symlink-in-root");
         try {

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -631,6 +631,37 @@ public class UtilTest {
     }
 
     @Test
+    @Issue("JENKINS-67372")
+    public void createDirectories() throws Exception {
+        assumeFalse(Functions.isWindows());
+        //  root
+        //      /a
+        //          /a1
+        //          /a2 => symlink to a1
+        //      /b => symlink to a
+        Path root = tmp.getRoot().toPath();
+        Path a = root.resolve("a");
+        Path a1 = a.resolve("a1");
+        Files.createDirectories(a1);
+
+        Path a2 = a.resolve("a2");
+        Util.createSymlink(a2.getParent().toFile(), a1.getFileName().toString(), a2.getFileName().toString(), TaskListener.NULL);
+
+        Path b = root.resolve("b");
+        Util.createSymlink(b.getParent().toFile(), a.getFileName().toString(), b.getFileName().toString(), TaskListener.NULL);
+
+        assertTrue(Files.isSymbolicLink(a2));
+        assertTrue(Files.isSymbolicLink(b));
+
+        assertEquals(a.resolve("new1"), Util.createDirectories(a.resolve("new1")).toRealPath());
+        assertEquals(a1.resolve("new2"), Util.createDirectories(a1.resolve("new2")).toRealPath());
+        assertEquals(a1.resolve("new3"), Util.createDirectories(a2.resolve("new3")).toRealPath());
+        assertEquals(a.resolve("new4"), Util.createDirectories(b.resolve("new4")).toRealPath());
+        assertEquals(a1.resolve("new5"), Util.createDirectories(b.resolve("a1").resolve("new5")).toRealPath());
+        assertEquals(a1.resolve("new6"), Util.createDirectories(b.resolve("a2").resolve("new6")).toRealPath());
+    }
+
+    @Test
     public void ifOverriddenSuccess() {
         assertTrue(Util.ifOverridden(() -> true, BaseClass.class, DerivedClassSuccess.class, "method"));
     }

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNoException;
 import static org.junit.Assume.assumeTrue;
 
 import hudson.model.TaskListener;
@@ -43,8 +44,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -659,6 +662,17 @@ public class UtilTest {
         assertEquals(a.resolve("new4"), Util.createDirectories(b.resolve("new4")).toRealPath());
         assertEquals(a1.resolve("new5"), Util.createDirectories(b.resolve("a1").resolve("new5")).toRealPath());
         assertEquals(a1.resolve("new6"), Util.createDirectories(b.resolve("a2").resolve("new6")).toRealPath());
+
+        Path newDirInRoot = Paths.get("/new-dir-in-root");
+        Path newSymlinkInRoot = Paths.get("/new-symlink-in-root");
+        try {
+            assertEquals(newDirInRoot.resolve("new1"), Util.createDirectories(newDirInRoot.resolve("new1")).toRealPath());
+            Util.createSymlink(newSymlinkInRoot.getParent().toFile(), newDirInRoot.getFileName().toString(), newSymlinkInRoot.getFileName().toString(), TaskListener.NULL);
+            assertEquals(newDirInRoot.resolve("new2"), Util.createDirectories(newSymlinkInRoot.resolve("new2")).toRealPath());
+        } catch (AccessDeniedException e) {
+            // Not running as root
+            assumeNoException(e);
+        }
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-67372](https://issues.jenkins.io/browse/JENKINS-67372). Fixes a regression introduced in #6025 when the Jenkins home directory is a symbolic link.

### Proposed changelog entries

- Restore support for symbolic links in the Jenkins home directory (regression in 2.325).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
