### PR TITLE
Backporting for LTS 2.319.3

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -132,6 +132,14 @@
                   <pattern>net</pattern>
                   <shadedPattern>io.jenkins.cli.shaded.net</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com</pattern>
+                  <shadedPattern>io.jenkins.cli.shaded.com</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>jakarta</pattern>
+                  <shadedPattern>io.jenkins.cli.shaded.jakarta</shadedPattern>
+                </relocation>
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/essentials.yml
+++ b/essentials.yml
@@ -1,7 +1,7 @@
 ---
 ath:
   useLocalSnapshots: false
-  athRevision: "acceptance-test-harness-1.106"
+  athRevision: "acceptance-test-harness-1.111"
   athImage: "jenkins/ath:1.97-pre"
   tests:
     - '*'


### PR DESCRIPTION
```
Latest core version: jenkins-2.330

Fixed
-----

JENKINS-67470		Major     		2.329 released Jan 11, 2022
	ClassNotFoundException when using service as part of SCM poll
	regression
	https://issues.jenkins.io/browse/JENKINS-67470

Candidates
----------

JENKINS-67470		Major     		2.329 released Jan 11, 2022
	ClassNotFoundException when using service as part of SCM poll
	regression
	https://issues.jenkins.io/browse/JENKINS-67470
```