### PR TITLE
[JENKINS-67609] Deduplicate help button question mark

### DIFF
--- a/war/src/main/less/modules/form.less
+++ b/war/src/main/less/modules/form.less
@@ -310,7 +310,7 @@
   border-radius: 100%;
 
   &::before {
-    content: "?";
+    content: "";
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
Fixes [JENKINS-67609](https://issues.jenkins.io/browse/JENKINS-67609)

The question mark on the new help button is set twice, but is only shown twice if you are using different themes.

![](https://i.imgur.com/FlnoVuo.png)

The change proposed removes the additional question mark and sticks to the "major" one.
![](https://i.imgur.com/xvnMePT.png)

Looks like that was originally introduced in https://github.com/jenkinsci/jenkins/pull/5842.

### Proposed changelog entries

* Render the question mark on the new help button only once so that it is not shown twice, even while using different themes.

### Proposed upgrade guidelines

N/A

### Submitter checklist

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
