### PR TITLE
[JENKINS-68277] Fix not being able to disable a plugin when dependent plugins are disabled

### DIFF
--- a/war/src/main/less/pages/plugin-manager.less
+++ b/war/src/main/less/pages/plugin-manager.less
@@ -33,8 +33,8 @@
   tr.all-dependents-disabled .enable input,
   tr.all-dependents-disabled .enable button,
   tr.all-dependents-disabled .enable .jenkins-toggle-switch label {
-    pointer-events: auto;
-    opacity: 1;
+    pointer-events: auto !important;
+    opacity: 1 !important;
     visibility: visible;
   }
 


### PR DESCRIPTION
See [JENKINS-68277](https://issues.jenkins.io/browse/JENKINS-68277)

This PR fixes not being able to disable a plugin when dependent plugins are disabled. This occurred due to CSS styling being overwritten by the disabled class styling - I've fixed it with an ` !important` however it would be good to rewrite this area completely as disabling/enabling inputs with CSS really isn't the best approach for accessibility/maintainability etc. 

### Steps to reproduce (thanks @basil)

- Install Jenkins in a clean Jenkins home.
- Go through the setup wizard and install the suggested plugin set.
- Install Blue Ocean and Jira Integration for Blue Ocean.
- Restart Jenkins.
- Observe that in ${JENKINS_URL/pluginManager/installed Jira Integration for Blue Ocean can be disabled but Jira cannot. Disable Jira Integration for Blue Ocean.
- Observe that ${JENKINS_HOME}/plugins/blueocean-jira.jpi.disabled was created.
- Restart Jenkins.
- Attempt to disable Jira

With this fix, you'll now be able to disable Jira ✨ 

### Proposed changelog entries

* Allow plugins to be disabled even when dependent plugins are disabled (regression in 2.325).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@basil 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
