### PR TITLE
[JENKINS-67515] Fix vertical icon alignment for build status in M and S icon sizes

### DIFF
--- a/war/src/main/less/base/layout-commons.less
+++ b/war/src/main/less/base/layout-commons.less
@@ -125,6 +125,8 @@ body.full-screen #main-panel {
 /* -------------------------------------- */
 
 h1.build-caption.page-headline {
+    display: flex;
+    align-items: center;
     max-width: 1200px;
     overflow: hidden;
     white-space: nowrap;

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1522,7 +1522,7 @@ svg.icon-xlg {
 }
 
 .jenkins-icon-adjacent {
-  margin-left: 0.2rem;
+  margin-left: 0.5rem;
 }
 
 /* -------------- Unclassified ---------- */

--- a/war/src/main/less/modules/icons.less
+++ b/war/src/main/less/modules/icons.less
@@ -89,11 +89,12 @@
 }
 
 .build-status-icon__wrapper {
-  display: inline-block;
+  display: inline-flex;
   position: relative;
 }
+
 .build-status-icon__outer {
-  display: block;
+  display: flex;
   position: absolute;
   top: 50%;
   left: 50%;

--- a/war/src/main/less/modules/table.less
+++ b/war/src/main/less/modules/table.less
@@ -63,7 +63,6 @@
         &:first-of-type {
           border-radius: var(--table-body-radius) 0 0 var(--table-body-radius);
           padding-left: calc(var(--table-padding) * 2);
-          padding-right: var(--table-padding);
         }
 
         &:last-of-type {


### PR DESCRIPTION
See [JENKINS-67515](https://issues.jenkins-ci.org/browse/JENKINS-67515).

**Before**
<img width="140" alt="image" src="https://user-images.githubusercontent.com/43062514/148241332-a7df7018-019a-4ac1-917a-d443edff7ef7.png">

**After**
<img width="135" alt="image" src="https://user-images.githubusercontent.com/43062514/148241357-438f813b-c0f3-4099-b924-d2d006bd39d2.png">

### Proposed changelog entries

* Fix vertical icon alignment for build status in medium (M) and small (S) icon sizes.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
