### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in publish artifact action

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.0.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Set version
         id: set-version


### PR DESCRIPTION
## Use Eclipse Temurin, not AdoptOpenJDK in publish artifact action

The 'adopt' distribution has moved to Eclipse Temurin and won't be updated at the AdoptOpenJDK location.

The [advanced usage](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt) describes the transition.

The [setup-java usage](https://github.com/actions/setup-java#usage) provides more general purpose info.

The current Adopt version is reporting:

```text
Run actions/setup-java@v2
Resolved Java 8.0.292+1 from tool-cache
Setting Java 8.0.292+1 as the default

Java configuration:
  Distribution: adopt
  Version: 8.0.292+1
  Path: /opt/hostedtoolcache/Java_Adopt_jdk/8.0.292-1/x64
```

The current Temurin version reports:

```text
Run actions/setup-java@v3.0.0
Resolved Java 8.0.322+6 from tool-cache
Setting Java 8.0.322+6 as the default

Java configuration:
  Distribution: temurin
  Version: 8.0.322+6
  Path: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/8.0.322-6/x64
```

The upgrade from JDK 8u292 to 8u322 is a positive step, since it is using a JDK version that is 12 months newer.

### Proposed changelog entries

N/A - skip changelog because there are no user visible results from this change

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

Any

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
