### PR TITLE
[JENKINS-64435] Fix live console output from being split

### DIFF
--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -47,14 +47,14 @@ THE SOFTWARE.
 
       <j:out value="${h.generateConsoleAnnotationScriptAndStylesheet()}"/>
 
-      <div class="logrecord-container">
+      <div>
         <j:choose>
           <!-- Do progressive console output -->
           <j:when test="${it.isLogUpdated()}">
-            <pre id="out" class="console-output" />
+            <div id="out" class="logrecord-container" />
               <div id="spinner">
-                <l:progressAnimation/>
-              </div>
+              <l:progressAnimation/>
+            </div>
             <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
                  startOffset="${offset}" onFinishEvent="jenkins:consoleFinished"/>
           </j:when>

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -47,24 +47,26 @@ THE SOFTWARE.
 
       <j:out value="${h.generateConsoleAnnotationScriptAndStylesheet()}"/>
 
-      <j:choose>
-        <!-- Do progressive console output -->
-        <j:when test="${it.isLogUpdated()}">
-          <pre id="out" class="console-output" />
-            <div id="spinner">
-              <l:progressAnimation/>
-            </div>
-          <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
-               startOffset="${offset}" onFinishEvent="jenkins:consoleFinished"/>
-        </j:when>
-        <!-- output is completed now. -->
-        <j:otherwise>
-          <pre class="console-output">
-            <st:getOutput var="output" />
-            <j:whitespace>${it.writeLogTo(offset,output)}</j:whitespace>
-          </pre>
-        </j:otherwise>
-      </j:choose>
+      <div class="logrecord-container">
+        <j:choose>
+          <!-- Do progressive console output -->
+          <j:when test="${it.isLogUpdated()}">
+            <pre id="out" class="console-output" />
+              <div id="spinner">
+                <l:progressAnimation/>
+              </div>
+            <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
+                 startOffset="${offset}" onFinishEvent="jenkins:consoleFinished"/>
+          </j:when>
+          <!-- output is completed now. -->
+          <j:otherwise>
+            <pre class="console-output">
+              <st:getOutput var="output" />
+              <j:whitespace>${it.writeLogTo(offset,output)}</j:whitespace>
+            </pre>
+          </j:otherwise>
+        </j:choose>
+      </div>
     </l:main-panel>
   </l:layout>
 </st:compress>


### PR DESCRIPTION
<img width="257" alt="image" src="https://user-images.githubusercontent.com/43062514/156940033-a1f6d03a-02e1-465b-93e9-33d287832643.png">

See [JENKINS-64435](https://issues.jenkins-ci.org/browse/JENKINS-64435).

There's a bug at the moment due to the console redesign which causes the live console output to be split (due to printing `pre` inside of another `pre`. This is a fix for the visual issue, ideally though we shouldn't be outputting `pre` inside of another `pre` (not sure the reason why we do that, happy to change that if people want as part of this PR).

### Proposed changelog entries

* Bug: Fix live console output from being split

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
