### PR TITLE
[JENKINS-68767] feat: Use user-friendly name in uninstaller view

### DIFF
--- a/core/src/main/resources/hudson/PluginWrapper/uninstall.groovy
+++ b/core/src/main/resources/hudson/PluginWrapper/uninstall.groovy
@@ -12,13 +12,13 @@ l.layout(permission: Jenkins.ADMINISTER) {
             l.task(icon: "icon-gear icon-md", href: "${rootURL}/manage", title: _("Manage Jenkins"))
         }
     }
-    def title = _("title", my.shortName)
+    def title = _("title", my.displayName)
     l.header(title:title)
     l.main_panel {
         h1 {
             text(title)
         }
-        p { raw _("msg",my.shortName) }
+        p { raw _("msg", my.displayName) }
         f.form(method:"post",action:"doUninstall") {
             f.submit(value:_("Yes"))
         }


### PR DESCRIPTION
See [JENKINS-68767](https://issues.jenkins.io/browse/JENKINS-68767)

The change proposed displays the plugin name over the artifact Id in the uninstall view of the plugin manager:
![Bildschirmfoto 2022-06-16 um 14 40 37](https://user-images.githubusercontent.com/13383509/174071805-b0900ce8-e488-40ad-a0b2-71c9e426f782.png)
instead of 
![Bildschirmfoto 2022-06-16 um 14 39 15](https://user-images.githubusercontent.com/13383509/174071599-f0ae3457-492e-4dce-a5ab-f51bd53296c2.png)

The artifact Id and the plugin name aren't always the same, but the plugin name is what is shown in the plugin manager, deprecation lists etc., hence it makes sense to use it here too.

### Proposed changelog entries

* Use user friendly plugin name in uninstallation view.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6666"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

