### PR TITLE
Stop overemphasizing console logs

### DIFF
--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -243,7 +243,7 @@ pre {
   background-color: var(--pre-background);
   color: var(--pre-color) !important;
   font-family: var(--font-family-mono) !important;
-  font-weight: 600 !important;
+  font-weight: 500 !important;
   line-height: 1.66 !important;
 
   a {


### PR DESCRIPTION
### Background

Please read [Common weight name mapping](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#common_weight_name_mapping) to understand how the numerical values 100 to 900 roughly correspond to the common weight names in the [OpenType specification](https://docs.microsoft.com/typography/opentype/spec/os2#usweightclass). As you can see, 400 is normal, 500 is medium, 600 is semibold, and 700 is bold.

Also, please read [Bold or italic](https://practicaltypography.com/bold-or-italic.html) from _Butterick’s Practical Typography_, noting the following (emphasis _not_ mine):

> **Nevertheless, some writers—let’s call them _overemphasizers_—just can’t get enough bold and italic. If they feel strongly about a point, they won’t hesitate to run the whole paragraph in bold type. Don’t be one of these people. This habit wears down your readers’ retinas and their patience. It also gives you nowhere to go when you need to emphasize a word. That’s no problem for overemphasizers, who resort to underlining bold text or _using a lot of bold italic. These are both terrible ideas._**

[`<dt>` is styled as semibold](https://github.com/jenkinsci/jenkins/blob/2696247bee9e05e6a15c415508924964f25646ca/war/src/main/less/modules/section.less#L177), while [`<dd>` is styled as medium](https://github.com/jenkinsci/jenkins/blob/2696247bee9e05e6a15c415508924964f25646ca/war/src/main/less/modules/section.less#L184). This makes sense, because the term deserves more emphasis than the definition. There is no problem of overemphasis here, since the ratio of emphasized to unemphasized text is small.

[`<th>` is styled as semibold](https://github.com/jenkinsci/jenkins/blob/2696247bee9e05e6a15c415508924964f25646ca/war/src/main/less/modules/table.less#L25), while [`<td>` is styled as medium](https://github.com/jenkinsci/jenkins/blob/2696247bee9e05e6a15c415508924964f25646ca/war/src/main/less/modules/table.less#L60). This also makes sense, because the header deserves more emphasis than the data. There is no problem of overemphasis here, since the ratio of emphasized to unemphasized text is small.

### Problem

[The entire console output is styled as semibold](https://github.com/jenkinsci/jenkins/blob/2696247bee9e05e6a15c415508924964f25646ca/war/src/main/less/base/style.less#L246). This does not make sense, as the console output is the main text. There is a problem of overemphasis here, since the entirety of the main text is emphasized.

### Solution

Consistent with `<dt>`/`<dd>` and `<th>`/`<td>`, style the console output as medium.

### Testing done

Viewed the page before and after. Before, the entire page was overemphasized:

![before](https://user-images.githubusercontent.com/29850/157099343-c1e1c694-b6e5-48d0-95a0-6fa5d8ff2b5c.png)

After, the page had a reasonable amount of emphasis:

![after](https://user-images.githubusercontent.com/29850/157099369-6d8c49a1-455a-45fc-99ba-6645df135f2c.png)

### Proposed changelog entries

* Stop overemphasizing console logs (regression in 2.335).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
