### PR TITLE
Fix `NP_BOOLEAN_RETURN_NULL` SpotBugs violations

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -25,6 +25,7 @@ package hudson.logging;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.thoughtworks.xstream.XStream;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
 import hudson.Extension;
 import hudson.FilePath;
@@ -293,6 +294,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
             return rest.startsWith(".") || rest.length()==0;
         }
 
+        @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "converting this to YesNoMaybe would break backward compatibility")
         public Boolean matches(LogRecord r) {
             boolean levelSufficient = r.getLevel().intValue() >= level;
             if (name.length() == 0) {

--- a/core/src/main/java/hudson/security/SidACL.java
+++ b/core/src/main/java/hudson/security/SidACL.java
@@ -27,6 +27,7 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.logging.Logger;
 import org.acegisecurity.acls.sid.GrantedAuthoritySid;
 import org.acegisecurity.acls.sid.PrincipalSid;
@@ -65,6 +66,7 @@ public abstract class SidACL extends ACL {
      *      true or false if {@link #hasPermission(Sid, Permission)} returns it.
      *      Otherwise null, indicating that this ACL doesn't have any entry for it.
      */
+    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "converting this to YesNoMaybe would break backward compatibility")
     protected Boolean _hasPermission(@NonNull Authentication a, Permission permission) {
         // ACL entries for this principal takes precedence
         Boolean b = hasPermission(new PrincipalSid(a),permission);

--- a/core/src/main/java/hudson/security/SparseACL.java
+++ b/core/src/main/java/hudson/security/SparseACL.java
@@ -25,6 +25,7 @@ package hudson.security;
 
 import static java.util.logging.Level.FINE;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -84,6 +85,7 @@ public class SparseACL extends SidACL {
         return false;
     }
 
+    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "converting this to YesNoMaybe would break backward compatibility")
     @Override
     protected Boolean hasPermission(Sid p, Permission permission) {
         for( ; permission!=null; permission=permission.impliedBy ) {

--- a/core/src/main/java/jenkins/YesNoMaybe.java
+++ b/core/src/main/java/jenkins/YesNoMaybe.java
@@ -23,6 +23,8 @@
  */
 package jenkins;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Enum that represents {@link Boolean} state (including null for the absence.)
  *
@@ -36,11 +38,13 @@ public enum YesNoMaybe {
     NO,
     MAYBE;
 
+    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "bridge method for backward compatibility")
     public static Boolean toBoolean(YesNoMaybe v) {
         if (v==null)    return null;
         return v.toBool();
     }
     
+    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "bridge method for backward compatibility")
     public Boolean toBool() {
         switch (this) {
         case YES:

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -164,16 +164,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
-        <Or>
-          <Class name="hudson.logging.LogRecorder$Target"/>
-          <Class name="hudson.security.SidACL"/>
-          <Class name="hudson.security.SparseACL"/>
-          <Class name="jenkins.security.stapler.StaplerDispatchValidator"/>
-          <Class name="jenkins.YesNoMaybe"/>
-        </Or>
-      </And>
-      <And>
         <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
         <Class name="jenkins.util.SystemProperties"/>
       </And>


### PR DESCRIPTION
For `NP_BOOLEAN_RETURN_NULL` violations, if the nullable `Boolean` was part of a public API there is nothing we can do about it without breaking backward compatibility, so I suppressed these violations. But the violation in `StaplerDispatchValidator` occurred on some private methods without API surface area, so I converted these to the [trilean](https://en.wikipedia.org/wiki/Three-valued_logic) `YesNoMaybe` class instead, which made the warning go away and I think made the code more readable as well.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
