### PR TITLE
Don't show status tooltip on nobuilt jobs

### DIFF
--- a/core/src/main/resources/lib/hudson/buildHealth.jelly
+++ b/core/src/main/resources/lib/hudson/buildHealth.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
                     </a>
                 </j:when>
                     <j:otherwise>
-                        <l:svgIcon href="${resURL}/images/${icons.getIconByClassSpec(buildHealth.iconClassName + ' icon-md').url}" tooltip="${buildHealth.score}%" />
+                        <l:svgIcon href="${resURL}/images/${icons.getIconByClassSpec(buildHealth.iconClassName + ' icon-md').url}"/>
                     </j:otherwise>
                 </j:choose>
             </div>


### PR DESCRIPTION
Fixes [JENKINS-67797](https://issues.jenkins.io/browse/JENKINS-67797)

This is a regression from the table modernization PR. The alternative text has been turned into tooltips, hence there are no tooltips on 2.319.3, based of Mark's screenshots.
https://github.com/jenkinsci/jenkins/commit/cee0d06770e6bed478e105368ef57371814f3f79#diff-633560a936835daf74727cace9bff8b456cce93c71f367710bd7865ff3d4d311L60
Should be safe to remove, the build status icon already tells you that a job didn't run yet.

### Proposed changelog entries

* Don't show build status on jobs that are not yet built (regression in 2.321).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
