### PR TITLE
Update font stack to use 'system-ui'

### DIFF
--- a/war/src/main/less/abstracts/theme.less
+++ b/war/src/main/less/abstracts/theme.less
@@ -1,6 +1,6 @@
 :root, .app-theme-picker__picker[data-theme=none] {
   // Font related properties
-  --font-family-sans: -apple-system, blinkmacsystemfont, "Segoe UI", roboto, "Noto Sans", oxygen, ubuntu, cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --font-family-sans: system-ui, "Segoe UI", roboto, "Noto Sans", oxygen, ubuntu, cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   --font-family-mono: ui-monospace, SFMono-Regular, SF Mono, JetBrainsMono, Consolas, monospace;
   --font-size-base: 1rem; // 16px
   --font-size-sm: 0.875rem; // 14px

--- a/war/src/main/less/styles.less
+++ b/war/src/main/less/styles.less
@@ -8,7 +8,7 @@ html {
   // The downside is that the page does not resize with the browser's font size,
   // only with the zoom level.
   font-size: 16px !important;
-  letter-spacing: -0.011em;
+  letter-spacing: -0.016em;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
This MR updates the default font stack for Jenkins so that it uses 'system-ui' (https://caniuse.com/font-family-system-ui), this brings better font consistency across browsers and makes Chrome render fonts the same way as other browsers, so Chrome shouldn't over-bold fonts anymore. The character spacing has also been tightened slightly for better legibility.

**Safari** - Pretty much the same
Before
![safari-before](https://user-images.githubusercontent.com/43062514/171061765-a50cfd6d-239b-4d8a-9967-fd24d7da205a.png)

After
![safari-after](https://user-images.githubusercontent.com/43062514/171061770-8f61e597-65b7-458a-a6b5-6748b473ebc1.png)

**Chrome** - Big difference!
Before
![chrome-before](https://user-images.githubusercontent.com/43062514/171061778-32b7b401-9278-4650-bc34-b33eb1a0c137.png)

After
![chrome-after](https://user-images.githubusercontent.com/43062514/171061938-29c1b88b-eb37-494d-940f-4b0ac8cf81e1.png)

**Firefox** - Pretty much the same
Before
![firefox-before](https://user-images.githubusercontent.com/43062514/171061807-9bd8b1b1-feb4-4e8e-80d7-319f4c6cfe66.png)

After
![firefox-after](https://user-images.githubusercontent.com/43062514/171061811-2a3ec743-65a3-44a8-ad7d-61808049bfd5.png)

### Proposed changelog entries

* Update Jenkins to use default system font on Chrome

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
