### PR TITLE
[JENKINS-68122] Avoid deadlock involving `RingBufferLogHandler.LogRecordRef` class loading (II)

### DIFF
--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -62,6 +62,7 @@ public class RingBufferLogHandler extends Handler {
 
     public RingBufferLogHandler(int ringSize) {
         records = new LogRecordRef[ringSize];
+        new LogRecordRef(new LogRecord(Level.INFO, "just forcing class loading")).get();
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-68122](https://issues.jenkins-ci.org/browse/JENKINS-68122). Amends #6018 + #6044. Alternative to #6444.

Effectiveness still being validated. Suggested by @roband7 (hope the GitHub and Jira ids align). I think the problem is in https://github.com/jenkinsci/jenkins/blob/71d5dd52a7f553a19cd6932c5713978ba8717747/core/src/main/java/hudson/slaves/SlaveComputer.java#L1062-L1092

https://github.com/basil/jenkins/commit/38efb0b99c20376c2dee27050b00530bda3fe776 is another variant.

https://github.com/jenkinsci/remoting/pull/527 _might_ offer a hotfix for those who cannot easily change the core (controller) version.

### Proposed changelog entries

* Avoid a deadlock between agent class loading and logging.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
