### PR TITLE
Backporting for LTS 2.319.3 (additional backports)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -298,7 +298,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.18</version>
+        <version>1.4.19</version>
       </dependency>
       <dependency>
         <groupId>net.sf.kxml</groupId>

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2261,7 +2261,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         this.getNodes().forEach(n -> nodeLabels.addAll(n.getAssignedLabels()));
         for (Iterator<Label> itr = labels.values().iterator(); itr.hasNext();) {
             Label l = itr.next();
-            if (includedLabels == null || includedLabels.contains(l)) {
+            if (includedLabels == null || includedLabels.contains(l) || l.matches(includedLabels)) {
                 if (nodeLabels.contains(l) || !l.getClouds().isEmpty()) {
                     // there is at least one static agent or one cloud that currently claims it can handle the label.
                     // if the cloud has been removed, or its labels updated such that it can not handle this, this is handle in later calls

--- a/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
+++ b/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
@@ -30,21 +30,28 @@ import hudson.BulkChange;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.Computer;
+import hudson.model.Descriptor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
+import hudson.model.Node;
 import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.Builder;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 
@@ -173,6 +180,84 @@ public class NodeProvisionerTest {
             // and all blue jobs should be still stuck in the queue
             for (Future<FreeStyleBuild> bb : blueBuilds)
                 assertFalse(bb.isDone());
+        }
+    }
+
+    @Issue("JENKINS-67635")
+    @Test
+    public void testJobWithCloudLabelExpressionProvisionsOnlyOneAgent() throws Exception {
+        DummyCloudImpl3 cloud1 = new DummyCloudImpl3(r);
+        DummyCloudImpl3 cloud2 = new DummyCloudImpl3(r);
+
+        cloud1.label = Label.get("cloud-1-label");
+        cloud2.label = Label.get("cloud-2-label");
+
+        r.jenkins.clouds.add(cloud1);
+        r.jenkins.clouds.add(cloud2);
+
+        FreeStyleProject p = r.createFreeStyleProject();
+        p.setAssignedLabel(Label.parseExpression("cloud-1-label || cloud-2-label"));
+
+        QueueTaskFuture<FreeStyleBuild> futureBuild = p.scheduleBuild2(0);
+        futureBuild.waitForStart();
+        r.assertBuildStatus(Result.SUCCESS, futureBuild);
+
+        assertEquals(1, cloud1.numProvisioned);
+        assertEquals(0, cloud2.numProvisioned);
+    }
+
+    private static class DummyCloudImpl3 extends Cloud {
+        private final transient JenkinsRule caller;
+        public int numProvisioned;
+        private Label label;
+
+        DummyCloudImpl3() {
+            super("DummyCloudImpl3");
+            this.caller = null;
+        }
+
+        DummyCloudImpl3(JenkinsRule caller) {
+            super("DummyCloudImpl3");
+            this.caller = caller;
+        }
+
+        @Override
+        public Collection<NodeProvisioner.PlannedNode> provision(Label label, int excessWorkload) {
+            List<NodeProvisioner.PlannedNode> r = new ArrayList<>();
+            if (! this.canProvision(label))
+                return r;
+
+            while (excessWorkload > 0) {
+                numProvisioned++;
+                Future<Node> f = Computer.threadPoolForRemoting.submit(new DummyCloudImpl3.Launcher());
+                r.add(new NodeProvisioner.PlannedNode(name + " #" + numProvisioned, f, 1));
+                excessWorkload -= 1;
+            }
+            return r;
+        }
+
+        @Override
+        public boolean canProvision(Label label) {
+            return label.matches(this.label.listAtoms());
+        }
+
+        private final class Launcher implements Callable<Node> {
+            private volatile Computer computer;
+
+            private Launcher() {}
+
+            @Override
+            public Node call() throws Exception {
+                DumbSlave slave = caller.createSlave(label);
+                computer = slave.toComputer();
+                computer.connect(false).get();
+                return slave;
+            }
+        }
+
+        @Override
+        public Descriptor<Cloud> getDescriptor() {
+            throw new UnsupportedOperationException();
         }
     }
 


### PR DESCRIPTION
Follow up from: https://github.com/jenkinsci/jenkins/pull/6187

```
Fixed
-----

JENKINS-67702		Minor     		Mon, 31 Jan 2022 11:26:06 +0000
	Backport XStream 1.4.19 to LTS
	https://issues.jenkins.io/browse/JENKINS-67702

JENKINS-67635		Major     		2.333
	Using "||" in pipeline targeting cloud labels cause multiple agents to be spun incessantly
	regression
	https://issues.jenkins.io/browse/JENKINS-67635

JENKINS-67470		Major     		2.329 released Jan 11, 2022
	ClassNotFoundException when using service as part of SCM poll
	regression
	https://issues.jenkins.io/browse/JENKINS-67470

Candidates
----------

JENKINS-67702		Minor     		Mon, 31 Jan 2022 11:26:06 +0000
	Backport XStream 1.4.19 to LTS
	https://issues.jenkins.io/browse/JENKINS-67702

JENKINS-67496		Major     		2.333
	Drag & drop is messed up, drag placeholders always have tiny size
	regression
	https://issues.jenkins.io/browse/JENKINS-67496

JENKINS-67627		Minor     		2.333
	Expandable text areas strip spaces
	regression
	https://issues.jenkins.io/browse/JENKINS-67627

JENKINS-67662		Minor     		2.333
	Tooltips show wrong feature name on checkboxes
	regression
	https://issues.jenkins.io/browse/JENKINS-67662

JENKINS-67635		Major     		2.333
	Using "||" in pipeline targeting cloud labels cause multiple agents to be spun incessantly
	regression
	https://issues.jenkins.io/browse/JENKINS-67635

```
- Pending to decide about
   - https://issues.jenkins.io/browse/JENKINS-67496
   - https://issues.jenkins.io/browse/JENKINS-67627
   - https://issues.jenkins.io/browse/JENKINS-67662
