### PR TITLE
WIP: Fix up breadcrumbs of "Manage Jenkins" items

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -36,7 +36,8 @@ THE SOFTWARE.
       If true, will hide all rows by default, and only the filter field will show them.
     </st:attribute>
   </st:documentation>
-  <l:layout title="${%Update Center} - ${%Plugin Manager}" permission="${app.SYSTEM_READ}">
+  <l:layout title="${%Update Center} - ${%Plugin Manager}" permission="${app.SYSTEM_READ}" type="one-column">
+    <l:breadcrumb href="${rootURL}/manage" title="${%Manage Jenkins}" position="parent" />
     <l:app-bar title="${%Plugin Manager}">
       <div class="jenkins-search">
         <input

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="${%Log}">
+  <l:breadcrumb title="${%Manage Jenkins}" href="${rootURL}/manage" position="parent"/>
   <st:include page="sidepanel.jelly" />
   <l:main-panel xmlns:local="local">
     <div class="jenkins-app-bar">

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
@@ -30,8 +30,6 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
-      <l:task href="${rootURL}/manage" icon="icon-gear icon-md" title="${%Manage Jenkins}"/>
       <l:task href="." icon="icon-clipboard icon-md" title="${%Log Recorders}">
         <l:isAdmin>
           <l:task href="new" icon="icon-new-package icon-md" title="${%New Log Recorder}"/>

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -29,6 +29,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
 <l:layout title="${%Nodes}">
   <st:include page="sidepanel.jelly" />
+  <l:hasAdministerOrManage>
+    <l:breadcrumb title="${%Manage Jenkins}" href="${rootURL}/manage" position="parent"/>
+  </l:hasAdministerOrManage>
   <l:main-panel>
     <j:set var="monitors" value="${it._monitors}"/>
     <j:set var="tableWidth" value="${3}"/>

--- a/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
@@ -31,8 +31,6 @@ THE SOFTWARE.
   <l:side-panel>
     <j:getStatic var="createPermission" className="hudson.model.Computer" field="CREATE"/>
     <l:tasks>
-      <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
-      <l:task href="${rootURL}/manage" icon="icon-gear icon-md" permissions="${app.MANAGE_AND_SYSTEM_READ}" title="${%Manage Jenkins}"/>
       <l:task href="new" icon="icon-new-computer icon-md" permission="${createPermission}" title="${%New Node}"/>
       <l:task href="${rootURL}/configureClouds" icon="icon-health-40to59 icon-md" permission="${app.SYSTEM_READ}"
               title="${app.hasPermission(app.ADMINISTER) ? '%Configure Clouds' : '%View Clouds'}"/>

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -11,7 +11,8 @@ def f=namespace(lib.FormTagLib)
 def l=namespace(lib.LayoutTagLib)
 def st=namespace("jelly:stapler")
 
-l.layout(permission:app.SYSTEM_READ, title:my.displayName, cssclass:request.getParameter('decorate')) {
+l.layout(permission:app.SYSTEM_READ, title:my.displayName, cssclass:request.getParameter('decorate'), type: 'one-column') {
+    l.breadcrumb(title: _('Manage Jenkins'), href: rootURL + '/manage', position: 'parent')
     l.main_panel {
         h1 {
             l.icon(class: 'icon-secure icon-xlg')

--- a/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configure.jelly
@@ -29,7 +29,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout permissions="${app.MANAGE_AND_SYSTEM_READ}" title="${%Configure System}">
   <st:include page="sidepanel.jelly" />
-  <f:breadcrumb-config-outline />
+  <l:breadcrumb title="${%Manage Jenkins}" href="${rootURL}/manage" position="parent"/>
+  <f:breadcrumb-config-outline title="${%Configure System}" />
   <l:main-panel>
     <div class="behavior-loading"><l:spinner text="${%LOADING}"/></div>
     <f:form method="post" name="config" action="configSubmit">

--- a/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/manage.jelly
@@ -27,14 +27,12 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout title="${%Manage Jenkins}" permissions="${app.MANAGE_AND_SYSTEM_READ}">
+  <l:layout title="${%Manage Jenkins}" permissions="${app.MANAGE_AND_SYSTEM_READ}" type="one-column">
     <l:header>
        <link rel="stylesheet" href="${resURL}/css/font-awesome/css/font-awesome.min.css" />
     </l:header>
 
-    <j:if test="${taskTags==null}">
-      <st:include page="sidepanel.jelly" />
-    </j:if>
+    <l:breadcrumb title="${%Manage Jenkins}" href="${rootURL}/manage" />
 
     <l:main-panel>
       <div class="jenkins-app-bar">

--- a/core/src/main/resources/jenkins/model/Jenkins/systemInfo.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/systemInfo.jelly
@@ -27,8 +27,9 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout permissions="${app.MANAGE_AND_SYSTEM_READ}" title="${%System Information}">
-    <st:include page="sidepanel.jelly" />
+  <l:layout permissions="${app.MANAGE_AND_SYSTEM_READ}" title="${%System Information}" type="one-column">
+    <l:breadcrumb title="${%Manage Jenkins}" href="${rootURL}/manage"/>
+    <l:breadcrumb title="${%System Information}"/>
     <l:main-panel>
       <l:hasPermission permission="${app.SYSTEM_READ}">
         <div class="jenkins-app-bar">

--- a/core/src/main/resources/jenkins/tools/GlobalToolConfiguration/index.groovy
+++ b/core/src/main/resources/jenkins/tools/GlobalToolConfiguration/index.groovy
@@ -7,13 +7,9 @@ def f=namespace(lib.FormTagLib)
 def l=namespace(lib.LayoutTagLib)
 def st=namespace("jelly:stapler")
 
-l.layout(permission:app.SYSTEM_READ, title:my.displayName) {
-    l.side_panel {
-        l.tasks {
-            l.task(icon:"icon-up icon-md", href:rootURL+'/', title:_("Back to Dashboard"))
-            l.task(icon:"icon-gear icon-md", href:"${rootURL}/manage", title:_("Manage Jenkins"))
-        }
-    }
+l.layout(permission:app.SYSTEM_READ, title:my.displayName, type:'one-column') {
+
+    l.breadcrumb(title: _("Manage Jenkins"), href: rootURL + "/manage", position: 'parent')
     set("readOnlyMode", !app.hasPermission(app.ADMINISTER))
     l.main_panel {
         h1 {

--- a/core/src/main/resources/lib/form/breadcrumb-config-outline.jelly
+++ b/core/src/main/resources/lib/form/breadcrumb-config-outline.jelly
@@ -26,8 +26,11 @@ THE SOFTWARE.
   <st:documentation>
     Adds one more in-page breadcrumb that jumps to sections in the page.
     Put this tag right before &lt;l:main-panel>
+    <st:attribute name="title">
+      Optional title for this breadcrumb
+    </st:attribute>
   </st:documentation>
 
   <st:adjunct includes="lib.form.breadcrumb-config-outline.init"/>
-  <l:breadcrumb title="${%configuration}" id="inpage-nav" />
+  <l:breadcrumb-with-menu title="${attrs.title?:'%configuration'}" id="inpage-nav" />
 </j:jelly>

--- a/core/src/main/resources/lib/layout/breadcrumb-with-menu.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb-with-menu.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
   <st:documentation>
-    Used inside &lt;l:layout> to render additional breadcrumb items.
+    Used inside &lt;l:layout> to render additional breadcrumb items that should have model link dropdowns.
 
     <st:attribute name="href">
       URL that the breadcrumb item links to. Can be omitted.
@@ -50,13 +50,10 @@ THE SOFTWARE.
     </j:otherwise>
   </j:choose>
   <j:if test="${mode=='breadcrumbs' and breadcrumbMode==position}">
-    <li id="${attrs.id}" class="item">
-      <a href="${attrs.href}">
+    <li id="${attrs.id}" class="${attrs.position} item">
+      <a href="${attrs.href}" class="model-link inside">
         ${attrs.title}
       </a>
     </li>
-    <j:if test="${breadcrumbMode=='parent'}">
-      <li class="separator"></li>
-    </j:if>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/breadcrumbBar.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumbBar.jelly
@@ -43,6 +43,12 @@ THE SOFTWARE.
             <ul id="breadcrumbs">
               <j:forEach var="anc" items="${request.ancestors}">
                 <j:if test="${h.isModel(anc.object) and anc.prev.url!=anc.url}">
+                  <j:if test="${it == anc.object and it != app}">
+                    <!-- render additional breadcrumb items with 'parent' position -->
+                    <j:set var="breadcrumbMode" value="parent"/>
+                    <d:invokeBody />
+                  </j:if>
+
                   <li class="item">
                     <a href="${anc.url}/" class="${h.isModelWithContextMenu(anc.object)?'model-link':null} inside">
                       <!-- Workaround to set desired name to first breadcrumb (instead of Jenkins) -->
@@ -71,6 +77,12 @@ THE SOFTWARE.
               </j:forEach>
 
               <!-- render additional breadcrumb items -->
+              <j:if test="${it == anc.object and it == app}">
+                <!-- render additional breadcrumb items with 'parent' position after root link and before current non-model breadcrumb -->
+                <j:set var="breadcrumbMode" value="parent"/>
+                <d:invokeBody />
+              </j:if>
+              <j:set var="breadcrumbMode" value="child"/>
               <d:invokeBody />
             </ul>
 


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/6055#issuecomment-996199170 reminded me that I wanted to clean up the breadcrumbs and sidepanels of items in "Manage Jenkins" for a long time (thanks @timja!).

This is early WIP demonstrating this probably can be done, if a bit hacky.

Previously, nothing below "Manage Jenkins" actually had a breadcrumb for it, because `/manage` isn't a ModelObject and the pages below it aren't its children. Instead, sidepanels typically, but not always, had "Back to Dashboard" (long before we called the breadcrumb for the top page that) and "Manage Jenkins" links at the top. Whether a page had a breadcrumb for itself at the end depended on whether it was implemented as a view for `Jenkins` (or an ancestor of that type), and whether it had a `breadcrumb-config-outline` (`Jenkins/configure.jelly` only), or whether it was its own `ModelObject`, e.g. `RootAction`.

The desired end state (and developer guideline) is as follows:

* Every page reachable from "Manage Jenkins" has a "Manage Jenkins" breadcrumb after "Dashboard".
* An exception to the previous item is any page that is accessible to users without permission to access "Manage Jenkins" (e.g. CLI, Nodes); in that case, the "Manage Jenkins" breadcrumb exists if and only if the user had the permission for it, basically mirroring today's https://github.com/jenkinsci/jenkins/blob/b0c61ecac17177d136e0685ae23653f8734714c0/core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly#L35 today.
* Every page reachable from "Manage Jenkins" has a "self" breadcrumb. Whether that is realistically doable manually, or whether I just rewrite a bunch of stuff to `RootAction` is TBD. (Right now it looks weird when it's a simple view with parent and self breadcrumbs, still need to insert a divider)
* Sidepanels do not include "Back to Dashboard" and "Manage Jenkins" links anymore.
* For any pages that would have empty sidepanels, their layout type is changed to one-column.

The current implementation is less than half-assed, but running it should give an idea where it's going for some of the Manage Jenkins entries.

@janfaracik PTAL in case I would disrupt your work/vision beyond the obvious conflict with #6055 (I still like your "sidepanel" there FWIW)
@timja because it's your fault 😄 

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
