### PR TITLE
Upgrade build toolchain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,15 @@ This will help minimize the diff, which makes reviewing PRs easier.
 We also do not recommend `*` imports in the production code.
 Please disable them in Settings > Editor > Codestyle > Java by setting _Class count to use import with '*'_ and Names count to use import with '*'_ to a high value, e.g. 100. 
 
+The addition of `@{jenkins.addOpens}` to `argLine` exposes a bug in IntelliJ IDEA.
+A patch has been proposed in [JetBrains/intellij-community#1976](https://github.com/JetBrains/intellij-community/pull/1976).
+Pending the merge and release of this patch, IntelliJ IDEA users should work around the problem as follows:
+
+1. Go to **Settings** > **Build, Execution, Deployment** > **Build Tools** > **Maven** > **Running Tests**.
+2. Under "Pass to JUnit process [the] following `maven-surefire-plugin` and `maven-failsafe-plugin` settings", uncheck `argLine`.
+
+Failure to work around the problem as described above will result in a `could not open '{jenkins.addOpens}'` failure when running tests in IntelliJ IDEA.
+
 ## Copyright
 
 The Jenkins core is licensed under [MIT license], with a few exceptions in bundled classes.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -828,6 +828,7 @@ THE SOFTWARE.
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <!-- Make sure to keep the directives in test/pom.xml and war/pom.xml in sync with these. -->
               <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.72</version>
+    <version>1.73</version>
     <relativePath />
   </parent>
 
@@ -85,7 +85,6 @@ THE SOFTWARE.
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
 
     <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
-    <java.level>8</java.level>
 
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
@@ -636,37 +635,6 @@ THE SOFTWARE.
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java1${java.level}</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <!-- Version specified in parent POM -->
-        <configuration>
-          <source>1.${java.level}</source>
-          <target>1.${java.level}</target>
-          <!-- default reuseCreated is more performant
-          feel free to uncomment if you have any issues on your platform
-          <compilerReuseStrategy>alwaysNew</compilerReuseStrategy>
-          -->
-        </configuration>
       </plugin>
 
       <plugin>

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -562,6 +562,10 @@
         <Class name="hudson.scm.PollingResult"/>
       </And>
       <And>
+        <Bug pattern="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA"/>
+        <Class name="hudson.model.ViewJob"/>
+      </And>
+      <And>
         <Bug pattern="STATIC_IV"/>
         <Or>
           <Class name="hudson.cli.Connection"/>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -42,13 +42,6 @@ THE SOFTWARE.
     <mavenDebug>false</mavenDebug>
     <!-- empty by default -->
     <jacocoSurefireArgs />
-
-    <!--
-      Filled in by maven-hpi-plugin from the MANIFEST.MF entry in jenkins.war, but we provide a default value for the benefit of IDEs.
-      Make sure to keep the directives in core/pom.xml and war/pom.xml in sync with these.
-    -->
-    <jenkins.addOpens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</jenkins.addOpens>
-
     <!-- Filled in by maven-hpi-plugin with the path to org-netbeans-insane-hook.jar extracted from jenkins-test-harness -->
     <jenkins.insaneHook />
   </properties>
@@ -380,6 +373,31 @@ THE SOFTWARE.
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jdk-8-and-below</id>
+      <activation>
+        <jdk>(,1.8]</jdk>
+      </activation>
+      <properties>
+        <!--
+          Filled in by maven-hpi-plugin from the MANIFEST.MF entry in jenkins.war, but we provide a default value for the benefit of IDEs.
+        -->
+        <jenkins.addOpens />
+      </properties>
+    </profile>
+    <profile>
+      <id>jdk-9-and-above</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <!--
+          Filled in by maven-hpi-plugin from the MANIFEST.MF entry in jenkins.war, but we provide a default value for the benefit of IDEs.
+          Make sure to keep the directives in core/pom.xml and war/pom.xml in sync with these.
+        -->
+        <jenkins.addOpens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</jenkins.addOpens>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -42,6 +42,15 @@ THE SOFTWARE.
     <mavenDebug>false</mavenDebug>
     <!-- empty by default -->
     <jacocoSurefireArgs />
+
+    <!--
+      Filled in by maven-hpi-plugin from the MANIFEST.MF entry in jenkins.war, but we provide a default value for the benefit of IDEs.
+      Make sure to keep the directives in core/pom.xml and war/pom.xml in sync with these.
+    -->
+    <jenkins.addOpens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</jenkins.addOpens>
+
+    <!-- Filled in by maven-hpi-plugin with the path to org-netbeans-insane-hook.jar extracted from jenkins-test-harness -->
+    <jenkins.insaneHook />
   </properties>
 
   <dependencyManagement>
@@ -73,10 +82,17 @@ THE SOFTWARE.
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <!-- For maven-hpi-plugin -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>1723.vcd938b_e66072</version>
+      <version>1731.v383b_5d6c3393</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -191,6 +207,15 @@ THE SOFTWARE.
         <artifactId>maven-hpi-plugin</artifactId>
         <!-- Version specified in grandparent POM -->
         <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>test-runtime</id>
+            <goals>
+              <goal>test-runtime</goal>
+            </goals>
+            <phase>test</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.kohsuke.stapler</groupId>
@@ -229,6 +254,7 @@ THE SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- version specified in grandparent pom -->
         <configuration>
+          <argLine>${jacocoSurefireArgs} -Xmx1g @{jenkins.addOpens} @{jenkins.insaneHook}</argLine>
           <systemPropertyVariables>
             <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
             <buildDirectory>${project.build.directory}</buildDirectory>
@@ -236,6 +262,24 @@ THE SOFTWARE.
           <reuseForks>false</reuseForks>
           <forkCount>${concurrency}</forkCount>
         </configuration>
+        <executions>
+          <!-- Unbind the default execution so that it does not run before test-runtime. -->
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>none</phase>
+          </execution>
+          <!-- Bind a new execution which, by virtue of being declared after test-runtime, will also run after it. -->
+          <execution>
+            <id>functional-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
@@ -333,38 +377,6 @@ THE SOFTWARE.
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jdk-8-and-below</id>
-      <activation>
-        <jdk>(,1.8]</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacocoSurefireArgs} -Xmx1g</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jdk-9-and-above</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacocoSurefireArgs} -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
@@ -35,7 +35,8 @@ public class JenkinsLogRecordsTest {
         assertThat("Records are displayed in reverse order",
             logRecords.stream().map(LogRecord::getMessage).collect(Collectors.toList()),
             containsInRelativeOrder("Completed initialization", "Started initialization"));
-        if (new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("9"))) { // TODO https://github.com/jenkinsci/jenkins-test-harness/issues/359
+        VersionNumber javaVersion = new VersionNumber(System.getProperty("java.specification.version"));
+        if (javaVersion.isOlderThan(new VersionNumber("9")) || javaVersion.isNewerThanOrEqualTo(new VersionNumber("17"))) { // TODO https://github.com/jenkinsci/jenkins-test-harness/issues/359
             LogRecord lr = new LogRecord(Level.INFO, "collect me");
             Logger.getLogger(Jenkins.class.getName()).log(lr);
             WeakReference<LogRecord> ref = new WeakReference<>(lr);
@@ -46,5 +47,4 @@ public class JenkinsLogRecordsTest {
                 hasItem("<discarded>"));
         }
     }
-
 }

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -181,6 +181,7 @@ THE SOFTWARE.
               <mainClass>Main</mainClass>
             </manifest>
             <manifestEntries>
+              <!-- Make sure to keep the directives in core/pom.xml and test/pom.xml in sync with these. -->
               <Add-Opens>java.base/java.lang java.base/java.io java.base/java.util</Add-Opens>
               <Implementation-Version>${project.version}</Implementation-Version>
               <Hudson-Version>1.395</Hudson-Version>


### PR DESCRIPTION
Upgrades the build toolchain to the latest releases of the parent POM, test harness, and Maven HPI plugin. With all of the above, `JenkinsLogRecordsTest` now runs on Java 17.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
