### PR TITLE
Remove `japicmp`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,6 @@ updates:
       # Must remain within jetty 9.x until Java 8 support is removed, ignore jetty 10.x and jetty 11.x updates
       - dependency-name: "org.eclipse.jetty:jetty-maven-plugin"
         versions: [">=10.0.0"]
-      # Pending https://github.com/siom79/japicmp/pull/266
-      - dependency-name: "com.github.siom79.japicmp:japicmp-maven-plugin"
       # Winstone upgrades require multiple changes in pom.xml.  See https://github.com/jenkinsci/jenkins/pull/5439#discussion_r616418468
       - dependency-name: "org.jenkins-ci:winstone"
       # Starting with version 10.0, this library requires Java 11

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,6 @@ for (i = 0; i < buildTypes.size(); i++) {
             realtimeJUnit(healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml,war/junit.xml') {
               def mavenOptions = [
                 '-Pdebug',
-                '-Pjapicmp',
                 '--update-snapshots',
                 "-Dmaven.repo.local=$m2repo",
                 '-Dmaven.test.failure.ignore',
@@ -128,16 +127,6 @@ for (i = 0; i < buildTypes.size(); i++) {
                   fingerprint: true
                   )
             }
-            publishHTML([
-              allowMissing: true,
-              alwaysLinkToLastBuild: false,
-              includes: 'japicmp.html',
-              keepAll: false,
-              reportDir: 'core/target/japicmp',
-              reportFiles: 'japicmp.html',
-              reportName: 'API compatibility',
-              reportTitles: 'japicmp report',
-            ])
           }
         }
       }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -818,43 +818,5 @@ THE SOFTWARE.
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
       </properties>
     </profile>
-    <profile>
-      <id>japicmp</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.siom79.japicmp</groupId>
-            <artifactId>japicmp-maven-plugin</artifactId>
-            <!-- TODO https://github.com/siom79/japicmp/pull/266 -->
-            <version>0.14.4-20200728.214757-1</version>
-            <configuration>
-              <parameter>
-                <!-- see https://siom79.github.io/japicmp/MavenPlugin.html -->
-                <oldVersionPattern>\d+[.]\d+</oldVersionPattern>
-                <!-- <onlyModified>true</onlyModified> -->
-                <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
-              </parameter>
-              <oldClassPathDependencies>
-                <dependency>
-                  <!-- provided, so not visible in flattened artifact -->
-                  <groupId>javax.servlet</groupId>
-                  <artifactId>javax.servlet-api</artifactId>
-                  <version>3.1.0</version>
-                  <scope>provided</scope>
-                </dependency>
-              </oldClassPathDependencies>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>cmp</goal>
-                </goals>
-                <phase>verify</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
#4848 introduced a dependency on an unmerged and unreleased upstream change (siom79/japicmp#266). PRs that consume an unmerged and/or unreleased upstream change need to remain in draft state until the upstream change is merged and released. The dependency on an unmerged and unreleased upstream change should never have been introduced. Since it is now causing me problems in an unrelated PR, I am removing this dependency.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
