### PR TITLE
Suppress `NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD` SpotBugs violation

### DIFF
--- a/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
+++ b/core/src/main/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor.java
@@ -161,7 +161,12 @@ public class LegacyApiTokenAdministrativeMonitor extends AdministrativeMonitor {
     }
     
     @RequirePOST
-    @SuppressFBWarnings(value = "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", justification = "written to by Stapler")
+    @SuppressFBWarnings(
+            value = {
+                "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
+                "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"
+            },
+            justification = "written to by Stapler")
     public HttpResponse doRevokeAllSelected(@JsonBody RevokeAllSelectedModel content) throws IOException {
         for (RevokeAllSelectedUserAndUuid value : content.values) {
             if (value.userId == null) {

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -221,10 +221,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
-        <Class name="jenkins.security.apitoken.LegacyApiTokenAdministrativeMonitor"/>
-      </And>
-      <And>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
         <Or>
           <Class name="hudson.ClassicPluginStrategy"/>


### PR DESCRIPTION
Suppresses the following SpotBugs violation:

```
[ERROR] Medium: Read of unwritten public or protected field values in jenkins.security.apitoken.LegacyApiTokenAdministrativeMonitor.doRevokeAllSelected(LegacyApiTokenAdministrativeMonitor$RevokeAllSelectedModel) [jenkins.security.apitoken.LegacyApiTokenAdministrativeMonitor] At LegacyApiTokenAdministrativeMonitor.java:[line 166] NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD
```

This is a false positive. The field is written to by Stapler.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
