### PR TITLE
Forward compatibility with Java 17 Javadoc generation

### DIFF
--- a/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/HudsonHomeDiskUsageMonitor.java
@@ -99,8 +99,8 @@ public final class HudsonHomeDiskUsageMonitor extends AdministrativeMonitor {
 
     /**
      * Extension point for suggesting solutions for full JENKINS_HOME.
+     * Views are as follows:
      *
-     * <h3>Views</h3>
      * <dl>
      * <dt>message.jelly</dt>
      * <dd>

--- a/core/src/main/java/hudson/init/Initializer.java
+++ b/core/src/main/java/hudson/init/Initializer.java
@@ -38,9 +38,8 @@ import org.jvnet.hudson.reactor.Task;
 
 /**
  * Placed on methods to indicate that this method is to be run during the Jenkins start up to perform
- * some sort of initialization tasks.
+ * some sort of initialization tasks, for example:
  *
- * <h3>Example</h3>
  * <pre>
    &#64;Initializer(after=JOB_LOADED)
    public static void init() throws IOException {

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -90,7 +90,7 @@ import org.kohsuke.stapler.verb.POST;
  *
  * TODO: still a work in progress.
  *
- * <h3>Access Control</h3>
+ * <p><strong>Access Control</strong>:
  * {@link LogRecorder} is only visible for administrators and system readers, and this access control happens at
  * {@link jenkins.model.Jenkins#getLog()}, the sole entry point for binding {@link LogRecorder} to URL.
  *

--- a/core/src/main/java/hudson/model/ReconfigurableDescribable.java
+++ b/core/src/main/java/hudson/model/ReconfigurableDescribable.java
@@ -40,16 +40,15 @@ import org.kohsuke.stapler.StaplerRequest;
  * implement this. Rather, it is up to the designer of an extension point to mark the extension point
  * as {@link ReconfigurableDescribable}, as it requires coordination at the owner of the extension point.
  *
- * <h1>Use Cases</h1>
- * <h2>Invisible Property</h2>
  * <p>
+ * <strong>Invisible Property:</strong>
  * This mechanism can be used to create an entirely invisible {@link Describable}, which is handy
  * for {@link NodeProperty}, {@link JobProperty}, etc. To do so, define an empty config.jelly to prevent it from
  * showing up in the config UI, then implement {@link #reconfigure(StaplerRequest, JSONObject)}
  * and simply return {@code this}.
  *
- * <h2>Passing some values without going through clients</h2>
  * <p>
+ * <strong>Passing some values without going through clients:</strong>
  * Sometimes your {@link Describable} object may have some expensive objects that you might want to
  * hand over to the next instance. This hook lets you do that.
  *

--- a/core/src/main/java/hudson/tasks/BuildStep.java
+++ b/core/src/main/java/hudson/tasks/BuildStep.java
@@ -191,8 +191,8 @@ public interface BuildStep {
      * to perform necessary synchronizations.
      * </dl>
      *
-     * <h2>Migrating Older Implementation</h2>
      * <p>
+     * <strong>Migrating Older Implementations:</strong>
      * If you are migrating {@link BuildStep} implementations written for earlier versions of Hudson,
      * here's what you can do:
      *

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2982,9 +2982,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Gets the item by its path name from the given context
      *
-     * <h2>Path Names</h2>
-     *
-     * <p>If the name starts from '/', like "/foo/bar/zot", then it's interpreted as absolute.
+     * <p><strong>Path Names:</strong>
+     * If the name starts from '/', like "/foo/bar/zot", then it's interpreted as absolute.
      * Otherwise, the name should be something like "foo/bar" and it's interpreted like
      * relative path name in the file system is, against the given context.
      *

--- a/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
+++ b/core/src/main/java/jenkins/util/xstream/XStreamDOM.java
@@ -79,8 +79,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * that read from DOM and {@link HierarchicalStreamWriter} that writes to DOM. See
  * {@link #newReader()} and {@link #newWriter()} for those operations.
  *
- * <h3>XStreamDOM as a field of another XStream-enabled class</h3>
  * <p>
+ * <strong>XStreamDOM as a field of another XStream-enabled class:</strong>
  * {@link XStreamDOM} can be used as a type of a field of another class that's itself XStream-enabled,
  * such as this:
  *
@@ -106,8 +106,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * The {@link XStreamDOM} object in the bar field will have the "payload" element in its tag name
  * (which means the bar element cannot have multiple children.)
  *
- * <h3>XStream and name escaping</h3>
  * <p>
+ * <strong>XStream and name escaping:</strong>
  * Because XStream wants to use letters like '$' that's not legal as a name char in XML,
  * the XML data model that it thinks of (unescaped) is actually translated into the actual
  * XML-compliant infoset via {@link XmlFriendlyReplacer}. This translation is done by


### PR DESCRIPTION
Extracted from #6364. Without this, generating Javadoc on Java 17 fails with some obscure errors about heading levels being wrong.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
