### PR TITLE
EOL support for JRuby

### DIFF
--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -81,7 +81,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
 import jenkins.util.xstream.SafeURLConverter;
 
@@ -570,18 +569,12 @@ public class XStream2 extends XStream {
             throw new ConversionException("Refusing to unmarshal " + reader.getNodeName() + " for security reasons; see https://www.jenkins.io/redirect/class-filter/");
         }
 
-        /** TODO see comment in {@code whitelisted-classes.txt} */
-        private static final Pattern JRUBY_PROXY = Pattern.compile("org[.]jruby[.]proxy[.].+[$]Proxy\\d+");
-
         @Override
         public boolean canConvert(Class type) {
             if (type == null) {
                 return false;
             }
             String name = type.getName();
-            if (JRUBY_PROXY.matcher(name).matches()) {
-                return false;
-            }
             // claim we can convert all the scary stuff so we can throw exceptions when attempting to do so
             return ClassFilter.DEFAULT.isBlacklisted(name) || ClassFilter.DEFAULT.isBlacklisted(type);
         }

--- a/core/src/main/resources/jenkins/security/whitelisted-classes.txt
+++ b/core/src/main/resources/jenkins/security/whitelisted-classes.txt
@@ -135,33 +135,9 @@ org.apache.commons.fileupload.disk.DiskFileItem
 org.apache.commons.fileupload.util.FileItemHeadersImpl
 org.apache.tools.ant.Location
 
-# TODO see main ruby-runtime section below
-org.jenkinsci.jruby.JRubyMapper$DynamicProxy
-
 # TODO remove when https://github.com/jenkinsci/xtrigger-lib/pull/9 is widely adopted in fstrigger-plugin, urltrigger-plugin, etc.
 org.jenkinsci.lib.xtrigger.XTriggerCause
 org.jenkinsci.lib.xtrigger.XTriggerCauseAction
-
-# TODO remove (also XStream2.BlacklistedTypesConverter.JRUBY_PROXY) when Ruby Runtime is fixed
-# Related PRs:
-#   - https://github.com/jenkinsci/ruby-runtime-plugin/pull/5,
-#   - https://github.com/jenkinsci/ruby-runtime-plugin/pull/6
-#
-# oleg-nenashev in PR#6 we are trying to get help from last maintainers due to the plugin codebase splitbrain.
-#               It is required to fix JENKINS-50616 in a proper way for 2.107.x
-org.jruby.RubyArray
-org.jruby.RubyBignum
-org.jruby.RubyBoolean
-org.jruby.RubyBoolean$False
-org.jruby.RubyBoolean$True
-org.jruby.RubyFixnum
-org.jruby.RubyHash
-org.jruby.RubyNil
-org.jruby.RubyObject
-org.jruby.RubyString
-org.jruby.RubySymbol
-org.jruby.java.proxies.ConcreteJavaProxy
-org.jruby.runtime.builtin.IRubyObject
 
 org.jvnet.hudson.MemoryUsage
 org.jvnet.localizer.Localizable


### PR DESCRIPTION
The last piece of the puzzle for [JEP-7](https://github.com/jenkinsci/jep/blob/master/jep/7/README.adoc): dropping JRuby support from core. This breaks support for about two dozen infrequently used plugins, which are being suspended from distribution in jenkins-infra/update-center2#565. Since these plugins were deprecated so recently, my proposal is that we keep this PR on hold it and merge it _after_ the next LTS has shipped, at the beginning of a new LTS cycle.

### Proposed changelog entries

Support for [JRuby-based plugins](https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/) has been removed.

### Proposed upgrade guidelines

Support for JRuby-based plugins has been removed. See [the blog post](https://www.jenkins.io/blog/2021/12/22/deprecated-ruby-runtime/) for migration notes.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
