### PR TITLE
Ignore `hudson.model.QueueRestartTest`

### DIFF
--- a/test/src/test/java/hudson/model/QueueRestartTest.java
+++ b/test/src/test/java/hudson/model/QueueRestartTest.java
@@ -29,8 +29,10 @@ import static org.junit.Assert.assertFalse;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -39,6 +41,8 @@ public class QueueRestartTest {
 
     @Rule public RealJenkinsRule rr = new RealJenkinsRule();
 
+    @Ignore("Pending JENKINS-68319 sometimes fails, in CI & locally")
+    @Issue("JENKINS-68319")
     @LocalData("quietDown")
     @Test
     public void persistQueueOnRestart() throws Throwable {
@@ -49,6 +53,8 @@ public class QueueRestartTest {
         rr.then(QueueRestartTest::assertBuildFinishes);
     }
 
+    @Ignore("Pending JENKINS-68319 sometimes fails, in CI & locally")
+    @Issue("JENKINS-68319")
     @LocalData("quietDown")
     @Test
     public void persistQueueOnConsecutiveRestarts() throws Throwable {


### PR DESCRIPTION
I added these tests in #6453, and after debugging the tests I believe the tests are correct and that the race condition is in the code under test (i.e., Jenkins core). This is tracked in [JENKINS-68319](https://issues.jenkins.io/browse/JENKINS-68319). I managed to reproduce the problem locally once or twice, but then after that I failed to reproduce it locally after dozens of tries. Our CI builds appear to be doing a good job of hitting it:

- https://ci.jenkins.io/job/Core/job/jenkins/job/master/3733/
- https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6678/10/
- https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6678/7/
- https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6684/3/
- https://ci.jenkins.io/job/Core/job/jenkins/job/PR-6691/4/

Hitting this in PR builds doesn't tell us anything that we don't already know (i.e., the problem exists) and it doesn't help us debug the problem, but it does slow down the integration of new PRs. Therefore, I think it is in our best short-term interests to ignore these tests. I also think it is only a matter of time before the underlying bug causes further issues, so I think it is in our best long-term interests for a someone (especially an existing or aspiring member of the core team) to debug and resolve the underlying issue.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since="TODO")` or `@Deprecated(since="TODO", forRemoval=true)` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6705"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

