### PR TITLE
Stop builds in the order supplied

### DIFF
--- a/core/src/main/java/jenkins/cli/StopBuildsCommand.java
+++ b/core/src/main/java/jenkins/cli/StopBuildsCommand.java
@@ -56,6 +56,7 @@ public class StopBuildsCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
         Jenkins jenkins = Jenkins.get();
+        // Deduplicate job names, but preserve the order specified by the user.
         final Set<String> names = new LinkedHashSet<>(jobNames);
 
         final List<Job> jobsToStop = new ArrayList<>();

--- a/core/src/main/java/jenkins/cli/StopBuildsCommand.java
+++ b/core/src/main/java/jenkins/cli/StopBuildsCommand.java
@@ -31,8 +31,9 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Run;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -55,7 +56,7 @@ public class StopBuildsCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
         Jenkins jenkins = Jenkins.get();
-        final HashSet<String> names = new HashSet<>(jobNames);
+        final Set<String> names = new LinkedHashSet<>(jobNames);
 
         final List<Job> jobsToStop = new ArrayList<>();
         for (final String jobName : names) {


### PR DESCRIPTION
#5989 proposes some elaborate changes to tests to deal with the fact that `StopBuildsCommand` is not guaranteed to stop builds in any particular order. But it seems simpler and more intuitive to me to change the code under test rather than the test: by stopping builds in the order given by the user, it seems that we can behave in a less surprising way and also eliminate the test flakiness at the same time.

### Proposed changelog entries

Stop builds in the order they are provided from the CLI.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
