### PR TITLE
[JENKINS-67847] booleanRadio button is not shown correctly

### DIFF
--- a/core/src/main/resources/lib/form/booleanRadio.jelly
+++ b/core/src/main/resources/lib/form/booleanRadio.jelly
@@ -39,9 +39,7 @@ THE SOFTWARE.
   </st:documentation>
   <f:prepareDatabinding />
 
-  <f:radio name="_.${attrs.field}" value="true" checked="${instance[field]}" />
-  <label class="attach-previous">${attrs['true']?:'%Yes'}</label>
-  <f:radio name="_.${attrs.field}" value="false" checked="${!instance[field]}" />
-  <label class="attach-previous">${attrs['false']?:'%No'}</label>
+  <f:radioBlock name="_.${attrs.field}" value="true" title="${attrs['true']?:'%Yes'}" checked="${instance[field]}" />
+  <f:radioBlock name="_.${attrs.field}" value="false" title="${attrs['false']?:'%No'}" checked="${!instance[field]}" />
   <!-- TODO consider customizedFields -->
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-67847](https://issues.jenkins-ci.org/browse/JENKINS-67847).  An issue in Jenkins 2.335 but not an issue in Jenkins 2.332.

radioBlock is implemented in booleanRadio and it seems well.
![Boolean Radio](https://user-images.githubusercontent.com/20413055/154797184-ff525e14-3b24-4747-adae-6192d8ff53a4.gif)

### Proposed changelog entries

* Place text correctly on boolean radio controls (regression in 2.335).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- ~~If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))~~
- ~~If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).~~
