### PR TITLE
[JENKINS-67885] update the bundled `display-url-api` plugin

### DIFF
--- a/test/src/test/java/jenkins/install/LoadDetachedPluginsTest.java
+++ b/test/src/test/java/jenkins/install/LoadDetachedPluginsTest.java
@@ -70,7 +70,7 @@ public class LoadDetachedPluginsTest {
     @Test
     @LocalData
     public void upgradeFromJenkins1() throws IOException {
-        VersionNumber since = new VersionNumber("1.550");
+        VersionNumber since = new VersionNumber("1.490");
         rr.then(r -> {
             List<DetachedPlugin> detachedPlugins = DetachedPluginsUtil.getDetachedPlugins(since);
             assertThat("Plugins have been detached since the pre-upgrade version",

--- a/test/src/test/resources/jenkins/install/LoadDetachedPluginsTest/upgradeFromJenkins1/config.xml
+++ b/test/src/test/resources/jenkins/install/LoadDetachedPluginsTest/upgradeFromJenkins1/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson>
   <disabledAdministrativeMonitors/>
-  <version>1.550</version>
+  <version>1.490</version>
   <numExecutors>2</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -258,7 +258,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>display-url-api</artifactId>
-                  <version>2.3.4</version>
+                  <version>2.3.5</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
the bundled mailer plugin was DOA as it failed to start because the
bundled display-url-plugin was too old

Updates the disaplay-url plugin to 2.3.5 to fix the issue

See [JENKINS-67885](https://issues.jenkins-ci.org/browse/JENKINS-67885).

### Proposed changelog entries

* Update bundled display-url-plugin to prevent issues starting the mailer plugin for offline installations.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://www.jenkins.io/changelog/ -->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@Wadeck 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
