### PR TITLE
Suppress `URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD` SpotBugs violations

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2455,7 +2455,7 @@ public class Queue extends ResourceController implements Saveable {
      */
     @Restricted(NoExternalUse.class)
     @ExportedBean(defaultVisibility = 999)
-    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "it is exported, so it might be used")
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public static class StubItem {
 
         @Exported public StubTask task;

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -2312,6 +2312,7 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
         private final List<PluginWrapper> batch;
         private final long start;
         @Exported(inline = true)
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
         public volatile CompleteBatchJobStatus status = new CompleteBatchJob.Pending();
 
         public CompleteBatchJob(List<PluginWrapper> batch, long start, UUID correlationId) {

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -195,6 +195,7 @@ public class Search implements StaplerProxy {
     @ExportedBean(defaultVisibility=999)
     public static class Item {
         @Exported
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
         public String name;
 
         public Item(String name) {

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -587,6 +587,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
          * To display a general error message, set it here.
          *
          */
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
         public String errorMessage;
 
         /**

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -416,6 +416,7 @@ public class SCMTrigger extends Trigger<Item> {
     public static class BuildAction implements RunAction2 {
         private transient /*final*/ Run<?,?> run;
         @Deprecated
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "for backward compatibility")
         public transient /*final*/ AbstractBuild build;
 
         /**

--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -1,5 +1,6 @@
 package jenkins.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Functions;
 import hudson.Util;
 import hudson.model.Action;
@@ -255,37 +256,46 @@ public interface ModelObjectWithContextMenu extends ModelObject {
          * Human readable caption of the menu item. Do not use HTML.
          */
         @Exported
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
         public String displayName;
 
         /**
          * Optional URL to the icon image. Rendered as 24x24.
          */
         @Exported
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
         public String icon;
 
         /**
          * True to make a POST request rather than GET.
          * @since 1.504
          */
-        @Exported public boolean post;
+        @Exported
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
+        public boolean post;
 
         /**
          * True to require confirmation after a click.
          * @since 1.512
          */
-        @Exported public boolean requiresConfirmation;
+        @Exported
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
+        public boolean requiresConfirmation;
 
 
         /**
          * True to display this item as a section header.
          * @since 2.231
          */
-        @Exported public boolean header;
+        @Exported
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
+        public boolean header;
 
         /**
          * If this is a submenu, definition of subitems.
          */
         @Exported(inline=true)
+        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
         public ContextMenu subMenu;
 
         public MenuItem(String url, String icon, String displayName) {

--- a/core/src/main/java/jenkins/util/groovy/AbstractGroovyViewModule.java
+++ b/core/src/main/java/jenkins/util/groovy/AbstractGroovyViewModule.java
@@ -1,5 +1,6 @@
 package jenkins.util.groovy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.GroovyObjectSupport;
 import lib.FormTagLib;
 import lib.JenkinsTagLib;
@@ -20,9 +21,13 @@ import org.kohsuke.stapler.jelly.groovy.Namespace;
 public abstract class AbstractGroovyViewModule extends GroovyObjectSupport {
 
     public JellyBuilder builder;
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public FormTagLib f;
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public LayoutTagLib l;
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public JenkinsTagLib t;
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public Namespace st;
 
     protected AbstractGroovyViewModule(JellyBuilder b) {

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -25,6 +25,7 @@ package jenkins.widgets;
 
 import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.ParameterValue;
@@ -58,9 +59,13 @@ public class HistoryPageFilter<T> {
     public final List<HistoryPageEntry<Queue.Item>> queueItems = new ArrayList<>();
     public final List<HistoryPageEntry<Run>> runs = new ArrayList<>();
 
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public boolean hasUpPage = false; // there are newer builds than on this page
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public boolean hasDownPage = false; // there are older builds than on this page
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public long nextBuildNumber;
+    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
     public HistoryWidget widget;
 
     public long newestOnPage = Long.MIN_VALUE; // see updateNewestOldest()

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -437,22 +437,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
-        <Or>
-          <Class name="hudson.model.UpdateCenter$CompleteBatchJob"/>
-          <Class name="hudson.org.apache.tools.tar.TarOutputStream"/>
-          <Class name="hudson.search.Search$Item"/>
-          <Class name="hudson.security.HudsonPrivateSecurityRealm$SignupInfo"/>
-          <Class name="hudson.triggers.SCMTrigger$BuildAction"/>
-          <Class name="hudson.widgets.HistoryWidget"/>
-          <Class name="jenkins.model.Jenkins"/>
-          <Class name="jenkins.model.ModelObjectWithContextMenu$ContextMenu"/>
-          <Class name="jenkins.model.ModelObjectWithContextMenu$MenuItem"/>
-          <Class name="jenkins.util.groovy.AbstractGroovyViewModule"/>
-          <Class name="jenkins.widgets.HistoryPageFilter"/>
-        </Or>
-      </And>
-      <And>
         <Bug pattern="URLCONNECTION_SSRF_FD"/>
         <Or>
           <Class name="hudson.FilePath"/>


### PR DESCRIPTION
Suppresses the following SpotBugs violations:

```
[ERROR] Medium: Unread public/protected field: hudson.model.UpdateCenter$CompleteBatchJob.status [hudson.model.UpdateCenter$CompleteBatchJob] At UpdateCenter.java:[line 2314] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: hudson.search.Search$Item.name [hudson.search.Search$Item] At Search.java:[line 201] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: hudson.security.HudsonPrivateSecurityRealm$SignupInfo.errorMessage [hudson.security.HudsonPrivateSecurityRealm$1] At HudsonPrivateSecurityRealm.java:[line 225] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: hudson.triggers.SCMTrigger$BuildAction.build [hudson.triggers.SCMTrigger$BuildAction] At SCMTrigger.java:[line 426] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.model.ModelObjectWithContextMenu$MenuItem.displayName [jenkins.model.ModelObjectWithContextMenu$MenuItem] At ModelObjectWithContextMenu.java:[line 337] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.model.ModelObjectWithContextMenu$MenuItem.header [jenkins.model.ModelObjectWithContextMenu$ContextMenu] At ModelObjectWithContextMenu.java:[line 141] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.model.ModelObjectWithContextMenu$MenuItem.icon [jenkins.model.ModelObjectWithContextMenu$MenuItem] At ModelObjectWithContextMenu.java:[line 317] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.model.ModelObjectWithContextMenu$MenuItem.post [jenkins.model.ModelObjectWithContextMenu$ContextMenu] At ModelObjectWithContextMenu.java:[line 116] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.model.ModelObjectWithContextMenu$MenuItem.requiresConfirmation [jenkins.model.ModelObjectWithContextMenu$ContextMenu] At ModelObjectWithContextMenu.java:[line 127] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.model.ModelObjectWithContextMenu$MenuItem.subMenu [jenkins.model.Jenkins] At Jenkins.java:[line 4388] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.util.groovy.AbstractGroovyViewModule.f [jenkins.util.groovy.AbstractGroovyViewModule] At AbstractGroovyViewModule.java:[line 30] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.util.groovy.AbstractGroovyViewModule.l [jenkins.util.groovy.AbstractGroovyViewModule] At AbstractGroovyViewModule.java:[line 31] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.util.groovy.AbstractGroovyViewModule.st [jenkins.util.groovy.AbstractGroovyViewModule] At AbstractGroovyViewModule.java:[line 33] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.util.groovy.AbstractGroovyViewModule.t [jenkins.util.groovy.AbstractGroovyViewModule] At AbstractGroovyViewModule.java:[line 32] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.widgets.HistoryPageFilter.hasDownPage [jenkins.widgets.HistoryPageFilter] At HistoryPageFilter.java:[line 62] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.widgets.HistoryPageFilter.hasUpPage [jenkins.widgets.HistoryPageFilter] At HistoryPageFilter.java:[line 61] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.widgets.HistoryPageFilter.nextBuildNumber [jenkins.widgets.HistoryPageFilter] At HistoryPageFilter.java:[line 143] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
[ERROR] Medium: Unread public/protected field: jenkins.widgets.HistoryPageFilter.widget [hudson.widgets.HistoryWidget] At HistoryWidget.java:[line 180] URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD
```

Except for one, these were all false positives due to the field being `@Export`ed for use by Stapler. The one exception was `hudson.triggers.SCMTrigger$BuildAction.build`, a field which is no longer used but was retained for backward compatibility. In either case, there is no further action item so I have suppressed the warnings.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
