### PR TITLE
[JENKINS-68338] Credentials popup does not work in SSH Build Agents (regression in 2.344)

### DIFF
--- a/core/src/main/resources/hudson/model/Slave/help-launcher.jelly
+++ b/core/src/main/resources/hudson/model/Slave/help-launcher.jelly
@@ -27,6 +27,15 @@ THE SOFTWARE.
   <l:ajax>
     <div>
       ${%Controls how Jenkins starts this agent.}
+
+      <dl>
+        <j:forEach var="d" items="${h.getComputerLauncherDescriptors()}">
+          <dt><b>${d.displayName}</b></dt>
+          <dd>
+            <st:include class="${d.clazz}" page="help.jelly" optional="true"/>
+          </dd>
+        </j:forEach>
+      </dl>
     </div>
   </l:ajax>
 </j:jelly>

--- a/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
+++ b/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
@@ -47,8 +47,21 @@ THE SOFTWARE.
   <f:slave-mode name="mode" node="${it}" />
 
   <!-- TODO: should be packaged as a tag -->
-  <j:set var="computerLauncherDescriptors" value="${descriptor.computerLauncherDescriptors(it)}"/>
-  <f:dropdownDescriptorSelector title="${%Launch method}" field="launcher" descriptors="${computerLauncherDescriptors}"/>
+  <j:set var="itDescriptor" value="${descriptor}"/>
+  <f:dropdownList name="slave.launcher" title="${%Launch method}"
+                  help="${descriptor.getHelpFile('launcher')}">
+    <j:forEach var="d" items="${descriptor.computerLauncherDescriptors(it)}">
+      <f:dropdownListBlock value="${d.clazz.name}" name="${d.displayName}"
+                           selected="${it.launcher.descriptor==d}"
+                           title="${d.displayName}">
+        <j:set var="descriptor" value="${d}"/>
+        <j:set var="instance"
+               value="${it.launcher.descriptor==d ? it.launcher : null}"/>
+        <f:class-entry descriptor="${d}" />
+        <st:include from="${d}" page="${d.configPage}" optional="true"/>
+      </f:dropdownListBlock>
+    </j:forEach>
+  </f:dropdownList>
 
   <!-- pointless to show this if there's only one option, which is the default -->
   <j:set var="retentionStrategies" value="${descriptor.retentionStrategyDescriptors(it)}"/>


### PR DESCRIPTION
In the absence of a verified fix for [JENKINS-68338](https://issues.jenkins.io/browse/JENKINS-68338) by the end of the week, I plan to revert #6464 toward 2.346.

### Proposed changelog entries

Restore functionality of credentials popup in SSH Build Agents (regression in 2.344).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
