### PR TITLE
deflake Security400Test#ensureDoStopStillReachable

### DIFF
--- a/test/src/test/java/jenkins/security/stapler/Security400Test.java
+++ b/test/src/test/java/jenkins/security/stapler/Security400Test.java
@@ -251,7 +251,10 @@ public class Security400Test {
             atomicResult.set(0);
             assertEquals(0, atomicResult.get());
             QueueTaskFuture<FreeStyleBuild> futureBuild = p.scheduleBuild2(0);
-            futureBuild.waitForStart();
+            FreeStyleBuild build = futureBuild.waitForStart();
+
+            // we need to wait until the SemaphoreBuilder is running (blocked) otherwise the job is ABORTED not FAILURE
+            j.waitForMessage(SemaphoredBuilder.START_MESSAGE, build);
 
             WebRequest request = new WebRequest(new URL(j.getURL() + "computers/0/executors/0/stop"), HttpMethod.POST);
             Page page = wc.getPage(request);


### PR DESCRIPTION
if the build is not inside the builder then the build would be `ABORTED`
rather than `FAILED`.

we now wait until the log contains a message from the `SemaphoredBuilder` before
attempting to stop it to ensure a consistent error state for the test

```
[ERROR] Failures:
[ERROR]
jenkins.security.stapler.Security400Test.ensureDoStopStillReachable(jenkins.security.stapler.Security400Test)
[ERROR]   Run 1: Security400Test.ensureDoStopStillReachable:261
unexpected build status; build log was:
------
Legacy code started this job.  No cause information is available
Running as SYSTEM
Building in workspace
C:\workarea\source\github\jenkinsci\jenkins\test\target\j
h1441632370101236883\workspace\test0
Build was aborted
Aborted by unknown
Finished: ABORTED
```

was the previous error and I could reproduce this at will.

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
