### PR TITLE
Work around JENKINS-68215 when running on Java 17

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -135,6 +135,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TimeZone;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.logging.Level;
@@ -697,6 +698,13 @@ public class Functions {
 
         TimeZone tz = TimeZone.getTimeZone(getUserTimeZone());
         return tz.getDisplayName(tz.observesDaylightTime(), TimeZone.SHORT);
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static long getHourLocalTimezone() {
+        // Work around JENKINS-68215. When JENKINS-68215 is resolved, this logic can be moved back to Jelly.
+        TimeZone tz = TimeZone.getDefault();
+        return TimeUnit.MILLISECONDS.toHours(tz.getRawOffset() + tz.getDSTSavings());
     }
 
     /**

--- a/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
+++ b/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
   <link rel="stylesheet" type="text/css" href="${resURL}/scripts/yui/assets/skins/sam/resize.css"/>
   <script type="text/javascript" src="${resURL}/scripts/yui/resize/resize-min.js"></script>
 
-  <j:invokeStatic var="tz" className="java.util.TimeZone" method="getDefault"/>
-  <div id="build-timeline-div" data-hour-local-timezone="${(tz.rawOffset + tz.DSTSavings) / 3600000}"></div>
+  <j:invokeStatic var="hourLocalTimezone" className="hudson.Functions" method="getHourLocalTimezone"/>
+  <div id="build-timeline-div" data-hour-local-timezone="${hourLocalTimezone}"></div>
   <st:adjunct includes="hudson.model.BuildTimelineWidget.build-timeline-widget" />
 </j:jelly>


### PR DESCRIPTION
[JENKINS-68215](https://issues.jenkins.io/browse/JENKINS-68215) describes a curious little bug in the Jelly Expression Language (JEXL): unlike Groovy, it seems to prefer implementation method handles to abstract method handles when invoking methods, which leads to problems when running on Java 17 when those implementations are locked down. This is a legitimate bug, covered by both positive and negative automated tests (currently failing) in https://github.com/jenkinsci/stapler/pull/352, and Jelly cannot fully claim to support Java 17 until this bug is fixed.

This PR is not a fix for that bug. Rather, this PR is a workaround for the only known and confirmed manifestation of that bug that affects Jenkins (https://github.com/jenkinsci/agent-maintenance-plugin/blob/033d0dc6a93ac315c6a51c86d75e8511e471aaeb/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow/help-startTime.jelly#L4 and https://github.com/jenkinsci/agent-maintenance-plugin/blob/033d0dc6a93ac315c6a51c86d75e8511e471aaeb/src/main/resources/com/sap/prd/jenkins/plugins/agent_maintenance/MaintenanceWindow/help-endTime.jelly#L4 might also be a problem, but I haven't confirmed this).

Why implement a workaround? I normally detest them. But the reason I usually detest workarounds is that they often preclude the long-term solution. In this case nothing precludes someone from checking out `jenkinsci/stapler`, debugging the tests added in https://github.com/jenkinsci/stapler/pull/352, and adjusting Jelly evaluation logic until the tests pass. So one common reason to reject workarounds doesn't apply here.

Additionally, this is the only known user-visible issue I am aware of when running Jenkins on Java 17. And my experience has been, more often than not, that when problems are discovered on Java 11, they are often fixed on Java 17. So I would like to take Java 17 out of preview mode sometime soon and allow users to run Jenkins on Java 17 without having to pass the scary `--enable-future-java` flag. And I plan on telling users to do this if they run into issues on Java 11, because chances are those issues are already fixed on Java 17. So I would like to have this pesky issue on the build status trend page taken care of in order to be able to have the option of telling users "try Java 17" when supporting users.

[JENKINS-68215](https://issues.jenkins.io/browse/JENKINS-68215) will remain open after this PR is integrated. If someone with an interest in programming language runtimes offers a fix for JENKINS-68215, this workaround could be removed in the future. Of course, if lots of other cases like this crop up as more testing occurs on Java 17, investment in a long-term solution could possibly be justified. But at the present time, this issue appears to be relatively rare and uncommon, so perhaps a short-term solution like this may be good enough.

### Implementation

I just moved the logic from Jelly (JEXL) to Java where it is not susceptible to the bug. A simple workaround that should not affect the functionality in any way. Just moving the existing code to a different place essentially.

### Testing done

To test this I reproduced the original problem and saw the stack trace. Then I confirmed that with the change from this PR the stack trace was no longer printed.

### Proposed changelog entries

Fix a runtime error when viewing the build time trend on Java 17.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
