### PR TITLE
Suppress `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` SpotBugs violations

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.OverrideMustInvoke;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.FilePath;
 import hudson.Functions;
@@ -1047,6 +1048,7 @@ public class SlaveComputer extends Computer {
         }
 
         @Override
+        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "field is static for the reason explained in the Javadoc for LogHolder")
         public Void call() {
             SLAVE_LOG_HANDLER = new RingBufferLogHandler(ringBufferSize);
 

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -336,6 +336,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
 
     @Extension @Symbol("archiveArtifacts")
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "for backward compatibility")
         public DescriptorImpl() {
             DESCRIPTOR = this; // backward compatibility
         }

--- a/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
+++ b/core/src/main/java/jenkins/security/QueueItemAuthenticatorMonitor.java
@@ -23,6 +23,7 @@
  */
 package jenkins.security;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.Job;
@@ -72,6 +73,7 @@ public class QueueItemAuthenticatorMonitor extends AdministrativeMonitor {
     }
 
     @RequirePOST
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "field is static so that it can be written to by the static QueueListenerImpl class")
     public HttpResponse doAct(@QueryParameter String redirect, @QueryParameter String dismiss, @QueryParameter String reset) throws IOException {
         if (redirect != null) {
             return HttpResponses.redirectTo("https://www.jenkins.io/redirect/queue-item-security");

--- a/core/src/main/java/jenkins/security/UserDetailsCache.java
+++ b/core/src/main/java/jenkins/security/UserDetailsCache.java
@@ -28,6 +28,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.security.UserMayOrMayNotExistException2;
@@ -61,6 +62,7 @@ public final class UserDetailsCache {
      * Constructor intended to be instantiated by Jenkins only.
      */
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "field is static for script console")
     public UserDetailsCache() {
         if (EXPIRE_AFTER_WRITE_SEC == null || EXPIRE_AFTER_WRITE_SEC <= 0) {
             //just in case someone is trying to trick us

--- a/core/src/main/java/jenkins/slaves/NioChannelSelector.java
+++ b/core/src/main/java/jenkins/slaves/NioChannelSelector.java
@@ -1,5 +1,6 @@
 package jenkins.slaves;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.init.Terminator;
 import hudson.model.Computer;
@@ -18,6 +19,7 @@ import org.jenkinsci.remoting.nio.NioChannelHub;
 public class NioChannelSelector {
     private NioChannelHub hub;
 
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "field is static for script console")
     public NioChannelSelector() {
         try {
             if (!DISABLED) {

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -399,16 +399,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/>
-        <Or>
-          <Class name="hudson.slaves.SlaveComputer$SlaveInitializer"/>
-          <Class name="hudson.tasks.ArtifactArchiver$DescriptorImpl"/>
-          <Class name="jenkins.security.QueueItemAuthenticatorMonitor"/>
-          <Class name="jenkins.security.UserDetailsCache"/>
-          <Class name="jenkins.slaves.NioChannelSelector"/>
-        </Or>
-      </And>
-      <And>
         <Bug pattern="UG_SYNC_SET_UNSYNC_GET"/>
         <Or>
           <Class name="hudson.model.ListView"/>


### PR DESCRIPTION
Suppresses the following remaining `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD`. See the code for the justifications.

```
[ERROR] Medium: Write to static field hudson.slaves.SlaveComputer$LogHolder.SLAVE_LOG_HANDLER from instance method hudson.slaves.SlaveComputer$SlaveInitializer.call() [hudson.slaves.SlaveComputer$SlaveInitializer] At SlaveComputer.java:[line 1051] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: Write to static field hudson.tasks.ArtifactArchiver.DESCRIPTOR from instance method new hudson.tasks.ArtifactArchiver$DescriptorImpl() [hudson.tasks.ArtifactArchiver$DescriptorImpl] At ArtifactArchiver.java:[line 340] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: Write to static field jenkins.security.QueueItemAuthenticatorMonitor.anyBuildLaunchedAsSystemWithAuthenticatorPresent from instance method jenkins.security.QueueItemAuthenticatorMonitor.doAct(String, String, String) [jenkins.security.QueueItemAuthenticatorMonitor] At QueueItemAuthenticatorMonitor.java:[line 83] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: Write to static field jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC from instance method new jenkins.security.UserDetailsCache() [jenkins.security.UserDetailsCache, jenkins.security.UserDetailsCache] At UserDetailsCache.java:[line 67]Another occurrence at UserDetailsCache.java:[line 70] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[ERROR] Medium: Write to static field jenkins.slaves.NioChannelSelector.DISABLED from instance method new jenkins.slaves.NioChannelSelector() [jenkins.slaves.NioChannelSelector] At NioChannelSelector.java:[line 30] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
```

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
