### PR TITLE
Fix a `SE_BAD_FIELD` SpotBugs violation in `Job`

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -132,7 +132,6 @@ import org.kohsuke.stapler.verb.POST;
  *
  * @author Kohsuke Kawaguchi
  */
-@SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "TODO needs triage")
 public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, RunT>>
         extends AbstractItem implements ExtensionPoint, StaplerOverridable, ModelObjectWithChildren {
 
@@ -1410,65 +1409,91 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         return getIconColor().getIconClassName();
     }
 
+    private static class ChartLabel implements Comparable<ChartLabel> {
+        final Run run;
+
+        ChartLabel(Run r) {
+            this.run = r;
+        }
+
+        @Override
+        public int compareTo(ChartLabel that) {
+            return this.run.number - that.run.number;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            // JENKINS-2682 workaround for Eclipse compilation bug
+            // on (c instanceof ChartLabel)
+            if (o == null || !ChartLabel.class.isAssignableFrom( o.getClass() ))  {
+                return false;
+            }
+            ChartLabel that = (ChartLabel) o;
+            return run == that.run;
+        }
+
+        public Color getColor() {
+            // TODO: consider gradation. See
+            // http://www.javadrive.jp/java2d/shape/index9.html
+            Result r = run.getResult();
+            if (r == Result.FAILURE)
+                return ColorPalette.RED;
+            else if (r == Result.UNSTABLE)
+                return ColorPalette.YELLOW;
+            else if (r == Result.ABORTED || r == Result.NOT_BUILT)
+                return ColorPalette.GREY;
+            else
+                return ColorPalette.BLUE;
+        }
+
+        @Override
+        public int hashCode() {
+            return run.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            String l = run.getDisplayName();
+            if (run instanceof Build) {
+                String s = ((Build) run).getBuiltOnStr();
+                if (s != null)
+                    l += ' ' + s;
+            }
+            return l;
+        }
+    }
+
+    @SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS", justification = "category dataset is only relevant for coloring, not equality")
+    private static class ChartLabelStackedAreaRenderer2 extends StackedAreaRenderer2 {
+        private final CategoryDataset categoryDataset;
+
+        ChartLabelStackedAreaRenderer2(CategoryDataset categoryDataset) {
+            this.categoryDataset = categoryDataset;
+        }
+
+        @Override
+        public Paint getItemPaint(int row, int column) {
+            ChartLabel key = (ChartLabel) categoryDataset.getColumnKey(column);
+            return key.getColor();
+        }
+
+        @Override
+        public String generateURL(CategoryDataset dataset, int row, int column) {
+            ChartLabel label = (ChartLabel) dataset.getColumnKey(column);
+            return String.valueOf(label.run.number);
+        }
+
+        @Override
+        public String generateToolTip(CategoryDataset dataset, int row, int column) {
+            ChartLabel label = (ChartLabel) dataset.getColumnKey(column);
+            return label.run.getDisplayName() + " : " + label.run.getDurationString();
+        }
+    }
+
     public Graph getBuildTimeGraph() {
-        return new Graph(getLastBuildTime(),500,400) {
+        return new Graph(getLastBuildTime(), 500, 400) {
             @Override
             protected JFreeChart createGraph() {
-                class ChartLabel implements Comparable<ChartLabel> {
-                    final Run run;
-
-                    ChartLabel(Run r) {
-                        this.run = r;
-                    }
-
-                    @Override
-                    public int compareTo(ChartLabel that) {
-                        return this.run.number - that.run.number;
-                    }
-
-                    @Override
-                    public boolean equals(Object o) {
-                        // JENKINS-2682 workaround for Eclipse compilation bug
-                        // on (c instanceof ChartLabel)
-                        if (o == null || !ChartLabel.class.isAssignableFrom( o.getClass() ))  {
-                            return false;
-                        }
-                        ChartLabel that = (ChartLabel) o;
-                        return run == that.run;
-                    }
-
-                    public Color getColor() {
-                        // TODO: consider gradation. See
-                        // http://www.javadrive.jp/java2d/shape/index9.html
-                        Result r = run.getResult();
-                        if (r == Result.FAILURE)
-                            return ColorPalette.RED;
-                        else if (r == Result.UNSTABLE)
-                            return ColorPalette.YELLOW;
-                        else if (r == Result.ABORTED || r == Result.NOT_BUILT)
-                            return ColorPalette.GREY;
-                        else
-                            return ColorPalette.BLUE;
-                    }
-
-                    @Override
-                    public int hashCode() {
-                        return run.hashCode();
-                    }
-
-                    @Override
-                    public String toString() {
-                        String l = run.getDisplayName();
-                        if (run instanceof Build) {
-                            String s = ((Build) run).getBuiltOnStr();
-                            if (s != null)
-                                l += ' ' + s;
-                        }
-                        return l;
-                    }
-
-                }
-
                 DataSetBuilder<String, ChartLabel> data = new DataSetBuilder<>();
                 for (Run r : getNewBuilds()) {
                     if (r.isBuilding())
@@ -1512,28 +1537,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
                 ChartUtil.adjustChebyshev(dataset, rangeAxis);
                 rangeAxis.setStandardTickUnits(NumberAxis.createIntegerTickUnits());
 
-                StackedAreaRenderer ar = new StackedAreaRenderer2() {
-                    @Override
-                    public Paint getItemPaint(int row, int column) {
-                        ChartLabel key = (ChartLabel) dataset.getColumnKey(column);
-                        return key.getColor();
-                    }
-
-                    @Override
-                    public String generateURL(CategoryDataset dataset, int row,
-                            int column) {
-                        ChartLabel label = (ChartLabel) dataset.getColumnKey(column);
-                        return String.valueOf(label.run.number);
-                    }
-
-                    @Override
-                    public String generateToolTip(CategoryDataset dataset, int row,
-                            int column) {
-                        ChartLabel label = (ChartLabel) dataset.getColumnKey(column);
-                        return label.run.getDisplayName() + " : "
-                                + label.run.getDurationString();
-                    }
-                };
+                StackedAreaRenderer ar = new ChartLabelStackedAreaRenderer2(dataset);
                 plot.setRenderer(ar);
 
                 // crop extra space around the graph


### PR DESCRIPTION
Fixes this SpotBugs violation:

```
[ERROR] Medium: Class hudson.model.Job$4$1 defines non-transient non-serializable instance field this$1 [hudson.model.Job$4$1] In Job.java SE_BAD_FIELD
```

This was because we were creating an anonymous inner class extending a serializable class (`StackedAreaRenderer2`) that captured non-serializable instance fields from its enclosing outer class. I fixed this by pulling out it and its dependent class `ChartLabel` into private static classes. This should have no impact on functionality, but the resulting classes capture only the state they need, which is a good practice in general and also fixes the SpotBugs warning by preventing the capturing of non-serializable instance fields from the enclosing outer class.

I suggest reviewing this change with "Hide whitespace" enabled in the GitHub UI.

### Testing Done

Visited `${JOB_URL}/buildTimeTrend`; verified that the colors looked right and that I hit the following debugger breakpoint:

```
getColor:1438, Job$ChartLabel (hudson.model)
getItemPaint:1477, Job$ChartLabelStackedAreaRenderer2 (hudson.model)
drawItem:122, StackedAreaRenderer2 (hudson.util)
render:3886, CategoryPlot (org.jfree.chart.plot)
draw:3610, CategoryPlot (org.jfree.chart.plot)
draw:1229, JFreeChart (org.jfree.chart)
createBufferedImage:1431, JFreeChart (org.jfree.chart)
render:121, Graph (hudson.util)
doPng:154, Graph (hudson.util)
invokeVirtual:-1, 603589097 (java.lang.invoke.LambdaForm$DMH)
invoke:-1, 330059783 (java.lang.invoke.LambdaForm$MH)
invoke:-1, 122942606 (java.lang.invoke.LambdaForm$MH)
invokeExact_MT:-1, Invokers$Holder (java.lang.invoke)
invokeWithArguments:710, MethodHandle (java.lang.invoke)
invoke:398, Function$MethodFunction (org.kohsuke.stapler)
invoke:410, Function$InstanceFunction (org.kohsuke.stapler)
bindAndInvoke:208, Function (org.kohsuke.stapler)
bindAndInvokeAndServeResponse:141, Function (org.kohsuke.stapler)
doDispatch:558, MetaClass$11 (org.kohsuke.stapler)
dispatch:59, NameBasedDispatcher (org.kohsuke.stapler)
tryInvoke:766, Stapler (org.kohsuke.stapler)
invoke:898, Stapler (org.kohsuke.stapler)
doDispatch:224, MetaClass$2 (org.kohsuke.stapler)
dispatch:59, NameBasedDispatcher (org.kohsuke.stapler)
tryInvoke:766, Stapler (org.kohsuke.stapler)
invoke:898, Stapler (org.kohsuke.stapler)
doDispatch:289, MetaClass$4 (org.kohsuke.stapler)
dispatch:59, NameBasedDispatcher (org.kohsuke.stapler)
tryInvoke:766, Stapler (org.kohsuke.stapler)
invoke:898, Stapler (org.kohsuke.stapler)
invoke:694, Stapler (org.kohsuke.stapler)
service:240, Stapler (org.kohsuke.stapler)
service:790, HttpServlet (javax.servlet.http)
handle:799, ServletHolder (org.eclipse.jetty.servlet)
doFilter:1626, ServletHandler$ChainEnd (org.eclipse.jetty.servlet)
doFilter:156, PluginServletFilter$1 (hudson.util)
doFilter:128, UserLanguages$AcceptLanguageFilter (jenkins.telemetry.impl)
doFilter:153, PluginServletFilter$1 (hudson.util)
doFilter:80, ResourceDomainFilter (jenkins.security)
doFilter:153, PluginServletFilter$1 (hudson.util)
doFilter:125, MetricsFilter (jenkins.metrics.impl)
doFilter:153, PluginServletFilter$1 (hudson.util)
doFilter:159, PluginServletFilter (hudson.util)
doFilter:193, FilterHolder (org.eclipse.jetty.servlet)
doFilter:1601, ServletHandler$Chain (org.eclipse.jetty.servlet)
doFilter:159, CrumbFilter (hudson.security.csrf)
doFilter:193, FilterHolder (org.eclipse.jetty.servlet)
doFilter:1601, ServletHandler$Chain (org.eclipse.jetty.servlet)
doFilter:92, ChainedServletFilter$1 (hudson.security)
doFilter:52, AcegiSecurityExceptionFilter (jenkins.security)
doFilter:97, ChainedServletFilter$1 (hudson.security)
doFilter:53, UnwrapSecurityExceptionFilter (hudson.security)
doFilter:97, ChainedServletFilter$1 (hudson.security)
doFilter:122, ExceptionTranslationFilter (org.springframework.security.web.access)
doFilter:116, ExceptionTranslationFilter (org.springframework.security.web.access)
doFilter:97, ChainedServletFilter$1 (hudson.security)
doFilter:109, AnonymousAuthenticationFilter (org.springframework.security.web.authentication)
doFilter:97, ChainedServletFilter$1 (hudson.security)
doFilter:136, RememberMeAuthenticationFilter (org.springframework.security.web.authentication.rememberme)
doFilter:93, RememberMeAuthenticationFilter (org.springframework.security.web.authentication.rememberme)
doFilter:97, ChainedServletFilter$1 (hudson.security)
doFilter:219, AbstractAuthenticationProcessingFilter (org.springframework.security.web.authentication)
doFilter:213, AbstractAuthenticationProcessingFilter (org.springframework.security.web.authentication)
doFilter:97, ChainedServletFilter$1 (hudson.security)
doFilter:97, BasicHeaderProcessor (jenkins.security)
doFilter:97, ChainedServletFilter$1 (hudson.security)
doFilter:110, SecurityContextPersistenceFilter (org.springframework.security.web.context)
doFilter:80, SecurityContextPersistenceFilter (org.springframework.security.web.context)
doFilter:62, HttpSessionContextIntegrationFilter2 (hudson.security)
doFilter:97, ChainedServletFilter$1 (hudson.security)
doFilter:109, ChainedServletFilter (hudson.security)
doFilter:171, HudsonFilter (hudson.security)
doFilter:193, FilterHolder (org.eclipse.jetty.servlet)
doFilter:1601, ServletHandler$Chain (org.eclipse.jetty.servlet)
doFilter:53, CompressionFilter (org.kohsuke.stapler.compression)
doFilter:193, FilterHolder (org.eclipse.jetty.servlet)
doFilter:1601, ServletHandler$Chain (org.eclipse.jetty.servlet)
doFilter:85, CharacterEncodingFilter (hudson.util)
doFilter:193, FilterHolder (org.eclipse.jetty.servlet)
doFilter:1601, ServletHandler$Chain (org.eclipse.jetty.servlet)
doFilter:30, DiagnosticThreadNameFilter (org.kohsuke.stapler)
doFilter:193, FilterHolder (org.eclipse.jetty.servlet)
doFilter:1601, ServletHandler$Chain (org.eclipse.jetty.servlet)
doFilter:38, SuspiciousRequestFilter (jenkins.security)
doFilter:193, FilterHolder (org.eclipse.jetty.servlet)
doFilter:1601, ServletHandler$Chain (org.eclipse.jetty.servlet)
doHandle:548, ServletHandler (org.eclipse.jetty.servlet)
handle:143, ScopedHandler (org.eclipse.jetty.server.handler)
handle:578, SecurityHandler (org.eclipse.jetty.security)
handle:127, HandlerWrapper (org.eclipse.jetty.server.handler)
nextHandle:235, ScopedHandler (org.eclipse.jetty.server.handler)
doHandle:1624, SessionHandler (org.eclipse.jetty.server.session)
nextHandle:233, ScopedHandler (org.eclipse.jetty.server.handler)
doHandle:1434, ContextHandler (org.eclipse.jetty.server.handler)
nextScope:188, ScopedHandler (org.eclipse.jetty.server.handler)
doScope:501, ServletHandler (org.eclipse.jetty.servlet)
doScope:1594, SessionHandler (org.eclipse.jetty.server.session)
nextScope:186, ScopedHandler (org.eclipse.jetty.server.handler)
doScope:1349, ContextHandler (org.eclipse.jetty.server.handler)
handle:141, ScopedHandler (org.eclipse.jetty.server.handler)
handle:127, HandlerWrapper (org.eclipse.jetty.server.handler)
handle:516, Server (org.eclipse.jetty.server)
lambda$handle$1:388, HttpChannel (org.eclipse.jetty.server)
dispatch:-1, 1588103949 (org.eclipse.jetty.server.HttpChannel$$Lambda$455)
dispatch:633, HttpChannel (org.eclipse.jetty.server)
handle:380, HttpChannel (org.eclipse.jetty.server)
onFillable:277, HttpConnection (org.eclipse.jetty.server)
succeeded:311, AbstractConnection$ReadCallback (org.eclipse.jetty.io)
fillable:105, FillInterest (org.eclipse.jetty.io)
run:104, ChannelEndPoint$1 (org.eclipse.jetty.io)
runTask:338, EatWhatYouKill (org.eclipse.jetty.util.thread.strategy)
doProduce:315, EatWhatYouKill (org.eclipse.jetty.util.thread.strategy)
tryProduce:173, EatWhatYouKill (org.eclipse.jetty.util.thread.strategy)
run:131, EatWhatYouKill (org.eclipse.jetty.util.thread.strategy)
run:386, ReservedThreadExecutor$ReservedThread (org.eclipse.jetty.util.thread)
runJob:883, QueuedThreadPool (org.eclipse.jetty.util.thread)
run:1034, QueuedThreadPool$Runner (org.eclipse.jetty.util.thread)
run:829, Thread (java.lang)
```

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
