### PR TITLE
Bump minimum supported Remoting version from 3.14 to 4.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ THE SOFTWARE.
     <!-- Bundled Remoting version -->
     <remoting.version>3028.va_a_436db_35078</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
-    <remoting.minimum.supported.version>3.14</remoting.minimum.supported.version>
+    <remoting.minimum.supported.version>4.2.1</remoting.minimum.supported.version>
 
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -233,7 +233,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.main</groupId>
                   <artifactId>remoting</artifactId>
-                  <version>3.13</version>
+                  <version>4.2</version>
                   <type>jar</type>
                   <outputDirectory>${project.build.outputDirectory}/old-remoting</outputDirectory>
                   <destFileName>remoting-unsupported.jar</destFileName>


### PR DESCRIPTION
When the minimum Remoting version was set to 3.14, that version was about two years old. Now, it is about 5 years old, which is quite a long time. Many new features and bugs have been fixed since then, so I think it makes sense to bump the minimum Remoting version again. Remoting 4.2.1 was released about 2 years ago and had no major regressions, so this seems as good a version as any to start requiring.

### Proposed changelog entries

Update the minimum required Remoting version to 4.2.1.

### Proposed upgrade guidelines

The minimum required Remoting version has been increased to 4.2.1. Ensure that all agents are running a recent version of Remoting prior to upgrading.

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6671"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

