### PR TITLE
Remove invalid repeatable CSS

### DIFF
--- a/war/src/main/less/form/reorderable-list.less
+++ b/war/src/main/less/form/reorderable-list.less
@@ -15,7 +15,6 @@
 .repeated-chunk.last .show-if-not-last { visibility: hidden; }
 
 .repeated-chunk .show-if-not-only { visibility: visible; }
-.repeated-chunk.only .show-if-not-only { visibility: hidden; }
 
 /* == nested repeatable elements / 2 deep == */
 .repeated-chunk .repeated-chunk .show-if-last { visibility: hidden; }
@@ -25,7 +24,6 @@
 .repeated-chunk .repeated-chunk.last .show-if-not-last { visibility: hidden; }
 
 .repeated-chunk .repeated-chunk .show-if-not-only { visibility: visible; }
-.repeated-chunk .repeated-chunk.only .show-if-not-only { visibility: hidden; }
 
 /* == nested repeatable elements / 3 deep == */
 .repeated-chunk .repeated-chunk .repeated-chunk .show-if-last { visibility: hidden; }
@@ -34,8 +32,7 @@
 .repeated-chunk .repeated-chunk .repeated-chunk .show-if-not-last { visibility: visible; }
 .repeated-chunk .repeated-chunk .repeated-chunk.last .show-if-not-last { visibility: hidden; }
 
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-not-only { visibility: visible; }
-.repeated-chunk .repeated-chunk .repeated-chunk.only .show-if-not-only { visibility: hidden; }
+.repeated-chunk .repeated-chunk .show-if-not-only { visibility: visible; }
 
 /*
     <DIV>s marked with to-be-removed is used in conjunction with repeatable.jelly and hetero-list.jelly


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See https://github.com/jenkinsci/jenkins/pull/6467#pullrequestreview-940209292 and [JENKINS-14749](https://issues.jenkins.io/browse/JENKINS-14749)

Validated with the Git plugin, all looks good. Because these rules were invalid they would have been ignored,

I also cherry-picked this PR on top of https://github.com/jenkinsci/jenkins/pull/6467#pullrequestreview-940209292 and run

```
mvn clean verify -Dtest=lib.form.FormTest#autocompleteOffByDefault
```

Which showed no warnings anymore, output:

```
[INFO] Running lib.form.FormTest
=== Starting autocompleteOffByDefault(lib.form.FormTest)
   0.040 [id=17]	INFO	o.jvnet.hudson.test.WarExploder#explode: Using jenkins.war resources from /Users/timja/code/jenkins/jenkins/war/target/jenkins
   0.157 [id=17]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:62659/jenkins/
   0.313 [id=31]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.315 [id=30]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.834 [id=31]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.844 [id=36]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.849 [id=34]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   1.187 [id=38]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   1.187 [id=30]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   1.188 [id=33]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   1.190 [id=33]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   1.281 [id=30]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   3.749 [id=17]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   4.266 [id=17]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.771 s - in lib.form.FormTest
[INFO]
```

I've also validated that there is no more invalid CSS (at least in the `FormTest`) except for YUI, so we can remove the hacks to ignore, see https://github.com/jenkinsci/jenkins-test-harness/pull/424

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->
<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins-ci.org/issues/?filter=12146)).
