### PR TITLE
Reduce usages of `StringUtils`

### DIFF
--- a/core/src/main/java/hudson/model/AllView.java
+++ b/core/src/main/java/hudson/model/AllView.java
@@ -31,11 +31,11 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletException;
 import jenkins.util.SystemProperties;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -146,7 +146,7 @@ public class AllView extends View {
                     // name conflict, we cannot rename the all view anyway
                     return primaryView;
                 }
-                if (StringUtils.equals(v.getViewName(), primaryView)) {
+                if (Objects.equals(v.getViewName(), primaryView)) {
                     if (v instanceof AllView) {
                         allView = (AllView) v;
                     } else {

--- a/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -39,7 +38,7 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
 
     public static boolean areValidChoices(@NonNull String choices) {
         String strippedChoices = choices.trim();
-        return !StringUtils.isEmpty(strippedChoices) && strippedChoices.split(CHOICES_DELIMITER).length > 0;
+        return strippedChoices != null && !strippedChoices.isEmpty() && strippedChoices.split(CHOICES_DELIMITER).length > 0;
     }
 
     public ChoiceParameterDefinition(@NonNull String name, @NonNull String choices, @CheckForNull String description) {

--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -47,7 +47,6 @@ import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.fileupload.util.FileItemHeadersImpl;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -158,7 +157,7 @@ public class FileParameterValue extends ParameterValue {
             @SuppressFBWarnings(value = {"FILE_UPLOAD_FILENAME", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = "TODO needs triage")
             @Override
             public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-                if (!StringUtils.isEmpty(location) && !StringUtils.isEmpty(file.getName())) {
+                if (location != null && !location.isEmpty() && file.getName() != null && !file.getName().isEmpty()) {
                     listener.getLogger().println("Copying file to " + location);
                     FilePath ws = build.getWorkspace();
                     if (ws == null) {

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -54,7 +54,6 @@ import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import jenkins.util.MemoryReductionUtil;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.security.core.Authentication;
 
 /**
@@ -236,7 +235,7 @@ public class Items {
         StringTokenizer tokens = new StringTokenizer(list, ",");
         while (tokens.hasMoreTokens()) {
             String fullName = tokens.nextToken().trim();
-            if (StringUtils.isNotEmpty(fullName)) {
+            if (fullName != null && !fullName.isEmpty()) {
                 T item = jenkins.getItem(fullName, context, type);
                 if (item != null)
                     r.add(item);

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -237,7 +237,7 @@ public abstract class Slave extends Node implements Serializable {
     }
 
     public ComputerLauncher getLauncher() {
-        if (launcher == null && !StringUtils.isEmpty(agentCommand)) {
+        if (launcher == null && agentCommand != null && !agentCommand.isEmpty()) {
             try {
                 launcher = (ComputerLauncher) Jenkins.get().getPluginManager().uberClassLoader.loadClass("hudson.slaves.CommandLauncher").getConstructor(String.class, EnvVars.class).newInstance(agentCommand, null);
                 agentCommand = null;

--- a/core/src/main/java/hudson/model/ViewDescriptor.java
+++ b/core/src/main/java/hudson/model/ViewDescriptor.java
@@ -32,6 +32,7 @@ import hudson.views.ListViewColumnDescriptor;
 import hudson.views.ViewJobFilter;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
@@ -147,7 +148,7 @@ public abstract class ViewDescriptor extends Descriptor<View> {
             if (v.getViewName().equals(view.getViewName())) {
                 continue;
             }
-            if (StringUtils.equals(v.getDisplayName(), value)) {
+            if (Objects.equals(v.getDisplayName(), value)) {
                 return FormValidation.warning(Messages.View_DisplayNameNotUniqueWarning(value));
             }
         }

--- a/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
+++ b/core/src/main/java/hudson/security/HudsonAuthenticationEntryPoint.java
@@ -37,7 +37,6 @@ import java.text.MessageFormat;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
@@ -81,7 +80,7 @@ public class HudsonAuthenticationEntryPoint implements AuthenticationEntryPoint 
         } else {
             // give the opportunity to include the target URL
             String uriFrom = req.getRequestURI();
-            if (!StringUtils.isEmpty(req.getQueryString())) uriFrom += "?" + req.getQueryString();
+            if (req.getQueryString() != null && !req.getQueryString().isEmpty()) uriFrom += "?" + req.getQueryString();
             String loginForm = req.getContextPath() + loginFormUrl;
             loginForm = MessageFormat.format(loginForm, URLEncoder.encode(uriFrom, "UTF-8"));
             req.setAttribute("loginForm", loginForm);

--- a/core/src/main/java/jenkins/model/IdStrategy.java
+++ b/core/src/main/java/jenkins/model/IdStrategy.java
@@ -33,10 +33,10 @@ import hudson.model.AbstractDescribableImpl;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.ProtectedExternally;
@@ -253,7 +253,7 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
 
         @Override
         public boolean equals(@NonNull String id1, @NonNull String id2) {
-            return StringUtils.equals(id1, id2);
+            return Objects.equals(id1, id2);
         }
 
         @Override
@@ -289,7 +289,7 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
 
         @Override
         public boolean equals(@NonNull String id1, @NonNull String id2) {
-            return StringUtils.equals(keyFor(id1), keyFor(id2));
+            return Objects.equals(keyFor(id1), keyFor(id2));
         }
 
         @Override

--- a/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
+++ b/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
@@ -154,7 +154,7 @@ public abstract class ProjectNamingStrategy implements Describable<ProjectNaming
         public void checkName(String name) {
             if (StringUtils.isNotBlank(namePattern) && StringUtils.isNotBlank(name)) {
                 if (!Pattern.matches(namePattern, name)) {
-                    throw new Failure(StringUtils.isEmpty(description) ?
+                    throw new Failure(description == null || description.isEmpty() ?
                         Messages.Hudson_JobNameConventionNotApplyed(name, namePattern) :
                         description);
                 }

--- a/core/src/main/java/jenkins/mvn/FilePathGlobalSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/FilePathGlobalSettingsProvider.java
@@ -4,7 +4,6 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -27,7 +26,7 @@ public class FilePathGlobalSettingsProvider extends GlobalSettingsProvider {
 
     @Override
     public FilePath supplySettings(AbstractBuild<?, ?> build, TaskListener listener) {
-        if (StringUtils.isEmpty(path)) {
+        if (path == null || path.isEmpty()) {
             return null;
         }
 

--- a/core/src/main/java/jenkins/mvn/FilePathSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/FilePathSettingsProvider.java
@@ -4,7 +4,6 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -28,7 +27,7 @@ public class FilePathSettingsProvider extends SettingsProvider {
 
     @Override
     public FilePath supplySettings(AbstractBuild<?, ?> build, TaskListener listener) {
-        if (StringUtils.isEmpty(path)) {
+        if (path == null || path.isEmpty()) {
             return null;
         }
 

--- a/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
@@ -30,6 +30,7 @@ import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
 import static hudson.cli.DisablePluginCommand.RETURN_CODE_NOT_DISABLED_DEPENDANTS;
 import static hudson.cli.DisablePluginCommand.RETURN_CODE_NO_SUCH_PLUGIN;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
@@ -293,7 +294,7 @@ public class DisablePluginCommandTest {
         assertPluginDisabled("depender");
         assertPluginDisabled("mandatory-depender");
 
-        assertTrue("No log in quiet mode if all plugins disabled", StringUtils.isEmpty(result.stdout()));
+        assertThat("No log in quiet mode if all plugins disabled", result.stdout(), is(emptyOrNullString()));
     }
 
     /**

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -133,7 +133,6 @@ import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletHandler;
@@ -1283,7 +1282,7 @@ public class QueueTest {
         DomElement buildQueue = page.getElementById("buildQueue");
         DomNodeList<HtmlElement> anchors = buildQueue.getElementsByTagName("a");
         HtmlAnchor anchorWithTooltip = (HtmlAnchor) anchors.stream()
-                .filter(a -> StringUtils.isNotEmpty(a.getAttribute("tooltip")))
+                .filter(a -> a.getAttribute("tooltip") != null && !a.getAttribute("tooltip").isEmpty())
                 .findFirst().orElseThrow(IllegalStateException::new);
 
         String tooltip = anchorWithTooltip.getAttribute("tooltip");

--- a/test/src/test/java/jenkins/security/Security637Test.java
+++ b/test/src/test/java/jenkins/security/Security637Test.java
@@ -45,7 +45,6 @@ import java.net.URLStreamHandler;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -193,7 +192,7 @@ public class Security637Test {
                 URLJobProperty urlJobProperty = project.getProperty(URLJobProperty.class);
                 for (URL url : urlJobProperty.urlSet) {
                     URLStreamHandler handler = (URLStreamHandler) handlerField.get(url);
-                    if (StringUtils.isEmpty(url.getHost())) {
+                    if (url.getHost() == null || url.getHost().isEmpty()) {
                         assertThat(handler.getClass().getName(), not(containsString("SafeURLStreamHandler")));
                     } else {
                         assertThat(handler.getClass().getName(), containsString("SafeURLStreamHandler"));


### PR DESCRIPTION
Inspired by #6267. The fewer third-party dependencies we have, the easier maintenance becomes. This PR replaces some usages of third-party `StringUtils` functionality in favor of native Java Platform equivalents.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
