### PR TITLE
Fix `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` and `RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE` SpotBugs violations

### DIFF
--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -323,10 +323,6 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
     private void record(Run<?,?> build, FilePath ws, TaskListener listener, Map<String,String> record, final String targets) throws IOException, InterruptedException {
         for (Record r : ws.act(new FindRecords(targets, excludes, defaultExcludes, caseSensitive, build.getTimeInMillis()))) {
             Fingerprint fp = r.addRecord(build);
-            if(fp==null) {
-                listener.error(Messages.Fingerprinter_FailedFor(r.relativePath));
-                continue;
-            }
             fp.addFor(build);
             record.put(r.relativePath,fp.getHashString());
         }

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -245,7 +245,7 @@ public class JSONSignatureValidator {
     }
 
 
-    @SuppressFBWarnings(value = "NP_LOAD_OF_KNOWN_NULL_VALUE", justification = "https://github.com/spotbugs/spotbugs/issues/756")
+    @SuppressFBWarnings(value = {"NP_LOAD_OF_KNOWN_NULL_VALUE", "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE"}, justification = "https://github.com/spotbugs/spotbugs/issues/756")
     protected Set<TrustAnchor> loadTrustAnchors(CertificateFactory cf) throws IOException {
         // if we trust default root CAs, we end up trusting anyone who has a valid certificate,
         // which isn't useful at all

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -353,14 +353,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
-        <Class name="hudson.tasks.Fingerprinter"/>
-      </And>
-      <And>
-        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE"/>
-        <Class name="jenkins.util.JSONSignatureValidator"/>
-      </And>
-      <And>
         <Bug pattern="REDOS"/>
         <Or>
           <Class name="hudson.model.Computer"/>


### PR DESCRIPTION
Fixes these SpotBugs violations:

```
[ERROR] Medium: Redundant nullcheck of fp, which is known to be non-null in hudson.tasks.Fingerprinter.record(Run, FilePath, TaskListener, Map, String) [hudson.tasks.Fingerprinter] Redundant null check at Fingerprinter.java:[line 326] RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE
[ERROR] Medium: Redundant nullcheck of in which is known to be null in jenkins.util.JSONSignatureValidator.loadTrustAnchors(CertificateFactory) [jenkins.util.JSONSignatureValidator] Redundant null check at JSONSignatureValidator.java:[line 268] RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE
```

The latter was a false positive for a `try-with-resources` block, which I suppressed.

The former was indeed a redundant null check. `FingerprintMap#getOrCreate(Run, String, String)` calls `KeyedDataStorage#getOrCreate` (which is `@NonNull`) but that itself returns `KeyedDataStorage#get(String, boolean, P)` (which is `@CheckForNull`). This apparent contradiction can be resolved by considering that the second argument to `KeyedDataStorage#get(String, boolean, P)`, `createIfExist`, determines whether `KeyedDataStorage#get(String, boolean, P)` can return null or not. When `KeyedDataStorage#get(String, boolean, P)` is invoked by `KeyedDataStorage#get(String)`, `createIfNotExist` is false so `@CheckForNull` is appropriate on `KeyedDataStorage#get(String)`. When `KeyedDataStorage#get(String, boolean, P)` is invoked by `KeyedDataStorage#getOrCreate`, `createIfNotExist` is true so `@NonNull` is appropriate on `KeyedDataStorage#getOrCreate`. You can see this by reading through `KeyedDataStorage#get(String, boolean, P)`; note the `IllegalStateException` if `t==null && createIfNotExist`. So SpotBugs is correct: null can never occur at `Fingerprinter.record(Run, FilePath, TaskListener, Map, String)`. So I deleted the redundant null check.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
