### PR TITLE
[JENKINS-41218] Use systemd for Linux installers

### DIFF
--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -255,7 +255,7 @@ public class WebAppMain implements ServletContextListener {
                         Files.deleteIfExists(BootFailure.getBootFailureFile(_home).toPath());
 
                         // at this point we are open for business and serving requests normally
-                        LOGGER.info("Jenkins is fully up and running");
+                        Jenkins.get().getLifecycle().onReady();
                         success = true;
                     } catch (Error e) {
                         new HudsonFailedToLoad(e).publish(context, _home);

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -55,6 +55,19 @@ import org.apache.commons.io.FileUtils;
 public abstract class Lifecycle implements ExtensionPoint {
     private static Lifecycle INSTANCE = null;
 
+    public Lifecycle() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Jenkins jenkins = Jenkins.getInstanceOrNull();
+            if (jenkins != null) {
+                try {
+                    jenkins.cleanUp();
+                } catch (Throwable t) {
+                    LOGGER.log(Level.SEVERE, "Failed to clean up. Shutdown will continue.", t);
+                }
+            }
+        }));
+    }
+
     /**
      * Gets the singleton instance.
      *

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -254,6 +254,8 @@ public abstract class Lifecycle implements ExtensionPoint {
     /**
      * Called when Jenkins startup is finished or when Jenkins has finished reloading its
      * configuration.
+     *
+     * @since 2.333
      */
     public void onReady() {
         LOGGER.log(Level.INFO, "Jenkins is fully up and running");
@@ -264,6 +266,8 @@ public abstract class Lifecycle implements ExtensionPoint {
      *
      * <p>Callers must also send an {@link #onReady()} notification when Jenkins has finished
      * reloading its configuration.
+     *
+     * @since 2.333
      */
     public void onReload(@NonNull String user, @CheckForNull String remoteAddr) {
         if (remoteAddr != null) {
@@ -278,6 +282,8 @@ public abstract class Lifecycle implements ExtensionPoint {
 
     /**
      * Called when Jenkins is beginning its shutdown.
+     *
+     * @since 2.333
      */
     public void onStop(@NonNull String user, @CheckForNull String remoteAddr) {
         if (remoteAddr != null) {
@@ -297,6 +303,8 @@ public abstract class Lifecycle implements ExtensionPoint {
      *
      * @param timeout The amount by which to extend the timeout.
      * @param unit The time unit of the timeout argument.
+     *
+     * @since TODO
      */
     public void onExtendTimeout(long timeout, @NonNull TimeUnit unit) {}
 
@@ -305,6 +313,8 @@ public abstract class Lifecycle implements ExtensionPoint {
      *
      * @param status The status string. This is free-form and can be used for various purposes:
      *     general state feedback, completion percentages, human-readable error message, etc.
+     *
+     * @since 2.333
      */
     public void onStatusUpdate(String status) {
         LOGGER.log(Level.INFO, status);

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -275,6 +276,16 @@ public abstract class Lifecycle implements ExtensionPoint {
             LOGGER.log(Level.INFO, "Stopping Jenkins as requested by {0}", user);
         }
     }
+
+    /**
+     * Tell the service manager to extend the startup or shutdown timeout. The value specified is a
+     * time during which either {@link #onExtendTimeout(long, TimeUnit)} must be called again or
+     * startup/shutdown must complete.
+     *
+     * @param timeout The amount by which to extend the timeout.
+     * @param unit The time unit of the timeout argument.
+     */
+    public void onExtendTimeout(long timeout, @NonNull TimeUnit unit) {}
 
     /**
      * Called when Jenkins service state has changed.

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -255,7 +255,7 @@ public abstract class Lifecycle implements ExtensionPoint {
      * Called when Jenkins startup is finished or when Jenkins has finished reloading its
      * configuration.
      *
-     * @since 2.333
+     * @since 2.333 and 2.332.1
      */
     public void onReady() {
         LOGGER.log(Level.INFO, "Jenkins is fully up and running");
@@ -267,7 +267,7 @@ public abstract class Lifecycle implements ExtensionPoint {
      * <p>Callers must also send an {@link #onReady()} notification when Jenkins has finished
      * reloading its configuration.
      *
-     * @since 2.333
+     * @since 2.333 and 2.332.1
      */
     public void onReload(@NonNull String user, @CheckForNull String remoteAddr) {
         if (remoteAddr != null) {
@@ -283,7 +283,7 @@ public abstract class Lifecycle implements ExtensionPoint {
     /**
      * Called when Jenkins is beginning its shutdown.
      *
-     * @since 2.333
+     * @since 2.333 and 2.332.1
      */
     public void onStop(@NonNull String user, @CheckForNull String remoteAddr) {
         if (remoteAddr != null) {
@@ -304,7 +304,7 @@ public abstract class Lifecycle implements ExtensionPoint {
      * @param timeout The amount by which to extend the timeout.
      * @param unit The time unit of the timeout argument.
      *
-     * @since TODO
+     * @since 2.335 and 2.332.1
      */
     public void onExtendTimeout(long timeout, @NonNull TimeUnit unit) {}
 
@@ -314,7 +314,7 @@ public abstract class Lifecycle implements ExtensionPoint {
      * @param status The status string. This is free-form and can be used for various purposes:
      *     general state feedback, completion percentages, human-readable error message, etc.
      *
-     * @since 2.333
+     * @since 2.333 and 2.332.1
      */
     public void onStatusUpdate(String status) {
         LOGGER.log(Level.INFO, status);

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -24,6 +24,8 @@
 
 package hudson.lifecycle;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionPoint;
 import hudson.Functions;
 import hudson.Util;
@@ -107,6 +109,9 @@ public abstract class Lifecycle implements ExtensionPoint {
                 } else if (System.getenv("SMF_FMRI") != null && System.getenv("SMF_RESTARTER") != null) {
                     // when we are run by Solaris SMF, these environment variables are set.
                     instance = new SolarisSMFLifecycle();
+                } else if (System.getenv("NOTIFY_SOCKET") != null) {
+                    // When we are running under systemd with Type=notify, this environment variable is set.
+                    instance = new SystemdLifecycle();
                 } else {
                     // if run on Unix, we can do restart
                     try {
@@ -230,6 +235,55 @@ public abstract class Lifecycle implements ExtensionPoint {
         } catch (RestartNotSupportedException e) {
             return false;
         }
+    }
+
+    /**
+     * Called when Jenkins startup is finished or when Jenkins has finished reloading its
+     * configuration.
+     */
+    public void onReady() {
+        LOGGER.log(Level.INFO, "Jenkins is fully up and running");
+    }
+
+    /**
+     * Called when Jenkins is reloading its configuration.
+     *
+     * <p>Callers must also send an {@link #onReady()} notification when Jenkins has finished
+     * reloading its configuration.
+     */
+    public void onReload(@NonNull String user, @CheckForNull String remoteAddr) {
+        if (remoteAddr != null) {
+            LOGGER.log(
+                    Level.INFO,
+                    "Reloading Jenkins as requested by {0} from {1}",
+                    new Object[] {user, remoteAddr});
+        } else {
+            LOGGER.log(Level.INFO, "Reloading Jenkins as requested by {0}", user);
+        }
+    }
+
+    /**
+     * Called when Jenkins is beginning its shutdown.
+     */
+    public void onStop(@NonNull String user, @CheckForNull String remoteAddr) {
+        if (remoteAddr != null) {
+            LOGGER.log(
+                    Level.INFO,
+                    "Stopping Jenkins as requested by {0} from {1}",
+                    new Object[] {user, remoteAddr});
+        } else {
+            LOGGER.log(Level.INFO, "Stopping Jenkins as requested by {0}", user);
+        }
+    }
+
+    /**
+     * Called when Jenkins service state has changed.
+     *
+     * @param status The status string. This is free-form and can be used for various purposes:
+     *     general state feedback, completion percentages, human-readable error message, etc.
+     */
+    public void onStatusUpdate(String status) {
+        LOGGER.log(Level.INFO, status);
     }
 
     private static final Logger LOGGER = Logger.getLogger(Lifecycle.class.getName());

--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -1,0 +1,62 @@
+package hudson.lifecycle;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * {@link Lifecycle} that delegates its responsibility to {@code systemd(1)}.
+ *
+ * @author Basil Crow
+ */
+@Restricted(NoExternalUse.class)
+@Extension(optional = true)
+public class SystemdLifecycle extends ExitLifecycle {
+
+    private static final Logger LOGGER = Logger.getLogger(SystemdLifecycle.class.getName());
+
+    interface Systemd extends Library {
+        Systemd INSTANCE = Native.load("systemd", Systemd.class);
+
+        int sd_notify(int unset_environment, String state) throws LastErrorException;
+    }
+
+    @Override
+    public void onReady() {
+        super.onReady();
+        notify("READY=1");
+    }
+
+    @Override
+    public void onReload(@NonNull String user, @CheckForNull String remoteAddr) {
+        super.onReload(user, remoteAddr);
+        notify("RELOADING=1");
+    }
+
+    @Override
+    public void onStop(@NonNull String user, @CheckForNull String remoteAddr) {
+        super.onStop(user, remoteAddr);
+        notify("STOPPING=1");
+    }
+
+    @Override
+    public void onStatusUpdate(String status) {
+        super.onStatusUpdate(status);
+        notify(String.format("STATUS=%s", status));
+    }
+
+    private static synchronized void notify(String message) {
+        try {
+            Systemd.INSTANCE.sd_notify(0, message);
+        } catch (LastErrorException e) {
+            LOGGER.log(Level.WARNING, null, e);
+        }
+    }
+}

--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -6,6 +6,7 @@ import com.sun.jna.Native;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
@@ -44,6 +45,12 @@ public class SystemdLifecycle extends ExitLifecycle {
     public void onStop(@NonNull String user, @CheckForNull String remoteAddr) {
         super.onStop(user, remoteAddr);
         notify("STOPPING=1");
+    }
+
+    @Override
+    public void onExtendTimeout(long timeout, @NonNull TimeUnit unit) {
+        super.onExtendTimeout(timeout, unit);
+        notify(String.format("EXTEND_TIMEOUT_USEC=%d", unit.toMicros(timeout)));
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1181,6 +1181,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             @Override
             protected void onInitMilestoneAttained(InitMilestone milestone) {
                 initLevel = milestone;
+                getLifecycle().onExtendTimeout(EXTEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                 if (milestone == PLUGINS_PREPARED) {
                     // set up Guice to enable injection as early as possible
                     // before this milestone, ExtensionList.ensureLoaded() won't actually try to locate instances
@@ -5518,6 +5519,12 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static boolean AUTOMATIC_AGENT_LAUNCH = SystemProperties.getBoolean(Jenkins.class.getName() + ".automaticAgentLaunch", true);
+
+    /**
+     * The amount of time by which to extend the startup notification timeout as each initialization milestone is attained.
+     */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
+    public static /* not final */ int EXTEND_TIMEOUT_SECONDS = SystemProperties.getInteger(Jenkins.class.getName() + ".extendTimeoutSeconds", 15);
 
     private static final Logger LOGGER = Logger.getLogger(Jenkins.class.getName());
     private static final SecureRandom RANDOM = new SecureRandom();


### PR DESCRIPTION
## [JENKINS-41218](https://issues.jenkins.io/browse/JENKINS-41218) Use `systemd` for Linux installers instead of System V `init`

See [Jenkins developers mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/mRxFPGfuljA/m/y7Rb96V5AgAJ) for more details.

The Linux installers for Jenkins 2.335, 2.336, and 2.337 weekly releases use systemd instead of System V init.  They include migration steps that read the existing System V init script settings and convert them to systemd override configuration settings.

The systemd service has been the default and the preferred system and service manager on most Linux distributions for many years.  Jenkins use of systemd unifies the service management method across all three of our Linux installers and allows us to describe configuration actions for Debian, Red Hat, and SUSE installers with a single set of instructions.

Resolves the following known issues with the Linux installers:

* [JENKINS-41218](https://issues.jenkins.io/browse/JENKINS-41218) - Switch Linux installers from System V init to systemd
* [JENKINS-65809](https://issues.jenkins.io/browse/JENKINS-65809) - Restart the Jenkins service after plugin updates on Debian 11 (bullseye)
* [JENKINS-56219](https://issues.jenkins.io/browse/JENKINS-56219) - Restart systemd service when the controller exits unexpectedly
* [JENKINS-31656](https://issues.jenkins.io/browse/JENKINS-31656) - Return zero from RPM init script on successful stop
* [JENKINS-67487](https://issues.jenkins.io/browse/JENKINS-67487) - Correctly report startup result on Amazon Linux 2 installed with the rpm package
* [JENKINS-67404](https://issues.jenkins.io/browse/JENKINS-67404) - Do not fail startup with timeout on systems with slow DNS resolution

Changes include:

* Notify `systemd(1)` about start-up completion and other service status changes (#6228)
* Extend startup notification timeout as each initialization milestone is attained (#6237)
* Jenkins should terminate cleanly on `SIGTERM` (#6230)
* Note at-since from #6228 and #6237 (#6252)
* Update `@since` for 2.332.1

### Proposed changelog entries

* Use `systemd` based Linux installers instead of installers based on System V `init`.

### Proposed upgrade guidelines

Jenkins installers for Linux packages now use `systemd` to manage the configuration settings and the Jenkins service.  Settings from the previous System V based `init` installations are migrated to `systemd` during package upgrade.  Configuration setting changes are now performed with the command `systemctl edit jenkins` on all Linux packages.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@basil 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
