### PR TITLE
Suppress more stack traces from `DefaultJnlpSlaveReceiver.channelClosed`

### DIFF
--- a/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
+++ b/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
@@ -9,6 +9,7 @@ import hudson.TcpSlaveAgentListener.ConnectionFromCurrentPeer;
 import hudson.model.Computer;
 import hudson.model.Slave;
 import hudson.remoting.Channel;
+import hudson.remoting.ChannelClosedException;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.ComputerLauncherFilter;
 import hudson.slaves.DelegatingComputerLauncher;
@@ -188,7 +189,7 @@ public class DefaultJnlpSlaveReceiver extends JnlpAgentReceiver {
     public void channelClosed(@NonNull JnlpConnectionState event) {
         final String nodeName = event.getProperty(JnlpConnectionState.CLIENT_NAME_KEY);
         IOException cause = event.getCloseCause();
-        if (cause instanceof ClosedChannelException) {
+        if (cause instanceof ClosedChannelException || cause instanceof ChannelClosedException) {
             LOGGER.log(Level.INFO, "{0} for {1} terminated: {2}", new Object[] {Thread.currentThread().getName(), nodeName, cause});
         } else if (cause != null) {
             LOGGER.log(Level.WARNING, Thread.currentThread().getName() + " for " + nodeName + " terminated",


### PR DESCRIPTION
Amends #4066.

```
…	WARNING	j.s.DefaultJnlpSlaveReceiver#channelClosed: Executing … for … terminated
java.nio.channels.ClosedChannelException
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.doSend(ProtocolStack.java:702)
	at org.jenkinsci.remoting.protocol.ApplicationLayer.write(ApplicationLayer.java:156)
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer$ByteBufferCommandTransport.write(ChannelApplicationLayer.java:327)
Caused: hudson.remoting.ChannelClosedException: Channel "unknown": Protocol stack cannot write data anymore. ChannelApplicationLayer reports that the NIO Channel is closed
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer$ByteBufferCommandTransport.write(ChannelApplicationLayer.java:330)
	at hudson.remoting.AbstractByteBufferCommandTransport.write(AbstractByteBufferCommandTransport.java:303)
	at hudson.remoting.Channel.send(Channel.java:765)
	at hudson.remoting.Channel.close(Channel.java:1480)
	at hudson.remoting.Channel.close(Channel.java:1447)
	at hudson.slaves.SlaveComputer.closeChannel(SlaveComputer.java:923)
	at hudson.slaves.SlaveComputer.kill(SlaveComputer.java:889)
	at hudson.model.AbstractCIBase.killComputer(AbstractCIBase.java:95)
	at jenkins.model.Jenkins.lambda$_cleanUpDisconnectComputers$11(Jenkins.java:3705)
	at hudson.model.Queue._withLock(Queue.java:1395)
	at hudson.model.Queue.withLock(Queue.java:1269)
	at jenkins.model.Jenkins._cleanUpDisconnectComputers(Jenkins.java:3701)
	at jenkins.model.Jenkins.cleanUp(Jenkins.java:3582)
	at org.jvnet.hudson.test.JenkinsRule._stopJenkins(JenkinsRule.java:566)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:514)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:625)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

### Proposed changelog entries

* Suppress some uninteresting stack traces related to closed agent channels.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
