### PR TITLE
Upgrade Surefire from 2.22.2 to 3.0.0-M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,8 @@ THE SOFTWARE.
     <mockito.version>4.6.1</mockito.version>
     <spotless.version>2.22.6</spotless.version>
 
-    <!-- TODO 3.x versions expose "GC overhead limit exceeded" errors in this test suite -->
-    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
+    <maven-surefire-report-plugin.version>3.0.0-M1</maven-surefire-report-plugin.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Reliving history, one flaky test suite at a time.