### PR TITLE
More miscellaneous test cleanup

### DIFF
--- a/test/src/test/java/hudson/cli/ConsoleCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConsoleCommandTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.fail;
 
 import hudson.Functions;
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Result;
@@ -84,7 +85,7 @@ public class ConsoleCommandTest {
         } else {
             project.getBuildersList().add(new Shell("echo 1"));
         }
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
         
         final CLICommandInvoker.Result result = command	
                 .authorizedTo(Jenkins.READ, Item.READ)	
@@ -163,7 +164,7 @@ public class ConsoleCommandTest {
         } else {
             project.getBuildersList().add(new Shell("echo 1"));
         }
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
@@ -181,9 +182,9 @@ public class ConsoleCommandTest {
         } else {
             project.getBuildersList().add(new Shell("echo ${BUILD_NUMBER}"));
         }
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 3"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project));
+        j.assertLogContains("echo 3", j.buildAndAssertSuccess(project));
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)
@@ -249,9 +250,9 @@ public class ConsoleCommandTest {
         } else {
             project.getBuildersList().add(new Shell("echo 1\necho 2\necho 3\necho 4\necho 5"));
         }
-        j.buildAndAssertSuccess(project);
-        assertThat(project.getBuildByNumber(1).getLog(), containsString("echo 1"));
-        assertThat(project.getBuildByNumber(1).getLog(), containsString("echo 5"));
+        FreeStyleBuild build = j.buildAndAssertSuccess(project);
+        j.assertLogContains("echo 1", build);
+        j.assertLogContains("echo 5", build);
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Item.READ, Item.BUILD)

--- a/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadJobCommandTest.java
@@ -61,7 +61,7 @@ public class ReloadJobCommandTest {
 
         FreeStyleProject project = j.createFreeStyleProject("aProject");
         project.getBuildersList().add(createScriptBuilder("echo 1"));
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
 
         changeProjectOnTheDisc(project, "echo 1", "echo 2");
 
@@ -73,14 +73,14 @@ public class ReloadJobCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: user is missing the Job/Configure permission"));
 
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
     }
 
     @Test public void reloadJobShouldFailWithoutJobReadPermission() throws Exception {
 
         FreeStyleProject project = j.createFreeStyleProject("aProject");
         project.getBuildersList().add(createScriptBuilder("echo 1"));
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
 
         changeProjectOnTheDisc(project, "echo 1", "echo 2");
 
@@ -92,7 +92,7 @@ public class ReloadJobCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such item ‘aProject’ exists."));
 
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
     }
 
     @Test public void reloadJobShouldSucceed() throws Exception {
@@ -100,7 +100,7 @@ public class ReloadJobCommandTest {
         FreeStyleProject project = j.createFreeStyleProject("aProject");
         project.getBuildersList().add(createScriptBuilder("echo 1"));
 
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
 
         changeProjectOnTheDisc(project, "echo 1", "echo 2");
 
@@ -110,7 +110,7 @@ public class ReloadJobCommandTest {
 
         assertThat(result, succeededSilently());
 
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project));
     }
 
     @Test public void reloadJobShouldFailIfJobDoesNotExist() {
@@ -143,9 +143,9 @@ public class ReloadJobCommandTest {
         FreeStyleProject project3 = j.createFreeStyleProject("aProject3");
         project3.getBuildersList().add(createScriptBuilder("echo 1"));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
-        assertThat(project3.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project2));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project3));
 
         changeProjectOnTheDisc(project1, "echo 1", "echo 2");
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
@@ -157,9 +157,9 @@ public class ReloadJobCommandTest {
 
         assertThat(result, succeededSilently());
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
-        assertThat(project3.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project2));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project3));
     }
 
     @Test public void reloadJobManyShouldFailIfFirstJobDoesNotExist() throws Exception {
@@ -169,8 +169,8 @@ public class ReloadJobCommandTest {
         FreeStyleProject project2 = j.createFreeStyleProject("aProject2");
         project2.getBuildersList().add(createScriptBuilder("echo 1"));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project2));
 
         changeProjectOnTheDisc(project1, "echo 1", "echo 2");
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
@@ -184,8 +184,8 @@ public class ReloadJobCommandTest {
         assertThat(result.stderr(), containsString("never_created: No such item ‘never_created’ exists."));
         assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project2));
     }
 
     @Test public void reloadJobManyShouldFailIfMiddleJobDoesNotExist() throws Exception {
@@ -195,8 +195,8 @@ public class ReloadJobCommandTest {
         FreeStyleProject project2 = j.createFreeStyleProject("aProject2");
         project2.getBuildersList().add(createScriptBuilder("echo 1"));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project2));
 
         changeProjectOnTheDisc(project1, "echo 1", "echo 2");
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
@@ -210,8 +210,8 @@ public class ReloadJobCommandTest {
         assertThat(result.stderr(), containsString("never_created: No such item ‘never_created’ exists."));
         assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project2));
     }
 
     @Test public void reloadJobManyShouldFailIfLastJobDoesNotExist() throws Exception {
@@ -221,8 +221,8 @@ public class ReloadJobCommandTest {
         FreeStyleProject project2 = j.createFreeStyleProject("aProject2");
         project2.getBuildersList().add(createScriptBuilder("echo 1"));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project2));
 
         changeProjectOnTheDisc(project1, "echo 1", "echo 2");
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
@@ -236,8 +236,8 @@ public class ReloadJobCommandTest {
         assertThat(result.stderr(), containsString("never_created: No such item ‘never_created’ exists."));
         assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project2));
     }
 
     @Test public void reloadJobManyShouldFailIfMoreJobsDoNotExist() throws Exception {
@@ -247,8 +247,8 @@ public class ReloadJobCommandTest {
         FreeStyleProject project2 = j.createFreeStyleProject("aProject2");
         project2.getBuildersList().add(createScriptBuilder("echo 1"));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project2));
 
         changeProjectOnTheDisc(project1, "echo 1", "echo 2");
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
@@ -263,8 +263,8 @@ public class ReloadJobCommandTest {
         assertThat(result.stderr(), containsString("never_created2: No such item ‘never_created2’ exists."));
         assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project2));
     }
 
     @Test public void reloadJobManyShouldSucceedEvenAJobIsSpecifiedTwice() throws Exception {
@@ -273,8 +273,8 @@ public class ReloadJobCommandTest {
         FreeStyleProject project2 = j.createFreeStyleProject("aProject2");
         project2.getBuildersList().add(createScriptBuilder("echo 1"));
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project2));
 
         changeProjectOnTheDisc(project1, "echo 1", "echo 2");
         changeProjectOnTheDisc(project2, "echo 1", "echo 2");
@@ -285,8 +285,8 @@ public class ReloadJobCommandTest {
 
         assertThat(result, succeededSilently());
 
-        assertThat(project1.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
-        assertThat(project2.scheduleBuild2(0).get().getLog(), containsString("echo 2"));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project1));
+        j.assertLogContains("echo 2", j.buildAndAssertSuccess(project2));
     }
 
     /**

--- a/test/src/test/java/hudson/cli/SetBuildDescriptionCommandTest.java
+++ b/test/src/test/java/hudson/cli/SetBuildDescriptionCommandTest.java
@@ -61,7 +61,7 @@ public class SetBuildDescriptionCommandTest {
     @Test public void setBuildDescriptionShouldFailWithoutJobReadPermission() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject("aProject");
         project.getBuildersList().add(createScriptBuilder("echo 1"));
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ)
@@ -74,7 +74,7 @@ public class SetBuildDescriptionCommandTest {
     @Test public void setBuildDescriptionShouldFailWithoutRunUpdatePermission1() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject("aProject");
         project.getBuildersList().add(createScriptBuilder("echo 1"));
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Item.READ, Jenkins.READ)
@@ -88,7 +88,7 @@ public class SetBuildDescriptionCommandTest {
         FreeStyleProject project = j.createFreeStyleProject("aProject");
         project.getBuildersList().add(createScriptBuilder("echo 1"));
         FreeStyleBuild build = j.buildAndAssertSuccess(project);
-        assertThat(build.getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", build);
         assertThat(build.getDescription(), equalTo(null));
 
         CLICommandInvoker.Result result = command
@@ -133,7 +133,7 @@ public class SetBuildDescriptionCommandTest {
     @Test public void setBuildDescriptionShouldFailIfBuildDoesNotExist() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject("aProject");
         project.getBuildersList().add(createScriptBuilder("echo 1"));
-        assertThat(project.scheduleBuild2(0).get().getLog(), containsString("echo 1"));
+        j.assertLogContains("echo 1", j.buildAndAssertSuccess(project));
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Item.READ, Jenkins.READ)

--- a/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
@@ -113,7 +113,7 @@ public class RunParameterDefinitionTest {
                                                                              null));
         paramProject.addProperty(pdp);
 
-        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        FreeStyleBuild build = j.buildAndAssertSuccess(paramProject);
         assertEquals(Integer.toString(project.getLastBuild().getNumber()),
                      build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
     }
@@ -145,7 +145,7 @@ public class RunParameterDefinitionTest {
                                                                              RunParameterFilter.ALL));
         paramProject.addProperty(pdp);
 
-        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        FreeStyleBuild build = j.buildAndAssertSuccess(paramProject);
         assertEquals(Integer.toString(project.getLastBuild().getNumber()),
                      build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
     }
@@ -176,7 +176,7 @@ public class RunParameterDefinitionTest {
                                                                              RunParameterFilter.COMPLETED));
         paramProject.addProperty(pdp);
 
-        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        FreeStyleBuild build = j.buildAndAssertSuccess(paramProject);
         assertEquals(Integer.toString(abortedBuild.getNumber()),
                      build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
     }
@@ -207,7 +207,7 @@ public class RunParameterDefinitionTest {
                                                                              RunParameterFilter.SUCCESSFUL));
         paramProject.addProperty(pdp);
 
-        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        FreeStyleBuild build = j.buildAndAssertSuccess(paramProject);
         assertEquals(Integer.toString(unstableBuild.getNumber()),
                      build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
     }
@@ -239,7 +239,7 @@ public class RunParameterDefinitionTest {
                                                                              RunParameterFilter.STABLE));
         paramProject.addProperty(pdp);
 
-        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        FreeStyleBuild build = j.buildAndAssertSuccess(paramProject);
         assertEquals(Integer.toString(successfulBuild.getNumber()),
                      build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
     }
@@ -259,7 +259,7 @@ public class RunParameterDefinitionTest {
                                                                              RunParameterFilter.ALL));
         paramProject.addProperty(pdp);
 
-        FreeStyleBuild build = paramProject.scheduleBuild2(0).get();
+        FreeStyleBuild build = j.buildAndAssertSuccess(paramProject);
         assertEquals(Integer.toString(project.getLastBuild().getNumber()),
                      build.getEnvironment(new LogTaskListener(LOGGER, Level.INFO)).get("RUN_NUMBER"));
 

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -24,7 +24,6 @@
 
 package hudson.tasks;
 
-import static hudson.tasks.LogRotatorTest.build;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
@@ -83,7 +82,7 @@ public class ArtifactArchiverTest {
             final FreeStyleProject project = j.createFreeStyleProject();
             project.getBuildersList().add(new CreateArtifact());
             project.getPublishersList().add(new ArtifactArchiver("f"));
-            assertEquals(Result.SUCCESS, build(project));
+            j.buildAndAssertSuccess(project);
             assertTrue(project.getBuildByNumber(1).getHasArtifacts());
         } finally {
             StandardArtifactManager.TAR_COMPRESSION = prevCompression;
@@ -107,7 +106,7 @@ public class ArtifactArchiverTest {
                 return true;
             }
         }));
-        assertEquals(Result.SUCCESS, build(project)); // #1
+        j.buildAndAssertSuccess(project); // #1
         File artifacts = project.getBuildByNumber(1).getArtifactsDir();
         File[] kids = artifacts.listFiles();
         assertEquals(1, kids.length);
@@ -128,7 +127,7 @@ public class ArtifactArchiverTest {
         assertFalse(aa.getAllowEmptyArchive());
         aa.setAllowEmptyArchive(true);
         project.getPublishersList().replaceBy(Collections.singleton(aa));
-        assertEquals("(no artifacts)", Result.SUCCESS, build(project));
+        j.buildAndAssertSuccess(project);
         assertFalse(project.getBuildByNumber(1).getHasArtifacts());
     }
 
@@ -264,10 +263,10 @@ public class ArtifactArchiverTest {
         ArtifactArchiver aa = new ArtifactArchiver("f");
         project.getPublishersList().replaceBy(Collections.singleton(aa));
         project.getBuildersList().replaceBy(Collections.singleton(new CreateArtifactAndFail()));
-        assertEquals(Result.FAILURE, build(project));
+        j.buildAndAssertStatus(Result.FAILURE, project);
         assertTrue(project.getBuildByNumber(1).getHasArtifacts());
         aa.setOnlyIfSuccessful(true);
-        assertEquals(Result.FAILURE, build(project));
+        j.buildAndAssertStatus(Result.FAILURE, project);
         assertTrue(project.getBuildByNumber(1).getHasArtifacts());
         assertFalse(project.getBuildByNumber(2).getHasArtifacts());
     }
@@ -315,7 +314,7 @@ public class ArtifactArchiverTest {
         project.getPublishersList().replaceBy(Collections.singleton(artifactArchiver));
         project.getBuildersList().replaceBy(Collections.singleton(new CreateDefaultExcludesArtifact()));
 
-        assertEquals(Result.SUCCESS, build(project)); // #1
+        j.buildAndAssertSuccess(project); // #1
         VirtualFile artifacts = project.getBuildByNumber(1).getArtifactManager().root();
         assertFalse(artifacts.child(".svn").child("file").exists());
         assertFalse(artifacts.child("dir").child(".svn").child("file").exists());
@@ -332,7 +331,7 @@ public class ArtifactArchiverTest {
         project.getPublishersList().replaceBy(Collections.singleton(artifactArchiver));
         project.getBuildersList().replaceBy(Collections.singleton(new CreateDefaultExcludesArtifact()));
 
-        assertEquals(Result.SUCCESS, build(project)); // #1
+        j.buildAndAssertSuccess(project); // #1
         VirtualFile artifacts = project.getBuildByNumber(1).getArtifactManager().root();
         assertTrue(artifacts.child(".svn").child("file").exists());
         assertTrue(artifacts.child("dir").child(".svn").child("file").exists());

--- a/test/src/test/java/hudson/tasks/LogRotatorTest.java
+++ b/test/src/test/java/hudson/tasks/LogRotatorTest.java
@@ -67,13 +67,13 @@ public class LogRotatorTest {
     public void successVsFailure() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setLogRotator(new LogRotator(-1, 2, -1, -1));
-        assertEquals(Result.SUCCESS, build(project)); // #1
+        j.buildAndAssertSuccess(project); // #1
         project.getBuildersList().replaceBy(Collections.singleton(new FailureBuilder()));
-        assertEquals(Result.FAILURE, build(project)); // #2
-        assertEquals(Result.FAILURE, build(project)); // #3
+        j.buildAndAssertStatus(Result.FAILURE, project); // #2
+        j.buildAndAssertStatus(Result.FAILURE, project); // #3
         assertEquals(1, numberOf(project.getLastSuccessfulBuild()));
         project.getBuildersList().replaceBy(Collections.emptySet());
-        assertEquals(Result.SUCCESS, build(project)); // #4
+        j.buildAndAssertSuccess(project); // #4
         assertEquals(4, numberOf(project.getLastSuccessfulBuild()));
         assertNull(project.getBuildByNumber(1));
         assertNull(project.getBuildByNumber(2));
@@ -85,13 +85,13 @@ public class LogRotatorTest {
     public void stableVsUnstable() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setLogRotator(new LogRotator(-1, 2, -1, -1));
-        assertEquals(Result.SUCCESS, build(project)); // #1
+        j.buildAndAssertSuccess(project); // #1
         project.getPublishersList().replaceBy(Collections.singleton(new TestsFail()));
-        assertEquals(Result.UNSTABLE, build(project)); // #2
-        assertEquals(Result.UNSTABLE, build(project)); // #3
+        j.buildAndAssertStatus(Result.UNSTABLE, project); // #2
+        j.buildAndAssertStatus(Result.UNSTABLE, project); // #3
         assertEquals(1, numberOf(project.getLastStableBuild()));
         project.getPublishersList().replaceBy(Collections.emptySet());
-        assertEquals(Result.SUCCESS, build(project)); // #4
+        j.buildAndAssertSuccess(project); // #4
         assertNull(project.getBuildByNumber(1));
         assertNull(project.getBuildByNumber(2));
     }
@@ -102,32 +102,32 @@ public class LogRotatorTest {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setLogRotator(new LogRotator(-1, 6, -1, 2));
         project.getPublishersList().replaceBy(Collections.singleton(new ArtifactArchiver("f", "", true, false)));
-        assertEquals("(no artifacts)", Result.FAILURE, build(project)); // #1
+        j.buildAndAssertStatus(Result.FAILURE, project); // #1
         assertFalse(project.getBuildByNumber(1).getHasArtifacts());
         project.getBuildersList().replaceBy(Collections.singleton(new CreateArtifact()));
-        assertEquals(Result.SUCCESS, build(project)); // #2
+        j.buildAndAssertSuccess(project); // #2
         assertTrue(project.getBuildByNumber(2).getHasArtifacts());
         project.getBuildersList().replaceBy(Arrays.asList(new CreateArtifact(), new FailureBuilder()));
-        assertEquals(Result.FAILURE, build(project)); // #3
+        j.buildAndAssertStatus(Result.FAILURE, project); // #3
         assertTrue(project.getBuildByNumber(2).getHasArtifacts());
         assertTrue(project.getBuildByNumber(3).getHasArtifacts());
-        assertEquals(Result.FAILURE, build(project)); // #4
+        j.buildAndAssertStatus(Result.FAILURE, project); // #4
         assertTrue(project.getBuildByNumber(2).getHasArtifacts());
         assertTrue(project.getBuildByNumber(3).getHasArtifacts());
         assertTrue(project.getBuildByNumber(4).getHasArtifacts());
-        assertEquals(Result.FAILURE, build(project)); // #5
+        j.buildAndAssertStatus(Result.FAILURE, project); // #5
         assertTrue(project.getBuildByNumber(2).getHasArtifacts());
         assertFalse("no better than #4", project.getBuildByNumber(3).getHasArtifacts());
         assertTrue(project.getBuildByNumber(4).getHasArtifacts());
         assertTrue(project.getBuildByNumber(5).getHasArtifacts());
         project.getBuildersList().replaceBy(Collections.singleton(new CreateArtifact()));
-        assertEquals(Result.SUCCESS, build(project)); // #6
+        j.buildAndAssertSuccess(project); // #6
         assertFalse("#2 is still lastSuccessful until #6 is complete", project.getBuildByNumber(2).getHasArtifacts());
         assertFalse(project.getBuildByNumber(3).getHasArtifacts());
         assertFalse(project.getBuildByNumber(4).getHasArtifacts());
         assertTrue(project.getBuildByNumber(5).getHasArtifacts());
         assertTrue(project.getBuildByNumber(6).getHasArtifacts());
-        assertEquals(Result.SUCCESS, build(project)); // #7
+        j.buildAndAssertSuccess(project); // #7
         assertNull(project.getBuildByNumber(1));
         assertNotNull(project.getBuildByNumber(2));
         assertFalse("lastSuccessful was #6 for ArtifactArchiver", project.getBuildByNumber(2).getHasArtifacts());
@@ -136,7 +136,7 @@ public class LogRotatorTest {
         assertFalse(project.getBuildByNumber(5).getHasArtifacts());
         assertTrue(project.getBuildByNumber(6).getHasArtifacts());
         assertTrue(project.getBuildByNumber(7).getHasArtifacts());
-        assertEquals(Result.SUCCESS, build(project)); // #8
+        j.buildAndAssertSuccess(project); // #8
         assertNull(project.getBuildByNumber(2));
         assertNotNull(project.getBuildByNumber(3));
         assertFalse(project.getBuildByNumber(3).getHasArtifacts());
@@ -198,10 +198,6 @@ public class LogRotatorTest {
         assertThat("run3 is last stable build", p.getLastStableBuild(), is(run3));
         assertThat("run3 is last successful build", p.getLastSuccessfulBuild(), is(run3));
         assertThat("we have artifacts in run3", run3.getHasArtifacts(), is(true));
-    }
-
-    static Result build(FreeStyleProject project) throws Exception {
-        return project.scheduleBuild2(0).get().getResult();
     }
 
     private static int numberOf(Run<?,?> run) {


### PR DESCRIPTION
Cleans up some tests by asserting that the build status is as we expect and by using more modern Jenkins test harness methods.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
