### PR TITLE
`ZipFile.name` trick did not work, using fallback: `java.lang.NullPointerException`

### DIFF
--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -424,7 +424,7 @@ public class Main {
         // There is no portable way to find where the locally cached copy
         // of jenkins.war/jar is; JDK 6 is too smart. (See JENKINS-2326.)
         try {
-            URL classFile = Main.class.getClassLoader().getResource("Main.class");
+            URL classFile = Main.class.getClassLoader().getResource("executable/Main.class");
             JarFile jf = ((JarURLConnection) classFile.openConnection()).getJarFile();
             return new File(jf.getName());
         } catch (Exception x) {


### PR DESCRIPTION
Fixes a minor (unreleased) regression from #6706: `java -jar jenkins.war` had started printing:

>`ZipFile.name` trick did not work, using fallback: `java.lang.NullPointerException`

### Proposed changelog entries

N/A (unreleased regression, this should make it into 2.358)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6757"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

