### PR TITLE
Restore original method signature of `CLICommand#getClientCharset`

### DIFF
--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -41,6 +41,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
@@ -406,8 +407,16 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
     public final String getSingleLineSummary() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         getCmdLineParser().printSingleLineUsage(out);
+        Charset charset;
         try {
-            return out.toString(getClientCharset().name());
+            charset = getClientCharset();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            return out.toString(charset.name());
         } catch (UnsupportedEncodingException e) {
             throw new AssertionError(e);
         }
@@ -420,8 +429,16 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
     public final String getUsage() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         getCmdLineParser().printUsage(out);
+        Charset charset;
         try {
-            return out.toString(getClientCharset().name());
+            charset = getClientCharset();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            return out.toString(charset.name());
         } catch (UnsupportedEncodingException e) {
             throw new AssertionError(e);
         }
@@ -433,9 +450,17 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
     @Restricted(NoExternalUse.class)
     public final String getLongDescription() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Charset charset;
+        try {
+            charset = getClientCharset();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         PrintStream ps;
         try {
-            ps = new PrintStream(out, false, getClientCharset().name());
+            ps = new PrintStream(out, false, charset.name());
         } catch (UnsupportedEncodingException e) {
             throw new AssertionError(e);
         }
@@ -443,7 +468,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
         printUsageSummary(ps);
         ps.close();
         try {
-            return out.toString(getClientCharset().name());
+            return out.toString(charset.name());
         } catch (UnsupportedEncodingException e) {
             throw new AssertionError(e);
         }
@@ -476,7 +501,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
         this.encoding = encoding;
     }
 
-    protected @NonNull Charset getClientCharset() {
+    protected @NonNull Charset getClientCharset() throws IOException, InterruptedException {
         if (encoding != null) {
             return encoding;
         }

--- a/core/src/main/java/hudson/cli/GroovyshCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyshCommand.java
@@ -29,10 +29,13 @@ import groovy.lang.Binding;
 import groovy.lang.Closure;
 import hudson.Extension;
 import java.io.BufferedInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
@@ -85,7 +88,15 @@ public class GroovyshCommand extends CLICommand {
 
         Binding binding = new Binding();
         // redirect "println" to the CLI
-        binding.setProperty("out", new PrintWriter(new OutputStreamWriter(stdout, getClientCharset()), true));
+        Charset charset;
+        try {
+            charset = getClientCharset();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        binding.setProperty("out", new PrintWriter(new OutputStreamWriter(stdout, charset), true));
         binding.setProperty("hudson", Jenkins.get()); // backward compatibility
         binding.setProperty("jenkins", Jenkins.get());
 

--- a/core/src/main/java/hudson/cli/ListChangesCommand.java
+++ b/core/src/main/java/hudson/cli/ListChangesCommand.java
@@ -7,6 +7,8 @@ import hudson.util.QuotedStringTokenizer;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.util.List;
 import jenkins.scm.RunWithSCM;
 import org.kohsuke.accmod.Restricted;
@@ -47,7 +49,15 @@ public class ListChangesCommand extends RunRangeCommand {
         // No other permission check needed.
         switch (format) {
         case XML:
-            PrintWriter w = new PrintWriter(new OutputStreamWriter(stdout, getClientCharset()));
+            Charset charset;
+            try {
+                charset = getClientCharset();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            PrintWriter w = new PrintWriter(new OutputStreamWriter(stdout, charset));
             w.println("<changes>");
             for (Run<?, ?> build : builds) {
                 if (build instanceof RunWithSCM) {

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -13,8 +13,11 @@ import hudson.model.TopLevelItem;
 import hudson.model.View;
 import hudson.model.ViewTest.CompositeView;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -156,8 +159,16 @@ public class ListJobsCommandTest {
 
             @Override
             protected boolean matchesSafely(ByteArrayOutputStream item) {
+                Charset charset;
                 try {
-                    return item.toString(command.getClientCharset().name()).isEmpty();
+                    charset = command.getClientCharset();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                try {
+                    return item.toString(charset.name()).isEmpty();
                 } catch (UnsupportedEncodingException e) {
                     throw new AssertionError(e);
                 }
@@ -179,8 +190,16 @@ public class ListJobsCommandTest {
             protected boolean matchesSafely(ByteArrayOutputStream item) {
 
                 Set<String> jobs;
+                Charset charset;
                 try {
-                    jobs = new HashSet<>(Arrays.asList(item.toString(command.getClientCharset().name()).split(System.getProperty("line.separator"))));
+                    charset = command.getClientCharset();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                try {
+                    jobs = new HashSet<>(Arrays.asList(item.toString(charset.name()).split(System.getProperty("line.separator"))));
                 } catch (UnsupportedEncodingException e) {
                     throw new AssertionError(e);
                 }


### PR DESCRIPTION
In #6050 I removed the `throws` clauses from `CLICommand#getClientCharset`. This turned out to be an ill-advised change, as it broke source compatibility with `jenkins-test-harness`, which I discovered recently when trying to compile `jenkins-test-harness` against recent cores. This was not intentional, so in this PR I am simply reverting the removal of the `throws` clauses and restoring the original clauses for source compatibility.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
