### PR TITLE
`git status` no longer clean after building in IntelliJ

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8">
+    <file url="file://$PROJECT_DIR$/bom/src/filter/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/bom/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/bom/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/cli/src/filter/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/cli/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/cli/src/main/resources" charset="UTF-8" />
@@ -11,8 +14,18 @@
     <file url="file://$PROJECT_DIR$/core/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/core/src/test/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/core/src/test/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/coverage/src/filter/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/coverage/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/coverage/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/filter/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/test/src/filter/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/test/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/test/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/test/src/test/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/test/src/test/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/war/src/filter/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/war/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/war/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/war/src/test/java" charset="UTF-8" />


### PR DESCRIPTION
Amends https://github.com/jenkinsci/jenkins/pull/6719#issuecomment-1172677526.

### Steps to reproduce

Run `git clean -fxd`, then `mvn clean verify -DskipTests` to compile Jenkins. Then, import the project into IntelliJ IDEA 2022.2 EAP (222.3048.13), having first deleted any existing imported projects if present. Go to **Project Structure** and set the SDK to Java 11, then click **Load Maven Project** when prompted. Wait for the project to be indexed, then go to **Build > Build Project**. Finally, run `git status`.

### Expected results

`git status` is clean.

### Actual results

After building the project, IntelliJ inserts some additional entries into `.idea/encodings.xml`, making `git status` dirty.

### Solution

I just checked in whatever IntelliJ had done to the file. Since that, I have been able to run through the steps to reproduce without any issue.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6763"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

