### PR TITLE
Fix broken script- and console icon in agent view

### DIFF
--- a/core/src/main/resources/hudson/slaves/SlaveComputer/systemInfo.jelly
+++ b/core/src/main/resources/hudson/slaves/SlaveComputer/systemInfo.jelly
@@ -35,7 +35,9 @@ THE SOFTWARE.
     <l:main-panel>
 
       <h1>
-        <img src="${imagesURL}/svgs/${it.icon}" width="48" height="48" alt=""/>
+        <span class="icon-lg">
+          <l:icon src="${it.icon}"/>
+        </span>
         ${it.caption} ${%System Information}
         <j:if test="${!empty(it.node.nodeDescription)}">
           <span style="font-size:smaller">(${it.node.nodeDescription})</span>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -39,7 +39,11 @@ THE SOFTWARE.
           <j:set var="icon" value="${it.icon}"/>
         </j:otherwise>
       </j:choose>
-      <h1><img src="${imagesURL}/svgs/${icon}" width="48" height="48" alt=""/> ${%Script Console}</h1>
+      <h1>
+        <span class="icon-lg">
+          <l:icon src="${icon}"/> ${%Script Console}
+        </span>
+      </h1>
 
       <j:choose>
         <j:when test="${it.channel != null}">


### PR DESCRIPTION
The change proposed addresses a regression from https://github.com/jenkinsci/jenkins/pull/6273/, where the computer symbol has been exchanged to an ionicon, but the reference in the Jelly path tries to resolve it in the svgs folder, where it doesn't exist, hence it displays a broken icon. It's located at `<rootUrl>/computer/<computerName>/systemInfo`, if you have more than one agent connected.

![](https://i.imgur.com/JA1XVJX.png)
![](https://i.imgur.com/Vg6eaHk.png)


### Proposed changelog entries

* Restore missing computer icon in the "System Information" view of an agent (regression in 2.335).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- ~~If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))~~
- ~~If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).~~
