### PR TITLE
Correct typo in servlet api dependabot exclusion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,6 @@ updates:
       # will require source code changes to replace javax.mail with jakarta.mail 
       # and some handling for plugins that depend on javax.mail being provided by Jenkins core.
       - dependency-name: "com.sun.mail:jakarta.mail"
-      # this is a banned dependency, we have a hack in our pom to prevent anyone else pulling it in
-      - dependency-name: "javax.servlet.servlet-api"
       # needs a jakarta upgrade project, imports changed
       - dependency-name: "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api"
       # Starting with version 2.0.2, this library requires Java 11

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
       # will require source code changes to replace javax.mail with jakarta.mail 
       # and some handling for plugins that depend on javax.mail being provided by Jenkins core.
       - dependency-name: "com.sun.mail:jakarta.mail"
+      # this is a banned dependency, we have a hack in our pom to prevent anyone else pulling it in
+      - dependency-name: "javax.servlet:servlet-api"
       # needs a jakarta upgrade project, imports changed
       - dependency-name: "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api"
       # Starting with version 2.0.2, this library requires Java 11


### PR DESCRIPTION
Noticed when reviewing https://github.com/jenkinsci/jenkins/pull/6588

it's correct on this line:
https://github.com/jenkinsci/jenkins/blob/229299fb9cb72be3b15693c6a8fc02e2bbdb850a/.github/dependabot.yml#L31-L32