### PR TITLE
Allow users with Computer.EXTENDED_READ to access and refresh all node monitors

### DIFF
--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -227,7 +227,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      */
     @RequirePOST
     public void doUpdateNow(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        Jenkins.get().checkPermission(Computer.EXTENDED_READ);
+        Jenkins.get().checkAnyPermission(Jenkins.MANAGE, Computer.EXTENDED_READ);
 
         for (NodeMonitor nodeMonitor : NodeMonitor.getAll()) {
             Thread t = nodeMonitor.triggerUpdate();

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -227,7 +227,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      */
     @RequirePOST
     public void doUpdateNow(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        Jenkins.get().checkPermission(Jenkins.MANAGE);
+        Jenkins.get().checkPermission(Computer.EXTENDED_READ);
 
         for (NodeMonitor nodeMonitor : NodeMonitor.getAll()) {
             Thread t = nodeMonitor.triggerUpdate();

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -36,6 +36,7 @@ import hudson.init.Initializer;
 import hudson.model.Descriptor.FormException;
 import hudson.model.listeners.SaveableListener;
 import hudson.node_monitors.NodeMonitor;
+import hudson.security.Permission;
 import hudson.slaves.NodeDescriptor;
 import hudson.triggers.SafeTimerTask;
 import hudson.util.DescribableList;
@@ -58,6 +59,8 @@ import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ModelObjectWithContextMenu.ContextMenu;
 import jenkins.util.Timer;
 import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -483,4 +486,8 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
         }
         return null;
     }
+
+    @Restricted(NoExternalUse.class) // called by jelly
+    public static final Permission[] EXTENDED_READ_AND_MANAGE =
+            new Permission[] { Computer.EXTENDED_READ, Jenkins.MANAGE };
 }

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -56,7 +56,7 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
 
     @Override
     public String getColumnCaption() {
-        // Hide this column from non-admins
+        // Hide this column from users without EXTENDED_READ permission
         return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
     }
 

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -57,7 +57,7 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
     @Override
     public String getColumnCaption() {
         // Hide this column from users without EXTENDED_READ permission
-        return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
+        return Jenkins.get().hasPermission(Computer.EXTENDED_READ) ? super.getColumnCaption() : null;
     }
 
     public static final DiskSpaceMonitorDescriptor DESCRIPTOR = new DiskSpaceMonitorDescriptor() {

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -78,8 +78,8 @@ public class SwapSpaceMonitor extends NodeMonitor {
 
     @Override
     public String getColumnCaption() {
-        // Hide this column from non-admins
-        return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
+        // Hide this column from users without EXTENDED_READ permission
+        return Jenkins.get().hasPermission(Computer.EXTENDED_READ) ? super.getColumnCaption() : null;
     }
 
     /**

--- a/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
@@ -59,8 +59,8 @@ public class TemporarySpaceMonitor extends AbstractDiskSpaceMonitor {
 
     @Override
     public String getColumnCaption() {
-        // Hide this column from non-admins
-        return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
+        // Hide this column from users without EXTENDED_READ permission
+        return Jenkins.get().hasPermission(Computer.EXTENDED_READ) ? super.getColumnCaption() : null;
     }
 
     /**

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -37,13 +37,13 @@ THE SOFTWARE.
       <div class="jenkins-app-bar__content">
         <h1>${%Manage nodes and clouds}</h1>
       </div>
-      <l:hasAdministerOrManage>
+      <l:hasPermission permission="{$it.EXTENDED_READ}">
         <div class="jenkins-app-bar__controls">
           <form method="post" action="updateNow">
             <s:submit value="${%Refresh status}"/>
           </form>
         </div>
-      </l:hasAdministerOrManage>
+      </l:hasPermission>
     </div>
 
     <table id="computers" class="jenkins-table sortable">

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
       <div class="jenkins-app-bar__content">
         <h1>${%Manage nodes and clouds}</h1>
       </div>
-      <j:if test="${h.hasPermission(app.MANAGE) || h.hasPermission(Computer.EXTENDED_READ)}">
+      <j:if test="${h.hasAnyPermission(it, it.EXTENDED_READ_AND_MANAGE)}">
         <div class="jenkins-app-bar__controls">
           <form method="post" action="updateNow">
             <s:submit value="${%Refresh status}"/>

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
       <div class="jenkins-app-bar__content">
         <h1>${%Manage nodes and clouds}</h1>
       </div>
-      <l:hasPermission permission="{$it.EXTENDED_READ}">
+      <l:hasPermission permission="${it.EXTENDED_READ}">
         <div class="jenkins-app-bar__controls">
           <form method="post" action="updateNow">
             <s:submit value="${%Refresh status}"/>

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -37,13 +37,13 @@ THE SOFTWARE.
       <div class="jenkins-app-bar__content">
         <h1>${%Manage nodes and clouds}</h1>
       </div>
-      <l:hasPermission permission="${it.EXTENDED_READ}">
+      <j:if test="${h.hasAnyPermission(app, it.EXTENDED_READ, app.MANAGE)}">
         <div class="jenkins-app-bar__controls">
           <form method="post" action="updateNow">
             <s:submit value="${%Refresh status}"/>
           </form>
         </div>
-      </l:hasPermission>
+      </j:if>
     </div>
 
     <table id="computers" class="jenkins-table sortable">

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
       <div class="jenkins-app-bar__content">
         <h1>${%Manage nodes and clouds}</h1>
       </div>
-      <j:if test="${h.hasAnyPermission(app, it.EXTENDED_READ, app.MANAGE)}">
+      <j:if test="${h.hasAnyPermission(it, it.EXTENDED_READ, app.MANAGE)}">
         <div class="jenkins-app-bar__controls">
           <form method="post" action="updateNow">
             <s:submit value="${%Refresh status}"/>

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
       <div class="jenkins-app-bar__content">
         <h1>${%Manage nodes and clouds}</h1>
       </div>
-      <j:if test="${h.hasAnyPermission(it, it.EXTENDED_READ, app.MANAGE)}">
+      <j:if test="${h.hasPermission(app.MANAGE) || h.hasPermission(Computer.EXTENDED_READ)}">
         <div class="jenkins-app-bar__controls">
           <form method="post" action="updateNow">
             <s:submit value="${%Refresh status}"/>


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).
-->

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

This PR allows users with `Computer.EXTENDED_READ` permissions to read and refresh all node monitors (`JENKINS_URL/computer/`). Currently it is set to `Jenkins.MANAGE` ("Overall/Administer"), which is too restrictive.

We're running our agents with a limited ephemeral disks in Azure with only 32GB available disk space. Our builds often fail because of "No space left on device". 

Unfortunately, for a regular user it is not possible to identify the which agent has no space left because the column is hidden from non-admins. 

Also `Update Now` action is usually triggers cleanup of not suitable agents. And it is also not available for non-admins. So the users need to manually delete the failing agent. 

I think the `Computer.EXTENDED_READ` is most appropriated permission to display and refresh this information.

### Proposed changelog entries

* Allow users with `Computer.EXTENDED_READ` permissions to read and refresh all node monitors.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
@mention
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
