### PR TITLE
[JENKINS-68848] Fix date format used to parse boot attempt timestamps

### DIFF
--- a/core/src/main/java/hudson/util/BootFailure.java
+++ b/core/src/main/java/hudson/util/BootFailure.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
-import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -64,7 +64,8 @@ public abstract class BootFailure extends ErrorObject {
                 if (f.exists()) {
                     try (BufferedReader failureFileReader = Files.newBufferedReader(f.toPath(), Charset.defaultCharset())) {
                         String line;
-                        DateFormat df = DateFormat.getDateInstance();
+                        // WebAppMain.recordBootAttempt uses Date.toString when writing, so that is the format we must parse.
+                        SimpleDateFormat df = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
                         while ((line = failureFileReader.readLine()) != null) {
                             try {
                                 dates.add(df.parse(line));

--- a/test/src/test/java/hudson/util/BootFailureTest.java
+++ b/test/src/test/java/hudson/util/BootFailureTest.java
@@ -150,7 +150,7 @@ public class BootFailureTest {
     }
 
     private static int bootFailures(File home) throws IOException {
-        return FileUtils.readLines(BootFailure.getBootFailureFile(home), StandardCharsets.UTF_8).size();
+        return new BootFailure() { }.loadAttempts(home).size();
     }
 
     @Issue("JENKINS-24696")


### PR DESCRIPTION
See [JENKINS-68848](https://issues.jenkins.io/browse/JENKINS-68848) and https://github.com/jenkinsci/jenkins/pull/5668.

This PR switches from `DateFormat.getDateInstance()` to a `SimpleDateFormat` using the format mentioned in the source code for `Date.toString`.  It also updates the tests to use `BootFailure.loadAttempts` to catch future regressions.

### Proposed changelog entries

* Make previous boot attempt timestamps available to `boot-failure.groovy` startup hooks (regression in 2.308).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since="TODO")` or `@Deprecated(since="TODO", forRemoval=true)` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6714"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

