### PR TITLE
[JENKINS-67470] Extend shading of Tyrus WebSocket client

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -149,6 +149,14 @@
                   <pattern>net</pattern>
                   <shadedPattern>io.jenkins.cli.shaded.net</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com</pattern>
+                  <shadedPattern>io.jenkins.cli.shaded.com</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>jakarta</pattern>
+                  <shadedPattern>io.jenkins.cli.shaded.jakarta</shadedPattern>
+                </relocation>
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
Solves [JENKINS-67470](https://issues.jenkins-ci.org/browse/JENKINS-67470) by amending #5128. ~Untested. @jlamasrios are you able to verify whether this solves your problem? It was not completely clear to me how to reproduce;~

> ~The problem is also easily reproduced by just trying to create a jakarta.xml.bind.annotation.W3CDomHandler instance from the plugin code.~

~but do you need to have any specific dependency (say on the `jaxb` plugin) for that to happen? Does it happen only on Java 11?~

### Proposed changelog entries

* `ClassNotFoundException: io.jenkins.cli.shaded.org.w3c.dom.Node` when using JAXB.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
