### PR TITLE
Remove unused deprecated method from `Listeners`

### DIFF
--- a/core/src/main/java/jenkins/util/Listeners.java
+++ b/core/src/main/java/jenkins/util/Listeners.java
@@ -71,14 +71,6 @@ public class Listeners {
         }
     }
 
-    /**
-     * @deprecated call {@link #notify(Class, boolean, Consumer)}
-     */
-    @Deprecated
-    public static <L> void notify(Class<L> listenerType, Consumer<L> notification) {
-        notify(listenerType, true, notification);
-    }
-
     private Listeners() {}
 
 }


### PR DESCRIPTION
This API only existed in one weekly and [`usage-in-plugins`](https://ci.jenkins.io/job/Infra/job/usage-in-plugins/job/master/) confirms it is unused.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
