### PR TITLE
[JENKINS-68303] Animate button when job already in queue

### DIFF
--- a/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
@@ -38,8 +38,11 @@ THE SOFTWARE.
                   <j:set var="title" value="${%Schedule_a_task(h.getRelativeDisplayNameFrom(job, itemGroup),it.taskNoun(job))}"/>
                 </j:otherwise>
               </j:choose>
+              <j:set var="isQueued" value="${app.queue.contains(job)}"/>
               <a id="${id}" tooltip="${title}" class="jenkins-table__button jenkins-table__button--green" href="${href}">
-                <l:icon src="symbol-play" />
+                <span class="${isQueued ? 'schedule-build-anime': ''}">
+                  <l:icon src="symbol-play" />
+                </span>
                 <st:adjunct includes="hudson.views.BuildButtonColumn.icon"/>
               </a>
             </div>

--- a/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
@@ -40,7 +40,7 @@ THE SOFTWARE.
               </j:choose>
               <j:set var="isQueued" value="${app.queue.contains(job)}"/>
               <a id="${id}" tooltip="${title}" class="jenkins-table__button jenkins-table__button--green" href="${href}">
-                <span class="${isQueued ? 'schedule-build-anime': ''}">
+                <span class="${isQueued ? 'pulse-animation': ''}">
                   <l:icon src="symbol-play" />
                 </span>
                 <st:adjunct includes="hudson.views.BuildButtonColumn.icon"/>

--- a/war/src/main/less/modules/icons.less
+++ b/war/src/main/less/modules/icons.less
@@ -122,8 +122,17 @@
   }
 }
 
-.schedule-build-anime {
+@keyframes pulse-animation {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+.pulse-animation {
   svg {
-    animation: fadeout 1.5s ease infinite;
+    animation: pulse-animation 2s ease infinite;
   }
 }

--- a/war/src/main/less/modules/icons.less
+++ b/war/src/main/less/modules/icons.less
@@ -121,3 +121,9 @@
     animation: spin 1.5s linear infinite;
   }
 }
+
+.schedule-build-anime {
+  svg {
+    animation: fadeout 1.5s ease infinite;
+  }
+}


### PR DESCRIPTION
In #5851, the `icon-clock-anime` was removed in favor of the `play-outline` icon. However, it removed the animation we had when the job was already in the build queue.

![Bildschirmfoto 2022-05-03 um 19 46 37](https://user-images.githubusercontent.com/13383509/166510915-d4141bdf-ae3a-412c-a0b3-3b892e06e317.png)

With this PR, we are getting back the animation on the schedule button when the job is present on the build queue:

https://user-images.githubusercontent.com/13383509/166511500-7aebe7e9-6b21-4f26-bc80-af3e1e935632.mp4

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-68303](https://issues.jenkins.io/browse/JENKINS-68303).

### Proposed changelog entries

* Fix indistinguishable build scheduling icon when the job is already in-queue.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@janfaracik @jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
