### PR TITLE
Upgrade Surefire from 2.22.2 to 3.0.0-M7 and 1100 MB Maven heap

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx800m
+-Xmx1100m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=hprof

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,12 @@ for (i = 0; i < buildTypes.size(); i++) {
         def changelistF = "${pwd tmp: true}/changelist"
         def m2repo = "${pwd tmp: true}/m2repo"
 
+        if (isUnix()) {
+          sh 'mkdir hprof'
+        } else {
+          bat 'mkdir hprof'
+        }
+
         // Now run the actual build.
         stage("${buildType} Build / Test") {
           timeout(time: 5, unit: 'HOURS') {
@@ -63,10 +69,8 @@ for (i = 0; i < buildTypes.size(); i++) {
               ]
               try {
                 infra.runMaven(mavenOptions, jdk)
-                if (isUnix()) {
-                  sh 'git add . && git diff --exit-code HEAD'
-                }
               } finally {
+                archiveArtifacts allowEmptyArchive: true, artifacts: 'hprof/*.hprof'
                 archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
               }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,6 @@ THE SOFTWARE.
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <mockito.version>4.6.1</mockito.version>
     <spotless.version>2.22.6</spotless.version>
-
-    <!-- TODO 3.x versions expose "GC overhead limit exceeded" errors in this test suite -->
-    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
How big does the heap have to be to avoid Maven out of memory errors? This variation of https://github.com/jenkinsci/jenkins/pull/6640 seeks to determine the answer to this question.