### PR TITLE
Add "copy to clipboard" button to the script console output

### DIFF
--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -55,7 +55,6 @@ THE SOFTWARE.
           <j:if test="${output!=null}">
             <h2>
               ${%Result}
-              <st:nbsp/>
               <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="${output}"/>
             </h2>
             <pre><st:out value="${output}"/></pre>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -53,7 +53,11 @@ THE SOFTWARE.
           <st:adjunct includes="org.kohsuke.stapler.codemirror.mode.groovy.groovy"/>
           <st:adjunct includes="org.kohsuke.stapler.codemirror.theme.default"/>
           <j:if test="${output!=null}">
-            <h2>${%Result}</h2>
+            <h2>
+              ${%Result}
+              <st:nbsp/>
+              <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="${output}"/>
+            </h2>
             <pre><st:out value="${output}"/></pre>
           </j:if>
         </j:when>

--- a/core/src/main/resources/lib/hudson/scriptConsole.properties
+++ b/core/src/main/resources/lib/hudson/scriptConsole.properties
@@ -28,3 +28,5 @@ description=\
 
 description2=\
   All the classes from all the plugins are visible. <code>jenkins.*</code>, <code>jenkins.model.*</code>, <code>hudson.*</code>, and <code>hudson.model.*</code> are pre-imported.
+clickToCopy=Click to copy
+successfullyCopied=Copied to clipboard


### PR DESCRIPTION
The script console output does now have a "copy to clipboard" button to grab the output with ease, when following the [issue reporting](https://www.jenkins.io/participate/report-issue/#Howtoreportanissue-WhatinformationtoprovideforEnvironmentandDescription) guide for example.:
![](https://i.imgur.com/gijZ24q.png)

### Proposed changelog entries

* Add a "copy to clipboard" button to the script console output.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-ux

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
