### PR TITLE
Note at-since from #6228 and #6237

### DIFF
--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -254,6 +254,8 @@ public abstract class Lifecycle implements ExtensionPoint {
     /**
      * Called when Jenkins startup is finished or when Jenkins has finished reloading its
      * configuration.
+     *
+     * @since 2.333
      */
     public void onReady() {
         LOGGER.log(Level.INFO, "Jenkins is fully up and running");
@@ -264,6 +266,8 @@ public abstract class Lifecycle implements ExtensionPoint {
      *
      * <p>Callers must also send an {@link #onReady()} notification when Jenkins has finished
      * reloading its configuration.
+     *
+     * @since 2.333
      */
     public void onReload(@NonNull String user, @CheckForNull String remoteAddr) {
         if (remoteAddr != null) {
@@ -278,6 +282,8 @@ public abstract class Lifecycle implements ExtensionPoint {
 
     /**
      * Called when Jenkins is beginning its shutdown.
+     *
+     * @since 2.333
      */
     public void onStop(@NonNull String user, @CheckForNull String remoteAddr) {
         if (remoteAddr != null) {
@@ -297,6 +303,8 @@ public abstract class Lifecycle implements ExtensionPoint {
      *
      * @param timeout The amount by which to extend the timeout.
      * @param unit The time unit of the timeout argument.
+     *
+     * @since TODO
      */
     public void onExtendTimeout(long timeout, @NonNull TimeUnit unit) {}
 
@@ -305,6 +313,8 @@ public abstract class Lifecycle implements ExtensionPoint {
      *
      * @param status The status string. This is free-form and can be used for various purposes:
      *     general state feedback, completion percentages, human-readable error message, etc.
+     *
+     * @since 2.333
      */
     public void onStatusUpdate(String status) {
         LOGGER.log(Level.INFO, status);


### PR DESCRIPTION
Amends #6228 and #6237.

So glad we enforce the order of non-existent Javadoc tags now. Too bad there's no check for the one relevant Javadoc tag in the Jenkins code base.

### Proposed changelog entries

too minor

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
