### PR TITLE
Fix `RV_RETURN_VALUE_IGNORED` SpotBugs violations

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1522,6 +1522,7 @@ public abstract class Run <JobT extends Job<JobT,RunT>,RunT extends Run<JobT,Run
      *
      * @since 1.349
      */
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED", justification = "method signature does not permit plumbing through the return value")
     public void writeLogTo(long offset, @NonNull XMLOutput out) throws IOException {
         long start = offset;
         if (offset > 0) {

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -479,6 +479,7 @@ public class SCMTrigger extends Trigger<Item> {
         /**
          * Used from {@code polling.jelly} to write annotated polling log to the given output.
          */
+        @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED", justification = "method signature does not permit plumbing through the return value")
         public void writePollingLogTo(long offset, XMLOutput out) throws IOException {
             // TODO: resurrect compressed log file support
             getPollingLogText().writeHtmlTo(offset, out.asWriter());
@@ -537,6 +538,7 @@ public class SCMTrigger extends Trigger<Item> {
          * Writes the annotated log to the given output.
          * @since 1.350
          */
+        @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED", justification = "method signature does not permit plumbing through the return value")
         public void writeLogTo(XMLOutput out) throws IOException {
             new AnnotatedLargeText<>(getLogFile(), Charset.defaultCharset(), true, this).writeHtmlTo(0,out.asWriter());
         }

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -395,14 +395,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>
-        <Or>
-          <Class name="hudson.model.Run"/>
-          <Class name="hudson.triggers.SCMTrigger$BuildAction"/>
-          <Class name="hudson.triggers.SCMTrigger$SCMAction"/>
-        </Or>
-      </And>
-      <And>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
         <Or>
           <Class name="jenkins.agents.WebSocketAgents$Session"/>


### PR DESCRIPTION
Fixes these SpotBugs violations:

```
[ERROR] Medium: Return value of hudson.console.AnnotatedLargeText.writeHtmlTo(long, Writer) ignored in hudson.model.Run.writeLogTo(long, XMLOutput) [hudson.model.Run] At Run.java:[line 1538] RV_RETURN_VALUE_IGNORED
[ERROR] Medium: Return value of hudson.console.AnnotatedLargeText.writeHtmlTo(long, Writer) ignored in hudson.triggers.SCMTrigger$BuildAction.writePollingLogTo(long, XMLOutput) [hudson.triggers.SCMTrigger$BuildAction] At SCMTrigger.java:[line 484] RV_RETURN_VALUE_IGNORED
[ERROR] Medium: Return value of hudson.console.AnnotatedLargeText.writeHtmlTo(long, Writer) ignored in hudson.triggers.SCMTrigger$SCMAction.writeLogTo(XMLOutput) [hudson.triggers.SCMTrigger$SCMAction] At SCMTrigger.java:[line 541] RV_RETURN_VALUE_IGNORED
```

Looking at the callers of `AnnotatedLargeText#writeHtmlTo(long, Writer)`:

- `AnnotatedLargeText#writeLogTo(long, Writer)` returns `long` and was checking the return value already to plumb it through as its own return value
- `Run#writeLogTo` was not checking the return value and returns `void` so it doesn't make sense to check it
- `SCMTrigger.SCMAction#writeLogTo` was not checking the return value and returns `void` so it doesn't make sense to check it
- `SCMTrigger.BuildAction#writePollingLogTo` was not checking the return value and returns `void` so it doesn't make sense to check it

Recall that the definition of `@CheckReturnValue` is:

> This annotation is used to denote a method whose return value should always be checked when invoking the method.

Given that three out of four callers do not and should not check the return value, I considered removing the annotation completely, but then I decided that it was better to leave it and make callers at least think about whether they need the return value or not, since it's easy enough to suppress. So then I just suppressed the warning for the three callers whose method signatures do not permit them to plumb through the return value.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
