### PR TITLE
[JENKINS-68296] Restore actions icon lookup with size

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2304,7 +2304,7 @@ public class Functions {
 
         if (iconMetadata == null) {
             // Icon could be provided as a simple iconFileName e.g. "help.svg"
-            iconMetadata = IconSet.icons.getIconByClassSpec(IconSet.toNormalizedIconNameClass(iconGuess) + " icon-md");
+            iconMetadata = IconSet.icons.getIconByClassSpec(IconSet.toNormalizedIconNameClass(iconGuess));
         }
 
         if (iconMetadata == null) {

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2304,7 +2304,7 @@ public class Functions {
 
         if (iconMetadata == null) {
             // Icon could be provided as a simple iconFileName e.g. "help.svg"
-            iconMetadata = IconSet.icons.getIconByClassSpec(IconSet.toNormalizedIconNameClass(iconGuess));
+            iconMetadata = IconSet.icons.getIconByClassSpec(IconSet.toNormalizedIconNameClass(iconGuess) + " icon-md");
         }
 
         if (iconMetadata == null) {

--- a/core/src/main/resources/lib/hudson/actions.jelly
+++ b/core/src/main/resources/lib/hudson/actions.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
       the action object itself is available in the 'action' variable
     -->
     <st:include page="action.jelly" from="${action}" optional="true">
-      <j:set var="icon" value="${action.iconClassName != null ? action.iconClassName : action.iconFileName}"/>
+      <j:set var="icon" value="${action.iconClassName != null ? action.iconClassName + ' icon-md' : action.iconFileName}"/>
       <j:if test="${icon!=null}">
         <j:choose>
           <j:when test="${h.getActionUrl(it.url,action).contains('pollingLog')}">


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-68296](https://issues.jenkins.io/browse/JENKINS-68296).

Prior to Jenkins `2.341` (jenkinsci/jenkins#6395), in the projects' actions sidepanel, the icons for each actions was search with a CSS class suffixed to its name. This value is used in https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/hudson/Functions.java#L2345
passed to https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/hudson/Functions.java#L2290 to https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/org/jenkins/ui/icon/IconSet.java#L203 all the way to https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/org/jenkins/ui/icon/IconSet.java#L175.

When the icons are added in the `IconSet` maps https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/org/jenkins/ui/icon/IconSet.java#L145, they are suffixed with their CSS class size (`icon-md`, `icon-sm`, etc) (because of https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/org/jenkins/ui/icon/Icon.java#L131 and example of usage here: https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/org/jenkins/ui/icon/IconSet.java#L554). This is important because looking in the map, only with the action's `iconClassName`, will never return the correct icon. 

After Jenkins `2.341` (included), the suffix was removed from `actions.jelly` https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/resources/lib/hudson/actions.jelly#L40. The initial search of the icon was returning `null`. But, a second iteration was done, transforming the icon reference with the prefix `icon-` and adding the size CSS class https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/hudson/Functions.java#L2307. The core icons svg are added using this prefix in `IconSet#initializeSVGs` function https://github.com/jenkinsci/jenkins/blob/bbd7ca2c4d63067ecc61c4a7840378520b761a41/core/src/main/java/org/jenkins/ui/icon/IconSet.java#L554. So, in this second iteration, if the reference of the icon in the jelly file is `redo`, the icon is search with `icon-redo` and then with `.icon-redo.icon-md`. This is working well for core icons, and other plugins that were already naming their icons `icon-XXX` (because the `IconSet#toNormalizedIconNameClass` is only adding `icon-` prefix if it's not present). However, not all plugins are using this prefix and so, their icons were not found. This is the case for the Gitlab Branch Source plugin.

Asking for the action icons with the CSS class for its size is fixing the problem the Gitlab Branch source plugin and with no size effect. 

<details>
<summary>Multibranch Pipeline sidepanel</summary>
Before:

![MultiBranch Pipeline sidepanel](https://user-images.githubusercontent.com/985955/167599257-5afd0c2d-bab5-4358-83e8-6bc036957542.png)

After:

![MultiBranch Pipeline sidepanel](https://user-images.githubusercontent.com/985955/167600524-e2a793b5-2c7c-4f61-baca-2f44ce23b85d.png)

</details>

<details>
<summary>Branch sidepanel</summary>
Before:

![Branch sidepanel](https://user-images.githubusercontent.com/985955/167599358-ab2d8010-1d76-4c68-b961-99f3a3d2a6e6.png)

After:

![Branch sidepanel](https://user-images.githubusercontent.com/985955/167597777-34a45864-64ab-4d93-94fa-c2a9a4d6ff23.png)

</details>

<details>
<summary>Run sidepanel</summary>
Before:

![Run sidepanel](https://user-images.githubusercontent.com/985955/167599462-aaa11cdc-6927-4462-8776-b544945fdcd7.png)

After:

![Run sidepanel](https://user-images.githubusercontent.com/985955/167597771-83bd18ce-dc47-4243-8915-797977fac25f.png)

</details>

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Display icons searched without an icon size CSS value (regression in 2.341).

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@basil @janfaracik @NotMyFault @jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
