### PR TITLE
Improve queue restart tests

### DIFF
--- a/test/src/test/java/hudson/model/QueueCrashTest.java
+++ b/test/src/test/java/hudson/model/QueueCrashTest.java
@@ -1,0 +1,72 @@
+package hudson.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import hudson.ExtensionList;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class QueueCrashTest {
+
+    @Rule public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+
+    @Test
+    public void persistQueueOnCrash() {
+        rr.thenWithHardShutdown(j -> {
+            // Speed up the test run by shortening the periodic save interval from 60 seconds to 5
+            // seconds.
+            Queue.Saver.DELAY_SECONDS = 5;
+
+            scheduleSomeBuild(j);
+            assertBuildIsScheduled(j);
+
+            // Wait for the periodic save to complete.
+            ExtensionList.lookupSingleton(Queue.Saver.class)
+                    .getNextSave()
+                    .get(30, TimeUnit.SECONDS);
+
+            // Ensure the periodic save process saved the queue, since the cleanup process will not
+            // run on a crash.
+            assertTrue(new File(j.jenkins.getRootDir(), "queue.xml").exists());
+        });
+        rr.then(QueueCrashTest::assertBuildIsScheduled);
+    }
+
+    @Test
+    public void doNotPersistQueueOnCrashBeforeSave() {
+        rr.thenWithHardShutdown(j -> {
+            // Avoid periodic save in order to simulate the scenario of a crash before initial save.
+            Queue.Saver.DELAY_SECONDS = (int) TimeUnit.DAYS.toSeconds(1);
+
+            scheduleSomeBuild(j);
+            assertBuildIsScheduled(j);
+
+            // Ensure the queue has not been saved in order to test that a crash in this scenario
+            // results in the queue being lost.
+            assertFalse(new File(j.jenkins.getRootDir(), "queue.xml").exists());
+        });
+        rr.then(QueueCrashTest::assertBuildIsNotScheduled);
+    }
+
+    private static void assertBuildIsScheduled(JenkinsRule j) {
+        j.jenkins.getQueue().maintain();
+        assertFalse(j.jenkins.getQueue().isEmpty());
+    }
+
+    private static void assertBuildIsNotScheduled(JenkinsRule j) {
+        j.jenkins.getQueue().maintain();
+        assertTrue(j.jenkins.getQueue().isEmpty());
+    }
+
+    private static void scheduleSomeBuild(JenkinsRule j) throws IOException {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.setAssignedLabel(Label.get("waitforit"));
+        p.scheduleBuild2(0);
+    }
+}

--- a/test/src/test/resources/hudson/model/QueueRestartTest/quietDown/init.groovy.d/quietDown.groovy
+++ b/test/src/test/resources/hudson/model/QueueRestartTest/quietDown/init.groovy.d/quietDown.groovy
@@ -1,0 +1,4 @@
+import jenkins.model.Jenkins
+
+// Start in a state that doesn't do any builds.
+Jenkins.get().doQuietDown()


### PR DESCRIPTION
This PR moves `QueueRestartTest#persistQueueOnCrash` to a separate test class (`QueueCrashTest`, still based on `RestartableJenkinsRule`) so that we can convert `QueueRestartTest` to `RealJenkinsRule` and make it more realistic. Once migrated to `RealJenkinsRule`, we make `QueueRestartTest` test the more realistic scenario of a user quieting down Jenkins (with a Groovy initialization script), restarting Jenkins (possibly multiple times, presumably to update plugins), and finally unquieting Jenkins and waiting for the queued build to finish.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
