### PR TITLE
Use standard `doclint`

### DIFF
--- a/core/src/main/java/hudson/util/ClassLoaderSanityThreadFactory.java
+++ b/core/src/main/java/hudson/util/ClassLoaderSanityThreadFactory.java
@@ -4,9 +4,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 /**
- *  Explicitly sets the {@link Thread#contextClassLoader} for threads it creates to its own classloader.
+ *  Explicitly sets the {@link Thread#setContextClassLoader} for threads it creates to its own classloader.
  *  This avoids issues where threads are lazily created (ex by invoking {@link java.util.concurrent.ScheduledExecutorService#schedule(Runnable, long, TimeUnit)})
- *   in a context where they would receive a customized {@link Thread#contextClassLoader} that was never meant to be used.
+ *   in a context where they would receive a customized {@link Thread#getContextClassLoader} that was never meant to be used.
  *
  *  Commonly this is a problem for Groovy use, where this may result in memory leaks.
  *  @see <a href="https://issues.jenkins.io/browse/JENKINS-49206">JENKINS-49206</a>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.77</version>
+    <version>1.78</version>
     <relativePath />
   </parent>
 
@@ -212,7 +212,6 @@ THE SOFTWARE.
           <!-- Version specified in parent POM -->
           <configuration>
             <quiet>true</quiet>
-            <doclint>all,-missing,-reference</doclint>
             <splitindex>true</splitindex>
           </configuration>
         </plugin>


### PR DESCRIPTION
Picking up https://github.com/jenkinsci/pom/pull/270. (actually in #6712)

As of #6366 we were also excluding

> `reference`: Checks for issues relating to the references to Java API elements from Javadoc tags (for example, item not found in `@see`, or a bad name after `@param`).

which seems wrong. Such issues are source code bugs which should be corrected.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6710"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

