### PR TITLE
[JENKINS-68887] `CssSyntaxError` when linting `war` module on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,7 +15,8 @@
 *.json          text
 *.jelly         text
 *.jellytag      text
-*.less          text
+# JENKINS-68887: postcss-less fails to properly parse .less files with Windows line breaks
+*.less          text eol=lf
 *.properties    text
 *.rb            text
 *.sh            text

--- a/war/.stylelintrc.js
+++ b/war/.stylelintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   extends: "stylelint-config-standard",
   rules: {
-    indentation: null
+    indentation: null,
+    linebreaks: "unix"
   },
   // Keeps the default level to warn to avoid breaking the current
   // CI build environment


### PR DESCRIPTION
### Steps to reproduce

Check out the repository on Windows, then run `mvn clean verify`.

### Expected results

**Note:** These are the _actual_ results when running on macOS or Linux.

The linter for the `war` module passes.

### Actual results

The linter for the `war` module fails after printing `327:3 Unknown word CssSyntaxError`.

### Evaluation

The stack trace is as follows:

```
CssSyntaxError: jenkinsci/jenkins/war/src/main/less/abstracts/theme.less:327:3: Unknown word
    at Input.error (jenkinsci/jenkins/war/node_modules/postcss-less/node_modules/postcss/lib/input.js:130:16)
    at LessParser.unknownWord (jenkinsci/jenkins/war/node_modules/postcss-less/node_modules/postcss/lib/parser.js:563:22)
    at LessParser.unknownWord (jenkinsci/jenkins/war/node_modules/postcss-less/lib/LessParser.js:209:11)
    at LessParser.other (jenkinsci/jenkins/war/node_modules/postcss-less/node_modules/postcss/lib/parser.js:168:12)
    at LessParser.other (jenkinsci/jenkins/war/node_modules/postcss-less/lib/LessParser.js:158:13)
    at LessParser.parse (jenkinsci/jenkins/war/node_modules/postcss-less/node_modules/postcss/lib/parser.js:77:16)
    at parse (jenkinsci/jenkins/war/node_modules/postcss-less/lib/index.js:11:12)
    at new LazyResult (jenkinsci/jenkins/war/node_modules/stylelint/node_modules/postcss/lib/lazy-result.js:60:16)
    at jenkinsci/jenkins/war/node_modules/stylelint/lib/getPostcssResult.js:110:19
    at async Promise.all (index 5)
```

Uncommenting https://github.com/shellscape/postcss-less/blob/984f4901aced4b74535d96b04242681d538d628b/lib/LessParser.js#L192= to examine the unknown structure, I see this on Windows:

```
unknown [
  [ 'word', 'each', 327, 3, 327, 6 ],
  [
    'brackets',
    '(@semantics, {\r\n    --@{key}-color: @value;\r\n  })',
    327,
    7,
    327,
    55
  ],
  [ 'space', '\r\n' ]
]
```

On Linux, I see:

```
unknown [
  [ 'word', 'each', 327, 3, 327, 6 ],
  [ '(', '(', 327, 7 ],
  [ 'at-word', '@semantics,', 327, 8, 327, 18 ],
  [ 'space', ' ' ],
  [ '{', '{', 327, 20 ],
  [ 'space', '\n    ' ],
  [ 'word', '--', 328, 5, 328, 6 ],
  [ 'at-word', '@', 328, 7, 328, 7 ],
  [ '{', '{', 328, 8 ],
  [ 'word', 'key', 328, 9, 328, 11 ],
  [ '}', '}', 328, 12 ],
  [ 'word', '-color', 328, 13, 328, 18 ],
  [ ':', ':', 328, 19 ],
  [ 'space', ' ' ],
  [ 'at-word', '@value', 328, 21, 328, 26 ],
  [ ';', ';', 328, 27 ],
  [ 'space', '\n  ' ],
  [ '}', '}', 329, 3 ],
  [ ')', ')', 329, 4 ],
  [ 'space', '\n' ]
]
```

The logic a few lines down in `LessParser.js` to parse `@each` blocks is expecting the latter type of tokenization, not the former. Since the "brackets" part of the erroneous tokenization had Windows line breaks in it, I theorized that might be the problem. Sure enough, converting the file to Unix line breaks resulted in a passing run.

### Solution

While it is arguably a bug in `postcss-less` that it cannot produce a proper parse tree in this scenario, I lack the motivation to whip up a minimal reproducible example (MRE) and submit an upstream bug report. To get our builds stable again on Windows, I am updating the `.gitattributes` file to check out `.less` files with Unix line breaks rather than automatically converting them to Windows line breaks.

### Bonus

Added `linebreaks: "unix"` to `.stylelintrc.js` to enforce Unix linebreaks and ensure no regressions are introduced in the future.

### Testing done

* Ran `mvn clean verify` on Linux and Windows before and after this PR. Before this PR, the linter for the `war` module passed on Linux and failed on Windows with the `Unknown word CssSyntaxError`. After this PR, the linter for the `war` module passed on both Linux and Windows.
* Intentionally introduced a Windows linebreak and verified that the linter failed as expected with "Expected linebreak to be unix".

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6744"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

