### PR TITLE
Document <l:progressAnimation> tag

### DIFF
--- a/core/src/main/resources/lib/layout/progressAnimation.jelly
+++ b/core/src/main/resources/lib/layout/progressAnimation.jelly
@@ -1,5 +1,15 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <st:documentation>
+    Display a CSS animation for progressive logging. This tag supersedes spinner.gif and is a drop in replacement:
+
+    From
+    {noformat}&lt;img src="${imagesURL}/spinner.gif" alt=""/>{noformat}
+    to
+    {noformat}&lt;l:progressAnimation/>{noformat}
+
+    @since 2.320
+  </st:documentation>
 
 <style>
 


### PR DESCRIPTION
The change proposed documents the `<l:progressAnimation>` tag, which was introduced in 2.320, to promote a modern alternative to spinner.gif.

### Proposed changelog entries

* N/A, skip-changelog. 

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
