### PR TITLE
Javadoc links between `Run` constructors and `LazyBuildMixIn`

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -319,6 +319,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     /**
      * Creates a new {@link Run}.
      * @param job Owner job
+     * @see LazyBuildMixIn#newBuild
      */
     protected Run(@NonNull JobT job) throws IOException {
         this(job, System.currentTimeMillis());
@@ -347,6 +348,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Loads a run from a log file.
+     * @see LazyBuildMixIn#loadBuild
      */
     protected Run(@NonNull JobT project, @NonNull File buildDir) throws IOException {
         this.project = project;

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -160,7 +160,8 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
 
     /**
      * Loads an existing build record from disk.
-     * The default implementation just calls the ({@link Job}, {@link File}) constructor of {@link #getBuildClass}.
+     * The default implementation just calls the ({@link Job}, {@link File}) constructor of {@link #getBuildClass},
+     * which will call {@link Run#Run(Job, File)}.
      */
     public RunT loadBuild(File dir) throws IOException {
         try {
@@ -174,7 +175,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
 
     /**
      * Creates a new build of this project for immediate execution.
-     * Calls the ({@link Job}) constructor of {@link #getBuildClass}.
+     * Calls the ({@link Job}) constructor of {@link #getBuildClass}, which will call {@link Run#Run(Job)}.
      * Suitable for {@link SubTask#createExecutable}.
      */
     public final synchronized RunT newBuild() throws IOException {


### PR DESCRIPTION
Since `LazyBuildMixIn` calls `Run` constructors using reflection, it is hard to figure out the control flow from an IDE. Javadoc links may help.

It would be better design to have a factory method which takes a `Job` instance and a couple of lambdas (instead of the `getBuildClass()`) which you could implement as method handles. This would work fine for `WorkflowJob`, something like:

```java
private LazyBuildMixIn<WorkflowJob, WorkflowRun> createBuildMixIn() {
    LazyBuildMixIn.of(this, WorkflowRun::new, WorkflowRun::new);
}
```

but https://github.com/jenkinsci/jenkins/blob/6d179998e18adfbaa4e443c7e837135bf36c53d7/core/src/main/java/hudson/model/AbstractProject.java#L270-L281 could not work that way without changes in all `AbstractProject` subtypes.

### Proposed changelog entries

* N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6736"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

