### PR TITLE
Fill in `@since todo` annotations for the past releases

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -3455,7 +3455,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     private static final long serialVersionUID = 1L;
 
     @Restricted(NoExternalUse.class)
-    @RestrictedSince("TODO")
+    @RestrictedSince("2.328")
     public static final int SIDE_BUFFER_SIZE = 1024;
 
     private static final Logger LOGGER = Logger.getLogger(FilePath.class.getName());

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1073,11 +1073,11 @@ public class Util {
     /**
      * Copies a single file by using Ant.
      *
-     * @deprecated since TODO; use {@link Files#copy(Path, Path, CopyOption...)} directly
+     * @deprecated since 2.335; use {@link Files#copy(Path, Path, CopyOption...)} directly
      */
     @Deprecated
     @Restricted(NoExternalUse.class)
-    @RestrictedSince("TODO")
+    @RestrictedSince("2.335")
     public static void copyFile(@NonNull File src, @NonNull File dst) throws BuildException {
         Copy cp = new Copy();
         cp.setProject(new Project());

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -107,7 +107,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
      */
     @Deprecated
     @Restricted(NoExternalUse.class)
-    @RestrictedSince("TODO")
+    @RestrictedSince("2.324")
     public final transient CopyOnWriteList<Target> targets = new CopyOnWriteList<>();
     private List<Target> loggers = new ArrayList<>();
     private static final TargetComparator TARGET_COMPARATOR = new TargetComparator();

--- a/core/src/main/java/hudson/logging/LogRecorderManager.java
+++ b/core/src/main/java/hudson/logging/LogRecorderManager.java
@@ -83,7 +83,7 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
      */
     @Deprecated
     @Restricted(NoExternalUse.class)
-    @RestrictedSince("TODO")
+    @RestrictedSince("2.323")
     public final transient Map<String, LogRecorder> logRecorders = new CopyOnWriteMap.Tree<>();
 
     private List<LogRecorder> recorders;

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -286,7 +286,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
      * Get the cause if temporary offline.
      *
      * @return null if not temporary offline or there was no cause given.
-     * @since TODO
+     * @since 2.340
      */
     public OfflineCause getTemporaryOfflineCause() {
         return temporaryOfflineCause;

--- a/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
+++ b/core/src/main/java/jenkins/ClassLoaderReflectionToolkit.java
@@ -27,7 +27,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * but once that is made consistent with production Jenkins we can re-evaluate the fallback code.
  */
 @Restricted(NoExternalUse.class)
-@RestrictedSince("TODO")
+@RestrictedSince("2.324")
 public class ClassLoaderReflectionToolkit {
 
     private static <T extends Exception> Object invoke(Method method, Class<T> exception, Object obj, Object... args) throws T {

--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -164,7 +164,7 @@ public interface ModelObjectWithContextMenu extends ModelObject {
         /**
          * Add a separator row (no icon, no URL, no text).
          *
-         * @since TODO - Provide version
+         * @since 2.340
          */
         public ContextMenu addSeparator() {
             final MenuItem item = new MenuItem();
@@ -319,7 +319,7 @@ public interface ModelObjectWithContextMenu extends ModelObject {
 
         /**
          * The type of menu item
-         * @since TODO
+         * @since 2.340
          */
         @Exported
         @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")


### PR DESCRIPTION
This PR fills in `@since TODO` annotations from past releases.

### Proposed changelog entries

* N/A, skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
