### PR TITLE
Jenkins should terminate cleanly on `SIGTERM`

### DIFF
--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -58,8 +58,8 @@ public abstract class Lifecycle implements ExtensionPoint {
             if (jenkins != null) {
                 try {
                     jenkins.cleanUp();
-                } catch (Throwable e) {
-                    LOGGER.log(Level.SEVERE, "Failed to clean up. Shutdown will continue.", e);
+                } catch (Throwable t) {
+                    LOGGER.log(Level.SEVERE, "Failed to clean up. Shutdown will continue.", t);
                 }
             }
         }));

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -52,6 +52,19 @@ import org.apache.commons.io.FileUtils;
 public abstract class Lifecycle implements ExtensionPoint {
     private static Lifecycle INSTANCE = null;
 
+    public Lifecycle() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Jenkins jenkins = Jenkins.getInstanceOrNull();
+            if (jenkins != null) {
+                try {
+                    jenkins.cleanUp();
+                } catch (Throwable e) {
+                    LOGGER.log(Level.SEVERE, "Failed to clean up. Shutdown will continue.", e);
+                }
+            }
+        }));
+    }
+
     /**
      * Gets the singleton instance.
      *


### PR DESCRIPTION
When Jenkins receives `SIGTERM` (e.g., when shut down via a service manager or Ctrl-C rather than via `/safeExit` or `/safeRestart`), it doesn't perform cleanup. This PR corrects the problem by registering a shutdown hook to perform cleanup in these scenarios.

I tested this by applying this PR on top of #6228 and ensuring that `SIGTERM` caused the `cleanUp()` method to be invoked after this change (it wasn't before this change).

### Proposed changelog entries

Run cleanup before terminating the controller process due to a Unix `TERM` signal.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
