### PR TITLE
Use `ProcessHandle.current().pid()` in more places

### DIFF
--- a/core/src/main/java/jenkins/slaves/restarter/UnixSlaveRestarter.java
+++ b/core/src/main/java/jenkins/slaves/restarter/UnixSlaveRestarter.java
@@ -67,7 +67,7 @@ public class UnixSlaveRestarter extends SlaveRestarter {
      * Gets the current executable name.
      */
     private static String getCurrentExecutable() {
-        int pid = LIBC.getpid();
+        long pid = ProcessHandle.current().pid();
         String name = "/proc/" + pid + "/exe";
         File exe = new File(name);
         if (exe.exists()) {


### PR DESCRIPTION
Utilizes new Java 11 functionality by calling `ProcessHandle.current.pid()` in more places rather than less reliable alternatives like JNA or `RuntimeMXBean`. To test this I ran `PingThreadTest` locally successfully. The change to `UnixSlaveRestarter` is pretty benign and I don't anticipate any problems there. I intentionally did not tackle `jenkins.util.JavaVMArguments` in this PR because it is a little more complex and would need more significant testing than I have time for right now.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6746"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

