### PR TITLE
[JENKINS-68103] Fix build progress bar not taking the user to console output

### DIFF
--- a/war/src/main/less/modules/breadcrumbs.less
+++ b/war/src/main/less/modules/breadcrumbs.less
@@ -209,6 +209,7 @@
     left: -10px;
     bottom: -7px;
     right: -10px;
+    pointer-events: none;
   }
 
   &:hover {


### PR DESCRIPTION
See [JENKINS-68103](https://issues.jenkins.io/browse/JENKINS-68103)

Essentially the hitbox for the link above the progress bar was too tall, meaning that it was very hard to click the progress bar.

### Testing done

I changed the number of executors on the built-in node from 2 to 3, then I created a Freestyle job with a shell command of `sleep 86400` and checked the "Execute concurrent builds if necessary" option. On Jenkins 2.339, I could see the animated progress bar for all three, and clicking on the progress bar took me to the console as expected. On Jenkins 2.440, I could see the animated progress bar for all three, but hovering over each one made an arrow drop down and made it impossible to click on the progress bar, and clicking on each one took me to the build page rather than the console output. With this PR, the behavior is back to the way it was in 2.339.

### Proposed changelog entries

* Clicking the build progress bar again takes the user to the console output (regression in 2.340).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@basil

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
