### PR TITLE
[JEP-7] Comment updates after removing JRuby support

### DIFF
--- a/core/src/main/java/hudson/util/LogTaskListener.java
+++ b/core/src/main/java/hudson/util/LogTaskListener.java
@@ -40,7 +40,8 @@ import java.util.logging.Logger;
 /**
  * {@link TaskListener} which sends messages to a {@link Logger}.
  */
-public class LogTaskListener implements TaskListener, Closeable {
+@SuppressWarnings("deprecation") // to preserve serial form
+public class LogTaskListener extends AbstractTaskListener implements TaskListener, Closeable {
 
     // would be simpler to delegate to the LogOutputStream but this would incompatibly change the serial form
     private final TaskListener delegate;

--- a/core/src/main/java/hudson/util/LogTaskListener.java
+++ b/core/src/main/java/hudson/util/LogTaskListener.java
@@ -37,13 +37,10 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
-// TODO: AbstractTaskListener is empty now, but there are dependencies on that e.g. Ruby Runtime - JENKINS-48116)
-// The change needs API deprecation policy or external usages cleanup.
-
 /**
  * {@link TaskListener} which sends messages to a {@link Logger}.
  */
-public class LogTaskListener extends AbstractTaskListener implements TaskListener, Closeable {
+public class LogTaskListener implements TaskListener, Closeable {
 
     // would be simpler to delegate to the LogOutputStream but this would incompatibly change the serial form
     private final TaskListener delegate;

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -48,9 +48,6 @@ import java.util.logging.Logger;
 import jenkins.util.SystemProperties;
 import org.kohsuke.stapler.framework.io.WriterOutputStream;
 
-// TODO: AbstractTaskListener is empty now, but there are dependencies on that e.g. Ruby Runtime - JENKINS-48116)
-// The change needs API deprecation policy or external usages cleanup.
-
 /**
  * {@link TaskListener} that generates output into a single stream.
  *
@@ -59,7 +56,7 @@ import org.kohsuke.stapler.framework.io.WriterOutputStream;
  *
  * @author Kohsuke Kawaguchi
  */
-public class StreamTaskListener extends AbstractTaskListener implements TaskListener, Closeable {
+public class StreamTaskListener implements TaskListener, Closeable {
     @NonNull
     private PrintStream out;
     @CheckForNull

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -56,7 +56,8 @@ import org.kohsuke.stapler.framework.io.WriterOutputStream;
  *
  * @author Kohsuke Kawaguchi
  */
-public class StreamTaskListener implements TaskListener, Closeable {
+@SuppressWarnings("deprecation") // to preserve serial form
+public class StreamTaskListener extends AbstractTaskListener implements TaskListener, Closeable {
     @NonNull
     private PrintStream out;
     @CheckForNull

--- a/core/src/main/resources/hudson/model/Api/index.jelly
+++ b/core/src/main/resources/hudson/model/Api/index.jelly
@@ -84,18 +84,6 @@ THE SOFTWARE.
            <code>ast.literal_eval(urllib.urlopen("...").read())</code>
          </p>
         </dd>
-
-        <!--
-        <dt><a href="ruby?pretty=true">Ruby API</a></dt>
-        <dd>
-         <p>
-           Access the same data as Ruby literals that can be <code>eval</code>ed.
-
-           However, when you do this, beware of the security implication. If you are connecting
-           to a non-trusted Jenkins, the server can send you malicious Python programs.
-         </p>
-        </dd>
-        -->
       </dl>
 
       <p>

--- a/test/src/test/java/hudson/util/LogTaskListenerTest.java
+++ b/test/src/test/java/hudson/util/LogTaskListenerTest.java
@@ -63,17 +63,22 @@ public class LogTaskListenerTest {
         r.createOnlineSlave().getChannel().call(new Log(l));
         assertEquals("[from agent]", logging.getMessages().toString());
     }
+
     private static final class Log extends MasterToSlaveCallable<Void, RuntimeException> {
+
         private final TaskListener l;
+
         Log(TaskListener l) {
             this.l = l;
         }
+
         @Override
         public Void call() throws RuntimeException {
             l.getLogger().println("from agent");
             l.getLogger().flush();
             return null;
         }
+
     }
 
 }

--- a/test/src/test/java/hudson/util/LogTaskListenerTest.java
+++ b/test/src/test/java/hudson/util/LogTaskListenerTest.java
@@ -30,6 +30,7 @@ import hudson.console.HyperlinkNote;
 import hudson.model.TaskListener;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.security.MasterToSlaveCallable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -54,6 +55,25 @@ public class LogTaskListenerTest {
         l.getLogger().println();
         l.getLogger().println(HyperlinkNote.encodeTo(url, "there") + " from encoded");
         assertEquals("[plain line, from annotate, from hyperlink, there from encoded]", logging.getMessages().toString());
+    }
+
+    @Test
+    public void serialization() throws Exception {
+        TaskListener l = new LogTaskListener(Logger.getLogger("LogTaskListenerTest"), Level.INFO);
+        r.createOnlineSlave().getChannel().call(new Log(l));
+        assertEquals("[from agent]", logging.getMessages().toString());
+    }
+    private static final class Log extends MasterToSlaveCallable<Void, RuntimeException> {
+        private final TaskListener l;
+        Log(TaskListener l) {
+            this.l = l;
+        }
+        @Override
+        public Void call() throws RuntimeException {
+            l.getLogger().println("from agent");
+            l.getLogger().flush();
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
Amending #6209.

### Proposed changelog entries

* N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
