### PR TITLE
Clarify that FilePath telemetry collects component versions now

### DIFF
--- a/core/src/main/resources/jenkins/telemetry/impl/SlaveToMasterFileCallableUsage/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/SlaveToMasterFileCallableUsage/description.jelly
@@ -8,6 +8,10 @@
     Jenkins developers are considering disabling this kind of usage entirely.
     Since it is difficult to determine via static analysis or even manual code inspection which plugins are using this system,
     we are collecting information on how widely it is used.
-    The data includes names of Java classes mainly in Jenkins core and plugins as well as method names and line numbers.
-    It does not include the names of files being accessed or anything else not determined by versions of software components in use.
+    The data includes:
+    <ul>
+      <li>Java stack traces (names of Java classes mainly in Jenkins core and plugins as well as method names and line numbers) of file accesses on the controller from agents</li>
+      <li>Version numbers of Jenkins core and all installed plugins</li>
+    </ul>
+    We do <em>not</em> collect the names of files being accessed or anything else not determined by versions of software components in use.
 </j:jelly>


### PR DESCRIPTION
Note #6031 in the user documentation for this telemetry collection.

> <img width="1803" alt="Screenshot 2021-12-16 at 10 30 21" src="https://user-images.githubusercontent.com/1831569/146345723-5f74c7e1-4c54-4e40-9172-61d00b1279e1.png">


I don't think this is a big deal because general telemetry collects versions already, but let's still be clear about this.

### Proposed changelog entries

(too minor I think?)

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
