### PR TITLE
Suppress `NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR` SpotBugs violation

### DIFF
--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -87,6 +87,7 @@ public class SystemProperties {
 
     private static final Handler NULL_HANDLER = key -> null;
 
+    @SuppressFBWarnings(value = "NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR", justification = "the field is initialized by a static initializer, not a constructor")
     private static @NonNull Handler handler = NULL_HANDLER;
 
     // declared in WEB-INF/web.xml

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -151,10 +151,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
-        <Class name="jenkins.util.SystemProperties"/>
-      </And>
-      <And>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
         <Or>
           <Class name="hudson.cli.BuildCommand"/>


### PR DESCRIPTION
Suppresses the following SpotBugs violation:

```
[ERROR] Medium: Non-null field handler is not initialized by jenkins.util.SystemProperties.<static initializer for SystemProperties>() [jenkins.util.SystemProperties] At SystemProperties.java:[lines 88-172] NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR
```

I can't see what SpotBugs is complaining about here. The [check description](https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#np-non-null-field-is-not-initialized-np-nonnull-field-not-initialized-in-constructor) says:

> The field is marked as non-null, but isn't written to by the constructor. The field might be initialized elsewhere during constructor, or might always be initialized before use.

Well, it is indeed initialized before use, by a static initializer. I see no particular reason why we'd want to force initialization to be done by the constructor. The code appears to be fine, so I am just suppressing the warning.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
