### PR TITLE
Fix `LI_LAZY_INIT_UPDATE_STATIC` SpotBugs violation

### DIFF
--- a/core/src/main/java/jenkins/security/UserDetailsCache.java
+++ b/core/src/main/java/jenkins/security/UserDetailsCache.java
@@ -64,13 +64,15 @@ public final class UserDetailsCache {
     @Restricted(NoExternalUse.class)
     @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "field is static for script console")
     public UserDetailsCache() {
-        if (EXPIRE_AFTER_WRITE_SEC == null || EXPIRE_AFTER_WRITE_SEC <= 0) {
+        Integer expireAfterWriteSec = EXPIRE_AFTER_WRITE_SEC;
+        if (expireAfterWriteSec == null || expireAfterWriteSec <= 0) {
             //just in case someone is trying to trick us
-            EXPIRE_AFTER_WRITE_SEC = SystemProperties.getInteger(SYS_PROP_NAME, (int)TimeUnit.MINUTES.toSeconds(2));
-            if (EXPIRE_AFTER_WRITE_SEC <= 0) {
+            expireAfterWriteSec = SystemProperties.getInteger(SYS_PROP_NAME, (int)TimeUnit.MINUTES.toSeconds(2));
+            if (expireAfterWriteSec <= 0) {
                 //The property could also be set to a negative value
-                EXPIRE_AFTER_WRITE_SEC = (int)TimeUnit.MINUTES.toSeconds(2);
+                expireAfterWriteSec = (int)TimeUnit.MINUTES.toSeconds(2);
             }
+            EXPIRE_AFTER_WRITE_SEC = expireAfterWriteSec;
         }
         detailsCache = CacheBuilder.newBuilder().softValues().expireAfterWrite(EXPIRE_AFTER_WRITE_SEC, TimeUnit.SECONDS).build();
         existenceCache = CacheBuilder.newBuilder().softValues().expireAfterWrite(EXPIRE_AFTER_WRITE_SEC, TimeUnit.SECONDS).build();

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -134,10 +134,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="LI_LAZY_INIT_UPDATE_STATIC"/>
-        <Class name="jenkins.security.UserDetailsCache"/>
-      </And>
-      <And>
         <Bug pattern="MS_EXPOSE_REP"/>
         <Or>
           <Class name="hudson.model.ComputerSet"/>


### PR DESCRIPTION
Fixes the sole [`LI_LAZY_INIT_UPDATE_STATIC`](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#li-incorrect-lazy-initialization-and-update-of-static-field-li-lazy-init-update-static) SpotBugs violation in the codebase. Based on the bug description it seems that the problem was that

> after the field is set, the object stored into that location is further updated or accessed

So I fixed this by using a local variable to do all manipulation and only setting the field once we have its final value.

### Testing Done

Set `jenkins.security.UserDetailsCache.EXPIRE_AFTER_WRITE_SEC=-1` in the script console, hit reload from disk with a debugger breakpoint in the changed code, and exercised all changed code successfully with this stack trace:

```
<init>:73, UserDetailsCache (jenkins.security)
GUICE$TRAMPOLINE:-1, UserDetailsCache$$FastClassByGuice$$299491895 (jenkins.security)
apply:-1, UserDetailsCache$$FastClassByGuice$$299491895 (jenkins.security)
newInstance:82, DefaultConstructionProxyFactory$FastClassProxy (com.google.inject.internal)
provision:114, ConstructorInjector (com.google.inject.internal)
access$000:33, ConstructorInjector (com.google.inject.internal)
call:98, ConstructorInjector$1 (com.google.inject.internal)
provision:109, ProvisionListenerStackCallback$Provision (com.google.inject.internal)
onProvision:563, ExtensionFinder$GuiceFinder$SezpozModule (hudson)
provision:117, ProvisionListenerStackCallback$Provision (com.google.inject.internal)
provision:66, ProvisionListenerStackCallback (com.google.inject.internal)
construct:93, ConstructorInjector (com.google.inject.internal)
get:296, ConstructorBindingImpl$Factory (com.google.inject.internal)
get:40, ProviderToInternalFactoryAdapter (com.google.inject.internal)
get:169, SingletonScope$1 (com.google.inject.internal)
get:441, ExtensionFinder$GuiceFinder$FaultTolerantScope$1 (hudson)
get:45, InternalFactoryToProviderAdapter (com.google.inject.internal)
get:1100, InjectorImpl$1 (com.google.inject.internal)
_find:401, ExtensionFinder$GuiceFinder (hudson)
find:392, ExtensionFinder$GuiceFinder (hudson)
findComponents:357, ClassicPluginStrategy (hudson)
load:383, ExtensionList (hudson)
ensureLoaded:319, ExtensionList (hudson)
size:193, ExtensionList (hudson)
lookupSingleton:452, ExtensionList (hudson)
get:86, UserDetailsCache (jenkins.security)
reload:1099, User$AllUsers (hudson.model)
access$400:1075, User$AllUsers (hudson.model)
reload:656, User (hudson.model)
reload:4339, Jenkins (jenkins.model)
run:4309, Jenkins$18 (jenkins.model)
```

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
