### PR TITLE
[JENKINS-68122] Avoid deadlock involving `RingBufferLogHandler.LogRecordRef` class loading

### DIFF
--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -74,13 +74,16 @@ public class RingBufferLogHandler extends Handler {
     }
 
     @Override
-    public synchronized void publish(LogRecord record) {
-        int len = records.length;
-        records[(start + size) % len] = new LogRecordRef(record);
-        if (size == len) {
-            start = (start + 1) % len;
-        } else {
-            size++;
+    public void publish(LogRecord record) {
+        LogRecordRef logRecordRef = new LogRecordRef(record);
+        synchronized (this) {
+            int len = records.length;
+            records[(start + size) % len] = logRecordRef;
+            if (size == len) {
+                start = (start + 1) % len;
+            } else {
+                size++;
+            }
         }
     }
 


### PR DESCRIPTION
See [JENKINS-68122](https://issues.jenkins-ci.org/browse/JENKINS-68122). Amends #6018 + #6044.

**Effectiveness unconfirmed**—this is a speculative fix. (The exact problem is not obvious from the thread dump, since it somehow involves class loading, yet Java thread dumps do not indicate this detail.) @basil says he has a way to reproduce.

### Proposed changelog entries

* Avoid a deadlock between agent class loading and logging.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
