### PR TITLE
JENKINS-67858 Place ionicons at the same height as their associated text

### DIFF
--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1555,6 +1555,7 @@ body.no-sticker #bottom-sticker {
 svg.icon-sm {
     width: 16px;
     height: 16px;
+    vertical-align: top;
 
   svg {
     width: 16px;
@@ -1566,6 +1567,7 @@ svg.icon-sm {
 svg.icon-md {
     width: 24px;
     height: 24px;
+    vertical-align: top;
 
   svg {
     width: 24px;
@@ -1577,6 +1579,7 @@ svg.icon-md {
 svg.icon-lg {
     width: 32px;
     height: 32px;
+    vertical-align: top;
 
   svg {
     width: 32px;
@@ -1588,6 +1591,7 @@ svg.icon-lg {
 svg.icon-xlg {
     width: 48px;
     height: 48px;
+    vertical-align: top;
 
   svg {
     width: 48px;


### PR DESCRIPTION
See [JENKINS-67858](https://issues.jenkins.io/browse/JENKINS-67858)

This is an alternative approach to https://github.com/jenkinsci/jenkins/pull/6304, that addresses all occasions of misaligned ionicons, also in plugins:

<details>
  <summary>Maven integration, 2.337</summary>

![](https://i.imgur.com/NBzcem4.png)

</details>

<details>
  <summary>Maven integration, proposed change</summary>

![](https://i.imgur.com/yXhCrCY.png)

</details>

</details>

<details>
  <summary>Node overview, for reference</summary>

![](https://i.imgur.com/LWSBCEE.png)

</details>

Tango and icons from other sources and in other locations, like the sidebar, are unaffected by this change.

Closes https://github.com/jenkinsci/jenkins/pull/6304

### Proposed changelog entries

* [JENKINS-67858](https://issues.jenkins.io/browse/JENKINS-67858): Place icons at the same height as their associated text (regression in 2.335).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
