### PR TITLE
Update search input clear button to respect user's theme

### DIFF
--- a/war/src/main/less/form/search.less
+++ b/war/src/main/less/form/search.less
@@ -20,9 +20,28 @@
       -webkit-appearance: none;
     }
 
-    // By default the clear text button doesn't change the cursor on hover - lets turn it into a pointer
-    &::-webkit-search-cancel-button:hover {
+    &::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+      height: 1rem;
+      width: 1rem;
+      margin-right: 2px;
+      background: currentColor;
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 48C141.31 48 48 141.31 48 256s93.31 208 208 208 208-93.31 208-208S370.69 48 256 48zm75.31 260.69a16 16 0 11-22.62 22.62L256 278.63l-52.69 52.68a16 16 0 01-22.62-22.62L233.37 256l-52.68-52.69a16 16 0 0122.62-22.62L256 233.37l52.69-52.68a16 16 0 0122.62 22.62L278.63 256z'/%3E%3C/svg%3E");
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      opacity: 0;
+      pointer-events: none;
+      transform: scale(0.8);
+      transition: var(--standard-transition);
       cursor: pointer;
+
+      &:hover {
+        opacity: 0.75 !important;
+      }
+
+      &:active {
+        opacity: 1 !important;
+      }
     }
 
     &:hover {
@@ -34,6 +53,12 @@
       outline: none;
       border-color: var(--focus-input-border);
       box-shadow: var(--form-input-glow--focus);
+
+      &::-webkit-search-cancel-button {
+        opacity: 0.5;
+        pointer-events: all;
+        transform: scale(1);
+      }
     }
   }
 


### PR DESCRIPTION
**Before**
<img width="446" alt="image" src="https://user-images.githubusercontent.com/43062514/165800300-c9fb4cbf-1c65-487d-b547-1124eb0b9d8c.png">

**After**
<img width="448" alt="image" src="https://user-images.githubusercontent.com/43062514/165800229-cec51e82-5b0d-4cde-8568-a91fee7af8ae.png">

Small change to the webkit only clear button so that it'll respect the user's theme.

### How to reproduce (only on Webkit browsers)
* Go to any page with a new search bar (e.g. build history, plugin manager)
* Type
* Notice the clear button is black when using dark theme

With this change the clear button will now be the same colour as the text colour ✨ 

### Proposed changelog entries

* Search input clear button now respects user's theme.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
