### PR TITLE
Remove unnecessary shutdown hook

### DIFF
--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -55,19 +55,6 @@ import org.apache.commons.io.FileUtils;
 public abstract class Lifecycle implements ExtensionPoint {
     private static Lifecycle INSTANCE = null;
 
-    public Lifecycle() {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            Jenkins jenkins = Jenkins.getInstanceOrNull();
-            if (jenkins != null) {
-                try {
-                    jenkins.cleanUp();
-                } catch (Throwable t) {
-                    LOGGER.log(Level.SEVERE, "Failed to clean up. Shutdown will continue.", t);
-                }
-            }
-        }));
-    }
-
     /**
      * Gets the singleton instance.
      *


### PR DESCRIPTION
Reverts #6230. Adding a shutdown hook to core was never necessary, as Winstone already has one that invokes `hudson.WebAppMain.contextDestroyed` that invokes `jenkins.model.Jenkins.cleanUp`. This debug code proves it:

```java
diff --git a/core/src/main/java/jenkins/model/Jenkins.java b/core/src/main/java/jenkins/model/Jenkins.java
index d836e46ec5..0ae46a8aec 100644
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3554,6 +3554,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Called to shut down the system.
      */
     public void cleanUp() {
+        new Throwable("cleanUp()").printStackTrace(System.err);
         if (theInstance != this && theInstance != null) {
             LOGGER.log(Level.WARNING, "This instance is no longer the singleton, ignoring cleanUp()");
             return;
@@ -3561,6 +3562,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         synchronized (Jenkins.class) {
             if (cleanUpStarted) {
                 LOGGER.log(Level.WARNING, "Jenkins.cleanUp() already started, ignoring repeated cleanUp()");
+                new Throwable("Jenkins.cleanUp() already started, ignoring repeated cleanUp()").printStackTrace(System.err);
                 return;
             }
             cleanUpStarted = true;
```

Without the changes to `src/main` from this PR and with the above debugging code, I see the following (proving we are unnecessarily calling cleanup twice):

```
java.lang.Throwable: cleanUp()
        at jenkins.model.Jenkins.cleanUp(Jenkins.java:3557)
        at hudson.lifecycle.Lifecycle.lambda$new$0(Lifecycle.java:63)
        at java.base/java.lang.Thread.run(Thread.java:829)
java.lang.Throwable: cleanUp()
        at jenkins.model.Jenkins.cleanUp(Jenkins.java:3557)
        at hudson.WebAppMain.contextDestroyed(WebAppMain.java:374)
        at org.eclipse.jetty.server.handler.ContextHandler.callContextDestroyed(ContextHandler.java:1080)
        at org.eclipse.jetty.servlet.ServletContextHandler.callContextDestroyed(ServletContextHandler.java:584)
        at org.eclipse.jetty.server.handler.ContextHandler.contextDestroyed(ContextHandler.java:1043)
        at org.eclipse.jetty.servlet.ServletHandler.doStop(ServletHandler.java:319)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.security.SecurityHandler.doStop(SecurityHandler.java:430)
        at org.eclipse.jetty.security.ConstraintSecurityHandler.doStop(ConstraintSecurityHandler.java:423)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.session.SessionHandler.doStop(SessionHandler.java:520)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.handler.ContextHandler.stopContext(ContextHandler.java:1066)
        at org.eclipse.jetty.servlet.ServletContextHandler.stopContext(ServletContextHandler.java:386)
        at org.eclipse.jetty.webapp.WebAppContext.stopWebapp(WebAppContext.java:1454)
        at org.eclipse.jetty.webapp.WebAppContext.stopContext(WebAppContext.java:1420)
        at org.eclipse.jetty.server.handler.ContextHandler.doStop(ContextHandler.java:1120)
        at org.eclipse.jetty.servlet.ServletContextHandler.doStop(ServletContextHandler.java:297)
        at org.eclipse.jetty.webapp.WebAppContext.doStop(WebAppContext.java:547)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.Server.doStop(Server.java:470)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at winstone.Launcher.shutdown(Launcher.java:354)
        at winstone.ShutdownHook.run(ShutdownHook.java:26)
java.lang.Throwable: Jenkins.cleanUp() already started, ignoring repeated cleanUp()
        at jenkins.model.Jenkins.cleanUp(Jenkins.java:3565)
        at hudson.WebAppMain.contextDestroyed(WebAppMain.java:374)
        at org.eclipse.jetty.server.handler.ContextHandler.callContextDestroyed(ContextHandler.java:1080)
        at org.eclipse.jetty.servlet.ServletContextHandler.callContextDestroyed(ServletContextHandler.java:584)
        at org.eclipse.jetty.server.handler.ContextHandler.contextDestroyed(ContextHandler.java:1043)
        at org.eclipse.jetty.servlet.ServletHandler.doStop(ServletHandler.java:319)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.security.SecurityHandler.doStop(SecurityHandler.java:430)
        at org.eclipse.jetty.security.ConstraintSecurityHandler.doStop(ConstraintSecurityHandler.java:423)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.session.SessionHandler.doStop(SessionHandler.java:520)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.handler.ContextHandler.stopContext(ContextHandler.java:1066)
        at org.eclipse.jetty.servlet.ServletContextHandler.stopContext(ServletContextHandler.java:386)
        at org.eclipse.jetty.webapp.WebAppContext.stopWebapp(WebAppContext.java:1454)
        at org.eclipse.jetty.webapp.WebAppContext.stopContext(WebAppContext.java:1420)
        at org.eclipse.jetty.server.handler.ContextHandler.doStop(ContextHandler.java:1120)
        at org.eclipse.jetty.servlet.ServletContextHandler.doStop(ServletContextHandler.java:297)
        at org.eclipse.jetty.webapp.WebAppContext.doStop(WebAppContext.java:547)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.Server.doStop(Server.java:470)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at winstone.Launcher.shutdown(Launcher.java:354)
        at winstone.ShutdownHook.run(ShutdownHook.java:26)
```

With the changes to `src/main` from this PR and with the above debugging code, I see the following (proving that we are still running the cleanup from Winstone):

```
java.lang.Throwable: cleanUp()
        at jenkins.model.Jenkins.cleanUp(Jenkins.java:3557)
        at hudson.WebAppMain.contextDestroyed(WebAppMain.java:374)
        at org.eclipse.jetty.server.handler.ContextHandler.callContextDestroyed(ContextHandler.java:1080)
        at org.eclipse.jetty.servlet.ServletContextHandler.callContextDestroyed(ServletContextHandler.java:584)
        at org.eclipse.jetty.server.handler.ContextHandler.contextDestroyed(ContextHandler.java:1043)
        at org.eclipse.jetty.servlet.ServletHandler.doStop(ServletHandler.java:319)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.security.SecurityHandler.doStop(SecurityHandler.java:430)
        at org.eclipse.jetty.security.ConstraintSecurityHandler.doStop(ConstraintSecurityHandler.java:423)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.session.SessionHandler.doStop(SessionHandler.java:520)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.handler.ContextHandler.stopContext(ContextHandler.java:1066)
        at org.eclipse.jetty.servlet.ServletContextHandler.stopContext(ServletContextHandler.java:386)
        at org.eclipse.jetty.webapp.WebAppContext.stopWebapp(WebAppContext.java:1454)
        at org.eclipse.jetty.webapp.WebAppContext.stopContext(WebAppContext.java:1420)
        at org.eclipse.jetty.server.handler.ContextHandler.doStop(ContextHandler.java:1120)
        at org.eclipse.jetty.servlet.ServletContextHandler.doStop(ServletContextHandler.java:297)
        at org.eclipse.jetty.webapp.WebAppContext.doStop(WebAppContext.java:547)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStop(AbstractHandler.java:108)
        at org.eclipse.jetty.server.Server.doStop(Server.java:470)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        at winstone.Launcher.shutdown(Launcher.java:354)
        at winstone.ShutdownHook.run(ShutdownHook.java:26)
```

So why did I add the shutdown hook to core, and why do I need the odd `Throwable#printStackTrace` calls in the debug code above? Because it turns out that [logging from a shutdown hook doesn't work](https://stackoverflow.com/questions/13825403/java-how-to-get-logger-to-work-in-shutdown-hook). This is probably what led me to the state of confusion to add a shutdown hook to core in #6230. To get proper logging during cleanup after a `SIGTERM`, we need to do invoke the cleanup from outside a shutdown hook. This PR doesn't address the logging issue, but it does help by removing the (duplicate and unnecessary) shutdown hook from core. I will file a separate issue against Winstone to do web application shutdown from outside of a shutdown hook so that logging works when shutting down web applications.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
