### PR TITLE
Extend startup notification timeout as each initialization milestone is attained

### DIFF
--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -288,6 +289,16 @@ public abstract class Lifecycle implements ExtensionPoint {
             LOGGER.log(Level.INFO, "Stopping Jenkins as requested by {0}", user);
         }
     }
+
+    /**
+     * Tell the service manager to extend the startup or shutdown timeout. The value specified is a
+     * time during which either {@link #onExtendTimeout(long, TimeUnit)} must be called again or
+     * startup/shutdown must complete.
+     *
+     * @param timeout The amount by which to extend the timeout.
+     * @param unit The time unit of the timeout argument.
+     */
+    public void onExtendTimeout(long timeout, @NonNull TimeUnit unit) {}
 
     /**
      * Called when Jenkins service state has changed.

--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -6,6 +6,7 @@ import com.sun.jna.Native;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
@@ -44,6 +45,12 @@ public class SystemdLifecycle extends ExitLifecycle {
     public void onStop(@NonNull String user, @CheckForNull String remoteAddr) {
         super.onStop(user, remoteAddr);
         notify("STOPPING=1");
+    }
+
+    @Override
+    public void onExtendTimeout(long timeout, @NonNull TimeUnit unit) {
+        super.onExtendTimeout(timeout, unit);
+        notify(String.format("EXTEND_TIMEOUT_USEC=%d", unit.toMicros(timeout)));
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1181,6 +1181,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             @Override
             protected void onInitMilestoneAttained(InitMilestone milestone) {
                 initLevel = milestone;
+                getLifecycle().onExtendTimeout(15, TimeUnit.SECONDS);
                 if (milestone == PLUGINS_PREPARED) {
                     // set up Guice to enable injection as early as possible
                     // before this milestone, ExtensionList.ensureLoaded() won't actually try to locate instances

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1181,7 +1181,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             @Override
             protected void onInitMilestoneAttained(InitMilestone milestone) {
                 initLevel = milestone;
-                getLifecycle().onExtendTimeout(15, TimeUnit.SECONDS);
+                getLifecycle().onExtendTimeout(EXTEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                 if (milestone == PLUGINS_PREPARED) {
                     // set up Guice to enable injection as early as possible
                     // before this milestone, ExtensionList.ensureLoaded() won't actually try to locate instances
@@ -5519,6 +5519,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static boolean AUTOMATIC_AGENT_LAUNCH = SystemProperties.getBoolean(Jenkins.class.getName() + ".automaticAgentLaunch", true);
+
+    /**
+     * The amount of time by which to extend the startup notification timeout as each initialization milestone is attained.
+     */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
+    public static /* not final */ int EXTEND_TIMEOUT_SECONDS = SystemProperties.getInteger(Jenkins.class.getName() + ".extendTimeoutSeconds", 15);
 
     private static final Logger LOGGER = Logger.getLogger(Jenkins.class.getName());
     private static final SecureRandom RANDOM = new SecureRandom();


### PR DESCRIPTION
A potential problem with the startup notification support introduced in #6228 is very slow Jenkins installations. By default `systemd` waits up to 90 seconds for a service to start up before the start timeout is reached. I have seen some slow Jenkins installations that take longer than that. This PR introduces a new `Lifecycle` API for pushing back the timeout and adjusts the initialization logic to push the timeout back by 15 seconds as each initialization milestone is attained `STARTED`, `PLUGINS_LISTED`, `PLUGINS_PREPARED`, `PLUGINS_STARTED`, `EXTENSIONS_AUGMENTED`, `SYSTEM_CONFIG_LOADED`, `SYSTEM_CONFIG_ADAPTED`, `JOB_LOADED`, `JOB_CONFIG_ADAPTED`, and `COMPLETED`, so potentially increasing the timeout by another 2.5 minutes, as long as Jenkins is actually making progress in starting up. This should make it far less likely that people hit startup timeouts when using `systemd` with `Type=notify`, unless people have a huge amount of jobs that take many minutes to load. Even in that situation, we should be able to consume this new API from e.g. https://github.com/jenkinsci/cloudbees-folder-plugin/blob/d63f3c0efe1b951aba3278f671cd6dea192908ec/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java#L563-L581 to push back the timeout every 15 seconds or so as long as Jenkins continues to make progress in loading jobs.

To test this, I set the overall service timeout to an absurdly low value (2 seconds) and verified that the service still started up (in about 10 seconds), confirming that the timeout extension system was working.

### Proposed changelog entries

* Extend startup notification timeout as each initialization milestone is attained.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
