### PR TITLE
Don't cut off letters on the changeset view

### DIFF
--- a/war/src/main/less/base/layout-commons.less
+++ b/war/src/main/less/base/layout-commons.less
@@ -131,7 +131,6 @@ h1.build-caption.page-headline {
 
 h1.build-caption.page-headline > span {
   max-width: 1200px;
-  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
The change proposed fixes multiline letters being cut off on the changeset tab:

<details>
  <summary>Current weekly, take a close look on the "g"</summary>

![](https://i.imgur.com/lrOVn1X.png)

</details>

<details>
  <summary>Proposed change</summary>

![](https://i.imgur.com/F8Sq7oI.png)

</details>

<details>
  <summary>Build overview, for a better comparison</summary>

![](https://i.imgur.com/cf3rEvx.png)

</details>

The build status icon on the changeset tab is a bit smaller too, compared to the other tabs. I addressed that here as well.

### Proposed changelog entries

* Prevent multiline letters from being cut off on the changeset view tab.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
