### PR TITLE
[JENKINS-64299] Fix medium load statistics time series

### DIFF
--- a/core/src/main/java/hudson/model/MultiStageTimeSeries.java
+++ b/core/src/main/java/hudson/model/MultiStageTimeSeries.java
@@ -74,17 +74,17 @@ public class MultiStageTimeSeries implements Serializable {
     public final Color color;
 
     /**
-     * Updated every 10 seconds. Keep data up to 1 hour.
+     * Updated every 10 seconds. Keep data up to 6 hours.
      */
     @Exported
     public final TimeSeries sec10;
     /**
-     * Updated every 1 min. Keep data up to 1 day.
+     * Updated every 1 min. Keep data up to 2 days.
      */
     @Exported
     public final TimeSeries min;
     /**
-     * Updated every 1 hour. Keep data up to 4 weeks.
+     * Updated every 1 hour. Keep data up to 8 weeks.
      */
     @Exported
     public final TimeSeries hour;
@@ -169,7 +169,7 @@ public class MultiStageTimeSeries implements Serializable {
         public DateFormat createDateFormat() {
             switch (this) {
             case HOUR:  return new SimpleDateFormat("MMM/dd HH");
-            case MIN:   return new SimpleDateFormat("HH:mm");
+            case MIN:   return new SimpleDateFormat("E HH:mm");
             case SEC10: return new SimpleDateFormat("HH:mm:ss");
             default:    throw new AssertionError();
             }


### PR DESCRIPTION
See [JENKINS-64299](https://issues.jenkins-ci.org/browse/JENKINS-64299).

The problem with the medium length (updates every minute, keeps data of up to 2 days) is, according to @KalleOlaviNiemitalo, that labels are duplicated after 24 hrs. This change adds the weekday name to keep them unique.

This fixes a regression introduced in #4341.

## "After" at 18:49:05 (not yet two full days)

> ![Screenshot](https://user-images.githubusercontent.com/1831569/160251371-b10284db-f7f3-4e3b-b38f-aa84bb397286.png)

## "After" with more than two days

(Probably still wrong because of the DST switch tonight, I doubt 2:20 and 2:47 existed, but 🤷 different issue)

> ![Screenshot 2022-03-27 at 15 16 38](https://user-images.githubusercontent.com/1831569/160283339-057f9de1-3e32-4040-a68b-e5d59ba8bac0.png)

Also updates outdated Javadoc I missed in #4341.

### Proposed changelog entries

* Extend the medium length load statistics to cover 2 days instead of 1. Sometimes the data for the time period was not displayed correctly (regression in 2.204).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
