### PR TITLE
Fix `DMI_RANDOM_USED_ONLY_ONCE` SpotBugs violations

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -891,7 +891,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *      If non-null, use existing plugin manager.  create a new one.
      */
     @SuppressFBWarnings({
-        "DMI_RANDOM_USED_ONLY_ONCE", // TODO needs triage
         "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", // Trigger.timer
         "DM_EXIT" // Exit is wanted here
     })
@@ -934,9 +933,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if(secretFile.exists()) {
                 secretKey = secretFile.readTrim();
             } else {
-                SecureRandom sr = new SecureRandom();
                 byte[] random = new byte[32];
-                sr.nextBytes(random);
+                RANDOM.nextBytes(random);
                 secretKey = Util.toHexString(random);
                 secretFile.write(secretKey);
 
@@ -5509,6 +5507,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public static boolean AUTOMATIC_SLAVE_LAUNCH = true;
 
     private static final Logger LOGGER = Logger.getLogger(Jenkins.class.getName());
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     public static final PermissionGroup PERMISSIONS = Permission.HUDSON_PERMISSIONS;
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;

--- a/core/src/main/java/jenkins/slaves/EncryptedSlaveAgentJnlpFile.java
+++ b/core/src/main/java/jenkins/slaves/EncryptedSlaveAgentJnlpFile.java
@@ -1,6 +1,5 @@
 package jenkins.slaves;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
 import hudson.security.AccessControlled;
 import hudson.security.Permission;
@@ -40,6 +39,7 @@ import org.kohsuke.stapler.StaplerResponse;
 public class EncryptedSlaveAgentJnlpFile implements HttpResponse {
 
     private static final Logger LOG = Logger.getLogger(EncryptedSlaveAgentJnlpFile.class.getName());
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     /**
      * The object that owns the Jelly view that renders JNLP file.
@@ -69,7 +69,6 @@ public class EncryptedSlaveAgentJnlpFile implements HttpResponse {
         this.slaveName = slaveName;
     }
 
-    @SuppressFBWarnings(value = "DMI_RANDOM_USED_ONLY_ONCE", justification = "TODO needs triage")
     @Override
     public void generateResponse(StaplerRequest req, final StaplerResponse res, Object node) throws IOException, ServletException {
         RequestDispatcher view = req.getView(it, viewName);
@@ -86,7 +85,7 @@ public class EncryptedSlaveAgentJnlpFile implements HttpResponse {
             view.forward(req, temp);
 
             byte[] iv = new byte[128/8];
-            new SecureRandom().nextBytes(iv);
+            RANDOM.nextBytes(iv);
 
             byte[] jnlpMac;
             if(it instanceof SlaveComputer) {


### PR DESCRIPTION
Fixes the following SpotBugs violations:

```
[ERROR] High: Random object created and used only once in new jenkins.model.Jenkins(File, ServletContext, PluginManager) [jenkins.model.Jenkins] At Jenkins.java:[line 938] DMI_RANDOM_USED_ONLY_ONCE
[ERROR] High: Random object created and used only once in jenkins.slaves.EncryptedSlaveAgentJnlpFile.generateResponse(StaplerRequest, StaplerResponse, Object) [jenkins.slaves.EncryptedSlaveAgentJnlpFile] At EncryptedSlaveAgentJnl
pFile.java:[line 87] DMI_RANDOM_USED_ONLY_ONCE
```

The [bug description](https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#dmi-random-object-created-and-used-only-once-dmi-random-used-only-once) reads:

> This code creates a `java.util.Random` object, uses it to generate one random number, and then discards the `Random` object. This […] is inefficient. If possible, rewrite the code so that the `Random` object is created once and saved, and each time a new random number is required invoke a method on the existing Random object to obtain it. […] You should strongly consider using a `java.security.SecureRandom` instead (and avoid allocating a new `SecureRandom` for each random number needed).

This PR implements the suggestion by creating a `private static final` instance of `SecureRandom` for each class and using that rather than allocating a new `SecureRandom` for each random number needed. Note that per [the Javadoc](https://docs.oracle.com/javase/8/docs/api/java/util/Random.html):

> Instances of `java.util.Random` are threadsafe.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@StefanSpieker

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
