### PR TITLE
[JENKINS-68027] Degrade gracefully when script contains characters that cannot be encoded

### DIFF
--- a/core/src/main/java/hudson/tasks/CommandInterpreter.java
+++ b/core/src/main/java/hudson/tasks/CommandInterpreter.java
@@ -117,7 +117,7 @@ public abstract class CommandInterpreter extends Builder implements EnvVarsFilte
         int r = -1;
         try {
             try {
-                script = createScriptFile(ws);
+                script = createScriptFile(ws, listener);
             } catch (IOException e) {
                 Util.displayIOException(e, listener);
                 Functions.printStackTrace(e, listener.fatalError(Messages.CommandInterpreter_UnableToProduceScript()));
@@ -197,9 +197,19 @@ public abstract class CommandInterpreter extends Builder implements EnvVarsFilte
 
     /**
      * Creates a script file in a temporary name in the specified directory.
+     * @deprecated use {@link #createScriptFile(FilePath, TaskListener)}
      */
+    @Deprecated
     public FilePath createScriptFile(@NonNull FilePath dir) throws IOException, InterruptedException {
-        return dir.createTextTempFile("jenkins", getFileExtension(), getContents(), false);
+        return createScriptFile(dir, TaskListener.NULL);
+    }
+
+    /**
+     * Creates a script file in a temporary name in the specified directory.
+     * @since TODO
+     */
+    public FilePath createScriptFile(@NonNull FilePath dir, @NonNull TaskListener listener) throws IOException, InterruptedException {
+        return dir.createTextTempFile("jenkins", getFileExtension(), getContents(), listener, false);
     }
 
     public abstract String[] buildCommandLine(FilePath script);

--- a/core/src/main/java/hudson/tools/AbstractCommandInstaller.java
+++ b/core/src/main/java/hudson/tools/AbstractCommandInstaller.java
@@ -73,7 +73,7 @@ public abstract class AbstractCommandInstaller extends ToolInstaller {
     public FilePath performInstallation(ToolInstallation tool, Node node, TaskListener log) throws IOException, InterruptedException {
         FilePath dir = preferredLocation(tool, node);
         // TODO support Unix scripts with interpreter line (see Shell.buildCommandLine)
-        FilePath script = dir.createTextTempFile("hudson", getCommandFileExtension(), command);
+        FilePath script = dir.createTextTempFile("hudson", getCommandFileExtension(), command, log, true);
         try {
             String[] cmd = getCommandCall(script);
             int r = node.createLauncher(log).launch().cmds(cmd).stdout(log).pwd(dir).join();


### PR DESCRIPTION
### Steps to reproduce

See [JENKINS-68027](https://issues.jenkins.io/browse/JENKINS-68027). Create a freestyle job with a batch file build step containing `echo Ἄνδρα μοι ἔννεπε, Μοῦσα, πολύτροπον, ὃς μάλα πολλὰ`. Observe that the job's `config.xml` contains the polytonic Greek text encoded in UTF-8. Then run the job on Windows on a JVM with the default character encoding of `windows-1252`, which cannot express polytonic Greek text.

### Expected results

*Note:* These are the _actual_ results prior to jenkinsci/jenkins#6098:

The job runs to completion, but the polytonic Greek characters that could not be encoded in `windows-1252` are silently and lossily converted to ? characters:

```
echo ????? ???????? ???? ?? 
????? ???????? ???? ??
```

I hesitate to call these results "expected" because this is still not the ideal scenario, but at least the job doesn't fail.

### Actual results

As of jenkinsci/jenkins#6098 the job fails fatally with

```
FATAL: Unable to produce a script file
java.nio.charset.UnmappableCharacterException: Input length = 1
	at java.base/java.nio.charset.CoderResult.throwException(CoderResult.java:275)
	at java.base/sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:306)
	at java.base/sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:281)
	at java.base/sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125)
	at java.base/java.io.OutputStreamWriter.write(OutputStreamWriter.java:208)
	at java.base/java.io.BufferedWriter.flushBuffer(BufferedWriter.java:120)
	at java.base/java.io.BufferedWriter.close(BufferedWriter.java:268)
	at hudson.FilePath$CreateTextTempFile.invoke(FilePath.java:1659)
	at hudson.FilePath$CreateTextTempFile.invoke(FilePath.java:1629)
	at hudson.FilePath.act(FilePath.java:1199)
	at hudson.FilePath.act(FilePath.java:1182)
	at hudson.FilePath.createTextTempFile(FilePath.java:1623)
Caused: java.io.IOException: Failed to create a temp file on C:\Users\basil\.jenkins\workspace\test
	at hudson.FilePath.createTextTempFile(FilePath.java:1625)
	at hudson.tasks.CommandInterpreter.createScriptFile(CommandInterpreter.java:202)
	at hudson.tasks.CommandInterpreter.perform(CommandInterpreter.java:120)
	at hudson.tasks.CommandInterpreter.perform(CommandInterpreter.java:92)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:814)
	at hudson.model.Build$BuildExecution.build(Build.java:199)
	at hudson.model.Build$BuildExecution.doRun(Build.java:164)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:522)
	at hudson.model.Run.execute(Run.java:1896)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:442)
Build step 'Execute Windows batch command' marked build as failure
Finished: FAILURE
```

### Evaluation

Prior to jenkinsci/jenkins#6098, running a PowerShell or batch file script in a freestyle job that contained characters that cannot be expressed in the JVM's default character set would result in a silent lossy downcast of those characters into "?" due to the use of the old `FileWriter` class. After jenkinsci/jenkins#6098, the job fails explicitly and early due to the switch to NIO.2.

### Solution

Both the old behavior and the new behavior are not ideal. Silently doing a lossy conversion is not ideal because it does not alert users of a problem. But failing the entire job is also not ideal because it is a change in behavior, which users have complained about in [JENKINS-68027](https://issues.jenkins.io/browse/JENKINS-68027).

This PR takes a middle ground: restoring the old behavior, but printing a warning to the job's console output. This turns the error from a fatal error to a non-fatal error, which restores the original behavior. Yet it also alerts the user that there is a problem, which is an improvement over what we used to ship prior to jenkinsci/jenkins#6098.

### Testing done

I did an end-to-end test of the new functionality following the steps to reproduce and confirmed the bug was fixed. I also added a new unit test covering this functionality.

### Proposed changelog entries

* Degrade gracefully when script contains characters that cannot be encoded (regression in 2.329).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
