### PR TITLE
[JENKINS-67237] BuildTrigger waits until the dependency graph has been updated

### DIFF
--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -256,16 +256,16 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
     public static boolean execute(AbstractBuild build, BuildListener listener) {
         PrintStream logger = listener.getLogger();
         // Check all downstream Project of the project, not just those defined by BuildTrigger
-        
+
         DependencyGraph graphTemp;
-    	try {
-			graphTemp = Jenkins.get().getFutureDependencyGraph().get();
-		} catch (IllegalStateException | InterruptedException | ExecutionException e) {
-			//Use old version of dependency graph instead
-			graphTemp = Jenkins.get().getDependencyGraph();
-		}
+        try {
+            graphTemp = Jenkins.get().getFutureDependencyGraph().get();
+        } catch (IllegalStateException | InterruptedException | ExecutionException e) {
+            //Use old version of dependency graph instead
+            graphTemp = Jenkins.get().getDependencyGraph();
+        }
         DependencyGraph graph = graphTemp;
-        
+
         List<Dependency> downstreamProjects = new ArrayList<>(
                 graph.getDownstreamDependencies(build.getProject()));
         // Sort topologically

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -58,6 +58,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.DependencyDeclarer;
@@ -255,8 +256,16 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
     public static boolean execute(AbstractBuild build, BuildListener listener) {
         PrintStream logger = listener.getLogger();
         // Check all downstream Project of the project, not just those defined by BuildTrigger
-        // TODO this may not yet be up to date if rebuildDependencyGraphAsync has been used; need a method to wait for the last call made before now to finish
-        final DependencyGraph graph = Jenkins.get().getDependencyGraph();
+        
+        DependencyGraph graphTemp;
+    	try {
+			graphTemp = Jenkins.get().getFutureDependencyGraph().get();
+		} catch (IllegalStateException | InterruptedException | ExecutionException e) {
+			//Use old version of dependency graph instead
+			graphTemp = Jenkins.get().getDependencyGraph();
+		}
+        DependencyGraph graph = graphTemp;
+        
         List<Dependency> downstreamProjects = new ArrayList<>(
                 graph.getDownstreamDependencies(build.getProject()));
         // Sort topologically

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3569,6 +3569,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
             final Set<Future<?>> pending = _cleanUpDisconnectComputers(errors);
 
+            _cleanUpCancelDependencyGraphCalculation();
+
             _cleanUpInterruptReloadThread(errors);
 
             _cleanUpShutdownTriggers(errors);
@@ -3916,6 +3918,20 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             LOGGER.log(SEVERE, "Failed to release all loggers", e);
             // save for later
             errors.add(e);
+        }
+    }
+
+    private void _cleanUpCancelDependencyGraphCalculation() {
+        LOGGER.log(Level.FINE, "Canceling internal dependency graph calculation");
+        if (scheduledFutureDependencyGraph != null && !scheduledFutureDependencyGraph.isDone()) {
+            synchronized (dependencyGraphLock) {
+                scheduledFutureDependencyGraph.cancel(true);
+            }
+        }
+        if (calculatingFutureDependencyGraph != null && !calculatingFutureDependencyGraph.isDone()) {
+            synchronized (dependencyGraphLock) {
+                calculatingFutureDependencyGraph.cancel(true);
+            }
         }
     }
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3931,8 +3931,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 calculatingFutureDependencyGraph.cancel(true);
             }
         }
-
-
     }
 
     public Object getDynamic(String token) {
@@ -4951,10 +4949,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     private Future<DependencyGraph> scheduleCalculationOfFutureDependencyGraph(int delay, TimeUnit unit) {
         return Timer.get().schedule(() -> {
-            synchronized (dependencyGraphLock) {
-                //Wait for the currently running calculation to finish
-                calculatingFutureDependencyGraph.get();
+            //Wait for the currently running calculation to finish
+            calculatingFutureDependencyGraph.get();
 
+            synchronized (dependencyGraphLock) {
                 // Scheduled future becomes the currently calculating future
                 calculatingFutureDependencyGraph = scheduledFutureDependencyGraph;
                 scheduledFutureDependencyGraph = null;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4887,27 +4887,27 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return ExtensionList.lookupSingleton(URICheckEncodingMonitor.class).isCheckEnabled();
     }
 
-    
-    public Future<DependencyGraph> getFutureDependencyGraph(){
-        synchronized(dependencyGraphLock) {
+
+    public Future<DependencyGraph> getFutureDependencyGraph() {
+        synchronized (dependencyGraphLock) {
             //Scheduled future will be the most recent one --> Return
             if (scheduledFutureDependencyGraph != null) {
                 return scheduledFutureDependencyGraph;
             }
-            //Calculating future will be the most recent one --> Return 
-            if (calculatingFutureDependencyGraph != null ) {
+            //Calculating future will be the most recent one --> Return
+            if (calculatingFutureDependencyGraph != null) {
                 return calculatingFutureDependencyGraph;
             }
-            //No scheduled or calculating future --> Already completed dependency graph is the most recent one 
+            //No scheduled or calculating future --> Already completed dependency graph is the most recent one
             return CompletableFuture.completedFuture(dependencyGraph);
         }
     }
-    
-    
+
+
     public DependencyGraph createNewDependencyGraph() {
         return new DependencyGraph();
     }
-    
+
     /**
      * Rebuilds the dependency map.
      */
@@ -4929,7 +4929,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 1.522
      */
     public Future<DependencyGraph> rebuildDependencyGraphAsync() {
-        synchronized(dependencyGraphLock) {
+        synchronized (dependencyGraphLock) {
             // Collects calls to this method to avoid unnecessary calculation of the dependency graph
             if (scheduledFutureDependencyGraph != null) {
                 return scheduledFutureDependencyGraph;
@@ -4938,11 +4938,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return scheduledFutureDependencyGraph = scheduleCalculationOfFutureDependencyGraph(500, TimeUnit.MILLISECONDS);
         }
     }
-    
-    
+
+
     private Future<DependencyGraph> scheduleCalculationOfFutureDependencyGraph(int delay, TimeUnit unit) {
         return Timer.get().schedule(() -> {
-            
+
             //Wait for the currently running calculation to finish
             while (calculatingFutureDependencyGraph != null && !calculatingFutureDependencyGraph.isDone()) {
                 Thread.sleep(100);
@@ -4955,7 +4955,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             }
 
             rebuildDependencyGraph();
-            
+
             // Mark that we finished calculating the dependency graph
             synchronized (dependencyGraphLock) {
                 calculatingFutureDependencyGraph = null;
@@ -4963,7 +4963,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             return dependencyGraph;
         }, delay, unit);
     }
-    
+
 
     public DependencyGraph getDependencyGraph() {
         return dependencyGraph;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4905,11 +4905,15 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
     
     
+    public DependencyGraph createNewDependencyGraph() {
+        return new DependencyGraph();
+    }
+    
     /**
      * Rebuilds the dependency map.
      */
     public void rebuildDependencyGraph() {
-        DependencyGraph graph = new DependencyGraph();
+        DependencyGraph graph = createNewDependencyGraph();
         graph.build();
         // volatile acts a as a memory barrier here and therefore guarantees
         // that graph is fully build, before it's visible to other threads
@@ -5699,4 +5703,5 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             this.reason = reason;
         }
     }
+
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4917,15 +4917,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
 
-    public DependencyGraph createNewDependencyGraph() {
-        return new DependencyGraph();
-    }
-
     /**
      * Rebuilds the dependency map.
      */
     public void rebuildDependencyGraph() {
-        DependencyGraph graph = createNewDependencyGraph();
+        DependencyGraph graph = new DependencyGraph();
         graph.build();
         // volatile acts a as a memory barrier here and therefore guarantees
         // that graph is fully build, before it's visible to other threads

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -288,6 +288,8 @@ public class QueueTest {
         assertTrue("Got "+items[0], items[0] instanceof BlockedItem);
 
         q.save();
+        //For testing purposes we join with the dependency graph thread
+        r.jenkins.getFutureDependencyGraph().get();
     }
 
     public static final class FileItemPersistenceTestServlet extends HttpServlet {

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -288,8 +288,6 @@ public class QueueTest {
         assertTrue("Got "+items[0], items[0] instanceof BlockedItem);
 
         q.save();
-        //For testing purposes we join with the dependency graph thread
-        r.jenkins.getFutureDependencyGraph().get();
     }
 
     public static final class FileItemPersistenceTestServlet extends HttpServlet {

--- a/test/src/test/java/jenkins/model/JenkinsFutureDependencyGraphTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsFutureDependencyGraphTest.java
@@ -1,0 +1,146 @@
+package jenkins.model;
+
+import static org.mockito.Mockito.spy;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+import hudson.model.DependencyGraph;
+
+public class JenkinsFutureDependencyGraphTest {
+    
+    @Rule 
+    public JenkinsRule j = new JenkinsRule();
+    
+    
+    @Issue("JENKINS-67237")
+    @Test
+    public void testGetFutureDependencyGraphWithoutASingleRebuildBeforeHand() throws InterruptedException, ExecutionException  {
+        Jenkins jenkins = j.jenkins;
+           
+        DependencyGraph resultingGraph = jenkins.getFutureDependencyGraph().get();
+        assertThat("Completed future dependency graph should be equal to the stored dependency graph, but wasn't.", jenkins.getDependencyGraph(), is(resultingGraph));
+    }
+    
+    
+
+    
+    @Issue("JENKINS-67237")
+    @Test
+    public void testStartRebuildOfDependecyGraphWhileScheduled() throws InterruptedException, ExecutionException  {
+        Jenkins jenkins = j.jenkins;
+        
+        Future<DependencyGraph> firstFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();        
+        Future<DependencyGraph> secondFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
+        
+        assertThat("Two future dependency graphs that were scheduled in short succession should be equal, but weren't", firstFutureDependencyGraph, is(secondFutureDependencyGraph));
+        assertThat("Last scheduled future dependency graph should have been returned, but wasn't.", secondFutureDependencyGraph, is(jenkins.getFutureDependencyGraph()));
+    }
+    
+    @Issue("JENKINS-67237")
+    @Test
+    public void testStartRebuildOfDependencyGraphWhileAlreadyRebuilding() throws InterruptedException, ExecutionException  {
+        ObservableAndControllableDependencyGraph graph = new ObservableAndControllableDependencyGraph();
+        Jenkins jenkins = mockJenkinsWithControllableDependencyGraph(graph);
+        
+        
+        Future<DependencyGraph> firstFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
+        //Wait until rebuild has started
+        while(graph.getNumberOfStartedBuilds() < 1) {
+            Thread.sleep(500);
+        }
+        
+        Future<DependencyGraph> secondFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
+        
+        assertThat("Starting a new rebuild of the dependency graph while already rebuilding should result in two distinct future dependency graphs, but didn't.", firstFutureDependencyGraph, is(not(secondFutureDependencyGraph)));
+               
+        graph.setLetBuildFinish(true);
+        //Wait for both builds to complete
+        firstFutureDependencyGraph.get();
+        secondFutureDependencyGraph.get();
+        
+        assertThat("Two dependency graphs should have been built, but weren't.", graph.getNumberOfFinishedBuilds(),  is(2));
+        
+        
+    }
+    
+    
+    
+    @Issue("JENKINS-67237")
+    @Test
+    public void testStartRebuildOfDependencyGraphWhileAlreadyRebuildingAndAnotherOneScheduled() throws InterruptedException, ExecutionException  {
+        ObservableAndControllableDependencyGraph graph = new ObservableAndControllableDependencyGraph();
+        Jenkins jenkins = mockJenkinsWithControllableDependencyGraph(graph);
+        
+        
+        jenkins.rebuildDependencyGraphAsync();
+        //Wait until rebuild has started
+        while(graph.getNumberOfStartedBuilds() < 1) {
+            Thread.sleep(500);
+        }
+        
+        Future<DependencyGraph> secondFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
+        Future<DependencyGraph> thirdFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
+        
+        assertThat("Two future dependency graphs that were scheduled in short succession should be equal, but weren't", secondFutureDependencyGraph, is(thirdFutureDependencyGraph));
+        assertThat("Last scheduled future dependency graph should have been returned, but wasn't.", jenkins.getFutureDependencyGraph(), is(thirdFutureDependencyGraph));
+        
+        graph.setLetBuildFinish(true);
+        //Wait for builds to complete
+        thirdFutureDependencyGraph.get();
+        
+        assertThat("Two dependency graphs should have been built, but weren't.",graph.getNumberOfFinishedBuilds(), is(2));
+    }
+    
+    
+    
+    
+    private Jenkins mockJenkinsWithControllableDependencyGraph(ObservableAndControllableDependencyGraph observableAndControllableDependencyGraph) {
+        Jenkins mockedJenkins = spy(j.jenkins);
+        Mockito.when(mockedJenkins.createNewDependencyGraph()).thenReturn(observableAndControllableDependencyGraph);
+        return mockedJenkins;
+    }
+
+    /**
+     * The build state of this dependency graph is observable and controllable. 
+     */
+    class ObservableAndControllableDependencyGraph extends DependencyGraph {
+        
+        private volatile boolean letBuildFinish = false;
+        private volatile int numberOfStartedBuilds = 0;
+        private volatile int numberOfFinishedBuilds = 0;
+        
+        @Override
+        public void build() {
+            numberOfStartedBuilds++;
+            while (!letBuildFinish) {
+                //NOOP
+            }
+            numberOfFinishedBuilds++;
+        }
+        
+        
+        
+        public void setLetBuildFinish(boolean v) {
+            letBuildFinish = v;
+        }
+        
+        public int getNumberOfStartedBuilds() {
+            return numberOfStartedBuilds;
+        }
+        
+        public int getNumberOfFinishedBuilds() {
+            return numberOfFinishedBuilds;
+        }
+        
+    }
+}
+

--- a/test/src/test/java/jenkins/model/JenkinsFutureDependencyGraphTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsFutureDependencyGraphTest.java
@@ -26,7 +26,7 @@ public class JenkinsFutureDependencyGraphTest {
         Jenkins jenkins = j.jenkins;
 
         DependencyGraph resultingGraph = jenkins.getFutureDependencyGraph().get();
-        assertThat("Completed future dependency graph should be equal to the stored dependency graph, but wasn't.", jenkins.getDependencyGraph(), is(resultingGraph));
+        assertThat("Completed future dependency graph should be empty, but wasn't.", resultingGraph, is(DependencyGraph.EMPTY));
     }
 
 

--- a/test/src/test/java/jenkins/model/JenkinsFutureDependencyGraphTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsFutureDependencyGraphTest.java
@@ -1,108 +1,107 @@
 package jenkins.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.spy;
 
+import hudson.model.DependencyGraph;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mockito;
-import hudson.model.DependencyGraph;
 
 public class JenkinsFutureDependencyGraphTest {
-    
-    @Rule 
+
+    @Rule
     public JenkinsRule j = new JenkinsRule();
-    
-    
+
+
     @Issue("JENKINS-67237")
     @Test
     public void testGetFutureDependencyGraphWithoutASingleRebuildBeforeHand() throws InterruptedException, ExecutionException  {
         Jenkins jenkins = j.jenkins;
-           
+
         DependencyGraph resultingGraph = jenkins.getFutureDependencyGraph().get();
         assertThat("Completed future dependency graph should be equal to the stored dependency graph, but wasn't.", jenkins.getDependencyGraph(), is(resultingGraph));
     }
-    
-    
 
-    
+
+
+
     @Issue("JENKINS-67237")
     @Test
     public void testStartRebuildOfDependecyGraphWhileScheduled() throws InterruptedException, ExecutionException  {
         Jenkins jenkins = j.jenkins;
-        
-        Future<DependencyGraph> firstFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();        
+
+        Future<DependencyGraph> firstFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
         Future<DependencyGraph> secondFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
-        
+
         assertThat("Two future dependency graphs that were scheduled in short succession should be equal, but weren't", firstFutureDependencyGraph, is(secondFutureDependencyGraph));
         assertThat("Last scheduled future dependency graph should have been returned, but wasn't.", secondFutureDependencyGraph, is(jenkins.getFutureDependencyGraph()));
     }
-    
+
     @Issue("JENKINS-67237")
     @Test
     public void testStartRebuildOfDependencyGraphWhileAlreadyRebuilding() throws InterruptedException, ExecutionException  {
         ObservableAndControllableDependencyGraph graph = new ObservableAndControllableDependencyGraph();
         Jenkins jenkins = mockJenkinsWithControllableDependencyGraph(graph);
-        
-        
+
+
         Future<DependencyGraph> firstFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
         //Wait until rebuild has started
-        while(graph.getNumberOfStartedBuilds() < 1) {
+        while (graph.getNumberOfStartedBuilds() < 1) {
             Thread.sleep(500);
         }
-        
+
         Future<DependencyGraph> secondFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
-        
+
         assertThat("Starting a new rebuild of the dependency graph while already rebuilding should result in two distinct future dependency graphs, but didn't.", firstFutureDependencyGraph, is(not(secondFutureDependencyGraph)));
-               
+
         graph.setLetBuildFinish(true);
         //Wait for both builds to complete
         firstFutureDependencyGraph.get();
         secondFutureDependencyGraph.get();
-        
+
         assertThat("Two dependency graphs should have been built, but weren't.", graph.getNumberOfFinishedBuilds(),  is(2));
-        
-        
+
+
     }
-    
-    
-    
+
+
+
     @Issue("JENKINS-67237")
     @Test
     public void testStartRebuildOfDependencyGraphWhileAlreadyRebuildingAndAnotherOneScheduled() throws InterruptedException, ExecutionException  {
         ObservableAndControllableDependencyGraph graph = new ObservableAndControllableDependencyGraph();
         Jenkins jenkins = mockJenkinsWithControllableDependencyGraph(graph);
-        
-        
+
+
         jenkins.rebuildDependencyGraphAsync();
         //Wait until rebuild has started
-        while(graph.getNumberOfStartedBuilds() < 1) {
+        while (graph.getNumberOfStartedBuilds() < 1) {
             Thread.sleep(500);
         }
-        
+
         Future<DependencyGraph> secondFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
         Future<DependencyGraph> thirdFutureDependencyGraph = jenkins.rebuildDependencyGraphAsync();
-        
+
         assertThat("Two future dependency graphs that were scheduled in short succession should be equal, but weren't", secondFutureDependencyGraph, is(thirdFutureDependencyGraph));
         assertThat("Last scheduled future dependency graph should have been returned, but wasn't.", jenkins.getFutureDependencyGraph(), is(thirdFutureDependencyGraph));
-        
+
         graph.setLetBuildFinish(true);
         //Wait for builds to complete
         thirdFutureDependencyGraph.get();
-        
-        assertThat("Two dependency graphs should have been built, but weren't.",graph.getNumberOfFinishedBuilds(), is(2));
+
+        assertThat("Two dependency graphs should have been built, but weren't.", graph.getNumberOfFinishedBuilds(), is(2));
     }
-    
-    
-    
-    
+
+
+
+
     private Jenkins mockJenkinsWithControllableDependencyGraph(ObservableAndControllableDependencyGraph observableAndControllableDependencyGraph) {
         Jenkins mockedJenkins = spy(j.jenkins);
         Mockito.when(mockedJenkins.createNewDependencyGraph()).thenReturn(observableAndControllableDependencyGraph);
@@ -110,14 +109,14 @@ public class JenkinsFutureDependencyGraphTest {
     }
 
     /**
-     * The build state of this dependency graph is observable and controllable. 
+     * The build state of this dependency graph is observable and controllable.
      */
     class ObservableAndControllableDependencyGraph extends DependencyGraph {
-        
+
         private volatile boolean letBuildFinish = false;
         private volatile int numberOfStartedBuilds = 0;
         private volatile int numberOfFinishedBuilds = 0;
-        
+
         @Override
         public void build() {
             numberOfStartedBuilds++;
@@ -126,21 +125,21 @@ public class JenkinsFutureDependencyGraphTest {
             }
             numberOfFinishedBuilds++;
         }
-        
-        
-        
+
+
+
         public void setLetBuildFinish(boolean v) {
             letBuildFinish = v;
         }
-        
+
         public int getNumberOfStartedBuilds() {
             return numberOfStartedBuilds;
         }
-        
+
         public int getNumberOfFinishedBuilds() {
             return numberOfFinishedBuilds;
         }
-        
+
     }
 }
 

--- a/test/src/test/java/jenkins/model/JenkinsFutureDependencyGraphTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsFutureDependencyGraphTest.java
@@ -142,4 +142,3 @@ public class JenkinsFutureDependencyGraphTest {
 
     }
 }
-


### PR DESCRIPTION
See [JENKINS-67237](https://issues.jenkins.io/browse/JENKINS-67237).

### Proposed changelog entries

* When triggering a new build while the build graph is currently being re-computed, jenkins waits for the re-computation to finish. This guarantees that recently updated build triggers are executed.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
