### PR TITLE
`ParametersTest` flaked on Windows

### DIFF
--- a/test/src/test/java/hudson/model/ParametersTest.java
+++ b/test/src/test/java/hudson/model/ParametersTest.java
@@ -93,9 +93,7 @@ public class ParametersTest {
         assertEquals("run", ((HtmlElement) DomNodeUtil.selectSingleNode(element.getParentNode(), "div[contains(@class, 'jenkins-form-label')]")).getTextContent());
 
         j.submit(form);
-        Queue.Item q = j.jenkins.getQueue().getItem(project);
-        if (q != null) q.getFuture().get();
-        else Thread.sleep(1000);
+        j.waitUntilNoActivity();
 
         assertEquals("newValue", builder.getEnvVars().get("STRING"));
         assertEquals("true", builder.getEnvVars().get("BOOLEAN"));
@@ -127,9 +125,7 @@ public class ParametersTest {
         opt.setSelected(true);
 
         j.submit(form);
-        Queue.Item q = j.jenkins.getQueue().getItem(project);
-        if (q != null) q.getFuture().get();
-        else Thread.sleep(1000);
+        j.waitUntilNoActivity();
 
         assertNotNull(builder.getEnvVars());
         assertEquals("Choice <2>", builder.getEnvVars().get("CHOICE"));
@@ -205,9 +201,7 @@ public class ParametersTest {
         HtmlForm form = page.getFormByName("parameters");
 
         j.submit(form);
-        Queue.Item q = j.jenkins.getQueue().getItem(project);
-        if (q != null) q.getFuture().get();
-        else Thread.sleep(1000);
+        j.waitUntilNoActivity();
 
         assertFalse("file must not exist", project.getSomeWorkspace().child("filename").exists());
     }
@@ -231,6 +225,7 @@ public class ParametersTest {
         wc.setThrowExceptionOnFailingStatusCode(true);
         final HtmlForm form = page.getFormByName("parameters");
         HtmlFormUtil.submit(form, HtmlFormUtil.getButtonByCaption(form, "Build"));
+        j.waitUntilNoActivity();
     }
 
     @Issue("SECURITY-353")


### PR DESCRIPTION
Observed in [this run](https://ci.jenkins.io/job/Core/job/jenkins/job/master/3174/consoleFull):

```
[ERROR] unicodeParametersArePresetCorrectly(hudson.model.ParametersTest)  Time elapsed: 53.03 s  <<< ERROR!
jenkins.util.io.CompositeIOException: Unable to delete 'C:\Jenkins\workspace\Core_jenkins_master\test\target\j h1978149526669549233'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts.
	at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:96)
	at hudson.Util.deleteRecursive(Util.java:318)
	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1397)
	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1393)
	at hudson.FilePath.act(FilePath.java:1162)
	at hudson.FilePath.act(FilePath.java:1145)
	at hudson.FilePath.deleteRecursive(FilePath.java:1391)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.dispose(TemporaryDirectoryAllocator.java:93)
	at org.jvnet.hudson.test.TestEnvironment.dispose(TestEnvironment.java:84)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:520)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:619)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:829)
	Suppressed: java.nio.file.AccessDeniedException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h1978149526669549233\jobs\test0\builds\1\log
		at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:89)
		at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
		at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
		at java.base/sun.nio.fs.WindowsFileAttributeViews$Dos.updateAttributes(WindowsFileAttributeViews.java:242)
		at java.base/sun.nio.fs.WindowsFileAttributeViews$Dos.setReadOnly(WindowsFileAttributeViews.java:248)
		at jenkins.util.io.PathRemover.makeWritable(PathRemover.java:297)
		at jenkins.util.io.PathRemover.makeRemovable(PathRemover.java:258)
		at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:238)
		at jenkins.util.io.PathRemover.tryRemoveFile(PathRemover.java:202)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:213)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:93)
		... 14 more
```

This should correct the problem by ensuring that we wait until the build has finished before we try to shut down Jenkins.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
