### PR TITLE
Use latest maven for gitpod

### DIFF
--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,4 +1,3 @@
 FROM gitpod/workspace-full
 
-RUN brew install gh && \
-    bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && sdk install maven 3.8.4 && sdk default maven 3.8.4"
+RUN brew install gh


### PR DESCRIPTION
Now that maven 3.8.6 is out we can use that.

draft till I've checked it works