### PR TITLE
Deprecate `PosixException` in favor of `IOException`

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -42,7 +42,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Computer;
 import hudson.model.Item;
 import hudson.model.TaskListener;
-import hudson.os.PosixException;
 import hudson.remoting.Callable;
 import hudson.remoting.Channel;
 import hudson.remoting.DelegatingCallable;
@@ -1985,7 +1984,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * @since 1.311
      * @see #chmod(int)
      */
-    public int mode() throws IOException, InterruptedException, PosixException {
+    public int mode() throws IOException, InterruptedException {
         if (!isUnix())   return -1;
         return act(new Mode());
     }

--- a/core/src/main/java/hudson/os/PosixException.java
+++ b/core/src/main/java/hudson/os/PosixException.java
@@ -1,9 +1,13 @@
 package hudson.os;
 
+import java.io.IOException;
+
 /**
  * Indicates an error during POSIX API call.
  * @author Kohsuke Kawaguchi
+ * @deprecated use {@link IOException}
  */
+@Deprecated
 public class PosixException extends RuntimeException {
 
     public PosixException(String message) {

--- a/core/src/main/java/hudson/util/IOUtils.java
+++ b/core/src/main/java/hudson/util/IOUtils.java
@@ -4,7 +4,6 @@ import static hudson.Util.fileToPath;
 
 import hudson.Functions;
 import hudson.Util;
-import hudson.os.PosixException;
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.File;
@@ -129,15 +128,11 @@ public class IOUtils {
      * care about access permissions.
      * <p>If the file is symlink, the mode is that of the link target, not the link itself.
      * @return a file mode, or -1 if not on Unix
-     * @throws PosixException if the file could not be statted, e.g. broken symlink
+     * @throws IOException if the file could not be statted, e.g. broken symlink
      */
-    public static int mode(File f) throws PosixException {
+    public static int mode(File f) throws IOException {
         if (Functions.isWindows())   return -1;
-        try {
-            return Util.permissionsToMode(Files.getPosixFilePermissions(fileToPath(f)));
-        } catch (IOException cause) {
-            throw new PosixException("Unable to get file permissions", cause);
-        }
+        return Util.permissionsToMode(Files.getPosixFilePermissions(fileToPath(f)));
     }
 
     /**

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -25,7 +25,6 @@
 package hudson.util.io;
 
 import hudson.Functions;
-import hudson.os.PosixException;
 import hudson.util.FileVisitor;
 import hudson.util.IOUtils;
 import java.io.File;
@@ -62,7 +61,7 @@ final class TarArchiver extends Archiver {
             if (mode != -1) {
                 e.setMode(mode);
             }
-        } catch (PosixException x) {
+        } catch (IOException x) {
             // ignore
         }
 

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -29,7 +29,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.DirectoryBrowserSupport;
-import hudson.os.PosixException;
 import hudson.remoting.Callable;
 import hudson.remoting.Channel;
 import hudson.remoting.RemoteInputStream;
@@ -1026,7 +1025,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
             @Override public int mode() throws IOException {
                 try {
                     return f.mode();
-                } catch (InterruptedException | PosixException x) {
+                } catch (InterruptedException x) {
                     throw new IOException(x);
                 }
             }


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/6323#discussion_r817148584. As of #5560 and #6323, there is no longer a reason for a dedicated `PosixException` class. The generic `IOException` class suffices for all use cases. Therefore this PR deprecates `PosixException` and rewrites any usages of `PosixException` within Jenkins core to use `IOException` instead.

### Migration path

This is a change in behavior, albeit a minor one. Back in #5560 I did a survey of `PosixException` and found that it was used in [Copy Artifact](https://plugins.jenkins.io/copyartifact/), [CloudBees Backup Plugin](https://docs.cloudbees.com/docs/release-notes/latest/plugins/infradna-backup-plugin/), and [Operations Center Context Plugin](https://docs.cloudbees.com/docs/release-notes/latest/plugins/operations-center-context-plugin/). Today, it is also used in [JNR Posix API](https://plugins.jenkins.io/jnr-posix-api/).

- If the plugin needs to support both old versions of Jenkins (without this PR) and new versions of Jenkins (with this PR), then catch both `PosixException` and `IOException` and handle them both the same way. This is why I am merely deprecating `PosixException` in this PR rather than restricting or deleting it.
- If the plugin only needs to support new versions of Jenkins (with this PR), then replace all references to `PosixException` with references to `IOException`.

### Proposed changelog entries

Deprecate `PosixException` in favor of `IOException`.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
