### PR TITLE
[JENKINS-67823] Don't append leading slash to foreign icons

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2336,10 +2336,6 @@ public class Functions {
         }
 
         if (iconMetadata == null) {
-            if (!iconGuess.startsWith("/")) {
-                iconGuess = "/" + iconGuess;
-            }
-
             iconSource = rootURL + (iconGuess.startsWith("/images/") || iconGuess.startsWith("/plugin/") ? getResourcePath() : "") + iconGuess;
         }
 

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2336,6 +2336,10 @@ public class Functions {
         }
 
         if (iconMetadata == null) {
+            if (!iconGuess.startsWith("/") && !iconGuess.startsWith("http")) {
+                iconGuess = "/" + iconGuess;
+            }
+
             iconSource = rootURL + (iconGuess.startsWith("/images/") || iconGuess.startsWith("/plugin/") ? getResourcePath() : "") + iconGuess;
         }
 

--- a/test/src/test/java/lib/layout/IconTest.java
+++ b/test/src/test/java/lib/layout/IconTest.java
@@ -151,7 +151,7 @@ public class IconTest  {
         assertIconToSymbolOkay(taskDivs.get(5).getElementsByTagName("svg").get(0));
 
         assertIconToImageOkay(taskDivs.get(6).getElementsByTagName("img").get(0), "/plugin/xxx/icon.png");
-        assertIconToImageOkay(taskDivs.get(7).getElementsByTagName("img").get(0), "/plugin/xxx/icon.png");
+        assertIconToImageOkay(taskDivs.get(7).getElementsByTagName("img").get(0), "plugin/xxx/icon.png");
     }
 
     @TestExtension("testTasks")

--- a/test/src/test/java/lib/layout/IconTest.java
+++ b/test/src/test/java/lib/layout/IconTest.java
@@ -151,7 +151,7 @@ public class IconTest  {
         assertIconToSymbolOkay(taskDivs.get(5).getElementsByTagName("svg").get(0));
 
         assertIconToImageOkay(taskDivs.get(6).getElementsByTagName("img").get(0), "/plugin/xxx/icon.png");
-        assertIconToImageOkay(taskDivs.get(7).getElementsByTagName("img").get(0), "plugin/xxx/icon.png");
+        assertIconToImageOkay(taskDivs.get(7).getElementsByTagName("img").get(0), "/plugin/xxx/icon.png");
     }
 
     @TestExtension("testTasks")


### PR DESCRIPTION
Fixes [JENKINS-67823](https://issues.jenkins.io/browse/JENKINS-67823)

The change proposed removes the leading slash for foreign icons, either added by other plugins or read from URLs, like the GitLab plugin does.
![](https://i.imgur.com/6kQin0M.png)
![](https://i.imgur.com/9XS2JQW.png)

### Proposed changelog entries

* Don't add leading slash to foreign icons (regression in 2.335).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
