### PR TITLE
[JENKINS-67722] Fix `/configure` link on custom log recorders

### DIFF
--- a/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
@@ -63,7 +63,7 @@ THE SOFTWARE.
           <local:row name="${lr.name}" href="${lr.searchUrl}/">
             <l:isAdmin>
               <div class="jenkins-table__cell__button-wrapper">
-                <a href="${rootURL}/${c.url}configure" class="jenkins-table__button">
+                <a href="${lr.searchUrl}/configure" class="jenkins-table__button">
                   <l:ionicon name="settings-outline" />
                 </a>
               </div>


### PR DESCRIPTION
Fixes [JENKINS-67722](https://issues.jenkins.io/browse/JENKINS-67722)

A regression from 2.322, where more tables have been modernized. The change proposed restores the original behavior, where clicking on the cogwheel of a custom log recorder redirects to `/log/<log recorder>/configure`, instead of /configure on the root URL.

### Proposed changelog entries

* The log recorder configure button links to the associated log recorder (regression in 2.322).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
