### PR TITLE
Register help icon again

### DIFF
--- a/core/src/main/java/org/jenkins/ui/icon/IconSet.java
+++ b/core/src/main/java/org/jenkins/ui/icon/IconSet.java
@@ -520,6 +520,7 @@ public class IconSet {
         images.add("video");
         images.add("warning");
         images.add("document-properties");
+        images.add("help");
 
         for (Map.Entry<String, String> size : sizes.entrySet()) {
             for (String image : images) {
@@ -549,6 +550,7 @@ public class IconSet {
         translations.put("icon-gear2", "symbol-settings");
         translations.put("icon-plugin", "symbol-plugins");
         translations.put("icon-up", "symbol-arrow-up");
+        translations.put("icon-help", "symbol-help-circle");
 
         return translations.getOrDefault(tangoIcon, null);
     }


### PR DESCRIPTION
The proposed change addresses a regression from the ionicon support PR: https://github.com/jenkinsci/jenkins/pull/6186/files#diff-f58b5cf9ae51828d19d0b7d299430741ba3ee9d4679d6213da61aaea0b3d1540L520-L521

A bunch of plugins actually rely on it, and it used to be a registered icon before.
![](https://i.imgur.com/uVDY3Ya.png)

I've chosen the help outline ionicon, I guess that fits the best, instead of reverting to material icons.
![](https://i.imgur.com/P484KeS.png)

### Proposed changelog entries

* Restore missing help icon (regression in 2.335).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
