### PR TITLE
[JENKINS-67602] Skip corrupted fingerprint files

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1411,7 +1411,11 @@ public class Fingerprint implements ModelObject, Saveable {
      * Performs Initialization of facets on a newly loaded Fingerprint.
      */
     private static void initFacets(@CheckForNull Fingerprint fingerprint) {
-        if (fingerprint == null || fingerprint.facets == null) {
+        if (fingerprint == null) {
+            return;
+        }
+        if (fingerprint.facets == null) {
+            logger.log(Level.WARNING, "Missing fingerprint facet, see JENKINS-67602");
             return;
         }
 

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1411,7 +1411,7 @@ public class Fingerprint implements ModelObject, Saveable {
      * Performs Initialization of facets on a newly loaded Fingerprint.
      */
     private static void initFacets(@CheckForNull Fingerprint fingerprint) {
-        if (fingerprint == null) {
+        if (fingerprint == null || fingerprint.facets == null) {
             return;
         }
 


### PR DESCRIPTION
See [JENKINS-67602](https://issues.jenkins-ci.org/browse/JENKINS-67602).

### Issue

We got a NPE because apparently the fingerprint xml files were corrupted. We had to delete them (`$JENKINS_HOME/fingerprints`) for Jenkins to work again. Maybe this could also be expanded by a nice error message, or actually checking the xml's at some other place. I have no experience in this codebase.

### Proposed changelog entries

* Skip corrupted fingerprint files

### log

```
14:34:12  java.lang.NullPointerException
14:34:12  	at hudson.model.Fingerprint.initFacets(Fingerprint.java:1412)
14:34:12  	at hudson.model.Fingerprint.load(Fingerprint.java:1355)
14:34:12  	at hudson.model.FingerprintMap.load(FingerprintMap.java:91)
14:34:12  	at hudson.model.FingerprintMap.load(FingerprintMap.java:46)
14:34:12  	at hudson.util.KeyedDataStorage.get(KeyedDataStorage.java:160)
14:34:12  	at hudson.model.FingerprintMap.get(FingerprintMap.java:81)
14:34:12  	at hudson.model.FingerprintMap.get(FingerprintMap.java:46)
14:34:12  	at hudson.util.KeyedDataStorage.getOrCreate(KeyedDataStorage.java:110)
14:34:12  	at hudson.model.FingerprintMap.getOrCreate(FingerprintMap.java:67)
14:34:12  	at hudson.model.FingerprintMap.getOrCreate(FingerprintMap.java:63)
14:34:12  	at com.cloudbees.plugins.credentials.CredentialsProvider.getOrCreateFingerprintOf(CredentialsProvider.java:1403)
14:34:12  	at com.cloudbees.plugins.credentials.CredentialsProvider.trackAll(CredentialsProvider.java:1459)
14:34:12  	at com.cloudbees.plugins.credentials.CredentialsProvider.track(CredentialsProvider.java:1421)
14:34:12  	at org.jenkinsci.plugins.credentialsbinding.MultiBinding.getCredentials(MultiBinding.java:200)
14:34:12  	at org.jenkinsci.plugins.credentialsbinding.impl.StringBinding.bindSingle(StringBinding.java:62)
14:34:12  	at org.jenkinsci.plugins.credentialsbinding.Binding.bind(Binding.java:150)
14:34:12  	at org.jenkinsci.plugins.credentialsbinding.impl.BindingStep$Execution2.doStart(BindingStep.java:134)
14:34:12  	at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution.lambda$run$0(GeneralNonBlockingStepExecution.java:77)
14:34:12  	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
14:34:12  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
14:34:12  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
14:34:12  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
14:34:12  	at java.base/java.lang.Thread.run(Thread.java:829)
14:34:12  Finished: FAILURE
```

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
