### PR TITLE
[JENKINS-67967] "View build information" is not readonly

### DIFF
--- a/core/src/main/resources/hudson/model/Run/configure.jelly
+++ b/core/src/main/resources/hudson/model/Run/configure.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
           <f:textbox name="displayName" value="${it.hasCustomDisplayName()?it.displayName:''}"/>
         </f:entry>
         <f:entry title="${%Description}" help="/help/run-config/description.html">
-          <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="${h.hasPermission(it,it.UPDATE)?'/markupFormatter/previewDescription':null}"/>
+          <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
         </f:entry>
 
         <j:if test="${h.hasPermission(it,it.UPDATE)}">

--- a/core/src/main/resources/hudson/model/Run/configure.jelly
+++ b/core/src/main/resources/hudson/model/Run/configure.jelly
@@ -30,9 +30,11 @@ THE SOFTWARE.
       <div class="behavior-loading"><l:spinner text="${%LOADING}"/></div>
       <f:form method="post" action="configSubmit" name="config">
         <f:entry title="${%DisplayName}" help="/help/run-config/displayName.html">
+          <j:set var="readOnlyMode" value="${!h.hasPermission(it,it.UPDATE)}"/>
           <f:textbox name="displayName" value="${it.hasCustomDisplayName()?it.displayName:''}"/>
         </f:entry>
         <f:entry title="${%Description}" help="/help/run-config/description.html">
+          <j:set var="readOnlyMode" value="${!h.hasPermission(it,it.UPDATE)}"/>
           <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
         </f:entry>
 

--- a/core/src/main/resources/hudson/model/Run/configure.jelly
+++ b/core/src/main/resources/hudson/model/Run/configure.jelly
@@ -29,13 +29,12 @@ THE SOFTWARE.
     <l:main-panel>
       <div class="behavior-loading"><l:spinner text="${%LOADING}"/></div>
       <f:form method="post" action="configSubmit" name="config">
+        <j:set var="readOnlyMode" value="${!h.hasPermission(it,it.UPDATE)}"/>
         <f:entry title="${%DisplayName}" help="/help/run-config/displayName.html">
-          <j:set var="readOnlyMode" value="${!h.hasPermission(it,it.UPDATE)}"/>
           <f:textbox name="displayName" value="${it.hasCustomDisplayName()?it.displayName:''}"/>
         </f:entry>
         <f:entry title="${%Description}" help="/help/run-config/description.html">
-          <j:set var="readOnlyMode" value="${!h.hasPermission(it,it.UPDATE)}"/>
-          <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
+          <f:textarea name="description" value="${it.description}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="${h.hasPermission(it,it.UPDATE)?'/markupFormatter/previewDescription':null}"/>
         </f:entry>
 
         <j:if test="${h.hasPermission(it,it.UPDATE)}">


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-67967](https://issues.jenkins-ci.org/browse/JENKINS-67967).

![Image](https://user-images.githubusercontent.com/20413055/159632183-d1c58ec0-4b74-4221-ba1d-452035fdc644.png)

When users who don't have permission enter the "View build information" pages, they are unable to edit the text.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Make "View build information" pages readonly for users who don't have permission.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [X] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
