### PR TITLE
Fix UtilTest#createDirectoriesInRoot() on mac

### DIFF
--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -46,7 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -676,7 +676,7 @@ public class UtilTest {
             assertEquals(newDirInRoot.resolve("new1"), Util.createDirectories(newDirInRoot.resolve("new1")).toRealPath());
             Util.createSymlink(newSymlinkInRoot.getParent().toFile(), newDirInRoot.getFileName().toString(), newSymlinkInRoot.getFileName().toString(), TaskListener.NULL);
             assertEquals(newDirInRoot.resolve("new2"), Util.createDirectories(newSymlinkInRoot.resolve("new2")).toRealPath());
-        } catch (AccessDeniedException e) {
+        } catch (FileSystemException e) {
             // Not running as root
             assumeNoException(e);
         }


### PR DESCRIPTION
```
[ERROR] Tests run: 27, Failures: 0, Errors: 1, Skipped: 2, Time elapsed: 0.247 s <<< FAILURE! - in hudson.UtilTest
[ERROR] createDirectoriesInRoot  Time elapsed: 0.012 s  <<< ERROR!
java.nio.file.FileSystemException: /new-dir-in-root: Read-only file system
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:100)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:389)
	at java.base/java.nio.file.Files.createDirectory(Files.java:690)
	at hudson.Util.createDirectories(Util.java:1785)
	at hudson.UtilTest.createDirectoriesInRoot(UtilTest.java:676)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
```