### PR TITLE
[JENKINS-68270] Fix third party weather icons in table view

### DIFF
--- a/core/src/main/resources/lib/hudson/ballColorTd.jelly
+++ b/core/src/main/resources/lib/hudson/ballColorTd.jelly
@@ -58,7 +58,7 @@ THE SOFTWARE.
 
         <j:choose>
           <j:when test="${iconClassName != null}">
-            <l:icon src="${iconClassName}" class="${iconClassName}" alt="${it.description}" tooltip="${it.description}" />
+            <l:icon class="${iconClassName} ${subIconSizeClass}" alt="${it.description}" tooltip="${it.description}" />
           </j:when>
           <j:otherwise>
             <!-- "it" is not a hudson.model.BallColor.  Let's try figure out the icon from its URL.  -->

--- a/test/src/test/java/lib/layout/IconTest.java
+++ b/test/src/test/java/lib/layout/IconTest.java
@@ -94,7 +94,7 @@ public class IconTest  {
 
         DomElement ballColorAborted = p.getElementById("ballColorAborted");
         List<DomElement> ballIcons = StreamSupport.stream(ballColorAborted.getChildElements().spliterator(), false).collect(Collectors.toList());
-        assertIconToSvgIconOkay(ballIcons.get(0).getFirstElementChild(), "icon-aborted");
+        assertIconToSvgIconOkay(ballIcons.get(0).getFirstElementChild(), "icon-aborted icon-md");
 
         DomElement statusIcons = p.getElementById("statusIcons");
         List<DomElement> statusIconsList = StreamSupport.stream(statusIcons.getChildElements().spliterator(), false).collect(Collectors.toList());


### PR DESCRIPTION
See [JENKINS-68270](https://issues.jenkins.io/browse/JENKINS-68270)

The change proposed calls the corresponding icon size of the view:

https://user-images.githubusercontent.com/13383509/163467000-41732a4a-32b3-4fb9-ad24-4b6b5e58e753.mp4

I'm unsure why this was set to `icon-lg` before, setting it to `icon-lg` again fixes it in the same way like my approach.

### Proposed changelog entries

* Fix third party weather icons in the table view (regression in 2.341).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
