### PR TITLE
Revert "Remove JNR (#5979)"

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -219,6 +219,11 @@ THE SOFTWARE.
         <version>${asm.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-posix</artifactId>
+        <version>3.1.15</version>
+      </dependency>
+      <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>windows-package-checker</artifactId>
         <version>1.2</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,6 +101,10 @@ THE SOFTWARE.
       <artifactId>jbcrypt</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
     </dependency>

--- a/core/src/main/java/hudson/os/PosixAPI.java
+++ b/core/src/main/java/hudson/os/PosixAPI.java
@@ -1,0 +1,37 @@
+package hudson.os;
+
+import jnr.constants.platform.Errno;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+import jnr.posix.util.DefaultPOSIXHandler;
+
+/**
+ * POSIX API wrapper.
+ * @author Kohsuke Kawaguchi
+ */
+public class PosixAPI {
+
+    private static POSIX posix;
+
+    /**
+     * Load the JNR implementation of the POSIX APIs for the current platform.
+     * Runtime exceptions will be of type {@link PosixException}.
+     * {@link IllegalStateException} will be thrown for methods not implemented on this platform.
+     * @return some implementation (even on Windows or unsupported Unix)
+     * @since 1.518
+     */
+    public static synchronized POSIX jnr() {
+        if (posix == null) {
+            posix = POSIXFactory.getPOSIX(new DefaultPOSIXHandler() {
+                @Override public void error(Errno error, String extraData) {
+                    throw new PosixException("native error " + error.description() + " " + extraData);
+                }
+
+                @Override public void error(Errno error, String methodName, String extraData) {
+                    throw new PosixException("native error calling " + methodName + ": " + error.description() + " " + extraData);
+                }
+            }, true);
+        }
+        return posix;
+    }
+}

--- a/core/src/main/java/hudson/os/PosixException.java
+++ b/core/src/main/java/hudson/os/PosixException.java
@@ -2,6 +2,7 @@ package hudson.os;
 
 /**
  * Indicates an error during POSIX API call.
+ * @see PosixAPI
  * @author Kohsuke Kawaguchi
  */
 public class PosixException extends RuntimeException {

--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -33,6 +33,8 @@ import com.sun.jna.Pointer;
 import com.sun.jna.StringArray;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.NativeLongByReference;
+import hudson.os.PosixAPI;
+import jnr.posix.POSIX;
 
 /**
  * GNU C library.
@@ -40,6 +42,7 @@ import com.sun.jna.ptr.NativeLongByReference;
  * <p>
  * Not available on all platforms (such as Linux/PPC, IBM mainframe, etc.), so the caller should recover gracefully
  * in case of {@link LinkageError}. See JENKINS-4820.
+ * <p>Consider deprecating all methods present also in {@link POSIX} (as obtained by {@link PosixAPI#jnr}).
  * @author Kohsuke Kawaguchi
  */
 public interface GNUCLibrary extends Library {

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 import hudson.FilePath.TarCompression;
 import hudson.model.TaskListener;
+import hudson.os.PosixAPI;
 import hudson.os.WindowsUtil;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.WorkspaceList;
@@ -476,6 +477,25 @@ public class FilePathTest {
                 copy = new FilePath(channels.british, tmp.getPath()).child("copy" + i);
                 childP.copyToWithPermission(copy);
             }
+    }
+
+    @Test public void copyToWithPermissionSpecialPermissions() throws IOException, InterruptedException {
+        assumeFalse(Functions.isWindows() || Platform.isDarwin());
+        File tmp = temp.getRoot();
+        File original = new File(tmp, "original");
+        FilePath originalP = new FilePath(channels.french, original.getPath());
+        originalP.touch(0);
+        PosixAPI.jnr().chmod(original.getAbsolutePath(), 02777); // Read/write/execute for everyone and setuid.
+
+        File sameChannelCopy = new File(tmp, "sameChannelCopy");
+        FilePath sameChannelCopyP = new FilePath(channels.french, sameChannelCopy.getPath());
+        originalP.copyToWithPermission(sameChannelCopyP);
+        assertEquals("Special permissions should be copied on the same machine", 02777, PosixAPI.jnr().stat(sameChannelCopy.getAbsolutePath()).mode() & 07777);
+
+        File diffChannelCopy = new File(tmp, "diffChannelCopy");
+        FilePath diffChannelCopyP = new FilePath(channels.british, diffChannelCopy.getPath());
+        originalP.copyToWithPermission(diffChannelCopyP);
+        assertEquals("Special permissions should not be copied across machines", 00777, PosixAPI.jnr().stat(diffChannelCopy.getAbsolutePath()).mode() & 07777);
     }
 
     @Test public void symlinkInTar() throws Exception {


### PR DESCRIPTION
End-to-end testing of jenkinsci/jenkins#5979 failed, so this PR needs to be reverted before we ship the next weekly. Once jenkinsci/maven-hpi-plugin#297 has been merged and released, and once `jnr-posix-api` is released with that version of the Maven HPI plugin, then this change can be reintroduced. I plan to propose a new PR at that time to reintroduce the change with thorough end-to-end testing. I plan to mark both this PR and #5979 as `skip-changelog` so that neither are shown in the release notes.