### PR TITLE
[JENKINS-67995] `SystemdLifecycle` logging "Operation not permitted" calling `sd_notify(3)` during startup

### DIFF
--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -1,6 +1,5 @@
 package hudson.lifecycle;
 
-import com.sun.jna.LastErrorException;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -26,7 +25,7 @@ public class SystemdLifecycle extends ExitLifecycle {
     interface Systemd extends Library {
         Systemd INSTANCE = Native.load("systemd", Systemd.class);
 
-        int sd_notify(int unset_environment, String state) throws LastErrorException;
+        int sd_notify(int unset_environment, String state);
     }
 
     @Override
@@ -60,10 +59,9 @@ public class SystemdLifecycle extends ExitLifecycle {
     }
 
     private static synchronized void notify(String message) {
-        try {
-            Systemd.INSTANCE.sd_notify(0, message);
-        } catch (LastErrorException e) {
-            LOGGER.log(Level.WARNING, null, e);
+        int rv = Systemd.INSTANCE.sd_notify(0, message);
+        if (rv < 0) {
+            LOGGER.log(Level.WARNING, "sd_notify(3) returned {0}", rv);
         }
     }
 }


### PR DESCRIPTION
### Problem

See [JENKINS-67995](https://issues.jenkins.io/browse/JENKINS-67995). On Debian 11, running Jenkins under `systemd` logs a few "Operation not permitted" stack traces. These stack traces do not interfere with startup, but they are annoying log spam.

### Evaluation

Please read the excellent and correct analysis in the bug report. The `systemd(1)` developers decided to return a negative error number on failure rather than following the standard `libc(7)` convention of returning -1 and setting `errno`. My JNA code assumed the latter convention rather than the former.

### Solution

Implement the error return convention described in [the `sd_notify(3)` manual page](https://www.freedesktop.org/software/systemd/man/sd_notify.html):

> On failure, these calls return a negative errno-style error code.

That is, examine only the return value and not `errno` (which is what JNA's `LastErrorException` does).

### Testing done

Reproduced the problem in `jenkinsci/packaging` when running under Debian 11. Was no longer able to reproduce the problem with the WAR from this PR.

### Note

I am marking this as a regression fix and a backport candidate, but I do not want people to be alarmed. This is just log spam, and there is no impact to production use cases besides printing the annoying messages.

### Proposed changelog entries

Remove unnecessary log spam when starting Jenkins under `systemd` on Debian 11 (regression in 2.333 and 2.332.1).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
