### PR TITLE
JENKINS-68752 Ignore duplicate log recorder keys

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorderManager.java
+++ b/core/src/main/java/hudson/logging/LogRecorderManager.java
@@ -104,7 +104,11 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
         this.recorders = recorders;
 
         Map<String, LogRecorder> values = recorders.stream()
-                .collect(toMap(LogRecorder::getName, Function.identity()));
+                .collect(toMap(
+                        LogRecorder::getName,
+                        Function.identity(),
+                        // see JENKINS-68752, ignore duplicates
+                        (recorder1, recorder2) -> recorder1));
         ((CopyOnWriteMap<String, LogRecorder>) logRecorders).replaceBy(values);
     }
 

--- a/core/src/main/java/hudson/logging/LogRecorderManager.java
+++ b/core/src/main/java/hudson/logging/LogRecorderManager.java
@@ -78,6 +78,9 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  * @author Kohsuke Kawaguchi
  */
 public class LogRecorderManager extends AbstractModelObject implements ModelObjectWithChildren, StaplerProxy {
+
+    private static final Logger LOGGER = Logger.getLogger(LogRecorderManager.class.getName());
+
     /**
      * {@link LogRecorder}s keyed by their {@linkplain LogRecorder#getName()}  name}.
      *
@@ -108,7 +111,10 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
                         LogRecorder::getName,
                         Function.identity(),
                         // see JENKINS-68752, ignore duplicates
-                        (recorder1, recorder2) -> recorder1));
+                        (recorder1, recorder2) -> {
+                            LOGGER.warning(String.format("Ignoring duplicate log recorder '%s', check $JENKINS_HOME/log and remove the duplicate recorder", recorder2.getName()));
+                            return recorder1;
+                        }));
         ((CopyOnWriteMap<String, LogRecorder>) logRecorders).replaceBy(values);
     }
 


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-68752](https://issues.jenkins.io/browse/JENKINS-68752).

not sure how this could happen short of copying files around on the file system.
I reproduced by duplicating a file which can duplicate the crash but the duplicate won't get updated by the web ui anyway.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Ignore duplicate log recorders keyed by same name

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6673"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

