### PR TITLE
Notify `systemd(1)` about start-up completion and other service status changes

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -255,7 +255,7 @@ public class WebAppMain implements ServletContextListener {
                         Files.deleteIfExists(BootFailure.getBootFailureFile(_home).toPath());
 
                         // at this point we are open for business and serving requests normally
-                        LOGGER.info("Jenkins is fully up and running");
+                        Jenkins.get().getLifecycle().onReady();
                         success = true;
                     } catch (Error e) {
                         new HudsonFailedToLoad(e).publish(context, _home);

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -110,7 +110,7 @@ public abstract class Lifecycle implements ExtensionPoint {
                     // when we are run by Solaris SMF, these environment variables are set.
                     instance = new SolarisSMFLifecycle();
                 } else if (System.getenv("NOTIFY_SOCKET") != null) {
-                    // When we are running under systemd, this environment variable is set.
+                    // When we are running under systemd with Type=notify, this environment variable is set.
                     instance = new SystemdLifecycle();
                 } else {
                     // if run on Unix, we can do restart

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -283,7 +283,7 @@ public abstract class Lifecycle implements ExtensionPoint {
      *     general state feedback, completion percentages, human-readable error message, etc.
      */
     public void onStatusUpdate(String status) {
-        LOGGER.info(status);
+        LOGGER.log(Level.INFO, status);
     }
 
     private static final Logger LOGGER = Logger.getLogger(Lifecycle.class.getName());

--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -17,7 +17,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Basil Crow
  */
 @Restricted(NoExternalUse.class)
-@Extension
+@Extension(optional = true)
 public class SystemdLifecycle extends ExitLifecycle {
 
     private static final Logger LOGGER = Logger.getLogger(SystemdLifecycle.class.getName());

--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -3,6 +3,7 @@ package hudson.lifecycle;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import java.util.logging.Level;
@@ -34,13 +35,13 @@ public class SystemdLifecycle extends ExitLifecycle {
     }
 
     @Override
-    public void onReload(@NonNull String user, String remoteAddr) {
+    public void onReload(@NonNull String user, @CheckForNull String remoteAddr) {
         super.onReload(user, remoteAddr);
         notify("RELOADING=1");
     }
 
     @Override
-    public void onStop(@NonNull String user, String remoteAddr) {
+    public void onStop(@NonNull String user, @CheckForNull String remoteAddr) {
         super.onStop(user, remoteAddr);
         notify("STOPPING=1");
     }

--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -1,0 +1,61 @@
+package hudson.lifecycle;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * {@link Lifecycle} that delegates its responsibility to {@code systemd(1)}.
+ *
+ * @author Basil Crow
+ */
+@Restricted(NoExternalUse.class)
+@Extension
+public class SystemdLifecycle extends ExitLifecycle {
+
+    private static final Logger LOGGER = Logger.getLogger(SystemdLifecycle.class.getName());
+
+    interface Systemd extends Library {
+        Systemd INSTANCE = Native.load("systemd", Systemd.class);
+
+        int sd_notify(int unset_environment, String state) throws LastErrorException;
+    }
+
+    @Override
+    public void onReady() {
+        super.onReady();
+        notify("READY=1");
+    }
+
+    @Override
+    public void onReload(@NonNull String user, String remoteAddr) {
+        super.onReload(user, remoteAddr);
+        notify("RELOADING=1");
+    }
+
+    @Override
+    public void onStop(@NonNull String user, String remoteAddr) {
+        super.onStop(user, remoteAddr);
+        notify("STOPPING=1");
+    }
+
+    @Override
+    public void onStatusUpdate(String status) {
+        super.onStatusUpdate(status);
+        notify(String.format("STATUS=%s", status));
+    }
+
+    private static synchronized void notify(String message) {
+        try {
+            Systemd.INSTANCE.sd_notify(0, message);
+        } catch (LastErrorException e) {
+            LOGGER.log(Level.WARNING, null, e);
+        }
+    }
+}


### PR DESCRIPTION
Refactors lifecycle-related notifications into a set of common methods in `Lifecycle`, then adds a new `SystemdLifecycle` that implements support for [`sd_notify(3)`](https://www.freedesktop.org/software/systemd/man/sd_notify.html). This allows `systemd` to have awareness of when Jenkins has finished starting up and allows `systemd` to correctly mark the service as failed if the Java process starts but Jenkins startup does not complete (e.g., due to a JCasC error).

I tested this with the following settings:

```
[Service]
Type=notify
NotifyAccess=main
```

Manual testing done:

- Started Jenkins with `systemctl start jenkins`; verified the command blocked until the service had fully started.
- Stopped Jenkins with `/safeExit`; verified the service was marked as `inactive (dead)` with `Status: "Jenkins stopped"`.
- Restarted Jenkins with `/safeRestart`; verified the service had `Status: "Restart in 10 seconds"`, then `Active: activating (start)`, then finally `Active: active (running)` after restarting.
- Updated a plugin and checked "Restart Jenkins when installation is complete and no jobs are running"; verified the service had `Status: "Restart in 10 seconds"`, then `Active: activating (start)`, then finally `Active: active (running)` after restarting.
- Ran the Molecule tests from jenkinsci/packaging#266 successfully against this PR.

### Proposed changelog entries

Startup completion notification is available with `systemd(1)`.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
