### PR TITLE
Added missing `@NonNull` annotations to overrides

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -26,6 +26,7 @@ package hudson;
 
 import com.thoughtworks.xstream.XStream;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Saveable;
@@ -400,6 +401,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
 
     @Extension @Symbol("proxy")
     public static class DescriptorImpl extends Descriptor<ProxyConfiguration> {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Proxy Configuration";

--- a/core/src/main/java/hudson/console/ConsoleAnnotationDescriptor.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotationDescriptor.java
@@ -24,6 +24,7 @@
 
 package hudson.console;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.DescriptorExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Descriptor;
@@ -55,6 +56,7 @@ public abstract class ConsoleAnnotationDescriptor extends Descriptor<ConsoleNote
      *
      * Users use this name to enable/disable annotations.
      */
+    @NonNull
     @Override
     public String getDisplayName() {
         return super.getDisplayName();

--- a/core/src/main/java/hudson/console/ExpandableDetailsNote.java
+++ b/core/src/main/java/hudson/console/ExpandableDetailsNote.java
@@ -24,6 +24,7 @@
 
 package hudson.console;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.MarkupText;
 import java.io.IOException;
@@ -67,6 +68,7 @@ public class ExpandableDetailsNote extends ConsoleNote {
 
     @Extension
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Expandable details";

--- a/core/src/main/java/hudson/console/HyperlinkNote.java
+++ b/core/src/main/java/hudson/console/HyperlinkNote.java
@@ -24,6 +24,7 @@
 
 package hudson.console;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.MarkupText;
 import hudson.Util;
@@ -102,6 +103,7 @@ public class HyperlinkNote extends ConsoleNote {
 
     @Extension @Symbol("hyperlink")
     public static class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Hyperlinks";

--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -72,6 +72,7 @@ public class ModelHyperlinkNote extends HyperlinkNote {
 
     @Extension @Symbol("hyperlinkToModels")
     public static class DescriptorImpl extends HyperlinkNote.DescriptorImpl {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Hyperlinks to models";

--- a/core/src/main/java/hudson/markup/EscapedMarkupFormatter.java
+++ b/core/src/main/java/hudson/markup/EscapedMarkupFormatter.java
@@ -24,6 +24,7 @@
 
 package hudson.markup;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
@@ -53,6 +54,7 @@ public class EscapedMarkupFormatter extends MarkupFormatter {
     @Extension @Symbol("plainText")
     public static class DescriptorImpl extends MarkupFormatterDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.EscapedMarkupFormatter_DisplayName();

--- a/core/src/main/java/hudson/model/AllView.java
+++ b/core/src/main/java/hudson/model/AllView.java
@@ -184,6 +184,7 @@ public class AllView extends View {
             return true;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.Hudson_ViewName();

--- a/core/src/main/java/hudson/model/BooleanParameterDefinition.java
+++ b/core/src/main/java/hudson/model/BooleanParameterDefinition.java
@@ -127,6 +127,7 @@ public class BooleanParameterDefinition extends SimpleParameterDefinition {
     // to avoid picking the Java reserved word "boolean" as the primary identifier
     @Extension @Symbol("booleanParam")
     public static class DescriptorImpl extends ParameterDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.BooleanParameterDefinition_DisplayName();

--- a/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
@@ -203,6 +203,7 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
 
     @Extension @Symbol({"choice", "choiceParam"})
     public static class DescriptorImpl extends ParameterDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ChoiceParameterDefinition_DisplayName();

--- a/core/src/main/java/hudson/model/FileParameterDefinition.java
+++ b/core/src/main/java/hudson/model/FileParameterDefinition.java
@@ -73,6 +73,7 @@ public class FileParameterDefinition extends ParameterDefinition {
 
     @Extension @Symbol({"file", "fileParam"})
     public static class DescriptorImpl extends ParameterDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.FileParameterDefinition_DisplayName();

--- a/core/src/main/java/hudson/model/FreeStyleProject.java
+++ b/core/src/main/java/hudson/model/FreeStyleProject.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import jenkins.model.Jenkins;
@@ -82,6 +83,7 @@ public class FreeStyleProject extends Project<FreeStyleProject, FreeStyleBuild> 
             DESCRIPTOR = this;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.FreeStyleProject_DisplayName();

--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
@@ -174,6 +175,7 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
     @Extension @Symbol("jdk")
     public static class DescriptorImpl extends ToolDescriptor<JDK> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.JDK_DisplayName();

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -26,6 +26,7 @@
 package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.diagnosis.OldDataMonitor;
@@ -499,6 +500,7 @@ public class ListView extends View implements DirectlyModifiableView {
 
     @Extension @Symbol("list")
     public static class DescriptorImpl extends ViewDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ListView_DisplayName();

--- a/core/src/main/java/hudson/model/MyView.java
+++ b/core/src/main/java/hudson/model/MyView.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Descriptor.FormException;
 import java.io.IOException;
@@ -99,6 +100,7 @@ public class MyView extends View {
             return Jenkins.get().isUseSecurity();
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.MyView_DisplayName();

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -25,6 +25,7 @@
 package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Descriptor.FormException;
@@ -235,6 +236,7 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
     @Extension @Symbol("myView")
     public static class DescriptorImpl extends UserPropertyDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.MyViewsProperty_DisplayName();

--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -138,6 +138,7 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
 
     @Extension @Symbol("password")
     public static final class ParameterDescriptorImpl extends ParameterDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.PasswordParameterDefinition_DisplayName();

--- a/core/src/main/java/hudson/model/ProxyView.java
+++ b/core/src/main/java/hudson/model/ProxyView.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Descriptor.FormException;
@@ -129,6 +130,7 @@ public class ProxyView extends View implements StaplerFallback {
     @Extension @Symbol("proxy")
     public static class DescriptorImpl extends ViewDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ProxyView_DisplayName();

--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -143,6 +143,7 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
 
     @Extension @Symbol({"run", "runParam"})
     public static class DescriptorImpl extends ParameterDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.RunParameterDefinition_DisplayName();

--- a/core/src/main/java/hudson/model/TextParameterDefinition.java
+++ b/core/src/main/java/hudson/model/TextParameterDefinition.java
@@ -55,6 +55,7 @@ public class TextParameterDefinition extends StringParameterDefinition {
 
     @Extension @Symbol({"text", "textParam"})
     public static class DescriptorImpl extends ParameterDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.TextParameterDefinition_DisplayName();

--- a/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
@@ -24,6 +24,7 @@
 
 package hudson.node_monitors;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.remoting.Callable;
@@ -46,6 +47,7 @@ public class ArchitectureMonitor extends NodeMonitor {
             return new GetArchTask();
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ArchitectureMonitor_DisplayName();

--- a/core/src/main/java/hudson/node_monitors/ClockMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ClockMonitor.java
@@ -24,6 +24,7 @@
 
 package hudson.node_monitors;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Computer;
@@ -72,6 +73,7 @@ public class ClockMonitor extends NodeMonitor {
             return n.getClockDifferenceCallable();
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ClockMonitor_DisplayName();

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -24,6 +24,7 @@
 
 package hudson.node_monitors;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;
@@ -61,6 +62,7 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
     }
 
     public static final DiskSpaceMonitorDescriptor DESCRIPTOR = new DiskSpaceMonitorDescriptor() {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.DiskSpaceMonitor_DisplayName();

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -24,6 +24,7 @@
 
 package hudson.node_monitors;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.remoting.Callable;
@@ -80,6 +81,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
             return monitoringData;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ResponseTimeMonitor_DisplayName();

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -24,6 +24,7 @@
 
 package hudson.node_monitors;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Functions;
@@ -101,6 +102,7 @@ public class SwapSpaceMonitor extends NodeMonitor {
             return new MonitorTask();
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.SwapSpaceMonitor_DisplayName();

--- a/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
@@ -24,6 +24,7 @@
 
 package hudson.node_monitors;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
@@ -82,6 +83,7 @@ public class TemporarySpaceMonitor extends AbstractDiskSpaceMonitor {
             DESCRIPTOR = this;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.TemporarySpaceMonitor_DisplayName();

--- a/core/src/main/java/hudson/scm/NullSCM.java
+++ b/core/src/main/java/hudson/scm/NullSCM.java
@@ -24,6 +24,7 @@
 
 package hudson.scm;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -69,6 +70,7 @@ public class NullSCM extends SCM {
             super(null);
         }
 
+        @NonNull
         @Override public String getDisplayName() {
             return Messages.NullSCM_DisplayName();
         }

--- a/core/src/main/java/hudson/search/UserSearchProperty.java
+++ b/core/src/main/java/hudson/search/UserSearchProperty.java
@@ -1,5 +1,6 @@
 package hudson.search;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.User;
 import hudson.model.UserProperty;
@@ -37,6 +38,7 @@ public class UserSearchProperty extends hudson.model.UserProperty {
 
     @Extension @Symbol("search")
     public static final class DescriptorImpl extends UserPropertyDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.UserSearchProperty_DisplayName();

--- a/core/src/main/java/hudson/security/AuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/AuthorizationStrategy.java
@@ -234,6 +234,7 @@ public abstract class AuthorizationStrategy extends AbstractDescribableImpl<Auth
 
         @Extension @Symbol("unsecured")
         public static final class DescriptorImpl extends Descriptor<AuthorizationStrategy> {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.AuthorizationStrategy_DisplayName();

--- a/core/src/main/java/hudson/security/FullControlOnceLoggedInAuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/FullControlOnceLoggedInAuthorizationStrategy.java
@@ -24,6 +24,7 @@
 
 package hudson.security;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Descriptor;
@@ -103,6 +104,7 @@ public class FullControlOnceLoggedInAuthorizationStrategy extends AuthorizationS
             DESCRIPTOR = this;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.FullControlOnceLoggedInAuthorizationStrategy_DisplayName();

--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -218,6 +218,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
 
     @Extension @Symbol("security")
     public static final class DescriptorImpl extends Descriptor<GlobalSecurityConfiguration> {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.GlobalSecurityConfiguration_DisplayName();

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -769,6 +769,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
         @Extension @Symbol("password")
         public static final class DescriptorImpl extends UserPropertyDescriptor {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.HudsonPrivateSecurityRealm_Details_DisplayName();
@@ -964,6 +965,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
     @Extension @Symbol("local")
     public static final class DescriptorImpl extends Descriptor<SecurityRealm> {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.HudsonPrivateSecurityRealm_DisplayName();

--- a/core/src/main/java/hudson/security/LegacyAuthorizationStrategy.java
+++ b/core/src/main/java/hudson/security/LegacyAuthorizationStrategy.java
@@ -24,6 +24,7 @@
 
 package hudson.security;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import java.util.Collection;
@@ -59,6 +60,7 @@ public final class LegacyAuthorizationStrategy extends AuthorizationStrategy {
 
     @Extension @Symbol("legacy")
     public static final class DescriptorImpl extends Descriptor<AuthorizationStrategy> {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.LegacyAuthorizationStrategy_DisplayName();

--- a/core/src/main/java/hudson/security/LegacySecurityRealm.java
+++ b/core/src/main/java/hudson/security/LegacySecurityRealm.java
@@ -24,6 +24,7 @@
 
 package hudson.security;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Descriptor;
@@ -106,6 +107,7 @@ public final class LegacySecurityRealm extends SecurityRealm implements Authenti
             DESCRIPTOR = this;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.LegacySecurityRealm_Displayname();

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -24,6 +24,7 @@
 
 package hudson.security;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionPoint;
@@ -715,6 +716,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
         @Symbol("none")
         public static class DescriptorImpl extends Descriptor<SecurityRealm> {
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.NoneSecurityRealm_DisplayName();

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -6,6 +6,7 @@
 
 package hudson.security.csrf;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
@@ -127,6 +128,7 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
             super(CRUMB_SALT.get(), SystemProperties.getString("hudson.security.csrf.requestfield", CrumbIssuer.DEFAULT_CRUMB_NAME));
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.DefaultCrumbIssuer_DisplayName();

--- a/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
+++ b/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
@@ -24,6 +24,7 @@
 
 package hudson.slaves;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
@@ -89,6 +90,7 @@ public class EnvironmentVariablesNodeProperty extends NodeProperty<Node> {
     @Extension @Symbol("envVars")
     public static class DescriptorImpl extends NodePropertyDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.EnvironmentVariablesNodeProperty_displayName();

--- a/core/src/main/java/hudson/slaves/RetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/RetentionStrategy.java
@@ -176,6 +176,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
 
         @Extension(ordinal = 100) @Symbol("always")
         public static class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.RetentionStrategy_Always_displayName();
@@ -289,6 +290,7 @@ public abstract class RetentionStrategy<T extends Computer> extends AbstractDesc
 
         @Extension @Symbol("demand")
         public static class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.RetentionStrategy_Demand_displayName();

--- a/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
@@ -28,6 +28,7 @@ import static hudson.Util.fixNull;
 import static java.util.logging.Level.INFO;
 
 import antlr.ANTLRException;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -248,6 +249,7 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
 
     @Extension @Symbol("schedule")
     public static class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.SimpleScheduledRetentionStrategy_displayName();

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -347,6 +347,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
             DESCRIPTOR = this; // backward compatibility
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ArtifactArchiver_DisplayName();

--- a/core/src/main/java/hudson/tasks/BatchFile.java
+++ b/core/src/main/java/hudson/tasks/BatchFile.java
@@ -25,6 +25,7 @@
 package hudson.tasks;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
@@ -113,6 +114,7 @@ public class BatchFile extends CommandInterpreter {
             return "/help/project-config/batch.html";
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.BatchFile_DisplayName();

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -24,6 +24,7 @@
 
 package hudson.tasks;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -331,6 +332,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
 
     @Extension @Symbol("fingerprint")
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.Fingerprinter_DisplayName();

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -28,6 +28,7 @@ package hudson.tasks;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
@@ -296,6 +297,7 @@ public class LogRotator extends BuildDiscarder {
 
     @Extension @Symbol("logRotator")
     public static final class LRDescriptor extends BuildDiscarderDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Log Rotation";

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -446,6 +446,7 @@ public class Maven extends Builder {
             return super.getHelpFile(fieldName);
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.Maven_DisplayName();
@@ -684,6 +685,7 @@ public class Maven extends Builder {
 
         @Extension @Symbol("maven")
         public static class DescriptorImpl extends ToolDescriptor<MavenInstallation> {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "Maven";
@@ -764,6 +766,7 @@ public class Maven extends Builder {
 
         @Extension @Symbol("maven")
         public static final class DescriptorImpl extends DownloadFromUrlInstaller.DescriptorImpl<MavenInstaller> {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.InstallFromApache();

--- a/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/Maven3MojoNote.java
@@ -24,6 +24,7 @@
 
 package hudson.tasks._maven;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.MarkupText;
 import hudson.console.ConsoleAnnotationDescriptor;
@@ -60,6 +61,7 @@ public class Maven3MojoNote extends ConsoleNote {
 
     @Extension @Symbol("maven3Mojos")
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Maven 3 Mojos";

--- a/core/src/main/java/hudson/tasks/_maven/MavenErrorNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenErrorNote.java
@@ -24,6 +24,7 @@
 
 package hudson.tasks._maven;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.MarkupText;
 import hudson.console.ConsoleAnnotationDescriptor;
@@ -47,6 +48,7 @@ public class MavenErrorNote extends ConsoleNote {
 
     @Extension @Symbol("mavenErrors")
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Maven Errors";

--- a/core/src/main/java/hudson/tasks/_maven/MavenMojoNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenMojoNote.java
@@ -24,6 +24,7 @@
 
 package hudson.tasks._maven;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.MarkupText;
 import hudson.console.ConsoleAnnotationDescriptor;
@@ -52,6 +53,7 @@ public class MavenMojoNote extends ConsoleNote {
 
     @Extension @Symbol("mavenMojos")
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Maven Mojos";

--- a/core/src/main/java/hudson/tasks/_maven/MavenWarningNote.java
+++ b/core/src/main/java/hudson/tasks/_maven/MavenWarningNote.java
@@ -24,6 +24,7 @@
 
 package hudson.tasks._maven;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.MarkupText;
 import hudson.console.ConsoleAnnotationDescriptor;
@@ -49,6 +50,7 @@ public class MavenWarningNote extends ConsoleNote {
 
     @Extension @Symbol("mavenWarnings")
     public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Maven Warnings";

--- a/core/src/main/java/hudson/tools/BatchCommandInstaller.java
+++ b/core/src/main/java/hudson/tools/BatchCommandInstaller.java
@@ -24,6 +24,7 @@
 
 package hudson.tools;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.util.LineEndingConversion;
@@ -60,6 +61,7 @@ public class BatchCommandInstaller extends AbstractCommandInstaller {
     @Extension @Symbol("batchFile")
     public static class DescriptorImpl extends Descriptor<BatchCommandInstaller> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.BatchCommandInstaller_DescriptorImpl_displayName();

--- a/core/src/main/java/hudson/tools/CommandInstaller.java
+++ b/core/src/main/java/hudson/tools/CommandInstaller.java
@@ -24,6 +24,7 @@
 
 package hudson.tools;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.util.LineEndingConversion;
@@ -59,6 +60,7 @@ public class CommandInstaller extends AbstractCommandInstaller {
     @Extension @Symbol("command")
     public static class DescriptorImpl extends Descriptor<CommandInstaller> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.CommandInstaller_DescriptorImpl_displayName();

--- a/core/src/main/java/hudson/tools/InstallSourceProperty.java
+++ b/core/src/main/java/hudson/tools/InstallSourceProperty.java
@@ -24,6 +24,7 @@
 
 package hudson.tools;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Saveable;
@@ -65,6 +66,7 @@ public class InstallSourceProperty extends ToolProperty<ToolInstallation> {
 
     @Extension @Symbol("installSource")
     public static class DescriptorImpl extends ToolPropertyDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.InstallSourceProperty_DescriptorImpl_displayName();

--- a/core/src/main/java/hudson/tools/ToolLocationNodeProperty.java
+++ b/core/src/main/java/hudson/tools/ToolLocationNodeProperty.java
@@ -24,6 +24,7 @@
 
 package hudson.tools;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.model.Descriptor;
@@ -118,6 +119,7 @@ public class ToolLocationNodeProperty extends NodeProperty<Node> {
     @Extension @Symbol("toolLocation")
     public static class DescriptorImpl extends NodePropertyDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ToolLocationNodeProperty_displayName();

--- a/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
+++ b/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
@@ -24,6 +24,7 @@
 
 package hudson.tools;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Functions;
@@ -92,6 +93,7 @@ public class ZipExtractionInstaller extends ToolInstaller {
     @Extension @Symbol("zip")
     public static class DescriptorImpl extends ToolInstallerDescriptor<ZipExtractionInstaller> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ZipExtractionInstaller_DescriptorImpl_displayName();

--- a/core/src/main/java/hudson/views/BuildButtonColumn.java
+++ b/core/src/main/java/hudson/views/BuildButtonColumn.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractItem;
 import org.jenkinsci.Symbol;
@@ -43,6 +44,7 @@ public class BuildButtonColumn extends ListViewColumn {
 
     @Extension(ordinal = DEFAULT_COLUMNS_ORDINAL_ACTIONS_START - 1) @Symbol("buildButton")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.BuildButtonColumn_DisplayName();

--- a/core/src/main/java/hudson/views/DefaultMyViewsTabBar.java
+++ b/core/src/main/java/hudson/views/DefaultMyViewsTabBar.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -42,6 +43,7 @@ public class DefaultMyViewsTabBar extends MyViewsTabBar {
 
     @Extension @Symbol("standard")
     public static class DescriptorImpl extends MyViewsTabBarDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.DefaultMyViewsTabsBar_DisplayName();

--- a/core/src/main/java/hudson/views/DefaultViewsTabBar.java
+++ b/core/src/main/java/hudson/views/DefaultViewsTabBar.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -42,6 +43,7 @@ public class DefaultViewsTabBar extends ViewsTabBar {
 
     @Extension @Symbol("standard")
     public static class DescriptorImpl extends ViewsTabBarDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.DefaultViewsTabsBar_DisplayName();

--- a/core/src/main/java/hudson/views/JobColumn.java
+++ b/core/src/main/java/hudson/views/JobColumn.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
 import org.jenkinsci.Symbol;
@@ -40,6 +41,7 @@ public class JobColumn extends ListViewColumn {
     // put this in the middle of icons and properties
     @Extension(ordinal = DEFAULT_COLUMNS_ORDINAL_ICON_END + 1) @Symbol("jobName")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.JobColumn_DisplayName();

--- a/core/src/main/java/hudson/views/LastDurationColumn.java
+++ b/core/src/main/java/hudson/views/LastDurationColumn.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,6 +36,7 @@ public class LastDurationColumn extends ListViewColumn {
 
     @Extension(ordinal = DEFAULT_COLUMNS_ORDINAL_PROPERTIES_START - 4) @Symbol("lastDuration")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.LastDurationColumn_DisplayName();

--- a/core/src/main/java/hudson/views/LastFailureColumn.java
+++ b/core/src/main/java/hudson/views/LastFailureColumn.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,6 +36,7 @@ public class LastFailureColumn extends ListViewColumn {
 
     @Extension(ordinal = DEFAULT_COLUMNS_ORDINAL_PROPERTIES_START - 2) @Symbol("lastFailure")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.LastFailureColumn_DisplayName();

--- a/core/src/main/java/hudson/views/LastStableColumn.java
+++ b/core/src/main/java/hudson/views/LastStableColumn.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,6 +36,7 @@ public class LastStableColumn extends ListViewColumn {
 
     @Extension(ordinal = DEFAULT_COLUMNS_ORDINAL_PROPERTIES_START - 3) @Symbol("lastStable")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.LastStableColumn_DisplayName();

--- a/core/src/main/java/hudson/views/LastSuccessColumn.java
+++ b/core/src/main/java/hudson/views/LastSuccessColumn.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,6 +36,7 @@ public class LastSuccessColumn extends ListViewColumn {
 
     @Extension(ordinal = DEFAULT_COLUMNS_ORDINAL_PROPERTIES_START - 1) @Symbol("lastSuccess")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.LastSuccessColumn_DisplayName();

--- a/core/src/main/java/hudson/views/StatusColumn.java
+++ b/core/src/main/java/hudson/views/StatusColumn.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.StatusIcon;
 import org.jenkinsci.Symbol;
@@ -41,6 +42,7 @@ public class StatusColumn extends ListViewColumn {
 
     @Extension(ordinal = DEFAULT_COLUMNS_ORDINAL_ICON_START - 1) @Symbol("status")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.StatusColumn_DisplayName();

--- a/core/src/main/java/hudson/views/WeatherColumn.java
+++ b/core/src/main/java/hudson/views/WeatherColumn.java
@@ -24,6 +24,7 @@
 
 package hudson.views;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,6 +36,7 @@ public class WeatherColumn extends ListViewColumn {
 
     @Extension(ordinal = DEFAULT_COLUMNS_ORDINAL_ICON_START - 2) @Symbol("weather")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.WeatherColumn_DisplayName();

--- a/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
+++ b/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
@@ -368,6 +368,7 @@ public class FileFingerprintStorage extends FingerprintStorage {
     @Extension
     public static class DescriptorImpl extends FingerprintStorageDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.FileFingerprintStorage_DisplayName();

--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -24,6 +24,7 @@
 
 package jenkins.management;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.diagnosis.ReverseProxySetupMonitor;
 import hudson.model.AdministrativeMonitor;
@@ -62,6 +63,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
         ignoredJenkinsRestOfUrls.add("configure");
     }
 
+    @NonNull
     @Override
     public String getDisplayName() {
         return Messages.AdministrativeMonitorsDecorator_DisplayName();

--- a/core/src/main/java/jenkins/model/BuildDiscarderProperty.java
+++ b/core/src/main/java/jenkins/model/BuildDiscarderProperty.java
@@ -24,6 +24,7 @@
 
 package jenkins.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
@@ -53,6 +54,7 @@ public class BuildDiscarderProperty extends OptionalJobProperty<Job<?, ?>> {
     @Symbol("buildDiscarder")
     public static class DescriptorImpl extends OptionalJobPropertyDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.BuildDiscarderProperty_displayName();

--- a/core/src/main/java/jenkins/model/DefaultUserCanonicalIdResolver.java
+++ b/core/src/main/java/jenkins/model/DefaultUserCanonicalIdResolver.java
@@ -25,6 +25,7 @@
 
 package jenkins.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Functions;
 import hudson.model.Descriptor;
@@ -59,6 +60,7 @@ public class DefaultUserCanonicalIdResolver extends User.CanonicalIdResolver {
     }
 
     public static final Descriptor<User.CanonicalIdResolver> DESCRIPTOR = new Descriptor<User.CanonicalIdResolver>() {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "compute default user ID";

--- a/core/src/main/java/jenkins/model/IdStrategy.java
+++ b/core/src/main/java/jenkins/model/IdStrategy.java
@@ -264,6 +264,7 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
         @Extension @Symbol("caseSensitive")
         public static class DescriptorImpl extends IdStrategyDescriptor {
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.IdStrategy_CaseSensitive_DisplayName();
@@ -308,6 +309,7 @@ public abstract class IdStrategy extends AbstractDescribableImpl<IdStrategy> imp
         @Extension
         public static class DescriptorImpl extends IdStrategyDescriptor {
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return Messages.IdStrategy_CaseSensitiveEmailAddress_DisplayName();

--- a/core/src/main/java/jenkins/mvn/DefaultGlobalSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/DefaultGlobalSettingsProvider.java
@@ -1,5 +1,6 @@
 package jenkins.mvn;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
@@ -26,6 +27,7 @@ public class DefaultGlobalSettingsProvider extends GlobalSettingsProvider {
     @Extension(ordinal = 99) @Symbol("standard")
     public static class DescriptorImpl extends GlobalSettingsProviderDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.DefaultGlobalSettingsProvider_DisplayName();

--- a/core/src/main/java/jenkins/mvn/DefaultSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/DefaultSettingsProvider.java
@@ -1,5 +1,6 @@
 package jenkins.mvn;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
@@ -26,6 +27,7 @@ public class DefaultSettingsProvider extends SettingsProvider {
     @Extension(ordinal = 99) @Symbol("standard")
     public static class DescriptorImpl extends SettingsProviderDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.DefaultSettingsProvider_DisplayName();

--- a/core/src/main/java/jenkins/mvn/FilePathGlobalSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/FilePathGlobalSettingsProvider.java
@@ -1,5 +1,6 @@
 package jenkins.mvn;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
@@ -41,6 +42,7 @@ public class FilePathGlobalSettingsProvider extends GlobalSettingsProvider {
     @Extension(ordinal = 10)
     public static class DescriptorImpl extends GlobalSettingsProviderDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.FilePathGlobalSettingsProvider_DisplayName();

--- a/core/src/main/java/jenkins/mvn/FilePathSettingsProvider.java
+++ b/core/src/main/java/jenkins/mvn/FilePathSettingsProvider.java
@@ -1,5 +1,6 @@
 package jenkins.mvn;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
@@ -41,6 +42,7 @@ public class FilePathSettingsProvider extends SettingsProvider {
     @Extension(ordinal = 10) @Symbol("filePath")
     public static class DescriptorImpl extends SettingsProviderDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.FilePathSettingsProvider_DisplayName();

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -408,6 +408,7 @@ public class ApiTokenProperty extends UserProperty {
     @Extension
     @Symbol("apiToken")
     public static final class DescriptorImpl extends UserPropertyDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.ApiTokenProperty_DisplayName();

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -193,6 +193,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
     @Extension @Symbol("upstream")
     public static final class DescriptorImpl extends TriggerDescriptor {
 
+        @NonNull
         @Override public String getDisplayName() {
             return Messages.ReverseBuildTrigger_build_after_other_projects_are_built();
         }

--- a/test/src/test/java/hudson/LauncherTest.java
+++ b/test/src/test/java/hudson/LauncherTest.java
@@ -158,6 +158,7 @@ public class LauncherTest {
         }
 
         @Extension public static final class DescriptorImpl extends Shell.DescriptorImpl {
+            @NonNull
             @Override public String getDisplayName() {
                 return "QuietShell";
             }
@@ -174,6 +175,7 @@ public class LauncherTest {
         }
 
         @Extension public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+            @NonNull
             @Override public String getDisplayName() {
                 return "QuietBatchFile";
             }

--- a/test/src/test/java/hudson/model/DownloadServiceTest.java
+++ b/test/src/test/java/hudson/model/DownloadServiceTest.java
@@ -3,6 +3,7 @@ package hudson.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.DownloadService.Downloadable;
 import hudson.tasks.Ant.AntInstaller;
 import hudson.tasks.Maven;
@@ -98,6 +99,7 @@ public class DownloadServiceTest {
         }
 
         public static final class DescriptorImpl extends DownloadFromUrlInstaller.DescriptorImpl<Maven.MavenInstaller> {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "";

--- a/test/src/test/java/hudson/model/FingerprintCleanupThreadTest.java
+++ b/test/src/test/java/hudson/model/FingerprintCleanupThreadTest.java
@@ -271,6 +271,7 @@ public class FingerprintCleanupThreadTest {
         @Extension
         public static class DescriptorImpl extends FingerprintStorageDescriptor {
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "TestFileFingerprintStorage";
@@ -353,6 +354,7 @@ public class FingerprintCleanupThreadTest {
         @Extension
         public static class DescriptorImpl extends FingerprintStorageDescriptor {
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "TestExternalFingerprintStorage";

--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -201,6 +201,7 @@ public class JobTest {
         }
 
         private static final class DescriptorImpl extends JobPropertyDescriptor {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "";

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -57,6 +57,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlFormUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.Functions;
 import hudson.Launcher;
@@ -1316,6 +1317,7 @@ public class QueueTest {
                 return new BrokenAffinityKeyProject(parent, name);
             }
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "Broken Affinity Key Project";

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -56,6 +56,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.javascript.host.html.HTMLElement;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.XmlFile;
 import hudson.diagnosis.OldDataMonitor;
@@ -518,6 +519,7 @@ public class ViewTest {
 
         @TestExtension
         public static class DescriptorImpl extends ViewPropertyDescriptor {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "Test property";
@@ -953,6 +955,7 @@ public class ViewTest {
             return customId;
         }
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return customDisplayName;

--- a/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.cli.CLICommandInvoker;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.AbstractDescribableImpl;
@@ -115,6 +116,7 @@ public class RobustReflectionConverterTest {
 
         @TestExtension
         public static class DescriptorImpl extends Descriptor<AcceptOnlySpecificKeyword> {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "AcceptOnlySpecificKeyword";
@@ -151,6 +153,7 @@ public class RobustReflectionConverterTest {
 
         @TestExtension
         public static class DescriptorImpl extends JobPropertyDescriptor {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "KeywordProperty";

--- a/test/src/test/java/jenkins/triggers/TriggerTest.java
+++ b/test/src/test/java/jenkins/triggers/TriggerTest.java
@@ -90,6 +90,7 @@ public class TriggerTest {
                 return item instanceof BuildableItem;
             }
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "Bad";

--- a/test/src/test/java/lib/form/ComboBoxTest.java
+++ b/test/src/test/java/lib/form/ComboBoxTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlElementUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.RelativePath;
 import hudson.model.AbstractDescribableImpl;
@@ -153,6 +154,7 @@ public class ComboBoxTest {
         @TestExtension("testEnsureXssNotPossible")
         public static class DescriptorImpl extends OptionalJobProperty.OptionalJobPropertyDescriptor {
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "XSS Property";

--- a/test/src/test/java/lib/form/HeteroListTest.java
+++ b/test/src/test/java/lib/form/HeteroListTest.java
@@ -37,6 +37,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlElementUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.javascript.host.html.HTMLAnchorElement;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -217,6 +218,7 @@ public class HeteroListTest {
         public static class DynamicDisplayNameDescriptor extends Descriptor<TestItemDescribable> {
             public String displayName = "NotYetDefined";
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return displayName;
@@ -258,6 +260,7 @@ public class HeteroListTest {
         public static class DescriptorImpl extends ToolDescriptor<Xss> {
             private Xss[] installations = new Xss[0];
 
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "XSS: <img src=x onerror=console.warn('" + getClass().getName() + "') />";

--- a/test/src/test/java/lib/form/SecretTextareaTest.java
+++ b/test/src/test/java/lib/form/SecretTextareaTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlHiddenInput;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.AbstractProject;
 import hudson.model.Project;
 import hudson.tasks.BuildStepDescriptor;
@@ -160,6 +161,7 @@ public class SecretTextareaTest {
 
         @TestExtension
         public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+            @NonNull
             @Override
             public String getDisplayName() {
                 return "Test Secret";


### PR DESCRIPTION
Added missing `@NonNull` annotations to overrides


### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
