### PR TITLE
Remove dubious warning suppressions

### DIFF
--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -98,7 +98,6 @@ public class BasicAuthenticationFilter implements Filter {
     }
 
     @Override
-    @SuppressWarnings("ACL.impersonate")
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse rsp = (HttpServletResponse) response;

--- a/core/src/main/java/hudson/security/FederatedLoginService.java
+++ b/core/src/main/java/hudson/security/FederatedLoginService.java
@@ -182,7 +182,6 @@ public abstract class FederatedLoginService implements ExtensionPoint {
          *      to the caller of your "doXyz" method, it will either render an error page or initiate
          *      a user registration session (provided that {@link SecurityRealm} supports that.)
          */
-        @SuppressWarnings("ACL.impersonate")
         @NonNull
         public User signin() throws UnclaimedIdentityException {
             User u = locateUser();

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -268,7 +268,6 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
     /**
      * Lets the current user silently login as the given user and report back accordingly.
      */
-    @SuppressWarnings("ACL.impersonate")
     private void loginAndTakeBack(StaplerRequest req, StaplerResponse rsp, User u) throws ServletException, IOException {
         HttpSession session = req.getSession(false);
         if (session != null) {

--- a/core/src/main/java/jenkins/PluginSubtypeMarker.java
+++ b/core/src/main/java/jenkins/PluginSubtypeMarker.java
@@ -54,7 +54,6 @@ import org.kohsuke.MetaInfServices;
  */
 @SupportedAnnotationTypes("*")
 @MetaInfServices(Processor.class)
-@SuppressWarnings("Since15")
 public class PluginSubtypeMarker extends AbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/core/src/main/java/jenkins/util/TreeString.java
+++ b/core/src/main/java/jenkins/util/TreeString.java
@@ -43,8 +43,6 @@ import org.apache.commons.lang.StringUtils;
  * @author Kohsuke Kawaguchi
  * @since 1.473
  */
-// CHECKSTYLE:OFF
-@SuppressWarnings("PMD")
 public final class TreeString implements Serializable {
     private static final long serialVersionUID = 3621959682117480904L;
 
@@ -191,7 +189,6 @@ public final class TreeString implements Serializable {
      * Default {@link Converter} implementation for XStream that does interning
      * scoped to one unmarshalling.
      */
-    @SuppressWarnings("all")
     public static final class ConverterImpl implements Converter {
         public ConverterImpl(final XStream xs) {}
 

--- a/core/src/main/java/jenkins/util/TreeStringBuilder.java
+++ b/core/src/main/java/jenkins/util/TreeStringBuilder.java
@@ -20,8 +20,6 @@ import java.util.Map;
  * @author Kohsuke Kawaguchi
  * @since 1.473
  */
-@SuppressWarnings({"PMD", "all"})
-//CHECKSTYLE:OFF
 public class TreeStringBuilder {
     Child root = new Child(new TreeString());
 

--- a/core/src/test/java/jenkins/util/TreeStringBuilderTest.java
+++ b/core/src/test/java/jenkins/util/TreeStringBuilderTest.java
@@ -12,8 +12,6 @@ import org.junit.Test;
  *
  * @author Kohsuke Kawaguchi
  */
-@SuppressWarnings({"PMD", "all"})
-//CHECKSTYLE:OFF
 public class TreeStringBuilderTest {
     /**
      * Tests the simple operations inside the builder.


### PR DESCRIPTION
See self-review for reasoning.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
