### PR TITLE
`generate-resources` before generating javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@ THE SOFTWARE.
           <arguments>-P release,sign</arguments>
           <!-- work around for a bug in javadoc plugin that causes the release to fail. see MRELEASE-271 -->
           <preparationGoals>clean install</preparationGoals>
-          <goals>-DskipTests -Danimal.sniffer.skip=false javadoc:javadoc deploy</goals>
+          <goals>-DskipTests -Danimal.sniffer.skip=false -Dspotbugs.skip -Dmaven.checkstyle.skip -Dspotless.check.skip generate-resources javadoc:javadoc deploy</goals>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>
           <tagNameFormat>jenkins-@{project.version}</tagNameFormat>


### PR DESCRIPTION
See https://github.com/jenkins-infra/docker-packaging/pull/36#issuecomment-1149093485

Running the `stage:release` locally I saw that goals was coming from the `pom.xml` file in this repo

I also added a few more skips to make the release a bit faster

This is required to unblock weekly release