### PR TITLE
Fix `EQ_GETCLASS_AND_CLASS_CONSTANT` SpotBugs violations

### DIFF
--- a/core/src/main/java/hudson/model/BooleanParameterDefinition.java
+++ b/core/src/main/java/hudson/model/BooleanParameterDefinition.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import java.util.Objects;
 import net.sf.json.JSONObject;
@@ -103,6 +104,7 @@ public class BooleanParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_GETCLASS_AND_CLASS_CONSTANT", justification = "ParameterDefinitionTest tests that subclasses are not equal to their parent classes, so the behavior appears to be intentional")
     public boolean equals(Object obj) {
         if (BooleanParameterDefinition.class != getClass())
             return super.equals(obj);

--- a/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
@@ -3,6 +3,7 @@ package hudson.model;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.util.FormValidation;
@@ -181,6 +182,7 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_GETCLASS_AND_CLASS_CONSTANT", justification = "ParameterDefinitionTest tests that subclasses are not equal to their parent classes, so the behavior appears to be intentional")
     public boolean equals(Object obj) {
         if (ChoiceParameterDefinition.class != getClass())
             return super.equals(obj);

--- a/core/src/main/java/hudson/model/FileParameterDefinition.java
+++ b/core/src/main/java/hudson/model/FileParameterDefinition.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.cli.CLICommand;
 import java.io.File;
@@ -140,6 +141,7 @@ public class FileParameterDefinition extends ParameterDefinition {
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_GETCLASS_AND_CLASS_CONSTANT", justification = "ParameterDefinitionTest tests that subclasses are not equal to their parent classes, so the behavior appears to be intentional")
     public boolean equals(Object obj) {
         if (FileParameterDefinition.class != getClass())
             return super.equals(obj);

--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.util.Secret;
 import java.util.Objects;
@@ -116,6 +117,7 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_GETCLASS_AND_CLASS_CONSTANT", justification = "ParameterDefinitionTest tests that subclasses are not equal to their parent classes, so the behavior appears to be intentional")
     public boolean equals(Object obj) {
         if (PasswordParameterDefinition.class != getClass())
             return super.equals(obj);

--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.util.EnumConverter;
 import hudson.util.RunList;
@@ -219,6 +220,7 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_GETCLASS_AND_CLASS_CONSTANT", justification = "ParameterDefinitionTest tests that subclasses are not equal to their parent classes, so the behavior appears to be intentional")
     public boolean equals(Object obj) {
         if (RunParameterDefinition.class != getClass())
             return super.equals(obj);

--- a/core/src/main/java/hudson/model/StringParameterDefinition.java
+++ b/core/src/main/java/hudson/model/StringParameterDefinition.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import java.util.Objects;
@@ -172,6 +173,7 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_GETCLASS_AND_CLASS_CONSTANT", justification = "ParameterDefinitionTest tests that subclasses are not equal to their parent classes, so the behavior appears to be intentional")
     public boolean equals(Object obj) {
         if (StringParameterDefinition.class != getClass())
             return super.equals(obj);

--- a/core/src/main/java/hudson/model/TextParameterDefinition.java
+++ b/core/src/main/java/hudson/model/TextParameterDefinition.java
@@ -25,6 +25,7 @@ package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import java.util.Objects;
 import net.sf.json.JSONObject;
@@ -85,6 +86,7 @@ public class TextParameterDefinition extends StringParameterDefinition {
     }
 
     @Override
+    @SuppressFBWarnings(value = "EQ_GETCLASS_AND_CLASS_CONSTANT", justification = "ParameterDefinitionTest tests that subclasses are not equal to their parent classes, so the behavior appears to be intentional")
     public boolean equals(Object obj) {
         if (TextParameterDefinition.class != getClass())
             return super.equals(obj);

--- a/core/src/main/java/hudson/util/NoClientBindProtocolSocketFactory.java
+++ b/core/src/main/java/hudson/util/NoClientBindProtocolSocketFactory.java
@@ -109,7 +109,7 @@ public class NoClientBindProtocolSocketFactory implements ProtocolSocketFactory 
      */
     @Override
     public boolean equals(Object obj) {
-        return obj != null && obj.getClass().equals(NoClientBindProtocolSocketFactory.class);
+        return obj != null && obj.getClass().equals(getClass());
     }
 
     /**

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -99,19 +99,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="EQ_GETCLASS_AND_CLASS_CONSTANT"/>
-        <Or>
-          <Class name="hudson.model.BooleanParameterDefinition"/>
-          <Class name="hudson.model.ChoiceParameterDefinition"/>
-          <Class name="hudson.model.FileParameterDefinition"/>
-          <Class name="hudson.model.PasswordParameterDefinition"/>
-          <Class name="hudson.model.RunParameterDefinition"/>
-          <Class name="hudson.model.StringParameterDefinition"/>
-          <Class name="hudson.model.TextParameterDefinition"/>
-          <Class name="hudson.util.NoClientBindProtocolSocketFactory"/>
-        </Or>
-      </And>
-      <And>
         <Bug pattern="FILE_UPLOAD_FILENAME"/>
         <Or>
           <Class name="hudson.model.FileParameterDefinition"/>


### PR DESCRIPTION
Fixes a violation of `EQ_GETCLASS_AND_CLASS_CONSTANT` in `NoClientBindProtocolSocketFactory`. All other violations seemed to be legitimate, but the existing behavior is covered by a test. Changing the existing behavior and the test makes me nervous that I would break something else, so instead I am suppressing the remaining violations with the justification that the existing behavior appears to be intentional.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
