### PR TITLE
Don't overflow on longer build names

### DIFF
--- a/war/src/main/less/base/layout-commons.less
+++ b/war/src/main/less/base/layout-commons.less
@@ -131,7 +131,8 @@ h1.build-caption.page-headline {
 
 h1.build-caption.page-headline > span {
   max-width: 1200px;
-  white-space: nowrap;
+  overflow: hidden;
+  line-height: 2.4rem;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
I'm addressing a comment on my previous PR about the text overflow from https://github.com/jenkinsci/jenkins/pull/6344#issuecomment-1065257403
Longer names or smaller screens now break the build name in multiple lines, while preserving the original issue the former PR addressed instead of vanishing behind buttons again:
![](https://i.imgur.com/pkKV802.png)
![](https://i.imgur.com/tIuLpKJ.png)

### Proposed changelog entries

* Split long build names in multiple times
Alternatively skip-changelog, as there's currently no weekly that contains the change.
### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
