### PR TITLE
Suppress `SE_INNER_CLASS` SpotBugs violations

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -394,6 +394,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     /**
      * Serialized form of {@link OSProcess} is the PID and {@link ProcessTree}
      */
+    @SuppressFBWarnings(value = "SE_INNER_CLASS", justification = "Serializing the outer instance is intended")
     private final class SerializedProcess implements Serializable {
         private final int pid;
         private static final long serialVersionUID = 1L;
@@ -2177,6 +2178,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
 
         private static final long serialVersionUID = 1L;
 
+        @SuppressFBWarnings(value = "SE_INNER_CLASS", justification = "Serializing the outer instance is intended")
         private class RemoteProcess extends OSProcess implements Serializable {
             private final IOSProcess proxy;
 

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -384,13 +384,6 @@
         <Class name="hudson.scm.PollingResult"/>
       </And>
       <And>
-        <Bug pattern="SE_INNER_CLASS"/>
-        <Or>
-          <Class name="hudson.util.ProcessTree$Remote$RemoteProcess"/>
-          <Class name="hudson.util.ProcessTree$SerializedProcess"/>
-        </Or>
-      </And>
-      <And>
         <Bug pattern="STATIC_IV"/>
         <Or>
           <Class name="hudson.cli.Connection"/>


### PR DESCRIPTION
Suppresses the following two SpotBugs violations:

```
[ERROR] Medium: hudson.util.ProcessTree$Remote$RemoteProcess is serializable and an inner class [hudson.util.ProcessTree$Remote$RemoteProcess] At ProcessTree.java:[lines 2180-2225] SE_INNER_CLASS
[ERROR] Medium: hudson.util.ProcessTree$SerializedProcess is serializable and an inner class [hudson.util.ProcessTree$SerializedProcess] At ProcessTree.java:[lines 397-406] SE_INNER_CLASS
```

The [description of the check](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#se-serializable-inner-class-se-inner-class) indicates that it's meant to catch accidental serializations of the outer instance, which might serialize more data than intended. In this case, the comments and the code are very clear that serializing the outer instance is intentional: we do so because it contains the process tree against which we call `get()` in the serialized inner instance. Since this code is working as intended, there is nothing to do except suppress the warning.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
