### PR TITLE
Generalize compatibility warning for compatibleSince

### DIFF
--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -67,8 +67,8 @@ PluginManager.UnexpectedException=Unexpected exception going through the retryin
 
 PluginManager.compatWarning=\
  Warning: The new version of this plugin is marked as incompatible with the installed version. \
- This is usually the case because its behavior changed, or because it uses a different settings format than the installed version. \
- Jobs using this plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
+ This is usually the case because its behavior or APIs changed, or because it uses a different settings format than the installed version. \
+ Other plugins with a dependency on this plugin may be incompatible with this update and no longer work as expected, jobs using this plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
  Consult the plugin release notes for details.
 PluginManager.parentDepCompatWarning=The following plugins are incompatible:
 PluginManager.parentCompatWarning=The following plugins are affected by this:
@@ -80,8 +80,8 @@ PluginManager.javaWarning=\
  Jenkins will refuse to load this plugin if installed.
 PluginManager.depCompatWarning=\
  Warning: This plugin requires newer versions of dependencies and at least one of those plugins is not compatible with the installed version. \
- This is usually the case because its behavior changed, or it uses a different settings format than the installed version. \
- Jobs using that plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
+ This is usually the case because its behavior or APIs changed, or it uses a different settings format than the installed version. \
+ Other plugins with a dependency on that plugin may be incompatible with this update and no longer work as expected, jobs using that plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
  Consult the plugin release notes for details.
 PluginManager.depCoreWarning=\
  Warning: This plugin has dependencies on other plugins that require Jenkins {0} or newer. \


### PR DESCRIPTION
https://groups.google.com/g/jenkinsci-dev/c/P9A90864Tqw/m/ifkaLrc4DwAJ recently discussed the wording of the `compatibleSince` warning. Since it's the only tool in our toolbox, and we've generally applied it liberally even if the message didn't _exactly_ apply, it makes sense to phrase it more generally.

This may also have helped the folks using `role-strategy` plugin and installing `matrix-auth` 3.0 anyway.

### Proposed changelog entries

too minor

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
