### PR TITLE
[JENKINS-67992] Add `Add-Opens` entry to `MANIFEST.MF`

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -182,6 +182,7 @@ THE SOFTWARE.
               <mainClass>Main</mainClass>
             </manifest>
             <manifestEntries>
+              <Add-Opens>java.base/java.lang java.base/java.io java.base/java.util java.base/java.util.concurrent</Add-Opens>
               <Implementation-Version>${project.version}</Implementation-Version>
               <Hudson-Version>1.395</Hudson-Version>
               <Jenkins-Version>${project.version}</Jenkins-Version>


### PR DESCRIPTION
### Problem

See [JENKINS-67992](https://issues.jenkins.io/browse/JENKINS-67992). When running Jenkins with Java 17, one needs to pass in several `--add-opens` directives on the command line when running `java -jar jenkins.war`. It is error-prone to do this [everywhere we run `java -jar jenkins.war`](https://github.com/jenkinsci/docker/blob/8a9f09e5f5ccfe2f2c2b13a9f0fe602f9500fa7c/jenkins.sh#L40-L47).

### Solution

Add an `Add-Opens` entry to `MANIFEST.MF` instead. Adding this entry has no impact on older versions of Java, so why not do it now? This just makes it easier to run Jenkins on Java 17.

### Testing done

Started Jenkins without `--add-opens` with the WAR from this PR and ran a Pipeline job successfully without observing any stack traces being printed in the Jenkins log on the following platforms:

- OpenJDK 8
- OpenJDK 11
- OpenJDK 17

### Future work

After this is released, I'll file follow-up PRs to remove any `--add-opens` entries we have strewn around the `jenkinsci` organization.

### Proposed changelog entries

* Support Java 17 without `--add-opens` command-line options.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
