### PR TITLE
[JENKINS-67602] Recover from fingerprint corruption earlier

### DIFF
--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -1414,10 +1414,6 @@ public class Fingerprint implements ModelObject, Saveable {
         if (fingerprint == null) {
             return;
         }
-        if (fingerprint.facets == null) {
-            logger.log(Level.WARNING, "Missing fingerprint facet, see JENKINS-67602");
-            return;
-        }
 
         for (FingerprintFacet facet : fingerprint.facets) {
             facet._setOwner(fingerprint);

--- a/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
+++ b/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
@@ -103,6 +103,11 @@ public class FileFingerprintStorage extends FingerprintStorage {
                         + (loaded != null ? loaded.getClass() : "null"));
             }
             Fingerprint f = (Fingerprint) loaded;
+            if (f.getPersistedFacets() == null) {
+                logger.log(Level.WARNING, "Malformed fingerprint {0}: Missing facets", configFile);
+                Files.deleteIfExists(Util.fileToPath(file));
+                return null;
+            }
             return f;
         } catch (IOException e) {
             if (Files.exists(Util.fileToPath(file)) && Files.size(Util.fileToPath(file)) == 0) {

--- a/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
+++ b/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
@@ -90,6 +90,9 @@ public class FileFingerprintStorage extends FingerprintStorage {
     /**
      * Load the Fingerprint stored inside the given file.
      */
+    @SuppressFBWarnings(
+            value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+            justification = "intentional check for fingerprint corruption")
     public static @CheckForNull Fingerprint load(@NonNull File file) throws IOException {
         XmlFile configFile = getConfigFile(file);
         if (!configFile.exists()) {


### PR DESCRIPTION
Amends #6334 based on information provided in recent Jira comments. The stack trace reported in [JENKINS-67602 (comment)](https://issues.jenkins.io/browse/JENKINS-67602?focusedCommentId=423113&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-423113) shows that once a corrupt fingerprint is loaded with a null `facets` field, skipping over the `null` field in `initFacets` isn't enough: the `null` field can still be returned from `getPersistedFacets()`, tripping up a future `FileFingerprintStorage.save()` operation.

This PR makes it so that if we notice a malformed fingerprint, we delete it as soon as possible rather than letting the corrupt data be loaded into memory and propagate through the rest of the system. We also log an informative message indicating which file was corrupt.

It might seem harsh to delete the corrupt file if we can't load it, but given the comments in `FileFingerprintStorage#load`, it seems that corruption of fingerprints is a long-standing issue, and we already delete corrupt fingerprints if they are of zero length or if they have malformed XML, so it seems in line with existing precedent to also delete them if they have a corrupt `facets` field.

To test this change, I intentionally corrupted a fingerprint by deleting its `facets` field. I verified that when starting up and loading the job, Jenkins logged the message added in this PR and that the corrupt fingerprint was then deleted.

### Proposed changelog entries

Delete corrupted fingerprint files.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
