### PR TITLE
[JENKINS-68542] Store inbound cookie key in connection state

### DIFF
--- a/core/src/main/java/hudson/cli/CLIAction.java
+++ b/core/src/main/java/hudson/cli/CLIAction.java
@@ -136,7 +136,7 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
                 }
             }
 
-            private void doClose() {
+            private void doClose() throws IOException {
                 close();
             }
 

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -921,7 +921,7 @@ public class SlaveComputer extends Computer {
         if (c != null) {
             try {
                 c.close();
-            } catch (IOException e) {
+            } catch (Exception e) {
                 logger.log(Level.SEVERE, "Failed to terminate channel to " + getDisplayName(), e);
             }
             Listeners.notify(ComputerListener.class, true, l -> l.onOffline(this, offlineCause));

--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -93,7 +93,7 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         Map<String, String> properties = new HashMap<>();
         properties.put(JnlpConnectionState.CLIENT_NAME_KEY, agent);
         properties.put(JnlpConnectionState.SECRET_KEY, secret);
-        String unsafeCookie = req.getHeader(JnlpConnectionState.COOKIE_KEY);
+        String unsafeCookie = req.getHeader(Engine.WEBSOCKET_COOKIE_KEY);
         String cookie;
         if (unsafeCookie != null) {
             // This will blow up if the client sent us a malformed cookie.
@@ -107,7 +107,7 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         LOGGER.fine(() -> "received " + remoteCapability);
         rsp.setHeader(Capability.KEY, new Capability().toASCII());
         rsp.setHeader(Engine.REMOTING_MINIMUM_VERSION_HEADER, RemotingVersionInfo.getMinimumSupportedVersion().toString());
-        rsp.setHeader(JnlpConnectionState.COOKIE_KEY, cookie);
+        rsp.setHeader(Engine.WEBSOCKET_COOKIE_KEY, cookie);
         return WebSockets.upgrade(new Session(state, agent, remoteCapability));
     }
 

--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -93,7 +93,7 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         Map<String, String> properties = new HashMap<>();
         properties.put(JnlpConnectionState.CLIENT_NAME_KEY, agent);
         properties.put(JnlpConnectionState.SECRET_KEY, secret);
-        String unsafeCookie = req.getHeader(Engine.WEBSOCKET_COOKIE_KEY);
+        String unsafeCookie = req.getHeader(Engine.WEBSOCKET_COOKIE_HEADER);
         String cookie;
         if (unsafeCookie != null) {
             // This will blow up if the client sent us a malformed cookie.
@@ -107,7 +107,7 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         LOGGER.fine(() -> "received " + remoteCapability);
         rsp.setHeader(Capability.KEY, new Capability().toASCII());
         rsp.setHeader(Engine.REMOTING_MINIMUM_VERSION_HEADER, RemotingVersionInfo.getMinimumSupportedVersion().toString());
-        rsp.setHeader(Engine.WEBSOCKET_COOKIE_KEY, cookie);
+        rsp.setHeader(Engine.WEBSOCKET_COOKIE_HEADER, cookie);
         return WebSockets.upgrade(new Session(state, agent, remoteCapability));
     }
 

--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -27,6 +27,7 @@ package jenkins.agents;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.InvisibleAction;
 import hudson.model.UnprotectedRootAction;
@@ -89,16 +90,24 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         state.setRemoteEndpointDescription(req.getRemoteAddr());
         state.fireBeforeProperties();
         LOGGER.fine(() -> "connecting " + agent);
-        // TODO or just pass all request headers?
         Map<String, String> properties = new HashMap<>();
         properties.put(JnlpConnectionState.CLIENT_NAME_KEY, agent);
         properties.put(JnlpConnectionState.SECRET_KEY, secret);
+        String unsafeCookie = req.getHeader(JnlpConnectionState.COOKIE_KEY);
+        String cookie;
+        if (unsafeCookie != null) {
+            // This will blow up if the client sent us a malformed cookie.
+            cookie = Util.toHexString(Util.fromHexString(unsafeCookie));
+        } else {
+            cookie = JnlpAgentReceiver.generateCookie();
+        }
+        properties.put(JnlpConnectionState.COOKIE_KEY, cookie);
         state.fireAfterProperties(Collections.unmodifiableMap(properties));
         Capability remoteCapability = Capability.fromASCII(remoteCapabilityStr);
         LOGGER.fine(() -> "received " + remoteCapability);
         rsp.setHeader(Capability.KEY, new Capability().toASCII());
         rsp.setHeader(Engine.REMOTING_MINIMUM_VERSION_HEADER, RemotingVersionInfo.getMinimumSupportedVersion().toString());
-        rsp.setHeader(JnlpConnectionState.COOKIE_KEY, JnlpAgentReceiver.generateCookie()); // TODO figure out what this is for, if anything
+        rsp.setHeader(JnlpConnectionState.COOKIE_KEY, cookie);
         return WebSockets.upgrade(new Session(state, agent, remoteCapability));
     }
 

--- a/core/src/main/java/jenkins/websocket/WebSocketEcho.java
+++ b/core/src/main/java/jenkins/websocket/WebSocketEcho.java
@@ -27,6 +27,7 @@ package jenkins.websocket;
 import hudson.Extension;
 import hudson.model.InvisibleAction;
 import hudson.model.RootAction;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
@@ -46,12 +47,12 @@ public class WebSocketEcho  extends InvisibleAction implements RootAction {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             return WebSockets.upgrade(new WebSocketSession() {
                 @Override
-                protected void text(String message) {
+                protected void text(String message) throws IOException {
                     sendText("hello " + message);
                 }
 
                 @Override
-                protected void binary(byte[] payload, int offset, int len) {
+                protected void binary(byte[] payload, int offset, int len) throws IOException {
                     ByteBuffer data = ByteBuffer.allocate(len);
                     for (int i = 0; i < len; i++) {
                         byte b = payload[offset + i];

--- a/core/src/main/java/jenkins/websocket/WebSocketSession.java
+++ b/core/src/main/java/jenkins/websocket/WebSocketSession.java
@@ -24,6 +24,7 @@
 
 package jenkins.websocket;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Future;
@@ -114,45 +115,45 @@ public abstract class WebSocketSession {
         LOGGER.log(Level.WARNING, "unhandled WebSocket service error", cause);
     }
 
-    protected void binary(byte[] payload, int offset, int len) {
+    protected void binary(byte[] payload, int offset, int len) throws IOException {
         LOGGER.warning("unexpected binary frame");
     }
 
-    protected void text(String message) {
+    protected void text(String message) throws IOException {
         LOGGER.warning("unexpected text frame");
     }
 
     @SuppressWarnings("unchecked")
-    protected final Future<Void> sendBinary(ByteBuffer data) {
+    protected final Future<Void> sendBinary(ByteBuffer data) throws IOException {
         try {
             return (Future<Void>) remoteEndpoint.getClass().getMethod("sendBytesByFuture", ByteBuffer.class).invoke(remoteEndpoint, data);
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new IOException(x);
         }
     }
 
-    protected final void sendBinary(ByteBuffer partialByte, boolean isLast) {
+    protected final void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
         try {
             remoteEndpoint.getClass().getMethod("sendPartialBytes", ByteBuffer.class, boolean.class).invoke(remoteEndpoint, partialByte, isLast);
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new IOException(x);
         }
     }
 
     @SuppressWarnings("unchecked")
-    protected final Future<Void> sendText(String text) {
+    protected final Future<Void> sendText(String text) throws IOException {
         try {
             return (Future<Void>) remoteEndpoint.getClass().getMethod("sendStringByFuture", String.class).invoke(remoteEndpoint, text);
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new IOException(x);
         }
     }
 
-    protected final void close() {
+    protected final void close() throws IOException {
         try {
             session.getClass().getMethod("close").invoke(session);
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new IOException(x);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3020.vcc32c3b_cc767</remoting.version>
+    <remoting.version>3023.v6f6127a_fffb_c</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3023.v6f6127a_fffb_c</remoting.version>
+    <remoting.version>3024.vf277b_15a_cee6</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.14</remoting.version>
+    <remoting.version>4.15-rc3016.6f32e99562f7</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3024.vf277b_15a_cee6</remoting.version>
+    <remoting.version>3025.vf64a_a_3da_6b_55</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.15-rc3016.6f32e99562f7</remoting.version>
+    <remoting.version>3020.vcc32c3b_cc767</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 


### PR DESCRIPTION
This ends up being stored in the channel properties, so that it can be
checked later on if the agent reconnects while the controller still
thinks it is connected.

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-68542](https://issues.jenkins.io/browse/JENKINS-68542).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Fix websocket reconnection in edge cases.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
