### PR TITLE
Upgrade `symbol-annotation` from 1.1 to 1.23

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,6 @@ updates:
       - dependency-name: "javax.servlet:javax.servlet-api"
       # log4j 1.2.17 is the final 1.x release
       - dependency-name: "log4j:log4j"
-      # using a newer version clashes in RequireUpperBoundDeps with plugins using a valid script-security dependency
-      - dependency-name: "org.jenkins-ci:symbol-annotation"
       # Must remain within jetty 9.x until Java 8 support is removed, ignore jetty 10.x and jetty 11.x updates
       - dependency-name: "org.eclipse.jetty:jetty-maven-plugin"
         versions: [">=10.0.0"]

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -239,7 +239,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>symbol-annotation</artifactId>
-        <version>1.1</version>
+        <version>1.23</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
Reintroduces #5265, which had been reverted in #5293 because using a newer version clashed in `RequireUpperBoundDeps` with plugins using a valid `script-security` dependency. Since that time, the long-term solution described in #5293 (splitting `symbol-annotation` into its own library and removing it from `structs-plugin`) has been implemented in jenkinsci/structs-plugin#112, and that release of `structs-plugin` (1.24) has been widely adopted since jenkinsci/bom#793 (1075.v14bef33e5d7b). So upgrading this dependency in core should not cause any of the Enforcer failures noted in #5293 except for plugin maintainers who intentionally chose to remain on an ancient version of `jenkinsci/bom`.

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
