### PR TITLE
Remove unnecessary padding around 'Build after other projects are built' radios

### DIFF
--- a/core/src/main/resources/jenkins/triggers/ReverseBuildTrigger/config.jelly
+++ b/core/src/main/resources/jenkins/triggers/ReverseBuildTrigger/config.jelly
@@ -28,20 +28,15 @@ THE SOFTWARE.
     <f:entry field="upstreamProjects" title="${%Projects to watch}">
         <f:textbox autoCompleteDelimChar=","/>
     </f:entry>
-    <f:entry title="">
-        <f:radio name="ReverseBuildTrigger.threshold" checked="${instance.threshold==null || instance.threshold.toString()=='SUCCESS'}"
-               title="${%Trigger only if build is stable}" value="SUCCESS"/>
-    </f:entry>
-    <f:entry title="">
-        <f:radio name="ReverseBuildTrigger.threshold" checked="${instance.threshold.toString()=='UNSTABLE'}"
-               title="${%Trigger even if the build is unstable}" value="UNSTABLE"/>
-    </f:entry>
-    <f:entry title="">
-        <f:radio name="ReverseBuildTrigger.threshold" checked="${instance.threshold.toString()=='FAILURE'}"
-               title="${%Trigger even if the build fails}" value="FAILURE"/>
-    </f:entry>
-    <f:entry title="">
-        <f:radio name="ReverseBuildTrigger.threshold" checked="${instance.threshold.toString()=='ABORTED'}"
-               title="${%Always trigger, even if the build is aborted}" value="ABORTED"/>
-    </f:entry>
+    <f:radio name="ReverseBuildTrigger.threshold" checked="${instance.threshold==null || instance.threshold.toString()=='SUCCESS'}"
+           title="${%Trigger only if build is stable}" value="SUCCESS"/>
+
+    <f:radio name="ReverseBuildTrigger.threshold" checked="${instance.threshold.toString()=='UNSTABLE'}"
+           title="${%Trigger even if the build is unstable}" value="UNSTABLE"/>
+
+    <f:radio name="ReverseBuildTrigger.threshold" checked="${instance.threshold.toString()=='FAILURE'}"
+           title="${%Trigger even if the build fails}" value="FAILURE"/>
+
+    <f:radio name="ReverseBuildTrigger.threshold" checked="${instance.threshold.toString()=='ABORTED'}"
+           title="${%Always trigger, even if the build is aborted}" value="ABORTED"/>
 </j:jelly>


### PR DESCRIPTION
This tiny MR removes the <f:entry/> component from the 'Build after other projects are built' radios as it was causing unnecessary padding.

**Before**
<img width="389" alt="image" src="https://user-images.githubusercontent.com/43062514/164795044-45bf5e90-9820-4132-95ba-39000c6516d2.png">

**After**
<img width="370" alt="image" src="https://user-images.githubusercontent.com/43062514/164794972-cc460e6d-5747-4c60-9319-fc71a8ca64fc.png">

### How to find

* Create a project
* Go to configure
* Click the 'Build after other projects are built' checkbox
* Notice the radios

### Proposed changelog entries

* Remove unnecessary padding around 'Build after other projects are built' radios

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
