### PR TITLE
Demonstrating JENKINS-68319

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -127,6 +127,7 @@
         <!-- Version specified in grandparent POM -->
         <configuration>
           <argLine>@{jacocoSurefireArgs}</argLine>
+          <skipTests>true</skipTests>
         </configuration>
       </plugin>
       <plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -722,6 +722,7 @@ THE SOFTWARE.
           <argLine>@{jacocoSurefireArgs}</argLine>
           <forkCount>0.5C</forkCount>
           <reuseForks>false</reuseForks>
+          <skipTests>true</skipTests>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,15 @@ THE SOFTWARE.
   </issueManagement>
 
   <properties>
+    <!-- Speed up the loop -->
+    <spotbugs.skip>true</spotbugs.skip>
+    <enforcer.skip>true</enforcer.skip>
+    <access-modifier-checker.skip>true</access-modifier-checker.skip>
+    <animal.sniffer.skip>true</animal.sniffer.skip>
+    <invoker.skip>true</invoker.skip>
+    <spotless.check.skip>true</spotless.check.skip>
+    <checkstyle.skip>true</checkstyle.skip>
+
     <revision>2.348</revision>
     <changelist>-SNAPSHOT</changelist>
 
@@ -84,8 +93,6 @@ THE SOFTWARE.
     <patch.request.repository>jenkins</patch.request.repository>
     <project.patchManagement.url>https://api.github.com</project.patchManagement.url>
     <patch.tracker.serverId>jenkins-jira</patch.tracker.serverId>
-
-    <animal.sniffer.skip>${skipTests}</animal.sniffer.skip>
 
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -255,6 +255,7 @@ THE SOFTWARE.
           </systemPropertyVariables>
           <reuseForks>false</reuseForks>
           <forkCount>${concurrency}</forkCount>
+          <test>hudson.model.QueueRestartTest#persistQueueOnConsecutiveRestarts</test>
         </configuration>
         <executions>
           <!-- Unbind the default execution so that it does not run before test-runtime. -->
@@ -325,7 +326,6 @@ THE SOFTWARE.
       </activation>
       <properties>
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-        <surefire.rerunFailingTestsCount>4</surefire.rerunFailingTestsCount>
         <surefire.skipAfterFailureCount>100</surefire.skipAfterFailureCount>
       </properties>
     </profile>


### PR DESCRIPTION
Demonstrating [JENKINS-68319](https://issues.jenkins.io/browse/JENKINS-68319) by running the newly-added functional test in a loop. I ran the test locally in a loop and it failed on the 16th attempt. I ran the test locally in a loop again and it failed on the 64th attempt.

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
