### PR TITLE
Clean up Javadoc for Java 17

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -322,14 +322,11 @@ public class WebAppMain implements ServletContextListener {
     /**
      * Determines the home directory for Jenkins.
      *
-     * <p>
-     * We look for a setting that affects the smallest scope first, then bigger ones later.
+     * <p>We look for a setting that affects the smallest scope first, then bigger ones later.
      *
-     * <p>
-     * People makes configuration mistakes, so we are trying to be nice
+     * <p>People make configuration mistakes, so we are trying to be nice
      * with those by doing {@link String#trim()}.
      *
-     * <p>
      * @return the File alongside with some description to help the user troubleshoot issues
      */
     public FileAndDescription getHomeDir(ServletContextEvent event) {

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -527,9 +527,6 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
      * then it will be loaded, then this method will be invoked
      * to perform any implementation-specific work.
      *
-     * <p>
-     *
-     *
      * @param src
      *      Item from which it's copied from. The same type as {@code this}. Never null.
      */

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1919,9 +1919,8 @@ public class Queue extends ResourceController implements Saveable {
          * amongst all the free executors on all possibly suitable nodes.
          * NOTE: To be able to re-use the same node during the next run this key should not change from one run to
          * another. You probably want to compute that key based on the job's name.
-         * <p>
-         * @return by default: {@link #getFullDisplayName()}
          *
+         * @return by default: {@link #getFullDisplayName()}
          * @see hudson.model.LoadBalancer
          */
         default String getAffinityKey() { return getFullDisplayName(); }

--- a/core/src/main/java/hudson/scheduler/Hash.java
+++ b/core/src/main/java/hudson/scheduler/Hash.java
@@ -33,15 +33,11 @@ import java.util.Random;
 /**
  * Generates a pseudo-random sequence of integers in the specified range.
  *
- * <p>
- * {@link CronTab} supports tokens like '@daily', which means "do it once a day".
+ * <p>{@link CronTab} supports tokens like '@daily', which means "do it once a day".
  * Exactly which time of the day this gets scheduled is randomized --- randomized
  * in the sense that it's spread out when many jobs choose @daily, but it's at
  * the same time stable so that every job sticks to a specific time of the day
  * even after the configuration is updated.
- *
- * <p>
- *
  *
  * @author Kohsuke Kawaguchi
  * @since 1.448

--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -67,7 +67,7 @@ import org.springframework.security.core.userdetails.UserDetails;
  * This causes the container to perform authentication, but there's no way
  * to find out whether the user has been successfully authenticated or not.
  * So to find this out, we then redirect the user to
- * {@link jenkins.model.Jenkins#doSecured(StaplerRequest, StaplerResponse) {@code /secured/...} page}.
+ * {@link jenkins.model.Jenkins#doSecured(StaplerRequest, StaplerResponse) /secured/... page}.
  *
  * <p>
  * The handler of the above URL checks if the user is authenticated,

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2983,12 +2983,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Gets the item by its path name from the given context
      *
      * <h2>Path Names</h2>
-     * <p>
-     * If the name starts from '/', like "/foo/bar/zot", then it's interpreted as absolute.
+     *
+     * <p>If the name starts from '/', like "/foo/bar/zot", then it's interpreted as absolute.
      * Otherwise, the name should be something like "foo/bar" and it's interpreted like
      * relative path name in the file system is, against the given context.
+     *
      * <p>For compatibility, as a fallback when nothing else matches, a simple path
      * like {@code foo/bar} can also be treated with {@link #getItemByFullName}.
+     *
      * @param context
      *      null is interpreted as {@link Jenkins}. Base 'directory' of the interpretation.
      * @since 1.406

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -460,9 +460,6 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
     /**
      * Finds the build #M where M is nearby the given 'n'.
      *
-     * <p>
-     *
-     *
      * @param n
      *      the index to start the search from
      * @param d


### PR DESCRIPTION
While working on some Java 17 changes, I was encountering Javadoc errors. Apparently the Java 17 compiler is a little more strict about Javadoc, especially with regard to empty paragraphs. Some of these fixes are harmless when applied to a Java 8/11 codebase, so we might as well apply them now for forward compatibility.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
