### PR TITLE
Second backporting for LTS 2.346.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -832,7 +832,7 @@ THE SOFTWARE.
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <!-- Make sure to keep the directives in test/pom.xml and war/pom.xml in sync with these. -->
-              <argLine>@{jacocoSurefireArgs} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+              <argLine>@{jacocoSurefireArgs} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -134,6 +134,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TimeZone;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.logging.Level;
@@ -696,6 +697,13 @@ public class Functions {
 
         TimeZone tz = TimeZone.getTimeZone(getUserTimeZone());
         return tz.getDisplayName(tz.observesDaylightTime(), TimeZone.SHORT);
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static long getHourLocalTimezone() {
+        // Work around JENKINS-68215. When JENKINS-68215 is resolved, this logic can be moved back to Jelly.
+        TimeZone tz = TimeZone.getDefault();
+        return TimeUnit.MILLISECONDS.toHours(tz.getRawOffset() + tz.getDSTSavings());
     }
 
     /**

--- a/core/src/main/java/hudson/cli/CLIAction.java
+++ b/core/src/main/java/hudson/cli/CLIAction.java
@@ -136,7 +136,7 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
                 }
             }
 
-            private void doClose() {
+            private void doClose() throws IOException {
                 close();
             }
 

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -921,7 +921,7 @@ public class SlaveComputer extends Computer {
         if (c != null) {
             try {
                 c.close();
-            } catch (IOException e) {
+            } catch (Exception e) {
                 logger.log(Level.SEVERE, "Failed to terminate channel to " + getDisplayName(), e);
             }
             Listeners.notify(ComputerListener.class, true, l -> l.onOffline(this, offlineCause));

--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -27,6 +27,7 @@ package jenkins.agents;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.InvisibleAction;
 import hudson.model.UnprotectedRootAction;
@@ -89,16 +90,24 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         state.setRemoteEndpointDescription(req.getRemoteAddr());
         state.fireBeforeProperties();
         LOGGER.fine(() -> "connecting " + agent);
-        // TODO or just pass all request headers?
         Map<String, String> properties = new HashMap<>();
         properties.put(JnlpConnectionState.CLIENT_NAME_KEY, agent);
         properties.put(JnlpConnectionState.SECRET_KEY, secret);
+        String unsafeCookie = req.getHeader(Engine.WEBSOCKET_COOKIE_HEADER);
+        String cookie;
+        if (unsafeCookie != null) {
+            // This will blow up if the client sent us a malformed cookie.
+            cookie = Util.toHexString(Util.fromHexString(unsafeCookie));
+        } else {
+            cookie = JnlpAgentReceiver.generateCookie();
+        }
+        properties.put(JnlpConnectionState.COOKIE_KEY, cookie);
         state.fireAfterProperties(Collections.unmodifiableMap(properties));
         Capability remoteCapability = Capability.fromASCII(remoteCapabilityStr);
         LOGGER.fine(() -> "received " + remoteCapability);
         rsp.setHeader(Capability.KEY, new Capability().toASCII());
         rsp.setHeader(Engine.REMOTING_MINIMUM_VERSION_HEADER, RemotingVersionInfo.getMinimumSupportedVersion().toString());
-        rsp.setHeader(JnlpConnectionState.COOKIE_KEY, JnlpAgentReceiver.generateCookie()); // TODO figure out what this is for, if anything
+        rsp.setHeader(Engine.WEBSOCKET_COOKIE_HEADER, cookie);
         return WebSockets.upgrade(new Session(state, agent, remoteCapability));
     }
 

--- a/core/src/main/java/jenkins/websocket/WebSocketEcho.java
+++ b/core/src/main/java/jenkins/websocket/WebSocketEcho.java
@@ -27,6 +27,7 @@ package jenkins.websocket;
 import hudson.Extension;
 import hudson.model.InvisibleAction;
 import hudson.model.RootAction;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
@@ -46,12 +47,12 @@ public class WebSocketEcho  extends InvisibleAction implements RootAction {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             return WebSockets.upgrade(new WebSocketSession() {
                 @Override
-                protected void text(String message) {
+                protected void text(String message) throws IOException {
                     sendText("hello " + message);
                 }
 
                 @Override
-                protected void binary(byte[] payload, int offset, int len) {
+                protected void binary(byte[] payload, int offset, int len) throws IOException {
                     ByteBuffer data = ByteBuffer.allocate(len);
                     for (int i = 0; i < len; i++) {
                         byte b = payload[offset + i];

--- a/core/src/main/java/jenkins/websocket/WebSocketSession.java
+++ b/core/src/main/java/jenkins/websocket/WebSocketSession.java
@@ -24,6 +24,7 @@
 
 package jenkins.websocket;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Future;
@@ -114,45 +115,45 @@ public abstract class WebSocketSession {
         LOGGER.log(Level.WARNING, "unhandled WebSocket service error", cause);
     }
 
-    protected void binary(byte[] payload, int offset, int len) {
+    protected void binary(byte[] payload, int offset, int len) throws IOException {
         LOGGER.warning("unexpected binary frame");
     }
 
-    protected void text(String message) {
+    protected void text(String message) throws IOException {
         LOGGER.warning("unexpected text frame");
     }
 
     @SuppressWarnings("unchecked")
-    protected final Future<Void> sendBinary(ByteBuffer data) {
+    protected final Future<Void> sendBinary(ByteBuffer data) throws IOException {
         try {
             return (Future<Void>) remoteEndpoint.getClass().getMethod("sendBytesByFuture", ByteBuffer.class).invoke(remoteEndpoint, data);
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new IOException(x);
         }
     }
 
-    protected final void sendBinary(ByteBuffer partialByte, boolean isLast) {
+    protected final void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
         try {
             remoteEndpoint.getClass().getMethod("sendPartialBytes", ByteBuffer.class, boolean.class).invoke(remoteEndpoint, partialByte, isLast);
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new IOException(x);
         }
     }
 
     @SuppressWarnings("unchecked")
-    protected final Future<Void> sendText(String text) {
+    protected final Future<Void> sendText(String text) throws IOException {
         try {
             return (Future<Void>) remoteEndpoint.getClass().getMethod("sendStringByFuture", String.class).invoke(remoteEndpoint, text);
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new IOException(x);
         }
     }
 
-    protected final void close() {
+    protected final void close() throws IOException {
         try {
             session.getClass().getMethod("close").invoke(session);
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new IOException(x);
         }
     }
 

--- a/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
+++ b/core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
   <link rel="stylesheet" type="text/css" href="${resURL}/scripts/yui/assets/skins/sam/resize.css"/>
   <script type="text/javascript" src="${resURL}/scripts/yui/resize/resize-min.js"></script>
 
-  <j:invokeStatic var="tz" className="java.util.TimeZone" method="getDefault"/>
-  <div id="build-timeline-div" data-hour-local-timezone="${(tz.rawOffset + tz.DSTSavings) / 3600000}"></div>
+  <j:invokeStatic var="hourLocalTimezone" className="hudson.Functions" method="getHourLocalTimezone"/>
+  <div id="build-timeline-div" data-hour-local-timezone="${hourLocalTimezone}"></div>
   <st:adjunct includes="hudson.model.BuildTimelineWidget.build-timeline-widget" />
 </j:jelly>

--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -94,8 +94,7 @@
         "plugins": [
             { "name": "email-ext", "suggested": true },
             { "name": "emailext-template" },
-            { "name": "mailer", "suggested": true },
-            { "name": "ssh" }
+            { "name": "mailer", "suggested": true }
         ]
     },
     {

--- a/core/src/main/resources/jenkins/slaves/systemInfo/ClassLoaderStatisticsSlaveInfo/systemInfo.groovy
+++ b/core/src/main/resources/jenkins/slaves/systemInfo/ClassLoaderStatisticsSlaveInfo/systemInfo.groovy
@@ -1,20 +1,21 @@
 import hudson.slaves.SlaveComputer
 
 def fmt = new java.text.DecimalFormat("0.0")
-def right = 'text-align: right'
 if (my instanceof SlaveComputer) {
     SlaveComputer c = my
 
-    table(class: 'bigtable') {
-        tr {
-            th _('Loading Type')
-            th _('Time (s)')
-            th _('Count')
+    table(class: 'jenkins-table') {
+        thead {
+            tr {
+                th { text(_('Loading Type')) }
+                th { text(_('Time (s)')) }
+                th { text(_('Count')) }
+            }
         }
         tr {
             td _('Classes')
-            td(style: right) {text(fmt.format(c.classLoadingTime / 1000000000))}
-            td(style: right) {
+            td {text(fmt.format(c.classLoadingTime / 1000000000))}
+            td {
                 text(c.classLoadingCount)
                 def classLoadingPrefetchCacheCount = c.classLoadingPrefetchCacheCount
                 if (classLoadingPrefetchCacheCount != -1) {
@@ -26,8 +27,8 @@ if (my instanceof SlaveComputer) {
         }
         tr {
             td _('Resources')
-            td(style: right) {text(fmt.format(c.resourceLoadingTime / 1000000000))}
-            td(style: right) {text(c.resourceLoadingCount)}
+            td {text(fmt.format(c.resourceLoadingTime / 1000000000))}
+            td {text(c.resourceLoadingCount)}
         }
     }
 }

--- a/core/src/main/resources/lib/layout/icon.jelly
+++ b/core/src/main/resources/lib/layout/icon.jelly
@@ -68,7 +68,7 @@ THE SOFTWARE.
         <j:arg value="${iconSrc.substring(7)}" />
         <j:arg value="${alt ?: ''}" />
         <j:arg value="${attrs.tooltip ?: ''}" />
-        <j:arg value="${iconMetadata.classSpec ?: ''}" />
+        <j:arg value="${attrs.class ?: iconMetadata.classSpec ?: ''}" />
         <j:arg value="${h.extractPluginNameFromIconSrc(iconSrc)}" />
       </j:invokeStatic>
       <j:out value="${icon}" />

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.74</version>
+    <version>1.73</version>
     <relativePath />
   </parent>
 
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3025.vf64a_a_3da_6b_55</remoting.version>
+    <remoting.version>4.13.2</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.73</version>
+    <version>1.74</version>
     <relativePath />
   </parent>
 
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>4.13</remoting.version>
+    <remoting.version>3025.vf64a_a_3da_6b_55</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -390,7 +390,7 @@ THE SOFTWARE.
           Filled in by maven-hpi-plugin from the MANIFEST.MF entry in jenkins.war, but we provide a default value for the benefit of IDEs.
           Make sure to keep the directives in core/pom.xml and war/pom.xml in sync with these.
         -->
-        <jenkins.addOpens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</jenkins.addOpens>
+        <jenkins.addOpens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED</jenkins.addOpens>
       </properties>
     </profile>
   </profiles>

--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -89,7 +89,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.TestExtension;
-import org.jvnet.hudson.test.TestPluginManager;
 import org.jvnet.hudson.test.recipes.PresetData;
 import org.jvnet.hudson.test.recipes.PresetData.DataSet;
 import org.kohsuke.args4j.CmdLineException;
@@ -434,25 +433,6 @@ public class AbstractProjectTest {
      */
     @Test
     public void configDotXmlSubmissionToDifferentType() throws Exception {
-        TestPluginManager tpm = (TestPluginManager) j.jenkins.pluginManager;
-        tpm.installDetachedPlugin("structs");
-        tpm.installDetachedPlugin("workflow-step-api");
-        tpm.installDetachedPlugin("scm-api");
-        tpm.installDetachedPlugin("workflow-api");
-        tpm.installDetachedPlugin("script-security");
-        tpm.installDetachedPlugin("jquery3-api");
-        tpm.installDetachedPlugin("snakeyaml-api");
-        tpm.installDetachedPlugin("jackson2-api");
-        tpm.installDetachedPlugin("popper-api");
-        tpm.installDetachedPlugin("plugin-util-api");
-        tpm.installDetachedPlugin("font-awesome-api");
-        tpm.installDetachedPlugin("bootstrap4-api");
-        tpm.installDetachedPlugin("echarts-api");
-        tpm.installDetachedPlugin("display-url-api");
-        tpm.installDetachedPlugin("checks-api");
-        tpm.installDetachedPlugin("junit");
-        tpm.installDetachedPlugin("matrix-project");
-
         j.jenkins.setCrumbIssuer(null);
         FreeStyleProject p = j.createFreeStyleProject();
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -144,7 +144,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>executable-war</artifactId>
-      <version>2.4</version>
+      <version>2.4.1</version>
       <scope>provided</scope>
     </dependency>
     <!-- offline profiler API when we need it -->

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -182,7 +182,7 @@ THE SOFTWARE.
             </manifest>
             <manifestEntries>
               <!-- Make sure to keep the directives in core/pom.xml and test/pom.xml in sync with these. -->
-              <Add-Opens>java.base/java.lang java.base/java.io java.base/java.util</Add-Opens>
+              <Add-Opens>java.base/java.lang java.base/java.io java.base/java.util java.desktop/com.sun.beans.introspect</Add-Opens>
               <Implementation-Version>${project.version}</Implementation-Version>
               <Hudson-Version>1.395</Hudson-Version>
               <Jenkins-Version>${project.version}</Jenkins-Version>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -277,7 +277,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>windows-slaves</artifactId>
-                  <version>1.0</version>
+                  <version>1.8.1</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -295,7 +295,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>script-security</artifactId>
-                  <version>1.75</version>
+                  <version>1172.v35f6a_0b_8207e</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -352,6 +352,14 @@ THE SOFTWARE.
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>snakeyaml-api</artifactId>
                   <version>1.27.0</version>
+                  <type>hpi</type>
+                </artifactItem>
+
+                <artifactItem>
+                  <!-- dependency of script-security -->
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>caffeine-api</artifactId>
+                  <version>2.9.3-65.v6a_47d0f4d1fe</version>
                   <type>hpi</type>
                 </artifactItem>
 

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1241,7 +1241,7 @@ td.progress-bar-done {
 }
 
 td.progress-bar-left {
-  background-color: #fff;
+  background-color: #EBECF0;
 }
 
 table.progress-bar.red {

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -469,7 +469,7 @@ div.behavior-loading {
   bottom: -1px;
   margin-left: -2rem;
   width: calc(100% + 4rem);   /* it needs to occupy the entire width or else the underlying content will see through */
-  z-index: 999;
+  z-index: 998; /* behind top-sticker */
 }
 
 .bottom-sticker-inner {


### PR DESCRIPTION
```
Fixed
-----

JENKINS-68215           Minor                   2.350
        IllegalAccessException fired when accessing the build time trend on Java 17
        https://issues.jenkins.io/browse/JENKINS-68215

JENKINS-68559           Minor                   2.350
        Update bundled plugins after 2022-05-17 security advisory
        https://issues.jenkins.io/browse/JENKINS-68559

JENKINS-68556           Minor                   2.350
        Remove SSH plugin from setup wizard plugin selection
        https://issues.jenkins.io/browse/JENKINS-68556

JENKINS-68591           Minor                   2.350
        Remote class loader statistics table uses old table style
        https://issues.jenkins.io/browse/JENKINS-68591

JENKINS-63766           Blocker                   2.350
        Metaspace memory leak in Pipeline when running on Java 11 (but not 8 or 17)
        https://issues.jenkins.io/browse/JENKINS-63766

JENKINS-68630           Minor                   2.350
        Class attributes does not work for symbols
        https://issues.jenkins.io/browse/JENKINS-68630

JENKINS-63636           Minor                   2.350
        Cannot see the end of the job progress bar
        https://issues.jenkins.io/browse/JENKINS-63636

JENKINS-68640           Minor                   2.350
        Bottom bar can hide elements from top bar
        https://issues.jenkins.io/browse/JENKINS-68640

JENKINS-68542           Minor                   2.350
        Broken reconnection when using websockets
        https://issues.jenkins.io/browse/JENKINS-68542
```