### PR TITLE
Use new style checkboxes for plugin manager

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/available.jelly
+++ b/core/src/main/resources/hudson/PluginManager/available.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
           <thead>
             <tr>
               <l:isAdmin>
-                <th width="32">${%Install}</th>
+                <th data-sort-disable="true" />
               </l:isAdmin>
               <th initialSortDir="down">${%Name}</th>
               <th>${%Released}</th>

--- a/core/src/main/resources/hudson/PluginManager/available.jelly
+++ b/core/src/main/resources/hudson/PluginManager/available.jelly
@@ -57,7 +57,9 @@ THE SOFTWARE.
           <thead>
             <tr>
               <l:isAdmin>
-                <th data-sort-disable="true" />
+                <th data-sort-disable="true">
+                  ${%Install}
+                </th>
               </l:isAdmin>
               <th initialSortDir="down">${%Name}</th>
               <th>${%Released}</th>

--- a/core/src/main/resources/hudson/PluginManager/check.jelly
+++ b/core/src/main/resources/hudson/PluginManager/check.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
   ${%lastUpdated(app.updateCenter.lastUpdatedString)}
-  <f:link href="checkUpdatesServer" post="true" clazz="jenkins-button jenkins-button--primary">
+  <f:link href="checkUpdatesServer" post="true" clazz="yui-button yui-submit-button submit-button primary">
     ${%Check now}
   </f:link>
   <j:if test="${app.pluginManager.lastErrorCheckUpdateCenters != null}">

--- a/core/src/main/resources/hudson/PluginManager/check.jelly
+++ b/core/src/main/resources/hudson/PluginManager/check.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
   ${%lastUpdated(app.updateCenter.lastUpdatedString)}
-  <f:link href="checkUpdatesServer" post="true" clazz="yui-button yui-submit-button submit-button primary">
+  <f:link href="checkUpdatesServer" post="true" clazz="jenkins-button jenkins-button--primary">
     ${%Check now}
   </f:link>
   <j:if test="${app.pluginManager.lastErrorCheckUpdateCenters != null}">

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -96,11 +96,15 @@ THE SOFTWARE.
                   name="${p.displayName}"
                   data-plugin-id="${h.xmlEscape(p.name)}">
                   <l:isAdmin>
-                    <td align="center" data="${isUpdates ? null : it.unscientific(p.popularity)}">
-                      <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
-                             checked="${installedOk ? 'checked' : null}"
-                             disabled="${installedOk ? 'disabled' : null}"
-                             data-compat-warning="${!p.isCompatible(cache)}"/>
+                    <td class="jenkins-table__cell--checkbox" data="${isUpdates ? null : it.unscientific(p.popularity)}">
+                      <span class="jenkins-checkbox">
+                        <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
+                               id="plugin.${p.name}.${p.sourceId}"
+                               checked="${installedOk ? 'checked' : null}"
+                               disabled="${installedOk ? 'disabled' : null}"
+                               data-compat-warning="${!p.isCompatible(cache)}"/>
+                        <label for="plugin.${p.name}.${p.sourceId}" />
+                      </span>
                     </td>
                   </l:isAdmin>
                   <td class="details"

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -63,10 +63,7 @@ THE SOFTWARE.
           <thead>
             <tr>
               <l:isAdmin>
-                <th initialSortDir="${isUpdates?null:'up'}"
-                    tooltip="${%Check to install the plugin}"
-                    width="32">${%Install}
-                </th>
+                <th data-sort-disable="true" />
               </l:isAdmin>
               <th initialSortDir="${isUpdates?'down':null}">${%Name}</th>
               <th>${%Released}</th>

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -93,7 +93,7 @@ THE SOFTWARE.
                   name="${p.displayName}"
                   data-plugin-id="${h.xmlEscape(p.name)}">
                   <l:isAdmin>
-                    <td class="jenkins-table__cell--checkbox" data="${isUpdates ? null : it.unscientific(p.popularity)}">
+                    <td class="jenkins-table__cell--checkbox">
                       <span class="jenkins-checkbox">
                         <input type="checkbox" name="plugin.${p.name}.${p.sourceId}"
                                id="plugin.${p.name}.${p.sourceId}"

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -63,7 +63,9 @@ THE SOFTWARE.
           <thead>
             <tr>
               <l:isAdmin>
-                <th data-sort-disable="true" />
+                <th data-sort-disable="true" tooltip="${%Check to install the plugin}">
+                  ${%Install}
+                </th>
               </l:isAdmin>
               <th initialSortDir="${isUpdates?'down':null}">${%Name}</th>
               <th>${%Released}</th>

--- a/war/src/main/js/templates/plugin-manager/available.hbs
+++ b/war/src/main/js/templates/plugin-manager/available.hbs
@@ -2,7 +2,10 @@
     <tr data-plugin-id="{{ this.name }}" data-plugin-version="{{ this.version }}">
         {{#if @root/admin }}
             <td align="center">
-                <input type="checkbox" name="plugin.{{ this.name }}.{{ this.sourceId }}">
+                <span class="jenkins-checkbox">
+                    <input type="checkbox" name="plugin.{{ this.name }}.{{ this.sourceId }}" id="plugin.{{ this.name }}.{{ this.sourceId }}">
+                    <label for="plugin.{{ this.name }}.{{ this.sourceId }}"></label>
+                </span>
             </td>
         {{/if}}
         <td>

--- a/war/src/main/js/templates/plugin-manager/available.hbs
+++ b/war/src/main/js/templates/plugin-manager/available.hbs
@@ -1,7 +1,7 @@
 {{#each plugins}}
     <tr data-plugin-id="{{ this.name }}" data-plugin-version="{{ this.version }}">
         {{#if @root/admin }}
-            <td align="center">
+            <td class="jenkins-table__cell--checkbox">
                 <span class="jenkins-checkbox">
                     <input type="checkbox" name="plugin.{{ this.name }}.{{ this.sourceId }}" id="plugin.{{ this.name }}.{{ this.sourceId }}">
                     <label for="plugin.{{ this.name }}.{{ this.sourceId }}"></label>

--- a/war/src/main/less/form/checkbox.less
+++ b/war/src/main/less/form/checkbox.less
@@ -33,7 +33,7 @@
     &:focus {
       & + label {
         &::before {
-          box-shadow: 0 0 0 5px var(--focus-input-glow), inset 0 0 0 2px var(--focus-input-border);
+          box-shadow: 0 0 0 5px var(--focus-input-glow), inset 0 0 0 5px var(--focus-input-border);
         }
       }
     }

--- a/war/src/main/less/modules/table.less
+++ b/war/src/main/less/modules/table.less
@@ -118,6 +118,7 @@
   &__cell--checkbox {
     padding: calc(var(--table-padding) * 2) !important;
     vertical-align: top !important;
+    width: calc((var(--table-padding) * 2) + 22px);
   }
 
   &__cell--no-wrap {

--- a/war/src/main/less/modules/table.less
+++ b/war/src/main/less/modules/table.less
@@ -115,6 +115,11 @@
     width: 3.5rem;
   }
 
+  &__cell--checkbox {
+    padding: calc(var(--table-padding) * 2) !important;
+    vertical-align: top !important;
+  }
+
   &__cell--no-wrap {
     white-space: nowrap;
   }


### PR DESCRIPTION
Small PR to use the new style checkboxes for the plugin manager.

**Before**
<img width="679" alt="image" src="https://user-images.githubusercontent.com/43062514/166081055-c4915dd5-6c96-4dd6-9e38-20cd7c6f9ed2.png">

**After**
<img width="580" alt="image" src="https://user-images.githubusercontent.com/43062514/167220163-2b17bb78-0f78-490d-b74d-875c34b0bcc4.png">

### Proposed changelog entries

* Use new style checkboxes for plugin manager.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
