### PR TITLE
[JENKINS-67858] Icons are placed higher than the text

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -53,10 +53,10 @@ THE SOFTWARE.
       </div>
 
       <h1>
-        <span class="icon-lg">
+        <span class="icon-lg1">
           <l:icon src="${it.iconClassName}" />
         </span>
-        ${it.caption}
+        <span class="jenkins-icon-header-adjacent">${it.caption}</span>
         <j:if test="${!empty(it.node.nodeDescription)}">
           <span style="font-size:smaller">(${it.node.nodeDescription})</span>
         </j:if>

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -52,11 +52,11 @@ THE SOFTWARE.
         </j:choose>
       </div>
 
-      <h1>
-        <span class="icon-lg1">
-          <l:icon src="${it.iconClassName}" />
+      <h1 style="display:flex; align-items:center;">
+        <span class="icon-lg" style="margin-right:5px;">
+          <l:icon src="${it.iconClassName}"/>
         </span>
-        <span class="jenkins-icon-header-adjacent">${it.caption}</span>
+        ${it.caption}
         <j:if test="${!empty(it.node.nodeDescription)}">
           <span style="font-size:smaller">(${it.node.nodeDescription})</span>
         </j:if>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -39,11 +39,11 @@ THE SOFTWARE.
           <j:set var="icon" value="${it.icon}"/>
         </j:otherwise>
       </j:choose>
-      <h1>
-        <span class="icon-lg1">
+      <h1 style="display:flex; align-items:center;">
+        <span class="icon-lg" style="margin-right:5px;">
           <l:icon src="${icon}"/>
         </span>
-        <span class="jenkins-icon-header-adjacent">${%Script Console}</span>
+        ${%Script Console}
       </h1>
 
       <j:choose>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -40,9 +40,10 @@ THE SOFTWARE.
         </j:otherwise>
       </j:choose>
       <h1>
-        <span class="icon-lg">
-          <l:icon src="${icon}"/> ${%Script Console}
+        <span class="icon-lg1">
+          <l:icon src="${icon}"/>
         </span>
+        <span class="jenkins-icon-header-adjacent">${%Script Console}</span>
       </h1>
 
       <j:choose>

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1527,6 +1527,24 @@ svg.icon-md {
     height: 24px;
   }
 }
+.jenkins-icon-header-adjacent{
+      margin-left: 2.5rem;
+      width: 16px;
+      height: 16px;
+}
+
+.icon-lg1,
+svg.icon-lg1 {
+    width: 32px;
+    height: 32px;
+
+  svg {
+     position: absolute;
+     top: 129px;
+    width: 32px;
+    height: 32px;
+  }
+}
 
 .icon-lg,
 svg.icon-lg {

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1527,24 +1527,6 @@ svg.icon-md {
     height: 24px;
   }
 }
-.jenkins-icon-header-adjacent{
-      margin-left: 2.5rem;
-      width: 16px;
-      height: 16px;
-}
-
-.icon-lg1,
-svg.icon-lg1 {
-    width: 32px;
-    height: 32px;
-
-  svg {
-     position: absolute;
-     top: 129px;
-    width: 32px;
-    height: 32px;
-  }
-}
 
 .icon-lg,
 svg.icon-lg {


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-67858](https://issues.jenkins-ci.org/browse/JENKINS-67858).

The original span class `icon-lg` will let the new icons in the wrong position , so I create a new span class `icon-lg1`
let the new icons in the correct position . I also create the new span class `jenkins-icon-header-adjacent` to make the text
in the correct position.
 
![Screenshot from 2022-02-23 07-23-05](https://user-images.githubusercontent.com/71805759/155350266-50ec8876-f607-4cae-9fb4-84e3d417c36d.png)

![Screenshot from 2022-02-23 07-23-30](https://user-images.githubusercontent.com/71805759/155350296-721e27d1-b3fa-40d2-8482-9ddabe4050d9.png)



<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fix the position of icons which are at the header .

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [X] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
