### PR TITLE
[JENKINS-68286] Allow extra classes with <layout:icon>

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2294,7 +2294,7 @@ public class Functions {
         // `iconGuess` must be class names if it contains a whitespace.
         //  It may contains extra css classes unrelated to icons.
         // Filter classes with `icon-` prefix.
-        if (iconMetadata == null && iconGuess.indexOf(' ') >= 0) {
+        if (iconMetadata == null && iconGuess.contains(" ")) {
             iconMetadata = IconSet.icons.getIconByClassSpec(filterIconNameClasses(iconGuess));
         }
 

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2289,12 +2289,17 @@ public class Functions {
             return null;
         }
 
-        StaplerRequest currentRequest = Stapler.getCurrentRequest();
-        currentRequest.getWebApp().getDispatchValidator().allowDispatch(currentRequest, Stapler.getCurrentResponse());
         Icon iconMetadata = IconSet.icons.getIconByClassSpec(iconGuess);
 
+        // `iconGuess` must be class names if it contains a whitespace.
+        //  It may contains extra css classes unrelated to icons.
+        // Filter classes with `icon-` prefix.
+        if (iconMetadata == null && iconGuess.indexOf(' ') >= 0) {
+            iconMetadata = IconSet.icons.getIconByClassSpec(filterIconNameClasses(iconGuess));
+        }
+
         if (iconMetadata == null) {
-            // Icon could be provided as a simple iconFileName e.g. "settings.png"
+            // Icon could be provided as a simple iconFileName e.g. "help.svg"
             iconMetadata = IconSet.icons.getIconByClassSpec(IconSet.toNormalizedIconNameClass(iconGuess) + " icon-md");
         }
 
@@ -2304,6 +2309,12 @@ public class Functions {
         }
 
         return iconMetadata;
+    }
+
+    private static @NonNull String filterIconNameClasses(@NonNull String classNames) {
+        return Arrays.stream(StringUtils.split(classNames, ' '))
+            .filter(className -> className.startsWith("icon-"))
+            .collect(Collectors.joining(" "));
     }
 
     @Restricted(NoExternalUse.class)

--- a/core/src/main/java/org/jenkins/ui/icon/Icon.java
+++ b/core/src/main/java/org/jenkins/ui/icon/Icon.java
@@ -68,7 +68,7 @@ public class Icon {
     /**
      * Creates a {@link IconType#CORE core} icon.
      *
-     * @param classSpec The icon class names.
+     * @param classSpec The icon class names. Expected to start with `icon-`.
      * @param style     The icon style.
      */
     public Icon(String classSpec, String style) {
@@ -78,7 +78,7 @@ public class Icon {
     /**
      * Creates a {@link IconType#CORE core} icon.
      *
-     * @param classSpec The icon class names.
+     * @param classSpec The icon class names. Expected to start with `icon-`.
      * @param url       The icon image url.
      * @param style     The icon style.
      */
@@ -96,7 +96,7 @@ public class Icon {
     /**
      * Icon instance.
      *
-     * @param classSpec The icon class specification.
+     * @param classSpec The icon class specification. Expected to start with `icon-`.
      * @param url       The icon image url.
      * @param style     The icon style.
      * @param iconType  The icon type.
@@ -108,7 +108,7 @@ public class Icon {
     /**
      * Creates an icon.
      *
-     * @param classSpec The icon class names.
+     * @param classSpec The icon class names. Expected to start with `icon-`.
      * @param url       The icon image url.
      * @param style     The icon style.
      * @param iconFormat the {@link IconFormat}.

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -638,5 +640,40 @@ public class FunctionsTest {
             }
             return this;
         }
+    }
+
+    @Test
+    public void tryGetIcon_shouldReturnNullForNull() throws Exception {
+        assertThat(Functions.tryGetIcon(null), is(nullValue()));
+    }
+
+    @Test
+    public void tryGetIcon_shouldReturnNullForSymbol() throws Exception {
+        assertThat(Functions.tryGetIcon("symbol-search"), is(nullValue()));
+    }
+
+    @Test
+    public void tryGetIcon_shouldReturnMetadataForExactSpec() throws Exception {
+        assertThat(Functions.tryGetIcon("icon-help icon-sm"), is(not(nullValue())));
+    }
+
+    @Test
+    public void tryGetIcon_shouldReturnMetadataForExtraSpec() throws Exception {
+        assertThat(Functions.tryGetIcon("icon-help icon-sm extra-class"), is(not(nullValue())));
+    }
+
+    @Test
+    public void tryGetIcon_shouldReturnMetadataForFilename() throws Exception {
+        assertThat(Functions.tryGetIcon("help.svg"), is(not(nullValue())));
+    }
+
+    @Test
+    public void tryGetIcon_shouldReturnMetadataForUrl() throws Exception {
+        assertThat(Functions.tryGetIcon("48x48/green.gif"), is(not(nullValue())));
+    }
+
+    @Test
+    public void tryGetIcon_shouldReturnNullForUnknown() throws Exception {
+        assertThat(Functions.tryGetIcon("icon-nosuchicon"), is(nullValue()));
     }
 }


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-68286](https://issues.jenkins.io/browse/JENKINS-68286).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->
`<layout:icon>`  decides icons to display with `class` attribute.
It fails to decide icon if you specify extra classes. But extra classes are often useful apply css.

This change does followings:

* Suppose icon classes start with `icon-`.
* Remove classes without `icon-` prefixes and retry decide icons if fail to decide icons.

### Proposed changelog entries

* Allow extra CSS classes with `<l:icon>`.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. : N/A
- [x] For dependency updates: links to external changelogs and, if possible, full diffs: N/A

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

N/A

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
