### PR TITLE
[JENKINS-55582] [JEP-230] Split `instance-identity` to a plugin

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -257,11 +257,6 @@ THE SOFTWARE.
         <version>${remoting.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.jenkins-ci.modules</groupId>
-        <artifactId>instance-identity</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>1.0.19</version>

--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -36,3 +36,9 @@ jdk-tool jaxb
 javax-activation-api javax-mail-api
 javax-activation-api sshd
 javax-mail-api sshd
+
+# JENKINS-55582
+bouncycastle-api instance-identity
+bouncycastle-api sshd
+javax-activation-api instance-identity
+javax-mail-api instance-identity

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -37,3 +37,6 @@ sshd 2.281 3.0.1
 
 javax-activation-api 2.330 1.2.0-2
 javax-mail-api 2.330 1.6.2-5
+
+# JENKINS-55582
+instance-identity 2.347 3.0.1

--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -14,7 +14,6 @@ and hence the Jenkins core pull request review and merge process is more sophist
 This document applies to the following components:
 
 * Jenkins core
-* Jenkins modules
 * Libraries included into the Jenkins core
 * Core components like Winstone, Executable WAR, etc.
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -137,6 +137,12 @@ THE SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>instance-identity</artifactId>
+      <version>3.0.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>antisamy-markup-formatter</artifactId>
       <version>2.7</version>

--- a/test/src/test/java/jenkins/security/ClassFilterImplTest.java
+++ b/test/src/test/java/jenkins/security/ClassFilterImplTest.java
@@ -58,7 +58,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
-import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
@@ -163,14 +162,6 @@ public class ClassFilterImplTest {
         Map<Saveable, OldDataMonitor.VersionRange> data = ExtensionList.lookupSingleton(OldDataMonitor.class).getData();
         assertEquals(Collections.singleton(config), data.keySet());
         assertThat(data.values().iterator().next().extra, allOf(containsString("LinkedListMultimap"), containsString("https://www.jenkins.io/redirect/class-filter/")));
-    }
-
-    @Test
-    @Issue("JENKINS-49543")
-    public void moduleClassesShouldBeWhitelisted() {
-        ClassFilterImpl filter = new ClassFilterImpl();
-        filter.check("org.jenkinsci.modules.windows_slave_installer.WindowsSlaveInstaller");
-        filter.check("org.jenkinsci.main.modules.instance_identity.PageDecoratorImpl");
     }
 
     @TestExtension("xstreamRequiresWhitelist")

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -97,10 +97,6 @@ THE SOFTWARE.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.modules</groupId>
-      <artifactId>instance-identity</artifactId>
-    </dependency>
-    <dependency>
       <!--
         We bundle slf4j binding since we got some components (sshd for example)
         that uses slf4j.
@@ -415,7 +411,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.modules</groupId>
                   <artifactId>sshd</artifactId>
-                  <version>3.0.3</version>
+                  <version>3.1.0</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -434,6 +430,12 @@ THE SOFTWARE.
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>javax-mail-api</artifactId>
                   <version>1.6.2-5</version>
+                  <type>hpi</type>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.jenkins-ci.modules</groupId>
+                  <artifactId>instance-identity</artifactId>
+                  <version>3.0.1</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
The merge of #6543 makes it finally practical to complete what was started in #5304.

### Testing done

Ran Jenkins against a clean home directory with `java -jar jenkins.war` and completed the setup wizard successfully. Verified there were no warnings for any plugins after completing the setup wizard.

### Next steps

If approved, https://github.com/jenkins-infra/update-center2/blob/d4bcc4ce0041e00b4a6a9773d24c4cd84731c4c7/resources/artifact-ignores.properties#L527-L529= will need to be adjusted to restore `instance-identity` to the Update Center.

### Proposed changelog entries

Convert the `instance-identity` module into a (detached) plugin.

### Proposed upgrade guidelines

Normally the new plugin will be automatically installed. If you use an “as-code” installation mechanism like a text file with a list of plugins, you may need to add `instance-identity` (version 3.0.1 or later) in order to restore this functionality.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
