### PR TITLE
Bump Guice from 5.0.1 to 5.1.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice-bom</artifactId>
-        <version>5.0.1</version>
+        <version>5.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -44,7 +44,6 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 import antlr.ANTLRException;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.thoughtworks.xstream.XStream;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -1345,9 +1344,6 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @Extension
     @Restricted(NoExternalUse.class)
     public static class EnforceSlaveAgentPortAdministrativeMonitor extends AdministrativeMonitor {
-        @Inject
-        Jenkins j;
-
         @Override
         public String getDisplayName() {
             return jenkins.model.Messages.EnforceSlaveAgentPortAdministrativeMonitor_displayName();
@@ -1358,13 +1354,13 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
 
         public int getExpectedPort() {
-            int slaveAgentPort = j.slaveAgentPort;
+            int slaveAgentPort = Jenkins.get().slaveAgentPort;
             return Jenkins.getSlaveAgentPortInitialValue(slaveAgentPort);
         }
 
         @RequirePOST
         public void doAct(StaplerRequest req, StaplerResponse rsp) throws IOException {
-            j.forceSetSlaveAgentPort(getExpectedPort());
+            Jenkins.get().forceSetSlaveAgentPort(getExpectedPort());
             rsp.sendRedirect2(req.getContextPath() + "/manage");
         }
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -160,7 +160,8 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>308.v852b473a2b8c</version>
+      <!-- TODO https://github.com/jenkinsci/structs-plugin/pull/122 -->
+      <version>315.v1cf0d78d9e85</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -117,6 +117,12 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>1074.v60e6c29b_b_44b_</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
       <version>408.vd726a_1130320</version>
       <scope>test</scope>
@@ -154,7 +160,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.24</version>
+      <version>308.v852b473a2b8c</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Supersedes #6219.

### Steps to reproduce

Upgrade Guice from 5.0.1 to 5.1.0 and then run `mvn clean verify -Dtest=hudson.AboutJenkinsTest\#onlyAdminOrManageOrSystemReadCanReadAbout`.

### Expected results

The test passes.

### Actual results

The test fails with the errors seen [here](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6219/6/testReport/junit/jenkins.slaves/OldRemotingAgentTest/Linux_jdk11___Linux_Build___Test___remoteConsoleNote/).

### Evaluation

Guice now does more classloading in `Guice#createInjector` than it did before (thanks to google/guice@dc7f485), which it has every right to do. But this breaks our handling of optional extensions. We handle optional extensions by first calling `Guice.createInjector` at line 281 of `ExtensionFinder`, and if it fails then calling it again with a reduced set of bindings on line 283 of `ExtensionFinder`. That fallback path apparently hasn't been exercised in a while, since it was completely broken in production context since 2016 (fixed in #6239) and could never possibly have worked in unit test context. Why not? The comment in the fallback reads: "failing to load all bindings are disastrous, so recover by creating minimum that works by just including the core" followed by a call to `Jenkins.class.getClassLoader()`. That would work in production, where the Jenkins classloader is the web application classloader (which doesn't have the plugins on it), but in unit test context it's the unit test class loader that has all the plugins on it. So this fallback never worked for unit tests. So our support for "optional" extensions never fully worked in unit tests, but we happened to get by because Guice was never loading very many classes in `Guice.createInjector`. The latest version of Guice does, so we can't get by anymore in unit test context (though we can in production context as #6239 demonstrates).

### Solution

I don't have a good idea of how to get the fallback to work properly in unit test context, but since it never worked to begin with it seems fine to just include the Credentials plugin on the test classpath in our unit tests.

### Proposed changelog entries

Jenkins has upgraded the Guice library from 5.0.1 to 5.1.0.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
