### PR TITLE
Backporting for LTS 2.346.2

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2345,30 +2345,32 @@ public class Functions {
         StaplerRequest currentRequest = Stapler.getCurrentRequest();
         String rootURL = currentRequest.getContextPath();
         Icon iconMetadata = tryGetIcon(iconGuess);
-        String iconSource = null;
 
+        String iconSource;
         if (iconMetadata != null) {
-            iconSource = iconMetadata.getQualifiedUrl(context);
+            iconSource = IconSet.tryTranslateTangoIconToSymbol(iconMetadata.getClassSpec(), () -> iconMetadata.getQualifiedUrl(context));
+        } else {
+            iconSource = guessIcon(iconGuess, rootURL);
         }
+        return iconSource;
+    }
 
-        if (iconMetadata == null) {
-            //noinspection HttpUrlsUsage
-            if (iconGuess.startsWith("http://") || iconGuess.startsWith("https://")) {
-                return iconGuess;
-            }
+    static String guessIcon(String iconGuess, String rootURL) {
+        String iconSource;
+        //noinspection HttpUrlsUsage
+        if (iconGuess.startsWith("http://") || iconGuess.startsWith("https://")) {
+            iconSource = iconGuess;
+        } else {
             if (!iconGuess.startsWith("/")) {
                 iconGuess = "/" + iconGuess;
             }
+            if (iconGuess.startsWith(rootURL)) {
+                if ((!rootURL.equals("/images") && !rootURL.equals("/plugin")) || iconGuess.startsWith(rootURL + rootURL)) {
+                    iconGuess = iconGuess.substring(rootURL.length());
+                }
+            }
             iconSource = rootURL + (iconGuess.startsWith("/images/") || iconGuess.startsWith("/plugin/") ? getResourcePath() : "") + iconGuess;
         }
-
-        if (iconMetadata != null && iconMetadata.getClassSpec() != null) {
-            String translatedIcon = IconSet.tryTranslateTangoIconToSymbol(iconMetadata.getClassSpec());
-            if (translatedIcon != null) {
-                return translatedIcon;
-            }
-        }
-
         return iconSource;
     }
 

--- a/core/src/main/java/hudson/util/BootFailure.java
+++ b/core/src/main/java/hudson/util/BootFailure.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
-import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -64,7 +64,8 @@ public abstract class BootFailure extends ErrorObject {
                 if (f.exists()) {
                     try (BufferedReader failureFileReader = Files.newBufferedReader(f.toPath(), Charset.defaultCharset())) {
                         String line;
-                        DateFormat df = DateFormat.getDateInstance();
+                        // WebAppMain.recordBootAttempt uses Date.toString when writing, so that is the format we must parse.
+                        SimpleDateFormat df = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
                         while ((line = failureFileReader.readLine()) != null) {
                             try {
                                 dates.add(df.parse(line));

--- a/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
+++ b/core/src/main/java/jenkins/slaves/DefaultJnlpSlaveReceiver.java
@@ -149,14 +149,14 @@ public class DefaultJnlpSlaveReceiver extends JnlpAgentReceiver {
     }
 
     @Override
+    @SuppressFBWarnings(value = "OS_OPEN_STREAM", justification = "Closed by hudson.slaves.SlaveComputer#kill")
     public void beforeChannel(@NonNull JnlpConnectionState event) {
         DefaultJnlpSlaveReceiver.State state = event.getStash(DefaultJnlpSlaveReceiver.State.class);
         final SlaveComputer computer = state.getNode();
         final OutputStream log = computer.openLogFile();
         state.setLog(log);
-        try (PrintWriter logw = new PrintWriter(new OutputStreamWriter(log, /* TODO switch agent logs to UTF-8 */ Charset.defaultCharset()), true)) {
-            logw.println("Inbound agent connected from " + event.getRemoteEndpointDescription());
-        }
+        PrintWriter logw = new PrintWriter(new OutputStreamWriter(log, /* TODO switch agent logs to UTF-8 */ Charset.defaultCharset()), true); // Closed by hudson.slaves.SlaveComputer#kill
+        logw.println("Inbound agent connected from " + event.getRemoteEndpointDescription());
         for (ChannelConfigurator cc : ChannelConfigurator.all()) {
             cc.onChannelBuilding(event.getChannelBuilder(), computer);
         }

--- a/core/src/main/java/org/jenkins/ui/icon/IconSet.java
+++ b/core/src/main/java/org/jenkins/ui/icon/IconSet.java
@@ -24,6 +24,8 @@
 
 package org.jenkins.ui.icon;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
 import hudson.PluginWrapper;
 import hudson.Util;
@@ -35,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.jelly.JellyContext;
@@ -558,16 +561,9 @@ public class IconSet {
         }
     }
 
-    /**
-     * This is a temporary function to replace Tango icons across Jenkins and plugins with
-     * appropriate Jenkins Symbols
-     *
-     * @param tangoIcon A tango icon in the format 'icon-* size-*', e.g. 'icon-gear icon-lg'
-     * @return a Jenkins Symbol (if one exists) otherwise null
-     */
-    @Restricted(NoExternalUse.class)
-    public static String tryTranslateTangoIconToSymbol(String tangoIcon) {
+    private static final Map<String, String> ICON_TO_SYMBOL_TRANSLATIONS;
 
+    static {
         Map<String, String> translations = new HashMap<>();
         translations.put("icon-application-certificate", "symbol-ribbon");
         translations.put("icon-document", "symbol-document-text");
@@ -591,9 +587,32 @@ public class IconSet {
         translations.put("icon-text", "symbol-details");
         translations.put("icon-up", "symbol-arrow-up");
         translations.put("icon-user", "symbol-people");
+        ICON_TO_SYMBOL_TRANSLATIONS = translations;
+    }
 
-        String cleanedTangoIcon = cleanName(tangoIcon);
-        return translations.getOrDefault(cleanedTangoIcon, null);
+    /**
+     * This is a temporary function to replace Tango icons across Jenkins and plugins with
+     * appropriate Jenkins Symbols
+     *
+     * @param tangoIcon A tango icon in the format 'icon-* size-*', e.g. 'icon-gear icon-lg'
+     * @return a Jenkins Symbol (if one exists) otherwise null
+     */
+    @Restricted(NoExternalUse.class)
+    public static String tryTranslateTangoIconToSymbol(@CheckForNull String tangoIcon) {
+        return tryTranslateTangoIconToSymbol(tangoIcon, () -> null);
+    }
+
+    /**
+     * This is a temporary function to replace Tango icons across Jenkins and plugins with
+     * appropriate Jenkins Symbols
+     *
+     * @param tangoIcon A tango icon in the format 'icon-* size-*', e.g. 'icon-gear icon-lg'
+     * @param defaultValueSupplier A supplier function that will be called if no icon translation is found
+     * @return a Jenkins Symbol (if one exists) otherwise the value returned by the supplier
+     */
+    @Restricted(NoExternalUse.class)
+    public static String tryTranslateTangoIconToSymbol(@CheckForNull String tangoIcon, @NonNull Supplier<String> defaultValueSupplier) {
+        return tangoIcon == null ? null : ICON_TO_SYMBOL_TRANSLATIONS.getOrDefault(cleanName(tangoIcon), defaultValueSupplier.get());
     }
 
     private static String cleanName(String tangoIcon) {

--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -2,7 +2,7 @@ function checkPluginsWithoutWarnings() {
     var inputs = document.getElementsByTagName('input');
     for(var i = 0; i < inputs.length; i++) {
         var candidate = inputs[i];
-        if(candidate.type === "checkbox") {
+        if(candidate.type === "checkbox" && !candidate.disabled) {
             candidate.checked = candidate.dataset.compatWarning === 'false';
         }
     }

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -639,4 +639,22 @@ public class FunctionsTest {
             return this;
         }
     }
+
+    @Test
+    public void guessIcon() throws Exception {
+        Jenkins.RESOURCE_PATH = "/static/12345678";
+        assertEquals("/jenkins/static/12345678/images/48x48/green.gif", Functions.guessIcon("jenkins/images/48x48/green.gif", "/jenkins"));
+        assertEquals("/jenkins/static/12345678/images/48x48/green.gif", Functions.guessIcon("/jenkins/images/48x48/green.gif", "/jenkins"));
+        assertEquals("/static/12345678/images/48x48/green.gif", Functions.guessIcon("images/48x48/green.gif", ""));
+        assertEquals("/jenkins/static/12345678/images/48x48/green.gif", Functions.guessIcon("images/48x48/green.gif", "/jenkins"));
+        assertEquals("/jenkins/static/12345678/images/48x48/green.gif", Functions.guessIcon("/images/48x48/green.gif", "/jenkins"));
+        assertEquals("/images/static/12345678/images/48x48/green.gif", Functions.guessIcon("/images/48x48/green.gif", "/images"));
+        assertEquals("/static/12345678/plugin/myartifactId/images/48x48/green.gif", Functions.guessIcon("/plugin/myartifactId/images/48x48/green.gif", ""));
+        assertEquals("/jenkins/static/12345678/plugin/myartifactId/images/48x48/green.gif", Functions.guessIcon("/plugin/myartifactId/images/48x48/green.gif", "/jenkins"));
+        assertEquals("/jenkins/static/12345678/plugin/myartifactId/images/48x48/green.gif", Functions.guessIcon("/jenkins/plugin/myartifactId/images/48x48/green.gif", "/jenkins"));
+        assertEquals("/plugin/static/12345678/plugin/myartifactId/images/48x48/green.gif", Functions.guessIcon("/plugin/myartifactId/images/48x48/green.gif", "/plugin"));
+        assertEquals("/plugin/static/12345678/plugin/myartifactId/images/48x48/green.gif", Functions.guessIcon("/plugin/plugin/myartifactId/images/48x48/green.gif", "/plugin"));
+        assertEquals("http://acme.com/icon.svg", Functions.guessIcon("http://acme.com/icon.svg", "/jenkins"));
+        assertEquals("https://acme.com/icon.svg", Functions.guessIcon("https://acme.com/icon.svg", "/jenkins"));
+    }
 }

--- a/test/src/test/java/hudson/util/BootFailureTest.java
+++ b/test/src/test/java/hudson/util/BootFailureTest.java
@@ -150,7 +150,7 @@ public class BootFailureTest {
     }
 
     private static int bootFailures(File home) throws IOException {
-        return FileUtils.readLines(BootFailure.getBootFailureFile(home), StandardCharsets.UTF_8).size();
+        return new BootFailure() { }.loadAttempts(home).size();
     }
 
     @Issue("JENKINS-24696")

--- a/war/src/main/less/form/radio.less
+++ b/war/src/main/less/form/radio.less
@@ -14,6 +14,7 @@
   &__input {
     position: absolute;
     opacity: 0;
+    margin-top: 10px;
 
     &:hover {
       & + label {
@@ -54,7 +55,9 @@
 
   &__label {
     position: relative;
+    top: -8px;
     display: inline-block;
+    margin-top: 10px;
     margin-bottom: 0;
     padding: 0 0 5px 32px;
     cursor: pointer;
@@ -88,7 +91,7 @@
 
   &__children {
     position: relative;
-    margin-top: 0;
+    margin-top: 10px;
     opacity: 0;
     padding-left: 32px;
     transition: var(--standard-transition);
@@ -116,7 +119,6 @@
 
   &__input:checked + &__label + &__children {
     visibility: visible;
-    margin-top: 10px;
     opacity: 1;
     max-height: none;
   }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2247,7 +2247,7 @@ function buildFormTree(form) {
 var toggleCheckboxes = function(toggle) {
     var inputs = document.getElementsByTagName("input");
     for(var i=0; i<inputs.length; i++) {
-        if(inputs[i].type === "checkbox") {
+        if(inputs[i].type === "checkbox" && !inputs[i].disabled) {
             inputs[i].checked = toggle;
         }
     }


### PR DESCRIPTION
```
Latest core version: jenkins-2.357

Fixed
-----

JENKINS-68752           Major                   2.357
        Jenkins version upgrade fails from 2.289.3 to 2.332.3 LTS
        https://issues.jenkins.io/browse/JENKINS-68752

JENKINS-68639           Minor                   2.357
        Malformed URLs for status icons images
        regression
        https://issues.jenkins.io/browse/JENKINS-68639

JENKINS-68785           Minor                   2.357
        No log messages for inbound agents after the first message (regression in 2.310)
        regression
        https://issues.jenkins.io/browse/JENKINS-68785

JENKINS-68730           Minor                   2.357
        Plugin manager selection mode unselects updated plugins
        https://issues.jenkins.io/browse/JENKINS-68730

JENKINS-68799           Minor                   2.357
        [Regression] Radio buttons have strange offset
        regression
        https://issues.jenkins.io/browse/JENKINS-68799

JENKINS-68848           Minor                   2.358
        BootFailure.loadAttempts always returns an empty list since Jenkins 2.308
        regression
        https://issues.jenkins.io/browse/JENKINS-68848
```