### PR TITLE
Add `@RestrictedSince` to update-since-todo.sh

### DIFF
--- a/update-since-todo.sh
+++ b/update-since-todo.sh
@@ -11,7 +11,7 @@ set -o pipefail
 declare -A commitsAndTags
 
 IFS=$'\n'
-for todo in $( git grep --line-number '@since TODO' -- *.java *.jelly *.js)
+for todo in $( git grep --line-number '@since TODO\|@RestrictedSince("TODO")' -- *.java *.jelly *.js)
 do
     #echo "TODO: $todo"
     file=$( echo "$todo" | cut -d : -f 1 )
@@ -28,8 +28,9 @@ do
         echo -e "\tfirst tag was $firstTag"
         commitsAndTags[$lineSha]="$firstTag"
         echo -e "\tUpdating file in place"
-        sedExpr="${line}s/@since TODO/@since ${firstTag//jenkins-/}/"
-        sed -i.bak "$sedExpr" "$file"
+        atSince="${line}s/@since TODO/@since ${firstTag//jenkins-/}/"
+        atRestrictedSince="${line}s/@RestrictedSince(\"TODO\")/@RestrictedSince(\"${firstTag//jenkins-/}\")/"
+        sed -i.bak "$atRestrictedSince;$atSince" "$file"
         rm -f "$file.bak"
     else
         echo -e "\tNot updating file, no tag found. Normal if the associated PR/commit is not merged and released yet; otherwise make sure to fetch tags from jenkinsci/jenkins"

--- a/update-since-todo.sh
+++ b/update-since-todo.sh
@@ -13,7 +13,7 @@ declare -A commitsAndTags
 IFS=$'\n'
 for todo in $( git grep --line-number '@since TODO\|@RestrictedSince("TODO")' -- *.java *.jelly *.js)
 do
-    #echo "TODO: $todo"
+    echo "$todo" | xargs
     file=$( echo "$todo" | cut -d : -f 1 )
     line=$( echo "$todo" | cut -d : -f 2 )
 
@@ -39,7 +39,7 @@ done
 
 if [[ "${#commitsAndTags[@]}" -gt 0 ]] ; then
   echo ''
-  echo "List of commits introducing new API and the first release they went in:"
+  echo "List of commits introducing new API or restricting access and the first release they went in:"
   declare -A releases
   for commit in "${!commitsAndTags[@]}" ; do
     release="${commitsAndTags[$commit]}"


### PR DESCRIPTION
This PR amends my previous PR https://github.com/jenkinsci/jenkins/pull/6396 which addresses left over `@since TODO`s from past releases. Unfortunately, `@RestrictedSince("TODO")`s weren't considered by it.

The change proposed does take care of it. To verify my changes, I ran the tool on the master branch: https://gist.github.com/NotMyFault/81ff02b02875eec1f0cf72440fe8824a

### Proposed changelog entries

* N/A, skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
