### PR TITLE
Fallback in `ExtensionFinder.java:287` fails in production context with No injectable constructor for type Jenkins

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -44,7 +44,6 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 import antlr.ANTLRException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.thoughtworks.xstream.XStream;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -1345,9 +1344,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @Extension
     @Restricted(NoExternalUse.class)
     public static class EnforceSlaveAgentPortAdministrativeMonitor extends AdministrativeMonitor {
-        @Inject
-        Jenkins j;
-
         @Override
         public String getDisplayName() {
             return jenkins.model.Messages.EnforceSlaveAgentPortAdministrativeMonitor_displayName();
@@ -1358,13 +1354,13 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
 
         public int getExpectedPort() {
-            int slaveAgentPort = j.slaveAgentPort;
+            int slaveAgentPort = Jenkins.get().slaveAgentPort;
             return Jenkins.getSlaveAgentPortInitialValue(slaveAgentPort);
         }
 
         @RequirePOST
         public void doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {
-            j.forceSetSlaveAgentPort(getExpectedPort());
+            Jenkins.get().forceSetSlaveAgentPort(getExpectedPort());
             rsp.sendRedirect2(req.getContextPath() + "/manage");
         }
 


### PR DESCRIPTION
Fallback in `ExtensionFinder.java:287` fails in production context with No injectable constructor for type Jenkins

### Steps to reproduce

- Start Jenkins with `java -jar jenkins.war` with Guice 5.0.1 (i.e., tip-of-trunk).
- Install only the CloudBees Folder plugin in the setup wizard (not the Credentials plugin!).
- Stop and start Jenkins; verify that Jenkins starts cleanly.
- Upgrade Guice to 5.1.0.
- Start Jenkins again with `java -jar jenkins.war`.
- Notice that Jenkins now fails to start with:

```
2022-02-01 04:44:57.557+0000 [id=42]    WARNING hudson.ExtensionFinder$Sezpoz#_find: Failed to load hudson.ExtensionFinder$GuiceFinder
com.google.inject.CreationException: Unable to create injector, see the following errors:

1) [Guice/MissingConstructor]: No injectable constructor for type Jenkins.

class Jenkins does not have a @Inject annotated constructor or a no-arg constructor.

Requested by:
1  : Jenkins.class(Jenkins.java:339)
     at Jenkins$EnforceSlaveAgentPortAdministrativeMonitor.j(Jenkins.java:1347)
      \_ for field j
     at hudson.ExtensionFinder$GuiceFinder$SezpozModule.configure(ExtensionFinder.java:533)

Learn more:
  https://github.com/google/guice/wiki/MISSING_CONSTRUCTOR

1 error

======================
Full classname legend:
======================
Jenkins:                                            "jenkins.model.Jenkins"
Jenkins$EnforceSlaveAgentPortAdministrativeMonitor: "jenkins.model.Jenkins$EnforceSlaveAgentPortAdministrativeMonitor"
========================
End of classname legend:
========================

        at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:576)
        at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:163)
        at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:110)
        at com.google.inject.Guice.createInjector(Guice.java:87)
        at com.google.inject.Guice.createInjector(Guice.java:69)
        at com.google.inject.Guice.createInjector(Guice.java:59)
        at hudson.ExtensionFinder$GuiceFinder.<init>(ExtensionFinder.java:287)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at java.base/java.lang.Class.newInstance(Class.java:584)
        at net.java.sezpoz.IndexItem.instance(IndexItem.java:181)
Caused: java.lang.InstantiationException
        at net.java.sezpoz.IndexItem.instance(IndexItem.java:191)
        at hudson.ExtensionFinder$Sezpoz._find(ExtensionFinder.java:706)
        at hudson.ExtensionFinder$Sezpoz.find(ExtensionFinder.java:692)
        at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:358)
        at hudson.ExtensionList.load(ExtensionList.java:384)
        at hudson.ExtensionList.ensureLoaded(ExtensionList.java:320)
        at hudson.ExtensionList.getComponents(ExtensionList.java:184)
        at jenkins.model.Jenkins$6.onInitMilestoneAttained(Jenkins.java:1187)
        at jenkins.InitReactorRunner$1.onAttained(InitReactorRunner.java:88)
        at org.jvnet.hudson.reactor.ReactorListener$Aggregator.lambda$onAttained$3(ReactorListener.java:108)
        at org.jvnet.hudson.reactor.ReactorListener$Aggregator.run(ReactorListener.java:115)
        at org.jvnet.hudson.reactor.ReactorListener$Aggregator.onAttained(ReactorListener.java:108)
        at org.jvnet.hudson.reactor.Reactor$1.run(Reactor.java:183)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:121)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

### Evaluation

Guice now does more classloading in `Guice#createInjector` than it did before (thanks to google/guice@dc7f485), which it has every right to do. But this breaks our handling of optional extensions. We handle optional extensions by first calling `Guice.createInjector` at line 281 of `ExtensionFinder`, and if it fails then calling it again with a reduced set of bindings on line 283 of `ExtensionFinder`. That fallback path apparently hasn't been exercised in a while, since `EnforceSlaveAgentPortAdministrativeMonitor` (added in 2016) can't be instantiated in the fallback code path.

### Solution

This PR fixes the problem in the fallback code path introduced in 2016 by making `EnforceSlaveAgentPortAdministrativeMonitor` instantiable from the fallback code path. Namely, we use `Jenkins.get()` to get the Jenkins god object rather than using Guice. With this in place, the fallback code path works, and Jenkins can be started again with Guice 5.1.0 with CloudBees Folder installed but not Credentials.

### Proposed changelog entries

Jenkins might fail to start in unusual edge cases involving optional plugins not being installed.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
