### PR TITLE
chore: Fill in since annotation for past releases

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -599,7 +599,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      * Replacement for {@link StaplerRequest#bindJSON(Class, JSONObject)} which honors {@link #newInstance(StaplerRequest, JSONObject)}.
      * This is automatically used inside {@link #newInstance(StaplerRequest, JSONObject)} so a direct call would only be necessary
      * in case the top level binding might use a {@link Descriptor} which overrides {@link #newInstance(StaplerRequest, JSONObject)}.
-     * @since TODO
+     * @since 2.342
      */
     public static <T> T bindJSON(StaplerRequest req, Class<T> type, JSONObject src) {
         return bindJSON(req, type, src, false);

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -530,7 +530,7 @@ public class UpdateSite {
      * Is this the legacy default update center site?
      * @deprecated
      *      Will be removed, currently returns always false.
-     * @since TODO
+     * @since 2.343
      */
     @Deprecated
     @Restricted(NoExternalUse.class)


### PR DESCRIPTION
```
 ➜  jenkins git:(chore/master/fill-in-since) ./update-since-todo.py 
Analyzing core/src/main/java/hudson/model/Descriptor.java:602
        first sha: 8f6e04bcb51081627c11df2a105bcb049a1c8339
        first tag was jenkins-2.342
        Updating file in place
Analyzing core/src/main/java/hudson/model/UpdateSite.java:533
        first sha: b5023f6bc7b3be31fdff34b539b51434778fc6a6
        first tag was jenkins-2.343
        Updating file in place

List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.342
  - https://github.com/jenkinsci/jenkins/commit/8f6e04bcb51081627c11df2a105bcb049a1c8339
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.343
  - https://github.com/jenkinsci/jenkins/commit/b5023f6bc7b3be31fdff34b539b51434778fc6a6
```

### Proposed changelog entries

* N/A, skip changelog

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6682"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

