### PR TITLE
[JENKINS-68704] Give Multibranch pipelines access to environment variables 

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2426,7 +2426,13 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      */
     public @NonNull EnvVars getEnvironment(@NonNull TaskListener listener) throws IOException, InterruptedException {
         Computer c = Computer.currentComputer();
-        Node n = c == null ? null : c.getNode();
+
+        if (c == null) {
+            Executor e = this.getExecutor();
+            c = e.owner;
+        }
+
+        Node n = c==null ? null : c.getNode();
 
         EnvVars env = getParent().getEnvironment(n, listener);
         env.putAll(getCharacteristicEnvVars());

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2432,7 +2432,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             c = e.owner;
         }
 
-        Node n = c==null ? null : c.getNode();
+        Node n = c == null ? null : c.getNode();
 
         EnvVars env = getParent().getEnvironment(n, listener);
         env.putAll(getCharacteristicEnvVars());

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2429,7 +2429,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
         if (c == null) {
             Executor e = this.getExecutor();
-            c = e.owner;
+            c = e == null ? null : e.owner;
         }
 
         Node n = c == null ? null : c.getNode();


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-68704](https://issues.jenkins.io/browse/JENKINS-68704).

The issue described in the ticket is caused by `Computer.currentComputer()` being null for Multibranch Pipelines. A non-null instance of it can be retrieved via the executor.

This fix may be a breaking change for some users as the environment variables of the executor will suddenly be set in Multibranch pipelines. However, this appears to be the expected behaviour and the bug has caused irritation before, for example in https://github.com/jenkinsci/git-client-plugin/pull/201#issuecomment-311173596 as the bug only occurs for Multibranch pipelines and not for Freestyle jobs.

### Proposed changelog entries

* Fix executor-resolving for Multibranch pipelines to allow access to environment variables.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

Anyone

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
