### PR TITLE
Do not use `javax.mail` for `doCheckAdminAddress`

### DIFF
--- a/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
+++ b/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java
@@ -18,8 +18,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
 import javax.servlet.ServletContext;
 import jenkins.util.SystemProperties;
 import jenkins.util.UrlHelper;
@@ -210,11 +208,11 @@ public class JenkinsLocationConfiguration extends GlobalConfiguration implements
     }
 
     public FormValidation doCheckAdminAddress(@QueryParameter String value) {
-        try {
-            new InternetAddress(value);
+        // TODO if equal to Messages.Mailer_Address_Not_Configured(), suggest configuring it with FormValidation.warning?
+        if (Util.fixNull(value).contains("@")) {
             return FormValidation.ok();
-        } catch (AddressException e) {
-            return FormValidation.error(e.getMessage());
+        } else {
+            return FormValidation.error(Messages.JenkinsLocationConfiguration_does_not_look_like_an_email_address());
         }
     }
 

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -57,6 +57,7 @@ IdStrategy.CaseSensitive.DisplayName=Case sensitive
 IdStrategy.CaseSensitiveEmailAddress.DisplayName=Case sensitive (email address)
 
 Mailer.Address.Not.Configured=address not configured yet <nobody@nowhere>
+JenkinsLocationConfiguration.does_not_look_like_an_email_address=Does not look like an email address
 Mailer.Localhost.Error=Please set a valid host name, instead of localhost
 Mailer.NotHttp.Error=The URL is invalid, please ensure you are using http:// or https:// with a valid domain.
 


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/6165#discussion_r779674859 for context.

https://stackoverflow.com/q/201323/12916 has plenty of advice but the best I saw was https://stackoverflow.com/a/202528/12916. This is just form validation; you can ignore it if you know better.

Note that this implementation is actually stricter than the status quo in some cases!

```
jshell> new InternetAddress("xxx")
$5 ==> xxx
```

As to requiring a `.`, well my old friend Adam may have been pulling my leg but he claims to have been the sysadmin for Anguilla back in the early days of the Internet and to have received mail as `a@ai`.

### Proposed changelog entries

* N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
