### PR TITLE
Upgrade Spring Framework from 5.3.16 to 5.3.18

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -54,6 +54,13 @@ THE SOFTWARE.
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>5.3.18</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <!-- https://docs.spring.io/spring-security/site/docs/5.5.4/reference/html5/#getting-maven-no-boot -->
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-bom</artifactId>


### PR DESCRIPTION
We were pulling in Spring Framework transitively through Spring Security, thus getting an older version. This PR explicitly adds the Spring Framework BOM to our build, at its latest version. In this way, we not only get the latest version in this PR but also stay at the latest version in the long term through Dependabot updates.

### Testing done

Diff of `jenkins.war` before and after this PR:

```
--- /tmp/old    2022-03-31 12:13:51.282058220 -0700
+++ /tmp/new    2022-03-31 12:17:33.244481847 -0700
@@ -1191,15 +1191,15 @@
 ./WEB-INF/lib/slf4j-api-1.7.36.jar
 ./WEB-INF/lib/slf4j-jdk14-1.7.36.jar
 ./WEB-INF/lib/spotbugs-annotations-4.6.0.jar
-./WEB-INF/lib/spring-aop-5.3.16.jar
-./WEB-INF/lib/spring-beans-5.3.16.jar
-./WEB-INF/lib/spring-context-5.3.16.jar
-./WEB-INF/lib/spring-core-5.3.16.jar
-./WEB-INF/lib/spring-expression-5.3.16.jar
+./WEB-INF/lib/spring-aop-5.3.18.jar
+./WEB-INF/lib/spring-beans-5.3.18.jar
+./WEB-INF/lib/spring-context-5.3.18.jar
+./WEB-INF/lib/spring-core-5.3.18.jar
+./WEB-INF/lib/spring-expression-5.3.18.jar
 ./WEB-INF/lib/spring-security-core-5.6.2.jar
 ./WEB-INF/lib/spring-security-crypto-5.6.2.jar
 ./WEB-INF/lib/spring-security-web-5.6.2.jar
-./WEB-INF/lib/spring-web-5.3.16.jar
+./WEB-INF/lib/spring-web-5.3.18.jar
 ./WEB-INF/lib/stapler-1669.v95a_4b_919a_b_a_2.jar
 ./WEB-INF/lib/stapler-adjunct-codemirror-1.3.jar
 ./WEB-INF/lib/stapler-adjunct-timeline-1.5.jar
```

### Proposed changelog entries

Upgrade [Spring Framework](https://spring.io/projects/spring-framework) 5.3.16 (released on February 17, 2022) to [5.3.18](https://github.com/spring-projects/spring-framework/releases/tag/v5.3.18) (released on March 31, 2022). This release of Spring Framework addresses the security vulnerability [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
