### PR TITLE
[JENKINS-68122] Avoid deadlock involving `RingBufferLogHandler.LogRecordRef` class loading (III)

### DIFF
--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -24,9 +24,11 @@
 
 package hudson.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.ref.SoftReference;
 import java.util.AbstractList;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -36,6 +38,9 @@ import java.util.logging.LogRecord;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(
+        value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
+        justification = "to guard against potential future compiler optimizations")
 public class RingBufferLogHandler extends Handler {
 
     private static final int DEFAULT_RING_BUFFER_SIZE = Integer.getInteger(RingBufferLogHandler.class.getName() + ".defaultSize", 256);
@@ -44,6 +49,13 @@ public class RingBufferLogHandler extends Handler {
         LogRecordRef(LogRecord referent) {
             super(referent);
         }
+    }
+
+    static {
+        // Preload the LogRecordRef class to avoid an ABBA deadlock between agent class loading and logging.
+        LogRecord r = new LogRecord(Level.INFO, "<preloading>");
+        // We call Objects.hash() to guard against potential future compiler optimizations.
+        Objects.hash(new LogRecordRef(r).get());
     }
 
     private int start = 0;


### PR DESCRIPTION
See [JENKINS-68122](https://issues.jenkins-ci.org/browse/JENKINS-68122). Amends #6018 + #6044. Alternative to #6444 & #6446.

Effectiveness still being validated. Variant of suggestion by @roband7 (hope the GitHub and Jira ids align). I think the problem is in https://github.com/jenkinsci/jenkins/blob/71d5dd52a7f553a19cd6932c5713978ba8717747/core/src/main/java/hudson/slaves/SlaveComputer.java#L1062-L1092

https://github.com/jenkinsci/remoting/pull/527 _might_ offer a hotfix for those who cannot easily change the core (controller) version.

### Proposed changelog entries

* Avoid a deadlock between agent class loading and logging.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
