### PR TITLE
Fix 'unavailable plugin' messages in plugin manager

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1436,7 +1436,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                         jsonObject.put("releaseTimestamp", releaseTimestamp);
                     }
                     if (hasLatestVersionNewerThanOffered(plugin)) {
-                        jsonObject.put("newerVersionAvailableNotOffered", Messages.PluginManager_newerVersionExists(plugin.latest));
+                        jsonObject.put("newerVersionAvailableNotOffered", Messages.PluginManager_newerVersionExists(plugin.latest, plugin.wiki));
                     }
                     return jsonObject;
                 })

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -91,12 +91,10 @@ PluginManager.adoptThisPlugin=\
   <strong>This plugin is up for adoption!</strong> We are looking for new maintainers. \
   Visit our <a href="https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" rel="noopener noreferrer" target="_blank">Adopt a Plugin</a> initiative for more information.
 PluginManager.newerVersionExists=\
-  A newer version than being offered for installation exists (version {0}). \
-  This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied.
-PluginManager.newerVersionEntry=\
-  This version of the plugin exists but it is not being offered as an update. \
+  A newer version than being offered for installation exists (version {0}), so the latest bug fixes or features are not available to you. \
   This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied. \
-  See the <a href="{0}" rel="noopener noreferrer" target="_blank">plugin documentation</a> for information about its requirements.
+  If you are using the latest version of Jenkins offered to you, this plugin release may not be available to your release line yet. \
+  See the <a href="{1}" rel="noopener noreferrer" target="_blank">plugin documentation</a> for information about its requirements.
 PluginManager.unavailable=Unavailable
 PluginManager.deprecationWarning=<strong>This plugin is deprecated.</strong> In general, this means that it is either obsolete, no longer being developed, or may no longer work. <a href="{0}" rel="noopener noreferrer" target="_blank">Learn more.</a>
 PluginManager.insecureUrl=\

--- a/core/src/main/resources/hudson/Messages_es.properties
+++ b/core/src/main/resources/hudson/Messages_es.properties
@@ -91,13 +91,6 @@ PluginManager.ago=Hace {0}
 PluginManager.adoptThisPlugin=\
   <strong>\u00a1Este plugin est\u00e1 en adopci\u00f3n!</strong> Buscamos nuevos mantenedores. \
   Visita nuestro sitio de la iniciativa <a href="https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" rel="noopener noreferrer" target="_blank">Adopte un plugin</a> para obtener m\u00e1s informaci\u00f3n.
-PluginManager.newerVersionExists=\
-  Existe una versi\u00f3n m\u00e1s nueva que la que se ofrece para la instalaci\u00f3n (versi\u00f3n {0}). \
-  Este es el t\u00edpico caso en el que no se satisfacen los requisitos del plugin, por ejemplo, una versi\u00f3n m\u00e1s reciente de Jenkins es necesaria.
-PluginManager.newerVersionEntry=\
-  Esta versi\u00f3n del plugin existe pero no se ofrece como actualizaci\u00f3n. \
-  Este es el t\u00edpico caso en el que no se satisfacen los requisitos del plugin, por ejemplo, una versi\u00f3n m\u00e1s reciente de Jenkins es necesaria. \
-  Consulte la <a href="{0}" rel="noopener noreferrer" target="_blank">documentaci\u00f3n del plugin</a> para obtener informaci\u00f3n sobre sus requisitos.
 PluginManager.unavailable=No disponible
 PluginManager.deprecationWarning=<strong>Este plugin est\u00e1 obsoleto.</strong> En general, esto significa que ya no se desarrolla o que puede dejar de funcionar. <a href="{0}" rel="noopener noreferrer" target="_blank">M\u00e1s informaci\u00f3n</a>
 

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -206,7 +206,7 @@ THE SOFTWARE.
                     </j:if>
                     <j:if test="${it.hasLatestVersionNewerThanOffered(p)}">
                       <div class="alert alert-info">
-                        ${%newerVersionExists(p.latest)}
+                        ${%newerVersionExists(p.latest, p.wiki)}
                       </div>
                     </j:if>
                   </td>

--- a/core/src/main/resources/hudson/PluginManager/table.properties
+++ b/core/src/main/resources/hudson/PluginManager/table.properties
@@ -48,7 +48,7 @@ newerVersionExists=\
   A newer version than being offered for installation exists (version {0}), so the latest bug fixes or features are not available to you. \
   This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied. \
   If you are using the latest version of Jenkins offered to you, this plugin release may not be available to your release line yet. \
-  See the <a href="{0}" rel="noopener noreferrer" target="_blank">plugin documentation</a> for information about its requirements.
+  See the <a href="{1}" rel="noopener noreferrer" target="_blank">plugin documentation</a> for information about its requirements.
 newerVersionEntry=\
   This version of the plugin exists but it is not being offered for installation, so the latest bug fixes or features are not available to you. \
   This is typically the case when plugin requirements, e.g. a recent version of Jenkins, are not satisfied. \

--- a/core/src/main/resources/hudson/PluginManager/table_it.properties
+++ b/core/src/main/resources/hudson/PluginManager/table_it.properties
@@ -70,16 +70,6 @@ instructions=Utilizzare la casella di ricerca soprastante per cercare i \
   componenti aggiuntivi disponibili.
 loading=Caricamento elenco componenti aggiuntivi in corso...
 Name=Nome
-newerVersionEntry=Questa versione del componente aggiuntivo esiste ma non è \
-  offerta come aggiornamento. Questo è il caso tipico se non sono soddisfatti \
-  dei requisiti relativi ai componenti aggiuntivi, ad es. disporre di una \
-  versione recente di Jenkins. Si veda la \
-  <a href="{0}" rel="noopener noreferrer" target="_blank">documentazione del componente aggiuntivo</a> \
-  per ulteriori informazioni relative ai suoi requisiti.
-newerVersionExists=Per questo componente aggiuntivo esiste una versione più \
-  recente di quella offerta per l''installazione (versione {0}). Questo è il \
-  caso tipico se non sono soddisfatti dei requisiti relativi ai componenti \
-  aggiuntivi, ad es. disporre di una versione recente di Jenkins.
 No\ updates=Nessun aggiornamento disponibile
 parentCompatWarning=I seguenti componenti aggiuntivi sono affetti da questo \
   problema:

--- a/core/src/main/resources/hudson/PluginManager/table_pl.properties
+++ b/core/src/main/resources/hudson/PluginManager/table_pl.properties
@@ -40,9 +40,5 @@ ago={0} temu
 adoptThisPlugin=\
   <strong>Ta wtyczka czeka na adopcje!</strong> Szukamy os\u00F3b ch\u0119tnych rozwija\u0107 t\u0119 wtyczk\u0119. \
   Przeczytaj nasz\u0105 inicjatyw\u0119 <a href="https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" rel="noopener noreferrer" target="_blank">Adopt a Plugin</a>, aby uzyska\u0107 wi\u0119cej informacji.
-newerVersionEntry=\
-  Ta wersja wtyczki istnieje, ale nie jest dost\u0119pna jej aktualizacja. \
-  Najcz\u0119\u015Bciej jest to spowodowane tym, \u017Ce np. wtyczka wymaga nowszej wersji Jenkinsa, co nie jest spe\u0142nione. \
-  Sprawd\u017A <a href="{0}" rel="noopener noreferrer" target="_blank">dokumentacje wtyczki</a> celem weryfikacji tych wymaga\u0144.
 unavailable=Niedost\u0119pna
 Applying\ this\ update\ will\ address\ security\ vulnerabilities\ in\ the\ currently\ installed\ version.=Zainstalowanie tej aktualizacji usunie podatno\u015Bci wyst\u0119puj\u0105ce w aktualnie zainstalowanej wersji.


### PR DESCRIPTION
This addresses two problems:

* The messages shown on the "Updates" tab (rendered server side) and "Available" tab (rendered client side) have previously diverged.
* The link in one message did not actually link to the plugin.

Additionally, the `Messages.properties` included an unused key, that is being cleaned up here.

Existing translations are deleted due to substantial message changes.

<details>
<summary>Screenshots</summary>

<img width="1596" alt="Screenshot 2022-06-13 at 19 30 49" src="https://user-images.githubusercontent.com/1831569/173413199-f0413ba6-0ff5-4e9e-8395-9e8ab7453474.png">
<img width="1596" alt="Screenshot 2022-06-13 at 19 30 46" src="https://user-images.githubusercontent.com/1831569/173413208-3c2bdc39-6383-485e-9ebb-d38bfc1e5066.png">

</details>

Amends #5462.

### Proposed changelog entries

* Fix 'unavailable plugin' messages in plugin manager.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
