### PR TITLE
[JENKINS-68291] Plugin Manager 'Installed' tab filter is not reset when clicking input "X" button

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -46,7 +46,7 @@ Behaviour.specify("#filter-box", '_table', 0, function(e) {
 
         layoutUpdateCallback.call();
     }
-    e.onkeyup = applyFilter;
+    e.addEventListener("input", () => applyFilter());
 
     (function() {
         var instructionsTd = document.getElementById("hidden-by-default-instructions-td");


### PR DESCRIPTION
See [JENKINS-68291](https://issues.jenkins.io/browse/JENKINS-68291)

### How to reproduce

* Open Plugin Manager, click the Installed tab
* Type a filter text like "file" into the filter field -> The installed plugins are filtered.
* Click the "X" button on the right of the filter box
* Bug: The plugin list remains filtered. The filter field text is empty, but the filter remains active until some key is pressed inside the filter field. The filter "file" is still applied and only 4 plugins are shown, even though the filter field is empty.

### Solution

Use the `input` event instead of `onkeyup` (this is what the other tabs do).

### Proposed changelog entries

* Plugin Manager 'Installed' tab filter now resets when clicking search clear button

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
