### PR TITLE
[JENKINS-67965] Fix checkbox focus state

### DIFF
--- a/war/src/main/less/form/checkbox.less
+++ b/war/src/main/less/form/checkbox.less
@@ -28,6 +28,28 @@
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
 
+  &:not(:disabled) {
+    &:active,
+    &:focus {
+      & + label {
+        &::before {
+          box-shadow: 0 0 0 5px var(--focus-input-glow), inset 0 0 0 2px var(--focus-input-border);
+        }
+      }
+    }
+
+    &:checked {
+      &:active,
+      &:focus {
+        & + label {
+          &::before {
+            box-shadow: 0 0 0 5px var(--focus-input-glow), inset 0 0 0 12px var(--focus-input-border);
+          }
+        }
+      }
+    }
+  }
+
   &:checked {
     & + label {
       &:active,


### PR DESCRIPTION
See [JENKINS-67965](https://issues.jenkins-ci.org/browse/JENKINS-67965).

<img width="464" alt="image" src="https://user-images.githubusercontent.com/43062514/156954146-586ec9c4-d06d-4581-9809-1f47ddd33b81.png">

Checkboxes lost their focus state, this PR fixes that.

### Proposed changelog entries

* Checkbox focus state restored

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
