### PR TITLE
Clean up `Jenkinsfile`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,128 +9,168 @@ def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumbe
 
 def failFast = false
 // Same memory sizing for both builds and ATH
-def javaOpts = ["JAVA_OPTS=-Xmx1536m -Xms512m","MAVEN_OPTS=-Xmx1536m -Xms512m"]
+def javaOpts = [
+  'JAVA_OPTS=-Xmx1536m -Xms512m',
+  'MAVEN_OPTS=-Xmx1536m -Xms512m',
+]
 
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '3')),
-    disableConcurrentBuilds(abortPrevious: true)
+  buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '3')),
+  disableConcurrentBuilds(abortPrevious: true)
 ])
 
 def buildTypes = ['Linux', 'Windows']
 def jdks = [8, 11]
 
 def builds = [:]
-for(i = 0; i < buildTypes.size(); i++) {
-for(j = 0; j < jdks.size(); j++) {
+for (i = 0; i < buildTypes.size(); i++) {
+  for (j = 0; j < jdks.size(); j++) {
     def buildType = buildTypes[i]
     def jdk = jdks[j]
     if (buildType == 'Windows' && jdk == 8) {
-        continue // unnecessary use of hardware
+      continue // unnecessary use of hardware
     }
     builds["${buildType}-jdk${jdk}"] = {
-        // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#node-labels for information on what node types are available
-        String agentContainerLabel = jdk == 8 ? 'maven' : 'maven-11'
-        if (buildType == 'Windows') {
-            agentContainerLabel += '-windows'
+      // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#node-labels for information on what node types are available
+      def agentContainerLabel = jdk == 8 ? 'maven' : 'maven-' + jdk
+      if (buildType == 'Windows') {
+        agentContainerLabel += '-windows'
+      }
+      node(agentContainerLabel) {
+        // First stage is actually checking out the source. Since we're using Multibranch
+        // currently, we can use "checkout scm".
+        stage('Checkout') {
+          checkout scm
         }
-        node(agentContainerLabel) {
-                // First stage is actually checking out the source. Since we're using Multibranch
-                // currently, we can use "checkout scm".
-                stage('Checkout') {
-                    checkout scm
-                }
 
-                def changelistF = "${pwd tmp: true}/changelist"
-                def m2repo = "${pwd tmp: true}/m2repo"
+        def changelistF = "${pwd tmp: true}/changelist"
+        def m2repo = "${pwd tmp: true}/m2repo"
 
-                // Now run the actual build.
-                stage("${buildType} Build / Test") {
-                    timeout(time: 300, unit: 'MINUTES') {
-                      realtimeJUnit(healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml,war/junit.xml') {
-                        // -Dmaven.repo.local=… tells Maven to create a subdir in the temporary directory for the local Maven repository
-                        // -ntp requires Maven >= 3.6.1
-                        def mvnCmd = "mvn -Pdebug -Pjapicmp -U -Dset.changelist help:evaluate -Dexpression=changelist -Doutput=$changelistF clean install -Dmaven.test.failure.ignore -V -B -ntp -Dmaven.repo.local=$m2repo -Dspotbugs.failOnError=false -Dcheckstyle.failOnViolation=false -e"
-                        infra.runWithMaven(mvnCmd, jdk.toString(), javaOpts, true)
-
-                        if(isUnix()) {
-                            sh 'git add . && git diff --exit-code HEAD'
-                        }
-                      }
-                    }
-                }
-
-                // Once we've built, archive the artifacts and the test results.
-                stage("${buildType} Publishing") {
-                        archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
-                        if (! fileExists('core/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml') ) {
-                            error 'junit 4 tests are no longer being run for the core package'
-                        }
-                        if (! fileExists('test/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml') ) {
-                            error 'junit 4 tests are no longer being run for the test package'
-                        } // cli has been migrated to junit 5
-                        if (failFast && currentBuild.result == 'UNSTABLE') {
-                            error 'There were test failures; halting early'
-                        }
-                    if (buildType == 'Linux' && jdk == jdks[0]) {
-                        def folders = env.JOB_NAME.split('/')
-                        if (folders.length > 1) {
-                            discoverGitReferenceBuild(scm: folders[1])
-                        }
-
-                        echo "Recording static analysis results for '${buildType}'"
-                        recordIssues enabledForFailure: true,
-                                tools: [java(), javaDoc()],
-                                filters: [excludeFile('.*Assert.java')],
-                                sourceCodeEncoding: 'UTF-8',
-                                skipBlames: true,
-                                trendChartType: 'TOOLS_ONLY'
-                        recordIssues([tool: spotBugs(pattern: '**/target/spotbugsXml.xml'),
-                                                 sourceCodeEncoding: 'UTF-8',
-                                                 skipBlames: true,
-                                                 trendChartType: 'TOOLS_ONLY',
-                                                 qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]])
-                        recordIssues([tool: checkStyle(pattern: '**/target/checkstyle-result.xml'),
-                                                   sourceCodeEncoding: 'UTF-8',
-                                                   skipBlames: true,
-                                                   trendChartType: 'TOOLS_ONLY',
-                                                   qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
-                        if (failFast && currentBuild.result == 'UNSTABLE') {
-                            error 'Static analysis quality gates not passed; halting early'
-                        }
-
-                        def changelist = readFile(changelistF)
-                        dir(m2repo) {
-                            archiveArtifacts artifacts: "**/*$changelist/*$changelist*",
-                                             excludes: '**/*.lastUpdated,**/jenkins-test*/',
-                                             allowEmptyArchive: true, // in case we forgot to reincrementalify
-                                             fingerprint: true
-                        }
-                        publishHTML([allowMissing: true, alwaysLinkToLastBuild: false, includes: 'japicmp.html', keepAll: false, reportDir: 'core/target/japicmp', reportFiles: 'japicmp.html', reportName: 'API compatibility', reportTitles: 'japicmp report'])
-                    }
-                }
+        // Now run the actual build.
+        stage("${buildType} Build / Test") {
+          timeout(time: 5, unit: 'HOURS') {
+            realtimeJUnit(healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml,war/junit.xml') {
+              def mavenOptions = [
+                '-Pdebug',
+                '-Pjapicmp',
+                '--update-snapshots',
+                "-Dmaven.repo.local=$m2repo",
+                '-Dmaven.test.failure.ignore',
+                '-Dspotbugs.failOnError=false',
+                '-Dcheckstyle.failOnViolation=false',
+                '-Dset.changelist',
+                'help:evaluate',
+                '-Dexpression=changelist',
+                "-Doutput=$changelistF",
+                'clean',
+                'install',
+              ]
+              infra.runMaven(mavenOptions, jdk.toString(), javaOpts, null, true)
+              if (isUnix()) {
+                sh 'git add . && git diff --exit-code HEAD'
+              }
+            }
+          }
         }
+
+        // Once we've built, archive the artifacts and the test results.
+        stage("${buildType} Publishing") {
+          archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
+          if (!fileExists('core/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
+            error 'JUnit 4 tests are no longer being run for the core package'
+          }
+          if (!fileExists('test/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
+            error 'JUnit 4 tests are no longer being run for the test package'
+          }
+          // cli has been migrated to JUnit 5
+          if (failFast && currentBuild.result == 'UNSTABLE') {
+            error 'There were test failures; halting early'
+          }
+          if (buildType == 'Linux' && jdk == jdks[0]) {
+            def folders = env.JOB_NAME.split('/')
+            if (folders.length > 1) {
+              discoverGitReferenceBuild(scm: folders[1])
+            }
+
+            echo "Recording static analysis results for '${buildType}'"
+            recordIssues(
+                enabledForFailure: true,
+                tools: [java(), javaDoc()],
+                filters: [excludeFile('.*Assert.java')],
+                sourceCodeEncoding: 'UTF-8',
+                skipBlames: true,
+                trendChartType: 'TOOLS_ONLY'
+                )
+            recordIssues([tool: spotBugs(pattern: '**/target/spotbugsXml.xml'),
+              sourceCodeEncoding: 'UTF-8',
+              skipBlames: true,
+              trendChartType: 'TOOLS_ONLY',
+              qualityGates: [
+                [threshold: 1, type: 'NEW', unstable: true],
+              ]])
+            recordIssues([tool: checkStyle(pattern: '**/target/checkstyle-result.xml'),
+              sourceCodeEncoding: 'UTF-8',
+              skipBlames: true,
+              trendChartType: 'TOOLS_ONLY',
+              qualityGates: [
+                [threshold: 1, type: 'TOTAL', unstable: true],
+              ]])
+            if (failFast && currentBuild.result == 'UNSTABLE') {
+              error 'Static analysis quality gates not passed; halting early'
+            }
+
+            def changelist = readFile(changelistF)
+            dir(m2repo) {
+              archiveArtifacts(
+                  artifacts: "**/*$changelist/*$changelist*",
+                  excludes: '**/*.lastUpdated,**/jenkins-test*/',
+                  allowEmptyArchive: true, // in case we forgot to reincrementalify
+                  fingerprint: true
+                  )
+            }
+            publishHTML([
+              allowMissing: true,
+              alwaysLinkToLastBuild: false,
+              includes: 'japicmp.html',
+              keepAll: false,
+              reportDir: 'core/target/japicmp',
+              reportFiles: 'japicmp.html',
+              reportName: 'API compatibility',
+              reportTitles: 'japicmp report',
+            ])
+          }
+        }
+      }
     }
-}}
+  }
+}
 
 builds.ath = {
-    node("docker-highmem") {
-        // Just to be safe
-        deleteDir()
-        def fileUri
-        def metadataPath
-        dir("sources") {
-            checkout scm
-            def mvnCmd = 'mvn --batch-mode --show-version -ntp -Pquick-build -am -pl war package -Dmaven.repo.local=$WORKSPACE_TMP/m2repo'
-            infra.runWithMaven(mvnCmd, "11", javaOpts, true)
-            dir("war/target") {
-                fileUri = "file://" + pwd() + "/jenkins.war"
-            }
-            metadataPath = pwd() + "/essentials.yml"
-        }
-        dir("ath") {
-            runATH jenkins: fileUri, metadataFile: metadataPath
-        }
+  node('docker-highmem') {
+    // Just to be safe
+    deleteDir()
+    def fileUri
+    def metadataPath
+    dir('sources') {
+      checkout scm
+      def mavenOptions = [
+        '-Pquick-build',
+        '-Dmaven.repo.local=$WORKSPACE_TMP/m2repo',
+        '-am',
+        '-pl',
+        'war',
+        'package',
+      ]
+      infra.runMaven(mavenOptions, '11', javaOpts, null, true)
+      dir('war/target') {
+        fileUri = 'file://' + pwd() + '/jenkins.war'
+      }
+      metadataPath = pwd() + '/essentials.yml'
     }
+    dir('ath') {
+      runATH jenkins: fileUri, metadataFile: metadataPath
+    }
+  }
 }
 
 builds.failFast = failFast


### PR DESCRIPTION
Editing the `Jenkinsfile` was getting really painful for me due to unusually long lines and inconsistent indentation. This PR cleans up the `Jenkinsfile` for this repository, mostly by applying Spotless auto-formatting to correct indentation problems and using `infra.runMaven()` rather than `infra.runWithMaven()` (which lets us consolidate some common Maven arguments). I suggest reviewing this with the "Hide whitespace" feature in GitHub enabled.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
