### PR TITLE
[JENKINS-68591] Use new layout for remote class loader stats

### DIFF
--- a/core/src/main/resources/jenkins/slaves/systemInfo/ClassLoaderStatisticsSlaveInfo/systemInfo.groovy
+++ b/core/src/main/resources/jenkins/slaves/systemInfo/ClassLoaderStatisticsSlaveInfo/systemInfo.groovy
@@ -1,20 +1,21 @@
 import hudson.slaves.SlaveComputer
 
 def fmt = new java.text.DecimalFormat("0.0")
-def right = 'text-align: right'
 if (my instanceof SlaveComputer) {
     SlaveComputer c = my
 
     table(class: 'jenkins-table') {
-        tr {
-            th               { text(_('Loading Type')) }
-            th(style: right) { text(_('Time (s)')) }
-            th(style: right) { text(_('Count')) }
+        thead {
+            tr {
+                th { text(_('Loading Type')) }
+                th { text(_('Time (s)')) }
+                th { text(_('Count')) }
+            }
         }
         tr {
             td _('Classes')
-            td(style: right) {text(fmt.format(c.classLoadingTime / 1000000000))}
-            td(style: right) {
+            td {text(fmt.format(c.classLoadingTime / 1000000000))}
+            td {
                 text(c.classLoadingCount)
                 def classLoadingPrefetchCacheCount = c.classLoadingPrefetchCacheCount
                 if (classLoadingPrefetchCacheCount != -1) {
@@ -26,8 +27,8 @@ if (my instanceof SlaveComputer) {
         }
         tr {
             td _('Resources')
-            td(style: right) {text(fmt.format(c.resourceLoadingTime / 1000000000))}
-            td(style: right) {text(c.resourceLoadingCount)}
+            td {text(fmt.format(c.resourceLoadingTime / 1000000000))}
+            td {text(c.resourceLoadingCount)}
         }
     }
 }

--- a/core/src/main/resources/jenkins/slaves/systemInfo/ClassLoaderStatisticsSlaveInfo/systemInfo.groovy
+++ b/core/src/main/resources/jenkins/slaves/systemInfo/ClassLoaderStatisticsSlaveInfo/systemInfo.groovy
@@ -5,11 +5,11 @@ def right = 'text-align: right'
 if (my instanceof SlaveComputer) {
     SlaveComputer c = my
 
-    table(class: 'bigtable') {
+    table(class: 'jenkins-table') {
         tr {
-            th _('Loading Type')
-            th _('Time (s)')
-            th _('Count')
+            th               { text(_('Loading Type')) }
+            th(style: right) { text(_('Time (s)')) }
+            th(style: right) { text(_('Count')) }
         }
         tr {
             td _('Classes')


### PR DESCRIPTION
## [JENKINS-68591](https://issues.jenkins.io/browse/JENKINS-68591) Use new layout for remote class loader statistics

The groovy generated layout matches the jelly layout.  If others have a better approach to improve it, I am open to suggestions.

No tests are included in the pull request because it is difficult to assert table layout from an automated test.

### Before

![current-remote-class-loader-statistics](https://user-images.githubusercontent.com/156685/169538772-a4cb0417-8967-4312-86c5-28412fc557b8.png)

### After

![new-remote-class-loader-statistics](https://user-images.githubusercontent.com/156685/169545885-73fbfe5f-4956-40ff-9b0c-a5e084a3bef5.png)

## Concern

The table expands to full width of the page.  Table readability is reasonable thanks to the change offered by @NotMyFault to use the left alignment rather than right alignment of the numerical data in the table

### Proposed changelog entries

* Show remote class loader statistics of agents with new table layout.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
