### PR TITLE
Add a full stop to the end of the Manage Users button description in the Manage Jenkins page

### DIFF
--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -32,7 +32,7 @@ HudsonPrivateSecurityRealm.Details.PasswordError=\
   The confirmed password is not the same as the one entered. \
   Please make sure to type the same password twice.
 HudsonPrivateSecurityRealm.ManageUserLinks.DisplayName=Manage Users
-HudsonPrivateSecurityRealm.ManageUserLinks.Description=Create/delete/modify users that can log in to this Jenkins
+HudsonPrivateSecurityRealm.ManageUserLinks.Description=Create/delete/modify users that can log in to this Jenkins.
 
 HudsonPrivateSecurityRealm.CreateAccount.TextNotMatchWordInImage=Text didn''t match the word shown in the image
 HudsonPrivateSecurityRealm.CreateAccount.PasswordNotMatch=Password didn''t match


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).
-->

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

Hi there, thanks for this awesome project.

This is a tiny PR to add a full stop to the end of the Manage Users button description in the Manage Jenkins page, as it is the only description on the page without a full stop.

Before:
![Screen Shot 2022-02-18 at 10 02 41 am](https://user-images.githubusercontent.com/7508115/154593274-f17be7c7-4366-43df-81af-c0aba4a52e41.png)

After:
![image](https://user-images.githubusercontent.com/7508115/154593635-b255cb89-c178-4dd2-b23e-b22104e9b927.png)


### Proposed changelog entries

Not needed or

* Add a full stop to the end of the Manage Users button description in the Manage Jenkins page.


<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- ~~(If applicable) Jira issue is well described~~
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- ~~Appropriate autotests or explanation to why this change has no tests~~
- ~~New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.~~
- ~~For dependency updates: links to external changelogs and, if possible, full diffs~~

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

anyone

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- ~~If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))~~
- ~~If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).~~
