### PR TITLE
Remove mention of how to parse with Python < 2.6

### DIFF
--- a/core/src/main/resources/hudson/model/Api/index.jelly
+++ b/core/src/main/resources/hudson/model/Api/index.jelly
@@ -75,6 +75,7 @@ THE SOFTWARE.
            Access the same data as Python for Python clients. This can be parsed into Python
            objects as <code>ast.literal_eval(urllib.urlopen("...").read())</code>
            and the resulting object tree is identical to that of JSON.
+         </p>
         </dd>
       </dl>
 

--- a/core/src/main/resources/hudson/model/Api/index.jelly
+++ b/core/src/main/resources/hudson/model/Api/index.jelly
@@ -73,16 +73,8 @@ THE SOFTWARE.
         <dd>
          <p>
            Access the same data as Python for Python clients. This can be parsed into Python
-           object as <code>eval(urllib.urlopen("...").read())</code> and the resulting object
-           tree is identical to that of JSON.
-
-           However, when you do this, beware of the security implication. If you are connecting
-           to a non-trusted Jenkins, the server can send you malicious Python programs. 
-         </p>
-         <p>
-           In Python 2.6 or later you can safely parse this output using 
-           <code>ast.literal_eval(urllib.urlopen("...").read())</code>
-         </p>
+           objects as <code>ast.literal_eval(urllib.urlopen("...").read())</code>
+           and the resulting object tree is identical to that of JSON.
         </dd>
       </dl>
 


### PR DESCRIPTION
Since even Python 2.6 was EOL:ed over 8 years ago, describing how to
parse the API output in earlier versions should not be needed.

No autotests, since this is a documentation change only.

### Submitter checklist

- [N/A] (If applicable) Jira issue is well described
- [N/A] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [N/A] Appropriate autotests or explanation to why this change has no tests
- [N/A] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [N/A] For dependency updates: links to external changelogs and, if possible, full diffs

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
