### PR TITLE
[JENKINS-64435] Don't show two console boxes when rendering the log file

### DIFF
--- a/core/src/main/resources/lib/hudson/progressiveText.jelly
+++ b/core/src/main/resources/lib/hudson/progressiveText.jelly
@@ -66,13 +66,7 @@ THE SOFTWARE.
               if(text!="") {
                 var p = document.createElement("DIV");
                 e.appendChild(p); // Needs to be first for IE
-                // Use "outerHTML" for IE; workaround for:
-                // http://www.quirksmode.org/bugreports/archives/2004/11/innerhtml_and_t.html
-                if (p.outerHTML) {
-                  p.outerHTML = '<pre>'+text+'</pre>';
-                  p = e.lastElementChild;
-                }
-                else p.innerHTML = text;
+                p.innerHTML = text;
                 Behaviour.applySubtree(p);
                 ElementResizeTracker.fireResizeCheck();
                 if(stickToBottom) scroller.scrollToBottom();


### PR DESCRIPTION
[JENKINS-64435](https://issues.jenkins.io/browse/JENKINS-64435)

This is a regression of 2.335, which polishes `<pre>` tags. Considering IE support has been dropped, this is safe to be removed.

|Proposed change   |Current weekly   |  
|---|---|
|![](https://i.imgur.com/YSkQgMn.png)   |![](https://i.imgur.com/KcoCcPE.png)   |

### Proposed changelog entries

* Only show one console box when viewing the build log (regression in 2.335 and 2.226)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
