### PR TITLE
Fill in some deprecation TODOs

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1188,7 +1188,7 @@ public class Util {
 
     /**
      * Concatenate multiple strings by inserting a separator.
-     * @deprecated since TODO; use {@link String#join(CharSequence, Iterable)}
+     * @deprecated since 2.292; use {@link String#join(CharSequence, Iterable)}
      */
     @Deprecated
     @NonNull

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1277,7 +1277,7 @@ public class Fingerprint implements ModelObject, Saveable {
     /**
      * Save the Fingerprint in the given file locally
      * @throws IOException Save error
-     * @deprecated as of TODO. Use {@link #save()} instead.
+     * @deprecated as of 2.242. Use {@link #save()} instead.
      */
     @Deprecated
     void save(File file) throws IOException {
@@ -1368,7 +1368,7 @@ public class Fingerprint implements ModelObject, Saveable {
 
     /**
      * Determines the file name from md5sum.
-     * @deprecated as of TODO. Use {@link #load(String)} instead.
+     * @deprecated as of 2.242. Use {@link #load(String)} instead.
      */
     @Deprecated
     /*package*/ static @CheckForNull Fingerprint load(@NonNull byte[] md5sum) throws IOException {
@@ -1379,7 +1379,7 @@ public class Fingerprint implements ModelObject, Saveable {
      * Loads a {@link Fingerprint} from a file in the image.
      * @return Loaded {@link Fingerprint}. Null if the config file does not exist or
      * malformed.
-     * @deprecated as of TODO. Use {@link #load(String)} instead.
+     * @deprecated as of 2.242. Use {@link #load(String)} instead.
      */
     @Deprecated
     /*package*/ static @CheckForNull Fingerprint load(@NonNull File file) throws IOException {

--- a/core/src/main/java/jenkins/fingerprints/FingerprintStorage.java
+++ b/core/src/main/java/jenkins/fingerprints/FingerprintStorage.java
@@ -55,7 +55,7 @@ public abstract class FingerprintStorage extends AbstractDescribableImpl<Fingerp
 
     /**
      * Returns the file system based {@link FileFingerprintStorage} configured on the system.
-     * @deprecated since TODO, use {@code ExtensionList.lookupSingleton(FileFingerprintStorage.class)} instead.
+     * @deprecated since 2.324, use {@code ExtensionList.lookupSingleton(FileFingerprintStorage.class)} instead.
      */
     @Deprecated
     public static FingerprintStorage getFileFingerprintStorage() {


### PR DESCRIPTION
Fills in some TODOs left behind when deprecating methods.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
