### PR TITLE
Ignore Checkstyle 10.0 and later

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,6 @@ updates:
       - dependency-name: "com.github.siom79.japicmp:japicmp-maven-plugin"
       # Winstone upgrades require multiple changes in pom.xml.  See https://github.com/jenkinsci/jenkins/pull/5439#discussion_r616418468
       - dependency-name: "org.jenkins-ci:winstone"
+      # Starting with version 10.0, this library requires Java 11
+      - dependency-name: "com.puppycrawl.tools:checkstyle"
+        versions: [">=10.0"]

--- a/cli/src/main/java/hudson/cli/PlainCLIProtocol.java
+++ b/cli/src/main/java/hudson/cli/PlainCLIProtocol.java
@@ -73,6 +73,7 @@ class PlainCLIProtocol {
         STDERR(false);
         /** True if sent from the client to the server; false if sent from the server to the client. */
         final boolean clientSide;
+
         Op(boolean clientSide) {
             this.clientSide = clientSide;
         }


### PR DESCRIPTION
#6316 proposes to upgrade Checkstyle from 9.3 to 10.0; however, we cannot do that because Checkstyle 10.0 requires Java 11. This PR ignores Checkstyle 10.0 and later in our Dependabot configuration.

As a bonus, we also fix a violation that only appears in Checkstyle 10.0. Even if we don't run Checkstyle 10.0, fixing this violation will make it easier to upgrade to 10.0 later once we drop support for Java 8.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
