### PR TITLE
[JENKINS-67662] Do not show wrong feature name in tooltips

### DIFF
--- a/core/src/main/resources/lib/form/entry.jelly
+++ b/core/src/main/resources/lib/form/entry.jelly
@@ -77,7 +77,7 @@ THE SOFTWARE.
       <j:when test="${possiblyEscapedTitle!=null}">
         <div class="jenkins-form-label help-sibling">
           <j:out value="${possiblyEscapedTitle}" />
-          <f:helpLink url="${attrs.help}" featureName="${title}"/>
+          <f:helpLink url="${attrs.help}" featureName="${attrs.title}"/>
         </div>
         <!-- Needs to have a .tr class otherwise custom uses of findFollowing
              findFollowingTR(listBox, "validation-error-area") will break -->
@@ -98,7 +98,7 @@ THE SOFTWARE.
       <j:otherwise>
         <div class="setting-main help-sibling">
           <d:invokeBody />
-          <f:helpLink url="${attrs.help}" featureName="${title}"/>
+          <f:helpLink url="${attrs.help}" featureName="${attrs.title}"/>
         </div>
         <!-- used to display the form validation error -->
         <div class="validation-error-area tr"><div colspan="2"></div><div></div><div></div></div>


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-67662](https://issues.jenkins-ci.org/browse/JENKINS-67662).

<details>
<summary>Screenshots</summary>

### Before
<img width="788" alt="Screenshot 2022-01-24 at 14 24 43" src="https://user-images.githubusercontent.com/1831569/150793265-5c779bc0-25d7-45a5-9a62-9a72f0183a54.png">

### After
<img width="629" alt="Screenshot 2022-01-24 at 14 41 32" src="https://user-images.githubusercontent.com/1831569/150793333-d52b8bf2-4d63-4cc3-a3c8-51100b9ef48a.png">

</details>

While this fix removes (wrong) information instead of replacing it with correct information, that seems intentional from JENKINS-55787 / #3921. Since the help button is no longer on the far right of the screen, there's no longer a problem finding the correct help link for a given form field either, so this doesn't seem like a big problem.

### Proposed changelog entries

* Show correct feature name in tooltips of help links (regression in 2.179).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
