### PR TITLE
Deprecating `Functions.singletonList`

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1936,6 +1936,13 @@ public class Functions {
         return url.endsWith(href);
     }
 
+    /**
+     * @deprecated From JEXL expressions ({@code ${…}}) in {@code *.jelly} files
+     *             you can use {@code [obj]} syntax to construct an {@link Object[]}
+     *             (which may be usable where a {@link List} is expected)
+     *             rather than {@code h.singletonList(obj)}.
+     */
+    @Deprecated
     public <T> List<T> singletonList(T t) {
         return List.of(t);
     }

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1938,7 +1938,7 @@ public class Functions {
 
     /**
      * @deprecated From JEXL expressions ({@code ${…}}) in {@code *.jelly} files
-     *             you can use {@code [obj]} syntax to construct an {@link Object[]}
+     *             you can use {@code [obj]} syntax to construct an {@code Object[]}
      *             (which may be usable where a {@link List} is expected)
      *             rather than {@code h.singletonList(obj)}.
      */

--- a/core/src/main/resources/hudson/model/Computer/ajaxExecutors.jelly
+++ b/core/src/main/resources/hudson/model/Computer/ajaxExecutors.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:ajax>
-    <t:executors computers="${h.singletonList(it)}" />
+    <t:executors computers="${[it]}"/>
   </l:ajax>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
@@ -46,6 +46,6 @@ THE SOFTWARE.
      <j:forEach var="box" items="${it.computerPanelBoxs}">
         <st:include it="${box}" page="box.jelly" />
     </j:forEach>
-    <t:executors computers="${h.singletonList(it)}" />
+    <t:executors computers="${[it]}"/>
   </l:side-panel>
 </j:jelly>


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/6732#discussion_r912016395.

### Proposed changelog entries

* Deprecating `Functions.singletonList` which is not normally needed in JEXL.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6740"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

