### PR TITLE
Use `Files.readSymbolicLink` where possible

### DIFF
--- a/core/src/main/java/jenkins/slaves/restarter/UnixSlaveRestarter.java
+++ b/core/src/main/java/jenkins/slaves/restarter/UnixSlaveRestarter.java
@@ -6,14 +6,13 @@ import static hudson.util.jna.GNUCLibrary.F_SETFD;
 import static hudson.util.jna.GNUCLibrary.LIBC;
 import static java.util.logging.Level.FINE;
 
-import com.sun.jna.Memory;
 import com.sun.jna.Native;
-import com.sun.jna.NativeLong;
 import com.sun.jna.StringArray;
 import hudson.Extension;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.util.List;
 import java.util.logging.Logger;
 import jenkins.util.JavaVMArguments;
@@ -73,11 +72,8 @@ public class UnixSlaveRestarter extends SlaveRestarter {
         File exe = new File(name);
         if (exe.exists()) {
             try {
-                String path = resolveSymlink(exe);
-                if (path != null) {
-                    return path;
-                }
-            } catch (IOException e) {
+                return Files.readSymbolicLink(exe.toPath()).toString();
+            } catch (IOException | InvalidPathException | UnsupportedOperationException e) {
                 LOGGER.log(FINE, "Failed to resolve symlink " + exe, e);
             }
             return name;
@@ -85,33 +81,6 @@ public class UnixSlaveRestarter extends SlaveRestarter {
 
         // cross-platform fallback
         return System.getProperty("java.home") + "/bin/java";
-    }
-
-    private static String resolveSymlink(File link) throws IOException {
-        String filename = link.getAbsolutePath();
-
-        for (int sz = 512; sz < 65536; sz *= 2) {
-            Memory m = new Memory(sz);
-            int r = LIBC.readlink(filename, m, new NativeLong(sz));
-            if (r < 0) {
-                int err = Native.getLastError();
-                if (err == 22 /*EINVAL --- but is this really portable?*/) {
-                    return null; // this means it's not a symlink
-                }
-                throw new IOException(
-                        "Failed to readlink " + link + " error=" + err + " " + LIBC.strerror(err));
-            }
-
-            if (r == sz) {
-                continue; // buffer too small
-            }
-
-            byte[] buf = new byte[r];
-            m.read(0, buf, 0, r);
-            return new String(buf, StandardCharsets.UTF_8);
-        }
-
-        throw new IOException("Failed to readlink " + link);
     }
 
     private static final Logger LOGGER = Logger.getLogger(UnixSlaveRestarter.class.getName());


### PR DESCRIPTION
Replaces some messy platform-specific logic with a call to Java's NIO.2 framework. Tested by connecting an inbount agent and getting the following stack trace in the debugger:

```
getCurrentExecutable:75, UnixSlaveRestarter (jenkins.slaves.restarter)
canWork:40, UnixSlaveRestarter (jenkins.slaves.restarter)
lambda$call$0:83, JnlpSlaveRestarterInstaller$FindEffectiveRestarters (jenkins.slaves.restarter)
test:-1, 1607972484 (jenkins.slaves.restarter.JnlpSlaveRestarterInstaller$FindEffectiveRestarters$$Lambda$109)
removeIf:1702, ArrayList (java.util)
removeIf:1690, ArrayList (java.util)
call:83, JnlpSlaveRestarterInstaller$FindEffectiveRestarters (jenkins.slaves.restarter)
call:66, JnlpSlaveRestarterInstaller$FindEffectiveRestarters (jenkins.slaves.restarter)
perform:211, UserRequest (hudson.remoting)
perform:54, UserRequest (hudson.remoting)
run:376, Request$2 (hudson.remoting)
lambda$wrap$0:78, InterceptingExecutorService (hudson.remoting)
call:-1, 1249884192 (hudson.remoting.InterceptingExecutorService$$Lambda$96)
run:264, FutureTask (java.util.concurrent)
runWorker:1128, ThreadPoolExecutor (java.util.concurrent)
run:628, ThreadPoolExecutor$Worker (java.util.concurrent)
lambda$newThread$0:122, Engine$1 (hudson.remoting)
run:-1, 484278768 (hudson.remoting.Engine$1$$Lambda$50)
run:829, Thread (java.lang)
```

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
