### PR TITLE
Backporting for LTS 2.332.2

### DIFF
--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -1,6 +1,5 @@
 package hudson.lifecycle;
 
-import com.sun.jna.LastErrorException;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -26,7 +25,7 @@ public class SystemdLifecycle extends ExitLifecycle {
     interface Systemd extends Library {
         Systemd INSTANCE = Native.load("systemd", Systemd.class);
 
-        int sd_notify(int unset_environment, String state) throws LastErrorException;
+        int sd_notify(int unset_environment, String state);
     }
 
     @Override
@@ -60,10 +59,9 @@ public class SystemdLifecycle extends ExitLifecycle {
     }
 
     private static synchronized void notify(String message) {
-        try {
-            Systemd.INSTANCE.sd_notify(0, message);
-        } catch (LastErrorException e) {
-            LOGGER.log(Level.WARNING, null, e);
+        int rv = Systemd.INSTANCE.sd_notify(0, message);
+        if (rv < 0) {
+            LOGGER.log(Level.WARNING, "sd_notify(3) returned {0}", rv);
         }
     }
 }

--- a/core/src/main/resources/lib/hudson/buildHealth.jelly
+++ b/core/src/main/resources/lib/hudson/buildHealth.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
                     </a>
                 </j:when>
                     <j:otherwise>
-                        <l:svgIcon href="${resURL}/images/${icons.getIconByClassSpec(buildHealth.iconClassName + ' icon-md').url}" tooltip="${buildHealth.score}%" />
+                        <l:svgIcon href="${resURL}/images/${icons.getIconByClassSpec(buildHealth.iconClassName + ' icon-md').url}"/>
                     </j:otherwise>
                 </j:choose>
             </div>

--- a/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
+++ b/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.slaves.restarter;
+
+import static org.junit.Assert.assertEquals;
+
+import hudson.Proc;
+import hudson.model.Slave;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.JNLPLauncher;
+import hudson.slaves.SlaveComputer;
+import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import jenkins.security.MasterToSlaveCallable;
+import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.util.JavaEnvUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsSessionRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+public class JnlpSlaveRestarterInstallerTest {
+
+    @Rule
+    public JenkinsSessionRule rr = new JenkinsSessionRule();
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule().record(JnlpSlaveRestarterInstaller.class, Level.FINE).capture(10);
+
+    @Issue("JENKINS-19055")
+    @Test
+    public void tcpReconnection() throws Throwable {
+        reconnection(false);
+    }
+
+    @Issue("JENKINS-66446")
+    @Test
+    public void webSocketReconnection() throws Throwable {
+        reconnection(true);
+    }
+
+    private void reconnection(boolean webSocket) throws Throwable {
+        AtomicReference<Proc> proc = new AtomicReference<>();
+        AtomicBoolean canWork = new AtomicBoolean();
+        try {
+            rr.then(r -> {
+                JNLPLauncher launcher = new JNLPLauncher(true);
+                launcher.setWebSocket(webSocket);
+                DumbSlave s = new DumbSlave("remote", tmp.newFolder("agent").getAbsolutePath(), launcher);
+                r.jenkins.addNode(s);
+                String secret = ((SlaveComputer) s.toComputer()).getJnlpMac();
+                File slaveJar = tmp.newFile();
+                FileUtils.copyURLToFile(new Slave.JnlpJar("agent.jar").getURL(), slaveJar);
+                proc.set(r.createLocalLauncher().launch().cmds(
+                    JavaEnvUtils.getJreExecutable("java"), "-jar", slaveJar.getAbsolutePath(),
+                    "-jnlpUrl", r.getURL() + "computer/remote/jenkins-agent.jnlp",
+                    "-secret", secret
+                ).stdout(System.out).start());
+                r.waitOnline(s);
+                assertEquals(1, s.getChannel().call(new JVMCount()).intValue());
+                while (!logging.getMessages().stream().anyMatch(msg -> msg.contains("Effective SlaveRestarter on remote:"))) {
+                    Thread.sleep(100);
+                }
+                // Likely true on Unix, likely false on Windows (not under winsw):
+                canWork.set(logging.getMessages().stream().anyMatch(msg -> msg.contains("Effective SlaveRestarter on remote: [jenkins.slaves.restarter.")));
+            });
+            rr.then(r -> {
+                DumbSlave s = (DumbSlave) r.jenkins.getNode("remote");
+                r.waitOnline(s);
+                assertEquals(canWork.get() ? 1 : 2, s.getChannel().call(new JVMCount()).intValue());
+            });
+        } finally {
+            if (proc.get() != null) {
+                proc.get().kill();
+            }
+        }
+    }
+
+    private static final class JVMCount extends MasterToSlaveCallable<Integer, RuntimeException> {
+        private static final String KEY = "launch-count";
+
+        @Override
+        public Integer call() throws RuntimeException {
+            int count = Integer.getInteger(KEY, 0) + 1;
+            System.setProperty(KEY, Integer.toString(count));
+            return count;
+        }
+    }
+
+}


### PR DESCRIPTION
```
Latest core version: jenkins-2.340

Fixed
-----

JENKINS-68007		Minor     		2.339
	Prefer --httpPort from JENKINS_ARGS over HTTP_PORT when the two differ
	https://issues.jenkins.io/browse/JENKINS-68007

JENKINS-67995		Minor     		2.339
	SystemdLifecycle logging "Operation not permitted" calling sd_notify(3) during startup
	regression
	https://issues.jenkins.io/browse/JENKINS-67995

JENKINS-67797		Minor     		2.336 (Feb 22, 2022)
	Weather status hover text reports wrong result on jobs not yet built
	regression
	https://issues.jenkins.io/browse/JENKINS-67797

JENKINS-66446		Critical  		2.338, Remoting 4.13
	WebSocket agent does not reconnect: ClassNotFoundException: jenkins.slaves.restarter.JnlpSlaveRestarterInstaller
	https://issues.jenkins.io/browse/JENKINS-66446

JENKINS-65809		Major     		2.335
	Jenkins fails to restart after plugin updates on Debian 11 (bullseye)
	https://issues.jenkins.io/browse/JENKINS-65809

JENKINS-41218		Critical  		2.335
	Provide native systemd unit
	https://issues.jenkins.io/browse/JENKINS-41218
```

Consider that only
- [JENKINS-67995](https://issues.jenkins.io/browse/JENKINS-67995)
- [JENKINS-67797](https://issues.jenkins.io/browse/JENKINS-67797)
- [JENKINS-66446](https://issues.jenkins.io/browse/JENKINS-66446)

contains changes to be backported to `jenkinsci/jenkins`.  

The rest of mentioned tickets contains fixes for `jenkinsci/packaging` (See: https://github.com/jenkinsci/packaging/pull/299)