### PR TITLE
Adds PR labels definitions to contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,26 +119,26 @@ The Jenkins project uses a well-defined set of labels to mark the status and con
 The complete list of labels can be found at https://github.com/jenkinsci/jenkins/labels.
 These labels are defined as follows:
 
-- `needs-docs` marks a pull requests as lacking documentation, either for developers (e.g., Javadoc) or users (e.g., changes the [Jenkins handbook](https://www.jenkins.io/doc/book/)).
+- `needs-docs` marks a pull request as lacking documentation, either for developers (e.g., Javadoc) or users (e.g., changes to the [Jenkins handbook](https://www.jenkins.io/doc/book/)).
 For such pull requests to be approved and merged, the corresponding changes to the documentation should be proposed.
 If those changes belong to a separate repository (e.g., `jenkins-infra/jenkins.io`), a secondary pull request should be created in draft state in the other repository and reviewed in tandem with the primary pull request that proposes the code change.
-- `needs-fix` marks a pull requests with reviews requesting some code change which are not addressed yet.
+- `needs-fix` marks a pull request which has pending requests for chaging that have not yet been addressed.
 Such pull requests will not be merged until the code has been fixed and the tests pass.
-- `needs-justification` marks pull requests on which maintainers are debating the motivation for the proposed changed.
+- `needs-justification` marks a pull request where the reasoning is unclear, incomplete or not entirely cogent.
 To properly evaluate the solution provided in a pull request, maintainers must be able to understand the high-level problem that the pull request attempts to solve.
 While the context might be obvious to the author, it is not always apparent to reviewers and maintainers.
 The use of design documents, high-level tracking epics, [minimal reproducible examples (MREs)](https://en.wikipedia.org/wiki/Minimal_reproducible_example), etc. is strongly encouraged.
-- `needs-more-review` marks pull requests which are lacking reviews and comments, because the changes are complex or because a debate started among reviewers and more opinions would be beneficial
-- `on-hold` marks pull requests depending on another event/release, and it cannot be merged right now.
+- `needs-more-review` marks a pull request lacking a sufficient number of review from subject-matter expert(s) (SME), either because the changes are complex and not sufficiently explained or because there is a lack of consensus regarding the proposed solution.
+- `on-hold` marks a pull request that depends on another event and cannot be merged until the completion of that event.
 When the dependent task has been completed, the pull request will be ready for merge.
-- `proposed-for-close` marks pull requests where there is either no consensus on the next steps, or where the next steps have not been pursed and an extended period of time has been elapsed.
+- `proposed-for-close` marks a pull request where there is either no consensus on the next steps or where the next steps have not been taken and an extended period of time has been elapsed.
 Such pull requests are typically closed approximately one week after the label has been applied.
 They can always be reopened once consensus has been reached on the next steps or when action is taking regarding these next steps.
-- `ready-for-merge` marks pull requests that met the acceptance criteria, as defined elsewhere in this document.
+- `ready-for-merge` marks a pull request that has met the acceptance criteria, as defined elsewhere in this document.
 If there is no negative feedback, such pull requests are typically merged within approximately 24 hours.
-- `stalled` marks pull requests with no activities but a reasonable content which would benefit the project.
+- `stalled` marks a pull request that is off to a promising start but requires additional effort to reach completion - effort that appears to have been abandoned.
 If the original author lacks the time and interest to continue the original effort, we suggest that someone else pick up where the original author left off to drive the effort to completion.
-- `work-in-progress` marks pull requests which are still under active development.
+- `work-in-progress` marks a pull request that remains under active development.
 Such pull requests are not ready for final review.
 
 To ensure that pull requests are processed efficiently, the `ready-for-merge`, `stalled`, and `proposed-for-close` labels are subject to time constraints.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,45 +113,47 @@ the repository maintainers will integrate it, prepare changelogs, and
 ensure it gets released in one of upcoming Weekly releases.
 There is no additional action required from pull request authors at this point.
 
-### Pull requests management
+### Pull request management
 
-The project is using some labels to mark the status and the content of the pull requests.
+The Jenkins project uses a well-defined set of labels to mark the status and content of pull requests.
 The complete list of labels can be found at https://github.com/jenkinsci/jenkins/labels.
-Out of those labels, here is a definition of labels the maintainers are using to manage the status of the pull requests:
+These labels are defined as follows:
 
 - `needs-docs` marks a pull requests as lacking documentation, either for developers (e.g., Javadoc) or users (e.g., changes the [Jenkins handbook](https://www.jenkins.io/doc/book/)).
 For such pull requests to be approved and merged, the corresponding changes to the documentation should be proposed.
-If those changes belong to a separate repository (e.g., `jenkins-infra/jenkins.io`), a secondary pull request should be created in draft state in the other repository and review in tandem with the primary pull request that proposes the code change.
+If those changes belong to a separate repository (e.g., `jenkins-infra/jenkins.io`), a secondary pull request should be created in draft state in the other repository and reviewed in tandem with the primary pull request that proposes the code change.
 - `needs-fix` marks a pull requests with reviews requesting some code change which are not addressed yet.
-Such pull requests won't be merged until the code has been fixed and the tests are passing
+Such pull requests will not be merged until the code has been fixed and the tests pass.
 - `needs-justification` marks pull requests on which maintainers are debating the motivation for the proposed changed.
-The maintainers are requiring a clear description of the high-level effort with which the pull request is associated.
-This is to ensure that the context of the changes is well understood by everyone.
-The use of design document, high-level tracking epics, minimal reproducible example with steps, etc. is encouraged.
+To properly evaluate the solution provided in a pull request, maintainers must be able to understand the high-level problem that the pull request attempts to solve.
+While the context might be obvious to the author, it is not always apparent to reviewers and maintainers.
+The use of design documents, high-level tracking epics, [minimal reproducible examples (MREs)](https://en.wikipedia.org/wiki/Minimal_reproducible_example), etc. is strongly encouraged.
 - `needs-more-review` marks pull requests which are lacking reviews and comments, because the changes are complex or because a debate started among reviewers and more opinions would be beneficial
 - `on-hold` marks pull requests depending on another event/release, and it cannot be merged right now.
 When the dependent task has been completed, the pull request will be ready for merge.
 - `proposed-for-close` marks pull requests where there is either no consensus on the next steps, or where the next steps have not been pursed and an extended period of time has been elapsed.
-such pull requests are typically closed within the next week after the label has been applied.
+Such pull requests are typically closed approximately one week after the label has been applied.
 They can always be reopened once consensus has been reached on the next steps or when action is taking regarding these next steps.
 - `ready-for-merge` marks pull requests that met the acceptance criteria, as defined elsewhere in this document.
-Such pull requests are usually merged within the next 24hrs after the label is applied, if there is no negative feeback
+If there is no negative feedback, such pull requests are typically merged within approximately 24 hours.
 - `stalled` marks pull requests with no activities but a reasonable content which would benefit the project.
-Such pull requests can be taken over by others
+If the original author lacks the time and interest to continue the original effort, we suggest that someone else pick up where the original author left off to drive the effort to completion.
 - `work-in-progress` marks pull requests which are still under active development.
-Such pull requests are not ready for final review
+Such pull requests are not ready for final review.
 
-In order to make sure pull requests are shipped in a timely manner, time constrains are applied to `ready-for-merge`, `stalled` and `proposed-for-close`. 
+To ensure that pull requests are processed efficiently, the `ready-for-merge`, `stalled`, and `proposed-for-close` labels are subject to time constraints.
 
-A pull request labeled with `ready-for-merge` is merged within the next 24hrs after the label is applied, if there is no negative feedback.
+A pull request labeled with `ready-for-merge` is merged after approximately 24 hours if there is no negative feedback.
 
-A pull request with no activites for the past 30 days can be marked with the label `stalled`.
+If a pull request has remained incomplete with no activity for over a month, we will make this explicit by labeling the PR as `stalled`.
 
-If a pull request marked with the label `stalled` has no new activited after 30days, it can be marked as `proposed-for-close`.
-7 days after this label is applied to a pull request, it will be closed.
+If a pull request labelled as `stalled` remains inactive for yet another month, we will label it as `proposed-for-close` in order to maintain an orderly PR queue.
+Approximately one week after this label is applied to a pull request, it will be closed.
 
-When creating the pull request, if you activate the _Allow edits by maintainers_, you accept that maintainers can push new commits into the pull requests.
-As some maintainers are willing to attend to typo fix, merge conflicts while reviewing pull requests, accepting edits from maintainers can speed up the integration of the pull requests into the project.
+While contributors are strongly encouraged to drive PRs to completion on their own, we recognize that in some situations the help of a maintainer can be valuable.
+Yet also, we recognize that some contributors prefer not to receive unsolicited changes.
+When opening a pull request, enabling the _Allow edits by maintainers_ option indicates that you accept that maintainers may push new commits into your pull request branch.
+As some maintainers are willing to fix typographical errors and merge conflicts while reviewing pull requests, accepting edits from maintainers can speed up the integration of your pull request.
 
 ## IntelliJ suggestion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,14 +137,14 @@ such pull requests are not ready for final review
 
 In order to make sure pull requests are shipped in a timely manner, time constrains are applied to `ready-for-merge`, `stalled` and `proposed-for-close`. 
 
-A pull-request labeled with `ready-for-merge` is merged within the next 24hrs after the label is applied, if there is no negative feedback.
+A pull request labeled with `ready-for-merge` is merged within the next 24hrs after the label is applied, if there is no negative feedback.
 
-A pull-request with no activites for the past 30 days can be marked with the label `stalled`.
+A pull request with no activites for the past 30 days can be marked with the label `stalled`.
 
-If a pull-request marked with the label `stalled` has no new activited after 30days, it can be marked as `proposed-for-close`. 
-96hrs after this label is applied to a pull-request, it will be closed.
+If a pull request marked with the label `stalled` has no new activited after 30days, it can be marked as `proposed-for-close`.
+96hrs after this label is applied to a pull request, it will be closed.
 
-When creating the pull-request, if you activate the _Allow edits by maintainers_, you accept that maintainers can push new commits into the pull requests. 
+When creating the pull request, if you activate the _Allow edits by maintainers_, you accept that maintainers can push new commits into the pull requests.
 As some maintainers are willing to attend to typo fix, merge conflicts while reviewing pull requests, accepting edits from maintainers can speed up the integration of the pull requests into the project.
 
 ## IntelliJ suggestion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,40 @@ the repository maintainers will integrate it, prepare changelogs, and
 ensure it gets released in one of upcoming Weekly releases.
 There is no additional action required from pull request authors at this point.
 
+### Pull-Requests management
+
+The project is using some labels to mark the status and the content of the pull-requests.
+The complete list of labels can be found at https://github.com/jenkinsci/jenkins/labels.
+Out of those labels, here are a definition of labels the maintainers are using to manage the status of the pull-requests:
+
+- `needs-docs` marks a pull-requests lacking documentation in the code or on jenkins.io ;
+such pull-requests won't be merged until the comments are addressed
+- `needs-fix` marks a pull-requests with reviews requesting some code change which are not addressed yet ;
+such pull-requests won't be merged until the code has been fixed and the tests are passing
+- `needs-justification` marks pull-requests on which maintainers are debating the motivation for the proposed changed
+- `needs-more-review` marks pull-requests which are lacking reviews and comments, because the changes are complex or because a debate started among reviewers and more opinions would be beneficial
+- `on-hold` marks pull-requests depending on another event/release, and it cannot be merged right now
+- `propose-for-close` marks pull-requests with no activities or consensus on its content and maintainers do not see a way forward ;
+such pull-requests are usually closed within the next 96hrs after the label is applied
+- `ready-for-merge` marks pull-requests which were reviewed and approved by at least two maintainers ;
+such pull-requests are usually merged within the next 24hrs after the label is applied, if there is no negative feeback
+- `stalled` marks pull-requests with no activities but a reasonnable content which would benefit the project ;
+such pull-requests can be taken over by others
+- `work-in-progress` marks pull-requests which are still under active development ;
+such pull-requests are not ready for final review
+
+In order to make sure pull-requests are shipped in a timely manner, time constrains are applied to `ready-for-merge`, `stalled` and `proposed-for-close`. 
+
+A pull-request labeled with `ready-for-merge` is merged within the next 24hrs after the label is applied, if there is no negative feedback.
+
+A pull-request with no activites for the past 30 days can be marked with the label `stalled`.
+
+If a pull-request marked with the label `stalled` has no new activited after 30days, it can be marked as `proposed-for-close`. 
+96hrs after this label is applied to a pull-request, it will be closed.
+
+When creating the pull-request, if you activate the _Allow edits by maintainers_, you accept that maintainers can push new commits into the pull-requests. 
+As some maintainers are willing to attend to typo fix, merge conflicts while reviewing pull-requests, accepting edits from maintainers can speed up the integration of the pull-requests into the project.
+
 ## IntelliJ suggestion
 
 In case you are using IntelliJ, please adjust the default setting in respect to whitespace fixes on save.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,29 +113,29 @@ the repository maintainers will integrate it, prepare changelogs, and
 ensure it gets released in one of upcoming Weekly releases.
 There is no additional action required from pull request authors at this point.
 
-### Pull-Requests management
+### Pull requests management
 
-The project is using some labels to mark the status and the content of the pull-requests.
+The project is using some labels to mark the status and the content of the pull requests.
 The complete list of labels can be found at https://github.com/jenkinsci/jenkins/labels.
-Out of those labels, here is a definition of labels the maintainers are using to manage the status of the pull-requests:
+Out of those labels, here is a definition of labels the maintainers are using to manage the status of the pull requests:
 
-- `needs-docs` marks a pull-requests lacking documentation in the code or on jenkins.io ;
-such pull-requests won't be merged until the comments are addressed
-- `needs-fix` marks a pull-requests with reviews requesting some code change which are not addressed yet ;
-such pull-requests won't be merged until the code has been fixed and the tests are passing
-- `needs-justification` marks pull-requests on which maintainers are debating the motivation for the proposed changed
-- `needs-more-review` marks pull-requests which are lacking reviews and comments, because the changes are complex or because a debate started among reviewers and more opinions would be beneficial
-- `on-hold` marks pull-requests depending on another event/release, and it cannot be merged right now
-- `proposed-for-close` marks pull-requests with no activities or consensus on its content and maintainers do not see a way forward ;
-such pull-requests are usually closed within the next 96hrs after the label is applied
-- `ready-for-merge` marks pull-requests which were reviewed and approved by at least two maintainers ;
-such pull-requests are usually merged within the next 24hrs after the label is applied, if there is no negative feeback
-- `stalled` marks pull-requests with no activities but a reasonable content which would benefit the project ;
-such pull-requests can be taken over by others
-- `work-in-progress` marks pull-requests which are still under active development ;
-such pull-requests are not ready for final review
+- `needs-docs` marks a pull requests lacking documentation in the code or on jenkins.io ;
+such pull requests won't be merged until the comments are addressed
+- `needs-fix` marks a pull requests with reviews requesting some code change which are not addressed yet ;
+such pull requests won't be merged until the code has been fixed and the tests are passing
+- `needs-justification` marks pull requests on which maintainers are debating the motivation for the proposed changed
+- `needs-more-review` marks pull requests which are lacking reviews and comments, because the changes are complex or because a debate started among reviewers and more opinions would be beneficial
+- `on-hold` marks pull requests depending on another event/release, and it cannot be merged right now
+- `proposed-for-close` marks pull requests with no activities or consensus on its content and maintainers do not see a way forward ;
+such pull requests are usually closed within the next 96hrs after the label is applied
+- `ready-for-merge` marks pull requests which were reviewed and approved by at least two maintainers ;
+such pull requests are usually merged within the next 24hrs after the label is applied, if there is no negative feeback
+- `stalled` marks pull requests with no activities but a reasonable content which would benefit the project ;
+such pull requests can be taken over by others
+- `work-in-progress` marks pull requests which are still under active development ;
+such pull requests are not ready for final review
 
-In order to make sure pull-requests are shipped in a timely manner, time constrains are applied to `ready-for-merge`, `stalled` and `proposed-for-close`. 
+In order to make sure pull requests are shipped in a timely manner, time constrains are applied to `ready-for-merge`, `stalled` and `proposed-for-close`. 
 
 A pull-request labeled with `ready-for-merge` is merged within the next 24hrs after the label is applied, if there is no negative feedback.
 
@@ -144,8 +144,8 @@ A pull-request with no activites for the past 30 days can be marked with the lab
 If a pull-request marked with the label `stalled` has no new activited after 30days, it can be marked as `proposed-for-close`. 
 96hrs after this label is applied to a pull-request, it will be closed.
 
-When creating the pull-request, if you activate the _Allow edits by maintainers_, you accept that maintainers can push new commits into the pull-requests. 
-As some maintainers are willing to attend to typo fix, merge conflicts while reviewing pull-requests, accepting edits from maintainers can speed up the integration of the pull-requests into the project.
+When creating the pull-request, if you activate the _Allow edits by maintainers_, you accept that maintainers can push new commits into the pull requests. 
+As some maintainers are willing to attend to typo fix, merge conflicts while reviewing pull requests, accepting edits from maintainers can speed up the integration of the pull requests into the project.
 
 ## IntelliJ suggestion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,18 +122,18 @@ These labels are defined as follows:
 - `needs-docs` marks a pull request as lacking documentation, either for developers (e.g., Javadoc) or users (e.g., changes to the [Jenkins handbook](https://www.jenkins.io/doc/book/)).
 For such pull requests to be approved and merged, the corresponding changes to the documentation should be proposed.
 If those changes belong to a separate repository (e.g., `jenkins-infra/jenkins.io`), a secondary pull request should be created in draft state in the other repository and reviewed in tandem with the primary pull request that proposes the code change.
-- `needs-fix` marks a pull request which has pending requests for chaging that have not yet been addressed.
+- `needs-fix` marks a pull request which has pending requests for change that have not yet been addressed.
 Such pull requests will not be merged until the code has been fixed and the tests pass.
 - `needs-justification` marks a pull request where the reasoning is unclear, incomplete or not entirely cogent.
 To properly evaluate the solution provided in a pull request, maintainers must be able to understand the high-level problem that the pull request attempts to solve.
 While the context might be obvious to the author, it is not always apparent to reviewers and maintainers.
 The use of design documents, high-level tracking epics, [minimal reproducible examples (MREs)](https://en.wikipedia.org/wiki/Minimal_reproducible_example), etc. is strongly encouraged.
-- `needs-more-review` marks a pull request lacking a sufficient number of review from subject-matter expert(s) (SME), either because the changes are complex and not sufficiently explained or because there is a lack of consensus regarding the proposed solution.
+- `needs-more-review` marks a pull request as lacking a sufficient number of reviews from subject-matter expert(s) (SME), either because the changes are complex and not sufficiently explained or because there is a lack of consensus regarding the proposed solution.
 - `on-hold` marks a pull request that depends on another event and cannot be merged until the completion of that event.
 When the dependent task has been completed, the pull request will be ready for merge.
-- `proposed-for-close` marks a pull request where there is either no consensus on the next steps or where the next steps have not been taken and an extended period of time has been elapsed.
+- `proposed-for-close` marks a pull request where there is either no consensus on the next steps or where the next steps have not been taken and an extended period of time has elapsed.
 Such pull requests are typically closed approximately one week after the label has been applied.
-They can always be reopened once consensus has been reached on the next steps or when action is taking regarding these next steps.
+They can always be reopened once consensus has been reached on the next steps or when action is taken regarding these next steps.
 - `ready-for-merge` marks a pull request that has met the acceptance criteria, as defined elsewhere in this document.
 If there is no negative feedback, such pull requests are typically merged within approximately 24 hours.
 - `stalled` marks a pull request that is off to a promising start but requires additional effort to reach completion - effort that appears to have been abandoned.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ There is no additional action required from pull request authors at this point.
 
 The project is using some labels to mark the status and the content of the pull-requests.
 The complete list of labels can be found at https://github.com/jenkinsci/jenkins/labels.
-Out of those labels, here are a definition of labels the maintainers are using to manage the status of the pull-requests:
+Out of those labels, here is a definition of labels the maintainers are using to manage the status of the pull-requests:
 
 - `needs-docs` marks a pull-requests lacking documentation in the code or on jenkins.io ;
 such pull-requests won't be merged until the comments are addressed
@@ -126,11 +126,11 @@ such pull-requests won't be merged until the code has been fixed and the tests a
 - `needs-justification` marks pull-requests on which maintainers are debating the motivation for the proposed changed
 - `needs-more-review` marks pull-requests which are lacking reviews and comments, because the changes are complex or because a debate started among reviewers and more opinions would be beneficial
 - `on-hold` marks pull-requests depending on another event/release, and it cannot be merged right now
-- `propose-for-close` marks pull-requests with no activities or consensus on its content and maintainers do not see a way forward ;
+- `proposed-for-close` marks pull-requests with no activities or consensus on its content and maintainers do not see a way forward ;
 such pull-requests are usually closed within the next 96hrs after the label is applied
 - `ready-for-merge` marks pull-requests which were reviewed and approved by at least two maintainers ;
 such pull-requests are usually merged within the next 24hrs after the label is applied, if there is no negative feeback
-- `stalled` marks pull-requests with no activities but a reasonnable content which would benefit the project ;
+- `stalled` marks pull-requests with no activities but a reasonable content which would benefit the project ;
 such pull-requests can be taken over by others
 - `work-in-progress` marks pull-requests which are still under active development ;
 such pull-requests are not ready for final review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,27 +119,27 @@ The project is using some labels to mark the status and the content of the pull 
 The complete list of labels can be found at https://github.com/jenkinsci/jenkins/labels.
 Out of those labels, here is a definition of labels the maintainers are using to manage the status of the pull requests:
 
-- `needs-docs` marks a pull requests as lacking documentation, either for developers (e.g., Javadoc) or users (e.g., changes the [Jenkins handbook](https://www.jenkins.io/doc/book/)) ;
-for such pull requests to be approved and merged, the corresponding changes to the documentation should be proposed.
+- `needs-docs` marks a pull requests as lacking documentation, either for developers (e.g., Javadoc) or users (e.g., changes the [Jenkins handbook](https://www.jenkins.io/doc/book/)).
+For such pull requests to be approved and merged, the corresponding changes to the documentation should be proposed.
 If those changes belong to a separate repository (e.g., `jenkins-infra/jenkins.io`), a secondary pull request should be created in draft state in the other repository and review in tandem with the primary pull request that proposes the code change.
-- `needs-fix` marks a pull requests with reviews requesting some code change which are not addressed yet ;
-such pull requests won't be merged until the code has been fixed and the tests are passing
-- `needs-justification` marks pull requests on which maintainers are debating the motivation for the proposed changed ;
-the maintainers are requiring a clear description of the high-level effort with which the pull request is associated.
+- `needs-fix` marks a pull requests with reviews requesting some code change which are not addressed yet.
+Such pull requests won't be merged until the code has been fixed and the tests are passing
+- `needs-justification` marks pull requests on which maintainers are debating the motivation for the proposed changed.
+The maintainers are requiring a clear description of the high-level effort with which the pull request is associated.
 This is to ensure that the context of the changes is well understood by everyone.
 The use of design document, high-level tracking epics, minimal reproducible example with steps, etc. is encouraged.
 - `needs-more-review` marks pull requests which are lacking reviews and comments, because the changes are complex or because a debate started among reviewers and more opinions would be beneficial
-- `on-hold` marks pull requests depending on another event/release, and it cannot be merged right now ;
-when the dependent task has been completed, the pull request will be ready for merge.
+- `on-hold` marks pull requests depending on another event/release, and it cannot be merged right now.
+When the dependent task has been completed, the pull request will be ready for merge.
 - `proposed-for-close` marks pull requests where there is either no consensus on the next steps, or where the next steps have not been pursed and an extended period of time has been elapsed.
 such pull requests are typically closed within the next week after the label has been applied.
 They can always be reopened once consensus has been reached on the next steps or when action is taking regarding these next steps.
-- `ready-for-merge` marks pull requests that met the acceptance criteria, as defined elsewhere in this document ;
-such pull requests are usually merged within the next 24hrs after the label is applied, if there is no negative feeback
-- `stalled` marks pull requests with no activities but a reasonable content which would benefit the project ;
-such pull requests can be taken over by others
-- `work-in-progress` marks pull requests which are still under active development ;
-such pull requests are not ready for final review
+- `ready-for-merge` marks pull requests that met the acceptance criteria, as defined elsewhere in this document.
+Such pull requests are usually merged within the next 24hrs after the label is applied, if there is no negative feeback
+- `stalled` marks pull requests with no activities but a reasonable content which would benefit the project.
+Such pull requests can be taken over by others
+- `work-in-progress` marks pull requests which are still under active development.
+Such pull requests are not ready for final review
 
 In order to make sure pull requests are shipped in a timely manner, time constrains are applied to `ready-for-merge`, `stalled` and `proposed-for-close`. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,16 +119,22 @@ The project is using some labels to mark the status and the content of the pull 
 The complete list of labels can be found at https://github.com/jenkinsci/jenkins/labels.
 Out of those labels, here is a definition of labels the maintainers are using to manage the status of the pull requests:
 
-- `needs-docs` marks a pull requests lacking documentation in the code or on jenkins.io ;
-such pull requests won't be merged until the comments are addressed
+- `needs-docs` marks a pull requests as lacking documentation, either for developers (e.g., Javadoc) or users (e.g., changes the [Jenkins handbook](https://www.jenkins.io/doc/book/)) ;
+for such pull requests to be approved and merged, the corresponding changes to the documentation should be proposed.
+If those changes belong to a separate repository (e.g., `jenkins-infra/jenkins.io`), a secondary pull request should be created in draft state in the other repository and review in tandem with the primary pull request that proposes the code change.
 - `needs-fix` marks a pull requests with reviews requesting some code change which are not addressed yet ;
 such pull requests won't be merged until the code has been fixed and the tests are passing
-- `needs-justification` marks pull requests on which maintainers are debating the motivation for the proposed changed
+- `needs-justification` marks pull requests on which maintainers are debating the motivation for the proposed changed ;
+the maintainers are requiring a clear description of the high-level effort with which the pull request is associated.
+This is to ensure that the context of the changes is well understood by everyone.
+The use of design document, high-level tracking epics, minimal reproducible example with steps, etc. is encouraged.
 - `needs-more-review` marks pull requests which are lacking reviews and comments, because the changes are complex or because a debate started among reviewers and more opinions would be beneficial
-- `on-hold` marks pull requests depending on another event/release, and it cannot be merged right now
-- `proposed-for-close` marks pull requests with no activities or consensus on its content and maintainers do not see a way forward ;
-such pull requests are usually closed within the next 96hrs after the label is applied
-- `ready-for-merge` marks pull requests which were reviewed and approved by at least two maintainers ;
+- `on-hold` marks pull requests depending on another event/release, and it cannot be merged right now ;
+when the dependent task has been completed, the pull request will be ready for merge.
+- `proposed-for-close` marks pull requests where there is either no consensus on the next steps, or where the next steps have not been pursed and an extended period of time has been elapsed.
+such pull requests are typically closed within the next week after the label has been applied.
+They can always be reopened once consensus has been reached on the next steps or when action is taking regarding these next steps.
+- `ready-for-merge` marks pull requests that met the acceptance criteria, as defined elsewhere in this document ;
 such pull requests are usually merged within the next 24hrs after the label is applied, if there is no negative feeback
 - `stalled` marks pull requests with no activities but a reasonable content which would benefit the project ;
 such pull requests can be taken over by others
@@ -142,7 +148,7 @@ A pull request labeled with `ready-for-merge` is merged within the next 24hrs af
 A pull request with no activites for the past 30 days can be marked with the label `stalled`.
 
 If a pull request marked with the label `stalled` has no new activited after 30days, it can be marked as `proposed-for-close`.
-96hrs after this label is applied to a pull request, it will be closed.
+7 days after this label is applied to a pull request, it will be closed.
 
 When creating the pull request, if you activate the _Allow edits by maintainers_, you accept that maintainers can push new commits into the pull requests.
 As some maintainers are willing to attend to typo fix, merge conflicts while reviewing pull requests, accepting edits from maintainers can speed up the integration of the pull requests into the project.

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -95,7 +95,7 @@ Also, not every change needs to be merged into the core.
 Many features would be better introduced as plugins that have separate release cycles and allow delivering changes faster.
 We want to extend the Jenkins core and incorporate widely used functionality and extension points there,
 but we try to keep the core as minimal as possible in terms of dependencies.
-When the motivation of the changes is not clear, the pull-requests needs to be labeled with `needs-justification`.
+When the motivation of the changes is not clear, the pull requests needs to be labeled with `needs-justification`.
 
 ==== Ensuring Compatibility
 
@@ -142,7 +142,7 @@ but sometimes the changes go straight to the pull requests.
 And we are fine with that, especially for small patches.
 Pull requests often become a venue to discuss feasibility, underlying technical decisions and design.
 We are fine with that as well.
-The pull-requests can be marked with `needs-more-review` to get more eyes on the changes.
+The pull requests can be marked with `needs-more-review` to get more eyes on the changes.
 If there is no consensus about the feasibility and implementation,
 code reviewers are expected to suggest proper channels for contributors to discuss their contributions.
 

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -95,7 +95,7 @@ Also, not every change needs to be merged into the core.
 Many features would be better introduced as plugins that have separate release cycles and allow delivering changes faster.
 We want to extend the Jenkins core and incorporate widely used functionality and extension points there,
 but we try to keep the core as minimal as possible in terms of dependencies.
-When the motivation of the changes is not clear, the pull requests needs to be labeled with `needs-justification`.
+When the motivation of the pull request is unclear, incomplete, or not entirely cogent, the pull request needs to be labeled with `needs-justification`.
 
 ==== Ensuring Compatibility
 
@@ -132,7 +132,7 @@ and we do not enforce a single code style across the codebase at the moment.
   We have a semi-automated process that is based on pull request summaries and labels.
   Core maintainers are expected to validate the entries as a part of the pull request review/merge process.
   See the checklist below in the _Merge process_ section.
-* When the proposed changes requires documentation but it is missing, use `needs-docs` label on the pull-request.
+* When the proposed change lacks sufficient documentation, use the `needs-docs` label on the pull request.
 
 ==== Building consensus
 
@@ -142,7 +142,7 @@ but sometimes the changes go straight to the pull requests.
 And we are fine with that, especially for small patches.
 Pull requests often become a venue to discuss feasibility, underlying technical decisions and design.
 We are fine with that as well.
-The pull requests can be marked with `needs-more-review` to get more eyes on the changes.
+The pull request can be marked with `needs-more-review` to get more eyes on the change.
 If there is no consensus about the feasibility and implementation,
 code reviewers are expected to suggest proper channels for contributors to discuss their contributions.
 
@@ -158,9 +158,9 @@ Code reviews do NOT pursue the following goals:
   Not everything is going to be merged, and reviewers are expected to focus on the Jenkins ecosystem integrity first.
   We guide contributors and help them to get their changes integrated, but it needs cooperation on both sides.
   It is **fine** to close invalid and inactive pull requests if there is no activity by a submitter or other contributors.
-  When a pull-request has no activities in the last 30days, it can be marked with the label `stalled`.
-  If there is no consensus or activities after 30 more days, the pull-request can be marked as `proposed-for-close`.
-  The pull-request will then be closed in the next 96hrs with no new activities.
+  When a pull request remains inactive for a month, it can be marked with the label `stalled`.
+  If the pull request remains inactive or without consensus for yet another month, the pull request can be marked as `proposed-for-close`.
+  The pull request should then be closed in approximately a week if this state persists.
 * Enforcing a particular coding style.
   Jenkins core has a complex codebase created by many contributors, and different files have different designs.
   Our main goal is to firstly have the code readable by other contributors.

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -95,6 +95,7 @@ Also, not every change needs to be merged into the core.
 Many features would be better introduced as plugins that have separate release cycles and allow delivering changes faster.
 We want to extend the Jenkins core and incorporate widely used functionality and extension points there,
 but we try to keep the core as minimal as possible in terms of dependencies.
+When the motivation of the changes is not clear, the pull-requests needs to be labeled with `needs-justification`.
 
 ==== Ensuring Compatibility
 
@@ -131,6 +132,7 @@ and we do not enforce a single code style across the codebase at the moment.
   We have a semi-automated process that is based on pull request summaries and labels.
   Core maintainers are expected to validate the entries as a part of the pull request review/merge process.
   See the checklist below in the _Merge process_ section.
+* When the proposed changes requires documentation but it is missing, use `needs-docs` label on the pull-request.
 
 ==== Building consensus
 
@@ -140,6 +142,7 @@ but sometimes the changes go straight to the pull requests.
 And we are fine with that, especially for small patches.
 Pull requests often become a venue to discuss feasibility, underlying technical decisions and design.
 We are fine with that as well.
+The pull-requests can be marked with `needs-more-review` to get more eyes on the changes.
 If there is no consensus about the feasibility and implementation,
 code reviewers are expected to suggest proper channels for contributors to discuss their contributions.
 
@@ -155,6 +158,9 @@ Code reviews do NOT pursue the following goals:
   Not everything is going to be merged, and reviewers are expected to focus on the Jenkins ecosystem integrity first.
   We guide contributors and help them to get their changes integrated, but it needs cooperation on both sides.
   It is **fine** to close invalid and inactive pull requests if there is no activity by a submitter or other contributors.
+  When a pull-request has no activities in the last 30days, it can be marked with the label `stalled`.
+  If there is no consensus or activities after 30 more days, the pull-request can be marked as `proposed-for-close`.
+  The pull-request will then be closed in the next 96hrs with no new activities.
 * Enforcing a particular coding style.
   Jenkins core has a complex codebase created by many contributors, and different files have different designs.
   Our main goal is to firstly have the code readable by other contributors.


### PR DESCRIPTION
There is no jira ticket for this.

The proposed changes are about contributors and maintainers guidelines, after the discussion started on https://groups.google.com/g/jenkinsci-dev/c/jGM7ISvQ-iA/m/58SBtMRlBAAJ.

I proposed to use a 30days period of no activities (comment or commit) from the author before adding a `stalled` label. Wait 30 more days without any new commit (from anyone) before adding the `proposed-for-closed`. Once at this stage, close the PR after 96hrs. 

The motivation here is to clarify the guideline, so we all agree on the procedure so we can keep the pull-requests list clean and moving forward.

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
