### PR TITLE
[JENKINS-68808] Exclude SVG optimisation from CSS minification

### DIFF
--- a/war/webpack.config.js
+++ b/war/webpack.config.js
@@ -153,7 +153,16 @@ module.exports = (env, argv) => ({
        }
     },
     minimizer: [
-      new CssMinimizerPlugin(),
+      new CssMinimizerPlugin({
+        minimizerOptions: {
+          preset: [
+            "default",
+            {
+              svgo: {"exclude": true},
+            },
+          ],
+        },
+      }),
     ],
   },
   resolve: {


### PR DESCRIPTION
See [JENKINS-68808](https://issues.jenkins.io/browse/JENKINS-68808).

**What caused the bug?**
Essentially the package we use to minify our CSS minifies SVGs too, this was causing issues as (I believe) it was optimising (shrinking) the boundaries of our inline SVGs in CSS. This isn't a negative thing, however it causes issues like this bug where sizes are set for the original boundaries, not the minified ones.

**What's the solution?**
There's two potential solutions for this - 

1. Correct the size of the SVG for the help button - this is easy to do and works, however this issue could crop up in other areas on Jenkins (as well as cause future issues) where there's a difference in outputted CSS between `dev` and `prod` builds. This led me to my preferred option...
2. Disable the minification of SVGs - this prevents this happening again in the future at the cost of inline SVGs not being optimised (not a major issue)

### Proposed changelog entries

* Fix help icon size (if necessary as the weekly hasn't released yet)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@basil @jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6690"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

