### PR TITLE
Add Java 17 to build/test matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ properties([
 ])
 
 def buildTypes = ['Linux', 'Windows']
-def jdks = [8, 11]
+def jdks = [8, 11, 17]
 
 def builds = [:]
 for (i = 0; i < buildTypes.size(); i++) {
@@ -29,6 +29,9 @@ for (i = 0; i < buildTypes.size(); i++) {
     def jdk = jdks[j]
     if (buildType == 'Windows' && jdk == 8) {
       continue // unnecessary use of hardware
+    }
+    if (buildType == 'Windows' && jdk == 17) {
+      continue // TODO pending jenkins-infra/helpdesk#2822
     }
     builds["${buildType}-jdk${jdk}"] = {
       // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#node-labels for information on what node types are available

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -818,5 +818,21 @@ THE SOFTWARE.
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
       </properties>
     </profile>
+    <profile>
+      <id>jdk-9-and-above</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -822,5 +822,27 @@ THE SOFTWARE.
         <failIfNoTests>false</failIfNoTests>
       </properties>
     </profile>
+    <profile>
+      <id>jdk-17-and-above</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <!--
+          Animal Sniffer does not work on Java 17, but we cannot remove it from our configuration
+          entirely until we drop support for Java 8. As a temporary solution, we skip it when
+          running on Java 17. When JENKINS-54842 is resolved, this can be deleted.
+        -->
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+
+        <!--
+          Spotless requires custom arguments to be added to .mvn/jvm.config when running on Java 17,
+          but we cannot add those custom arguments until we drop support for Java 8. As a temporary
+          workaround, we skip Spotless when running on Java 17. When JENKINS-68015 is resolved, this
+          can be deleted.
+        -->
+        <spotless.check.skip>true</spotless.check.skip>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -229,7 +229,6 @@ THE SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <configuration>
-          <argLine>${jacocoSurefireArgs} -Xmx1g</argLine>
           <systemPropertyVariables>
             <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
             <buildDirectory>${project.build.directory}</buildDirectory>
@@ -334,6 +333,38 @@ THE SOFTWARE.
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk-8-and-below</id>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>${jacocoSurefireArgs} -Xmx1g</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk-9-and-above</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>${jacocoSurefireArgs} -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED</argLine>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
### Problem

As of #6356 we are shipping core with a `MANIFEST.MF` that contains four (4) `--add-opens` directives that are needed in order to run Jenkins on current releases of XStream with Java 17. Unfortunately, these directives do not take effect during tests, so the tests fail with reflection-related errors.

### Solution

At its core, this PR adds the same `--add-opens` directives to the Surefire JVM arguments when running tests on Java 9+ to enable Java 17 testing. This allows us to add Java 17 to the build/test matrix in the `Jenkinsfile` and improves the project's platform support matrix, establishing a new quality baseline that will make it harder to introduce new incompatibilities by accident in the future.

### Implementation

There are two minor issues with Animal Sniffer and Spotless that I am working around in `pom.xml` pending the removal of Java 8 support; please read the comments and the referenced Jira tickets for more information.

### Testing done

I have been testing this PR successfully on Java 17 over many test runs throughout the past week. As of this PR, the vast majority of core and core components will be built and tested on Java 8, Java 11, and Java 17. 

### Future work

The plugin toolchain still has rough to nonexistent support for anything other than Java 8. I am working on a more comprehensive update to the plugin toolchain that covers Java 11 and Java 17 and will share more information once I have a clear design in mind.

### Proposed changelog entries

Run core test suite on Java 17.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).