### PR TITLE
Use diamond operator where possible

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -613,7 +613,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
             synchronized (this) {
               localTransitiveDependencies = transitiveDependencies;
               if (localTransitiveDependencies == null) {
-                CyclicGraphDetector<PluginWrapper> cgd = new CyclicGraphDetector<PluginWrapper>() {
+                CyclicGraphDetector<PluginWrapper> cgd = new CyclicGraphDetector<>() {
                     @Override
                     protected List<PluginWrapper> getEdges(PluginWrapper pw) {
                         List<PluginWrapper> dep = new ArrayList<>();

--- a/core/src/main/java/hudson/DescriptorExtensionList.java
+++ b/core/src/main/java/hudson/DescriptorExtensionList.java
@@ -251,7 +251,7 @@ public class DescriptorExtensionList<T extends Describable<T>, D extends Descrip
      * List up all the legacy instances currently in use.
      */
     public static Iterable<Descriptor> listLegacyInstances() {
-        return new Iterable<Descriptor>() {
+        return new Iterable<>() {
             @Override
             public Iterator<Descriptor> iterator() {
                 return new AdaptedIterator<ExtensionComponent<Descriptor>, Descriptor>(

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -169,7 +169,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
     @Override
     public @NonNull Iterator<T> iterator() {
         // we need to intercept mutation, so for now don't allow Iterator.remove
-        return new AdaptedIterator<ExtensionComponent<T>, T>(Iterators.readOnly(ensureLoaded().iterator())) {
+        return new AdaptedIterator<>(Iterators.readOnly(ensureLoaded().iterator())) {
             @Override
             protected T adapt(ExtensionComponent<T> item) {
                 return item.getInstance();
@@ -198,7 +198,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
      * Gets the read-only view of this {@link ExtensionList} where components are reversed.
      */
     public List<T> reverseView() {
-        return new AbstractList<T>() {
+        return new AbstractList<>() {
             @Override
             public T get(int index) {
                 return ExtensionList.this.get(size() - index - 1);

--- a/core/src/main/java/hudson/ExtensionListView.java
+++ b/core/src/main/java/hudson/ExtensionListView.java
@@ -56,7 +56,7 @@ public class ExtensionListView {
      * Creates a plain {@link List} backed by the current {@link ExtensionList}.
      */
     public static <T> List<T> createList(final Class<T> type) {
-        return new AbstractList<T>() {
+        return new AbstractList<>() {
             private ExtensionList<T> storage() {
                 return Jenkins.get().getExtensionList(type);
             }
@@ -103,7 +103,7 @@ public class ExtensionListView {
      * Creates a seriously hacked up {@link CopyOnWriteList} that acts as a view to the current {@link ExtensionList}.
      */
     public static <T> CopyOnWriteList<T> createCopyOnWriteList(final Class<T> type) {
-        return new CopyOnWriteList<T>() {
+        return new CopyOnWriteList<>() {
             private ExtensionList<T> storage() {
                 return Jenkins.get().getExtensionList(type);
             }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -467,7 +467,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                                 @Override
                                 public void run(Reactor reactor) throws Exception {
                                     try {
-                                        CyclicGraphDetector<PluginWrapper> cgd = new CyclicGraphDetector<PluginWrapper>() {
+                                        CyclicGraphDetector<PluginWrapper> cgd = new CyclicGraphDetector<>() {
                                             @Override
                                             protected List<PluginWrapper> getEdges(PluginWrapper p) {
                                                 List<PluginWrapper> next = new ArrayList<>();

--- a/core/src/main/java/hudson/console/ConsoleAnnotationOutputStream.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotationOutputStream.java
@@ -113,7 +113,7 @@ public class ConsoleAnnotationOutputStream<T> extends LineTransformationOutputSt
                     if (a != null) {
                         if (annotators == null)
                             annotators = new ArrayList<>();
-                        annotators.add(new ConsoleAnnotator<T>() {
+                        annotators.add(new ConsoleAnnotator<>() {
                             @Override
                             public ConsoleAnnotator<T> annotate(T context, MarkupText text) {
                                 return a.annotate(context, text, charPos);

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -149,7 +149,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
     };
 
     @Extension
-    public static final RunListener<Run> runDeleteListener = new RunListener<Run>() {
+    public static final RunListener<Run> runDeleteListener = new RunListener<>() {
         @Override
         public void onDeleted(Run run) {
             remove(run, true);

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -574,7 +574,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
      * @since 1.519
      */
     public Map<Computer, List<LogRecord>> getSlaveLogRecords() {
-        Map<Computer, List<LogRecord>> result = new TreeMap<>(new Comparator<Computer>() {
+        Map<Computer, List<LogRecord>> result = new TreeMap<>(new Comparator<>() {
             final Collator COLL = Collator.getInstance();
 
             @Override

--- a/core/src/main/java/hudson/logging/LogRecorderManager.java
+++ b/core/src/main/java/hudson/logging/LogRecorderManager.java
@@ -247,7 +247,7 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
             entryType = level;
         }
 
-        RSS.forwardToRss("Jenkins:log (" + entryType + " entries)", "", logs, new FeedAdapter<LogRecord>() {
+        RSS.forwardToRss("Jenkins:log (" + entryType + " entries)", "", logs, new FeedAdapter<>() {
             @Override
             public String getEntryTitle(LogRecord entry) {
                 return entry.getMessage();

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -158,7 +158,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P, R>, R extends A
      */
     protected transient List<Environment> buildEnvironments;
 
-    private final transient LazyBuildMixIn.RunMixIn<P, R> runMixIn = new LazyBuildMixIn.RunMixIn<P, R>() {
+    private final transient LazyBuildMixIn.RunMixIn<P, R> runMixIn = new LazyBuildMixIn.RunMixIn<>() {
         @Override protected R asRun() {
             return _this();
         }
@@ -1194,11 +1194,11 @@ public abstract class AbstractBuild<P extends AbstractProject<P, R>, R extends A
     public Iterable<AbstractBuild<?, ?>> getDownstreamBuilds(final AbstractProject<?, ?> that) {
         final Iterable<Integer> nums = getDownstreamRelationship(that).listNumbers();
 
-        return new Iterable<AbstractBuild<?, ?>>() {
+        return new Iterable<>() {
             @Override
             public Iterator<AbstractBuild<?, ?>> iterator() {
                 return Iterators.removeNull(
-                    new AdaptedIterator<Integer, AbstractBuild<?, ?>>(nums) {
+                    new AdaptedIterator<>(nums) {
                         @Override
                         protected AbstractBuild<?, ?> adapt(Integer item) {
                             return that.getBuildByNumber(item);

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -268,7 +268,7 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
     }
 
     private LazyBuildMixIn<P, R> createBuildMixIn() {
-        return new LazyBuildMixIn<P, R>() {
+        return new LazyBuildMixIn<>() {
             @SuppressWarnings("unchecked") // untypable
             @Override protected P asJob() {
                 return (P) AbstractProject.this;

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -146,7 +146,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      * Gets all the agent names.
      */
     public List<String> get_slaveNames() {
-        return new AbstractList<String>() {
+        return new AbstractList<>() {
             final List<Node> nodes = Jenkins.get().getNodes();
 
             @Override

--- a/core/src/main/java/hudson/model/DependencyGraph.java
+++ b/core/src/main/java/hudson/model/DependencyGraph.java
@@ -103,7 +103,7 @@ public class DependencyGraph implements Comparator<AbstractProject> {
      * See https://en.wikipedia.org/wiki/Tarjan's_strongly_connected_components_algorithm
      */
     private void topologicalDagSort() {
-        DirectedGraph<AbstractProject> g = new DirectedGraph<AbstractProject>() {
+        DirectedGraph<AbstractProject> g = new DirectedGraph<>() {
             @Override
             protected Collection<AbstractProject> nodes() {
                 final Set<AbstractProject> nodes = new HashSet<>();
@@ -342,7 +342,7 @@ public class DependencyGraph implements Comparator<AbstractProject> {
         return Collections.unmodifiableMap(m);
     }
 
-    private static final Comparator<DependencyGroup> NAME_COMPARATOR = new Comparator<DependencyGroup>() {
+    private static final Comparator<DependencyGroup> NAME_COMPARATOR = new Comparator<>() {
         @Override
         public int compare(DependencyGroup lhs, DependencyGroup rhs) {
             int cmp = lhs.getUpstreamProject().getName().compareTo(rhs.getUpstreamProject().getName());

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -356,7 +356,7 @@ public class Executor extends Thread implements ModelObject {
             SubTask task;
             // transition from idle to building.
             // perform this state change as an atomic operation wrt other queue operations
-            task = Queue.withLock(new Callable<SubTask>() {
+            task = Queue.withLock(new Callable<>() {
                 @Override
                 public SubTask call() throws Exception {
                     if (!owner.isOnline()) {

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -362,10 +362,10 @@ public class Fingerprint implements ModelObject, Saveable {
          */
         public Iterable<Integer> listNumbers() {
             final List<Range> ranges = getRanges();
-            return new Iterable<Integer>() {
+            return new Iterable<>() {
                 @Override
                 public Iterator<Integer> iterator() {
-                    return new Iterators.FlattenIterator<Integer, Range>(ranges) {
+                    return new Iterators.FlattenIterator<>(ranges) {
                         @Override
                         protected Iterator<Integer> expand(Range range) {
                             return Iterators.sequence(range.start, range.end).iterator();
@@ -380,10 +380,10 @@ public class Fingerprint implements ModelObject, Saveable {
          */
         public Iterable<Integer> listNumbersReverse() {
             final List<Range> ranges = getRanges();
-            return new Iterable<Integer>() {
+            return new Iterable<>() {
                 @Override
                 public Iterator<Integer> iterator() {
-                    return new Iterators.FlattenIterator<Integer, Range>(Iterators.reverse(ranges)) {
+                    return new Iterators.FlattenIterator<>(Iterators.reverse(ranges)) {
                         @Override
                         protected Iterator<Integer> expand(Range range) {
                             return Iterators.reverseSequence(range.start, range.end).iterator();
@@ -1164,7 +1164,7 @@ public class Fingerprint implements ModelObject, Saveable {
             this.transientFacets = Collections.unmodifiableList(transientFacets);
         }
 
-        return new AbstractCollection<FingerprintFacet>() {
+        return new AbstractCollection<>() {
             @Override
             public Iterator<FingerprintFacet> iterator() {
                 return Iterators.sequence(facets.iterator(), transientFacets.iterator());
@@ -1208,7 +1208,7 @@ public class Fingerprint implements ModelObject, Saveable {
      */
     public @NonNull Collection<FingerprintFacet> getSortedFacets() {
         List<FingerprintFacet> r = new ArrayList<>(getFacets());
-        r.sort(new Comparator<FingerprintFacet>() {
+        r.sort(new Comparator<>() {
             @Override
             public int compare(FingerprintFacet o1, FingerprintFacet o2) {
                 long a = o1.getTimestamp();

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -624,7 +624,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         return new HistoryWidget<Job, RunT>(this, getBuilds(), HISTORY_ADAPTER);
     }
 
-    public static final HistoryWidget.Adapter<Run> HISTORY_ADAPTER = new Adapter<Run>() {
+    public static final HistoryWidget.Adapter<Run> HISTORY_ADAPTER = new Adapter<>() {
         @Override
         public int compare(Run record, String key) {
             try {
@@ -1121,7 +1121,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         RSS.forwardToRss(
                 getDisplayName() + scmDisplayName + " changes",
                 getUrl() + "changes",
-                entries, new FeedAdapter<FeedItem>() {
+                entries, new FeedAdapter<>() {
                     @Override
                     public String getEntryTitle(FeedItem item) {
                         return "#" + item.getBuild().number + ' ' + item.e.getMsg() + " (" + item.e.getAuthor() + ")";

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -185,7 +185,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
      * {@link LabelAtom}s.
      */
     public final boolean matches(final Collection<LabelAtom> labels) {
-        return matches(new VariableResolver<Boolean>() {
+        return matches(new VariableResolver<>() {
             @Override
             public Boolean resolve(String name) {
                 for (LabelAtom a : labels)
@@ -619,7 +619,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     /**
      * Collects all the atoms in the expression.
      */
-    private static final LabelVisitor<Void, Set<LabelAtom>> ATOM_COLLECTOR = new LabelVisitor<Void, Set<LabelAtom>>() {
+    private static final LabelVisitor<Void, Set<LabelAtom>> ATOM_COLLECTOR = new LabelVisitor<>() {
         @Override
         public Void onAtom(LabelAtom a, Set<LabelAtom> param) {
             param.add(a);

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -325,7 +325,7 @@ public class Queue extends ResourceController implements Saveable {
 
     private transient volatile QueueSorter sorter;
 
-    private final transient AtmostOneTaskExecutor<Void> maintainerThread = new AtmostOneTaskExecutor<>(new Callable<Void>() {
+    private final transient AtmostOneTaskExecutor<Void> maintainerThread = new AtmostOneTaskExecutor<>(new Callable<>() {
         @Override
         public Void call() throws Exception {
             maintain();

--- a/core/src/main/java/hudson/model/ResourceController.java
+++ b/core/src/main/java/hudson/model/ResourceController.java
@@ -54,10 +54,10 @@ public class ResourceController {
     /**
      * View of {@link #inProgress} that exposes its {@link ResourceList}.
      */
-    private final Collection<ResourceList> resourceView = new AbstractCollection<ResourceList>() {
+    private final Collection<ResourceList> resourceView = new AbstractCollection<>() {
         @Override
         public Iterator<ResourceList> iterator() {
-            return new AdaptedIterator<ResourceActivity, ResourceList>(inProgress.iterator()) {
+            return new AdaptedIterator<>(inProgress.iterator()) {
                 @Override
                 protected ResourceList adapt(ResourceActivity item) {
                     return item.getResourceList();
@@ -129,7 +129,7 @@ public class ResourceController {
      */
     public boolean canRun(final ResourceList resources) {
         try {
-            return _withLock(new Callable<Boolean>() {
+            return _withLock(new Callable<>() {
                 @Override
                 public Boolean call() {
                     return !inUse.isCollidingWith(resources);
@@ -150,7 +150,7 @@ public class ResourceController {
      */
     public Resource getMissingResource(final ResourceList resources) {
         try {
-            return _withLock(new Callable<Resource>() {
+            return _withLock(new Callable<>() {
                 @Override
                 public Resource call() {
                     return resources.getConflict(inUse);

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -2541,7 +2541,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     /**
      * Sort by date. Newer ones first.
      */
-    public static final Comparator<Run> ORDER_BY_DATE = new Comparator<Run>() {
+    public static final Comparator<Run> ORDER_BY_DATE = new Comparator<>() {
         @Override
         public int compare(@NonNull Run lhs, @NonNull Run rhs) {
             long lt = lhs.getTimeInMillis();

--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -101,7 +101,7 @@ public final class RunMap<R extends Run<?, R>> extends AbstractLazyLoadRunMap<R>
      */
     @Override
     public Iterator<R> iterator() {
-        return new Iterator<R>() {
+        return new Iterator<>() {
             R last = null;
             R next = newestBuild();
 

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -45,7 +45,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  */
 public class ResponseTimeMonitor extends NodeMonitor {
     @Extension
-    public static final AbstractNodeMonitorDescriptor<Data> DESCRIPTOR = new AbstractAsyncNodeMonitorDescriptor<Data>() {
+    public static final AbstractNodeMonitorDescriptor<Data> DESCRIPTOR = new AbstractAsyncNodeMonitorDescriptor<>() {
 
         @Override
         protected Callable<Data, IOException> createCallable(Computer c) {

--- a/core/src/main/java/hudson/scm/EmptyChangeLogSet.java
+++ b/core/src/main/java/hudson/scm/EmptyChangeLogSet.java
@@ -13,7 +13,7 @@ import java.util.Iterator;
  */
 final class EmptyChangeLogSet extends ChangeLogSet<ChangeLogSet.Entry> {
     /*package*/ EmptyChangeLogSet(Run<?, ?> build) {
-        super(build, new RepositoryBrowser<ChangeLogSet.Entry>() {
+        super(build, new RepositoryBrowser<>() {
             @Override public URL getChangeSetLink(ChangeLogSet.Entry changeSet) throws IOException {
                 return null;
             }

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -339,7 +339,7 @@ public class Search implements StaplerProxy {
          * (both end inclusive.)
          */
         public List<String> subSequence(final int start) {
-            return new AbstractList<String>() {
+            return new AbstractList<>() {
                 @Override
                 public String get(int index) {
                     StringBuilder buf = new StringBuilder();

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -278,7 +278,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
         List<Dependency> downstreamProjects = new ArrayList<>(
                 graph.getDownstreamDependencies(build.getProject()));
         // Sort topologically
-        downstreamProjects.sort(new Comparator<Dependency>() {
+        downstreamProjects.sort(new Comparator<>() {
             @Override
             public int compare(Dependency lhs, Dependency rhs) {
                 // Swapping lhs/rhs to get reverse sort:

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -248,7 +248,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      */
     private static VariableResolver<String> propertiesGeneratingResolver(final VariableResolver<String> original) {
 
-        return new VariableResolver<String>() {
+        return new VariableResolver<>() {
 
             @Override
             public String resolve(String name) {

--- a/core/src/main/java/hudson/util/ConsistentHash.java
+++ b/core/src/main/java/hudson/util/ConsistentHash.java
@@ -145,7 +145,7 @@ public class ConsistentHash<T> {
          */
         Iterator<T> list(int queryPoint) {
             final int start = index(queryPoint);
-            return new DuplicateFilterIterator<>(new Iterator<T>() {
+            return new DuplicateFilterIterator<>(new Iterator<>() {
                 int pos = 0;
 
                 @Override

--- a/core/src/main/java/hudson/util/CopyOnWriteList.java
+++ b/core/src/main/java/hudson/util/CopyOnWriteList.java
@@ -96,8 +96,9 @@ public class CopyOnWriteList<E> implements Iterable<E> {
     @Override
     public Iterator<E> iterator() {
         final Iterator<? extends E> itr = core.iterator();
-        return new Iterator<E>() {
+        return new Iterator<>() {
             private E last;
+
             @Override
             public boolean hasNext() {
                 return itr.hasNext();

--- a/core/src/main/java/hudson/util/Futures.java
+++ b/core/src/main/java/hudson/util/Futures.java
@@ -37,7 +37,7 @@ public class Futures {
      * Creates a {@link Future} instance that already has its value pre-computed.
      */
     public static <T> Future<T> precomputed(final T value) {
-        return new Future<T>() {
+        return new Future<>() {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 return false;

--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -177,7 +177,7 @@ public class Iterators {
     public static <T> Iterable<T> reverse(final List<T> lst) {
         return () -> {
             final ListIterator<T> itr = lst.listIterator(lst.size());
-            return new Iterator<T>() {
+            return new Iterator<>() {
                 @Override
                 public boolean hasNext() {
                     return itr.hasPrevious();
@@ -205,7 +205,7 @@ public class Iterators {
     public static <T> Iterable<T> wrap(final Iterable<T> base) {
         return () -> {
             final Iterator<T> itr = base.iterator();
-            return new Iterator<T>() {
+            return new Iterator<>() {
                 @Override
                 public boolean hasNext() {
                     return itr.hasNext();
@@ -236,7 +236,7 @@ public class Iterators {
         final int size = (end - start) / step;
         if (size < 0)  throw new IllegalArgumentException("List size is negative");
 
-        return new AbstractList<Integer>() {
+        return new AbstractList<>() {
             @Override
             public Integer get(int index) {
                 if (index < 0 || index >= size)
@@ -289,7 +289,7 @@ public class Iterators {
      */
     @SuppressWarnings("unchecked")
     public static <U, T extends U> Iterator<T> subType(Iterator<U> itr, final Class<T> type) {
-        return (Iterator) new FilterIterator<U>(itr) {
+        return (Iterator) new FilterIterator<>(itr) {
             @Override
             protected boolean filter(U u) {
                 return type.isInstance(u);
@@ -301,7 +301,7 @@ public class Iterators {
      * Creates a read-only mutator that disallows {@link Iterator#remove()}.
      */
     public static <T> Iterator<T> readOnly(final Iterator<T> itr) {
-        return new Iterator<T>() {
+        return new Iterator<>() {
             @Override
             public boolean hasNext() {
                 return itr.hasNext();
@@ -334,7 +334,7 @@ public class Iterators {
      */
     @SafeVarargs
     public static <T> Iterable<T> sequence(final Iterable<? extends T>... iterables) {
-        return () -> new FlattenIterator<T, Iterable<? extends T>>(ImmutableList.copyOf(iterables)) {
+        return () -> new FlattenIterator<>(ImmutableList.copyOf(iterables)) {
             @Override
             protected Iterator<T> expand(Iterable<? extends T> iterable) {
                 return Iterators.<T>cast(iterable).iterator();
@@ -346,8 +346,9 @@ public class Iterators {
      * Filters another iterator by eliminating duplicates.
      */
     public static <T> Iterator<T> removeDups(Iterator<T> iterator) {
-        return new FilterIterator<T>(iterator) {
+        return new FilterIterator<>(iterator) {
             final Set<T> found = new HashSet<>();
+
             @Override
             protected boolean filter(T t) {
                 return found.add(t);
@@ -374,7 +375,7 @@ public class Iterators {
      * @since 1.485
      */
     public static <T> Iterator<T> limit(final Iterator<? extends T> base, final CountingPredicate<? super T> filter) {
-        return new Iterator<T>() {
+        return new Iterator<>() {
             private T next;
             private boolean end;
             private int index = 0;

--- a/core/src/main/java/hudson/util/PackedMap.java
+++ b/core/src/main/java/hudson/util/PackedMap.java
@@ -76,11 +76,11 @@ public final class PackedMap<K, V> extends AbstractMap<K, V> {
         }
     }
 
-    private final Set<Entry<K, V>> entrySet = new AbstractSet<Entry<K, V>>() {
+    private final Set<Entry<K, V>> entrySet = new AbstractSet<>() {
         @NonNull
         @Override
         public Iterator<Entry<K, V>> iterator() {
-            return new Iterator<Entry<K, V>>() {
+            return new Iterator<>() {
                 int index = 0;
                 @Override
                 public boolean hasNext() {
@@ -92,7 +92,7 @@ public final class PackedMap<K, V> extends AbstractMap<K, V> {
                 public Entry<K, V> next() {
                     final K k = (K) kvpairs[index++];
                     final V v = (V) kvpairs[index++];
-                    return new Entry<K, V>() {
+                    return new Entry<>() {
                         @Override
                         public K getKey() {
                             return k;
@@ -149,7 +149,7 @@ public final class PackedMap<K, V> extends AbstractMap<K, V> {
     @Override
     @SuppressWarnings("unchecked")
     public Collection<V> values() {
-        return new AbstractList<V>() {
+        return new AbstractList<>() {
             @Override
             public V get(int index) {
                 return (V) kvpairs[index * 2];

--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -109,7 +109,7 @@ public class RingBufferLogHandler extends Handler {
      */
     public List<LogRecord> getView() {
         // Since Jenkins.logRecords is a field used as an API, we are forced to implement a dynamic list.
-        return new AbstractList<LogRecord>() {
+        return new AbstractList<>() {
             @Override
             public LogRecord get(int index) {
                 // flip the order

--- a/core/src/main/java/hudson/util/RunList.java
+++ b/core/src/main/java/hudson/util/RunList.java
@@ -105,7 +105,7 @@ public class RunList<R extends Run> extends AbstractList<R> {
     }
 
     private static <R extends Run> Iterable<R> combine(Iterable<Iterable<R>> runLists) {
-        return Iterables.mergeSorted(runLists, new Comparator<R>() {
+        return Iterables.mergeSorted(runLists, new Comparator<>() {
             @Override
             public int compare(R o1, R o2) {
                 long lhs = o1.getTimeInMillis();
@@ -264,7 +264,7 @@ public class RunList<R extends Run> extends AbstractList<R> {
         size = null;
         first = null;
         final Iterable<R> nested = base;
-        base = new Iterable<R>() {
+        base = new Iterable<>() {
             @Override
             public Iterator<R> iterator() {
                 return hudson.util.Iterators.limit(nested.iterator(), predicate);
@@ -286,7 +286,7 @@ public class RunList<R extends Run> extends AbstractList<R> {
      * @since 1.507
      */
     public RunList<R> limit(final int n) {
-        return limit(new CountingPredicate<R>() {
+        return limit(new CountingPredicate<>() {
             @Override
             public boolean apply(int index, R input) {
                 return index < n;
@@ -344,7 +344,7 @@ public class RunList<R extends Run> extends AbstractList<R> {
      */
     public RunList<R> byTimestamp(final long start, final long end) {
         return
-        limit(new CountingPredicate<R>() {
+        limit(new CountingPredicate<>() {
             @Override
             public boolean apply(int index, R r) {
                 return start <= r.getTimeInMillis();
@@ -366,7 +366,7 @@ public class RunList<R extends Run> extends AbstractList<R> {
         // can't publish on-going builds
         return filter((Predicate<R>) r -> !r.isBuilding())
         // put at least 10 builds, but otherwise ignore old builds
-        .limit(new CountingPredicate<R>() {
+        .limit(new CountingPredicate<>() {
             @Override
             public boolean apply(int index, R r) {
                 return index < 10 || r.getTimeInMillis() >= t;

--- a/core/src/main/java/hudson/util/jna/Options.java
+++ b/core/src/main/java/hudson/util/jna/Options.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 @SuppressFBWarnings(value = "MS_OOI_PKGPROTECT", justification = "for backward compatibility")
 public interface Options {
-  Map<String, Object> UNICODE_OPTIONS = new HashMap<String, Object>() {
+  Map<String, Object> UNICODE_OPTIONS = new HashMap<>() {
     {
       put(OPTION_TYPE_MAPPER, W32APITypeMapper.UNICODE);
       put(OPTION_FUNCTION_MAPPER, W32APIFunctionMapper.UNICODE);

--- a/core/src/main/java/jenkins/PluginSubtypeMarker.java
+++ b/core/src/main/java/jenkins/PluginSubtypeMarker.java
@@ -59,7 +59,7 @@ public class PluginSubtypeMarker extends AbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         try {
-            ElementScanner9<Void, Void> scanner = new ElementScanner9<Void, Void>() {
+            ElementScanner9<Void, Void> scanner = new ElementScanner9<>() {
                 @Override
                 public Void visitType(TypeElement e, Void aVoid) {
                     if (!e.getModifiers().contains(Modifier.ABSTRACT)) {

--- a/core/src/main/java/jenkins/model/DefaultUserCanonicalIdResolver.java
+++ b/core/src/main/java/jenkins/model/DefaultUserCanonicalIdResolver.java
@@ -59,7 +59,7 @@ public class DefaultUserCanonicalIdResolver extends User.CanonicalIdResolver {
         return DESCRIPTOR;
     }
 
-    public static final Descriptor<User.CanonicalIdResolver> DESCRIPTOR = new Descriptor<User.CanonicalIdResolver>() {
+    public static final Descriptor<User.CanonicalIdResolver> DESCRIPTOR = new Descriptor<>() {
         @NonNull
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -200,7 +200,7 @@ public class Nodes implements Saveable {
     public boolean updateNode(final @NonNull Node node) throws IOException {
         boolean exists;
         try {
-            exists = Queue.withLock(new Callable<Boolean>() {
+            exists = Queue.withLock(new Callable<>() {
                 @Override
                 public Boolean call() throws Exception {
                     if (node == nodes.get(node.getNodeName())) {

--- a/core/src/main/java/jenkins/model/TransientActionFactory.java
+++ b/core/src/main/java/jenkins/model/TransientActionFactory.java
@@ -105,11 +105,11 @@ public abstract class TransientActionFactory<T> implements ExtensionPoint {
 
     @SuppressWarnings("rawtypes")
     private static final LoadingCache<ExtensionList<TransientActionFactory>, LoadingCache<CacheKey, List<TransientActionFactory<?>>>> cache =
-        CacheBuilder.newBuilder().weakKeys().build(new CacheLoader<ExtensionList<TransientActionFactory>, LoadingCache<CacheKey, List<TransientActionFactory<?>>>>() {
+        CacheBuilder.newBuilder().weakKeys().build(new CacheLoader<>() {
         @Override
         public LoadingCache<CacheKey, List<TransientActionFactory<?>>> load(final ExtensionList<TransientActionFactory> allFactories) throws Exception {
             final LoadingCache<CacheKey, List<TransientActionFactory<?>>> perJenkinsCache =
-                CacheBuilder.newBuilder().build(new CacheLoader<CacheKey, List<TransientActionFactory<?>>>() {
+                CacheBuilder.newBuilder().build(new CacheLoader<>() {
                 @Override
                 public List<TransientActionFactory<?>> load(CacheKey key) throws Exception {
                     List<TransientActionFactory<?>> factories = new ArrayList<>();

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -114,7 +114,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
     public Set<Integer> keySet() {
         Set<Integer> ks = keySet;
         if (ks == null) {
-            ks = new AbstractSet<Integer>() {
+            ks = new AbstractSet<>() {
                 @Override
                 public Iterator<Integer> iterator() {
                     return new Iterator() {
@@ -192,10 +192,10 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
     public Collection<R> values() {
         Collection<R> vals = values;
         if (vals == null) {
-            vals = new AbstractCollection<R>() {
+            vals = new AbstractCollection<>() {
                 @Override
                 public Iterator<R> iterator() {
-                    return new Iterator<R>() {
+                    return new Iterator<>() {
                         private final Iterator<Entry<Integer, R>> it = entrySet().iterator();
 
                         @Override

--- a/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
@@ -182,7 +182,7 @@ class BuildReferenceMapAdapter<R> implements SortedMap<Integer, R> {
         public Iterator<R> iterator() {
             // silently drop null, as if we didn't have them in this collection in the first place
             // this shouldn't be indistinguishable from concurrent modifications to the collection
-            return Iterators.removeNull(new AdaptedIterator<BuildReference<R>, R>(core.iterator()) {
+            return Iterators.removeNull(new AdaptedIterator<>(core.iterator()) {
                 @Override
                 protected R adapt(BuildReference<R> ref) {
                     return unwrap(ref);
@@ -299,7 +299,7 @@ class BuildReferenceMapAdapter<R> implements SortedMap<Integer, R> {
 
         @Override
         public Iterator<Entry<Integer, R>> iterator() {
-            return Iterators.removeNull(new AdaptedIterator<Entry<Integer, BuildReference<R>>, Entry<Integer, R>>(core.iterator()) {
+            return Iterators.removeNull(new AdaptedIterator<>(core.iterator()) {
                 @Override
                 protected Entry<Integer, R> adapt(Entry<Integer, BuildReference<R>> e) {
                     return _unwrap(e);

--- a/core/src/main/java/jenkins/model/lazy/LazyLoadRunMapEntrySet.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyLoadRunMapEntrySet.java
@@ -61,7 +61,7 @@ class LazyLoadRunMapEntrySet<R> extends AbstractSet<Map.Entry<Integer, R>> {
 
     @Override
     public Iterator<Map.Entry<Integer, R>> iterator() {
-        return new Iterator<Map.Entry<Integer, R>>() {
+        return new Iterator<>() {
             R last = null;
             R next = owner.newestBuild();
 

--- a/core/src/main/java/jenkins/scm/RunWithSCM.java
+++ b/core/src/main/java/jenkins/scm/RunWithSCM.java
@@ -95,12 +95,12 @@ public interface RunWithSCM<JobT extends Job<JobT, RunT>,
             return calculateCulprits();
         }
 
-        return new AbstractSet<User>() {
+        return new AbstractSet<>() {
             private Set<String> culpritIds = Set.copyOf(getCulpritIds());
 
             @Override
             public Iterator<User> iterator() {
-                return new AdaptedIterator<String, User>(culpritIds.iterator()) {
+                return new AdaptedIterator<>(culpritIds.iterator()) {
                     @Override
                     protected User adapt(String id) {
                         // TODO: Probably it should not auto-create users

--- a/core/src/main/java/jenkins/security/ImpersonatingExecutorService.java
+++ b/core/src/main/java/jenkins/security/ImpersonatingExecutorService.java
@@ -75,7 +75,7 @@ public final class ImpersonatingExecutorService extends InterceptingExecutorServ
 
     @Override
     protected <V> Callable<V> wrap(final Callable<V> r) {
-        return new Callable<V>() {
+        return new Callable<>() {
             @Override
             public V call() throws Exception {
                 try (ACLContext ctxt = ACL.as2(authentication)) {

--- a/core/src/main/java/jenkins/security/ImpersonatingScheduledExecutorService.java
+++ b/core/src/main/java/jenkins/security/ImpersonatingScheduledExecutorService.java
@@ -74,7 +74,7 @@ public final class ImpersonatingScheduledExecutorService extends InterceptingSch
 
     @Override
     protected <V> Callable<V> wrap(final Callable<V> r) {
-        return new Callable<V>() {
+        return new Callable<>() {
             @Override
             public V call() throws Exception {
                 try (ACLContext ctxt = ACL.as2(authentication)) {

--- a/core/src/main/java/jenkins/security/SecurityContextExecutorService.java
+++ b/core/src/main/java/jenkins/security/SecurityContextExecutorService.java
@@ -71,7 +71,7 @@ public class SecurityContextExecutorService extends InterceptingExecutorService 
     @Override
     protected <V> Callable<V> wrap(final Callable<V> c) {
         final SecurityContext callingContext = getContext();
-        return new Callable<V>() {
+        return new Callable<>() {
             @Override
             public V call() throws Exception {
                 SecurityContext old = getContext();

--- a/core/src/main/java/jenkins/util/ContextResettingExecutorService.java
+++ b/core/src/main/java/jenkins/util/ContextResettingExecutorService.java
@@ -38,7 +38,7 @@ public class ContextResettingExecutorService extends InterceptingExecutorService
 
     @Override
     protected <V> Callable<V> wrap(final Callable<V> r) {
-        return new Callable<V>() {
+        return new Callable<>() {
             @Override
             public V call() throws Exception {
                 Thread t = Thread.currentThread();

--- a/core/src/main/java/jenkins/util/TreeStringBuilder.java
+++ b/core/src/main/java/jenkins/util/TreeStringBuilder.java
@@ -141,7 +141,7 @@ public class TreeStringBuilder {
      * multiple {@link TreeString}s.
      */
     public void dedup() {
-        root.dedup(new HashMap<String, char[]>());
+        root.dedup(new HashMap<>());
     }
 
     /**

--- a/core/src/test/java/hudson/ChannelRule.java
+++ b/core/src/test/java/hudson/ChannelRule.java
@@ -33,13 +33,13 @@ public final class ChannelRule extends ExternalResource {
         final FastPipedOutputStream p1o = new FastPipedOutputStream(p1i);
         final FastPipedOutputStream p2o = new FastPipedOutputStream(p2i);
 
-        Future<Channel> f1 = executors.submit(new Callable<Channel>() {
+        Future<Channel> f1 = executors.submit(new Callable<>() {
             @Override
             public Channel call() throws Exception {
                 return new ChannelBuilder("This side of the channel", executors).withMode(Channel.Mode.BINARY).build(p1i, p2o);
             }
         });
-        Future<Channel> f2 = executors.submit(new Callable<Channel>() {
+        Future<Channel> f2 = executors.submit(new Callable<>() {
             @Override
             public Channel call() throws Exception {
                 return new ChannelBuilder("The other side of the channel", executors).withMode(Channel.Mode.BINARY).build(p2i, p1o);

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -153,7 +153,7 @@ public class ListJobsCommandTest {
 
     private TypeSafeMatcher<ByteArrayOutputStream> empty() {
 
-        return new TypeSafeMatcher<ByteArrayOutputStream>() {
+        return new TypeSafeMatcher<>() {
 
             @Override
             protected boolean matchesSafely(ByteArrayOutputStream item) {
@@ -178,7 +178,7 @@ public class ListJobsCommandTest {
 
     private TypeSafeMatcher<ByteArrayOutputStream> listsJobs(final String... expected) {
 
-        return new TypeSafeMatcher<ByteArrayOutputStream>() {
+        return new TypeSafeMatcher<>() {
 
             @Override
             protected boolean matchesSafely(ByteArrayOutputStream item) {

--- a/core/src/test/java/hudson/util/DescribableListTest.java
+++ b/core/src/test/java/hudson/util/DescribableListTest.java
@@ -69,7 +69,7 @@ public class DescribableListTest {
 
         @Override
         public Descriptor<Datum> getDescriptor() {
-            return new Descriptor<Datum>(Datum.class) {};
+            return new Descriptor<>(Datum.class) {};
         }
 
         @Override

--- a/test/src/test/java/hudson/bugs/DateConversionTest.java
+++ b/test/src/test/java/hudson/bugs/DateConversionTest.java
@@ -50,7 +50,7 @@ public class DateConversionTest {
 
         List<Future> futures = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            futures.add(es.submit(new Callable<Object>() {
+            futures.add(es.submit(new Callable<>() {
                 @Override
                 public Object call() {
                     for (int i = 0; i < 10000; i++)

--- a/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
@@ -117,7 +117,7 @@ public class OldDataMonitorTest {
         OldDataMonitor.report(slowSavable, (String) null);
         ExecutorService executors = Executors.newSingleThreadExecutor();
 
-        Future<Void> discardFuture = executors.submit(new Callable<Void>() {
+        Future<Void> discardFuture = executors.submit(new Callable<>() {
             @Override
             public Void call() {
                 oldDataMonitor.doDiscard(Stapler.getCurrentRequest(), Stapler.getCurrentResponse());

--- a/test/src/test/java/hudson/model/AbstractProjectTest.java
+++ b/test/src/test/java/hudson/model/AbstractProjectTest.java
@@ -54,7 +54,6 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.matrix.MatrixProject;
 import hudson.scm.NullSCM;
-import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import hudson.tasks.BatchFile;
@@ -241,7 +240,7 @@ public class AbstractProjectTest {
 
             @Override
             public SCMDescriptor<?> getDescriptor() {
-                return new SCMDescriptor<SCM>(null) {
+                return new SCMDescriptor<>(null) {
                 };
             }
         });

--- a/test/src/test/java/hudson/model/JobQueueTest.java
+++ b/test/src/test/java/hudson/model/JobQueueTest.java
@@ -24,7 +24,7 @@ public class JobQueueTest {
 
     @Before
     public void setUp() {
-        RunListener<Run> listener = new RunListener<Run>() {
+        RunListener<Run> listener = new RunListener<>() {
             @Override public  void onCompleted(Run r, TaskListener listener) {
                 JobQueueTest.fireCompletedFlag = true;
                 try {

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -841,7 +841,7 @@ public class ProjectTest {
         }
 
         @Override public SCMDescriptor<?> getDescriptor() {
-            return new SCMDescriptor<SCM>(null) {};
+            return new SCMDescriptor<>(null) {};
         }
 
         @Override

--- a/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/RunParameterDefinitionTest.java
@@ -290,7 +290,7 @@ public class RunParameterDefinitionTest {
 
         @Override
         public Descriptor<Publisher> getDescriptor() {
-            return new Descriptor<Publisher>(ResultPublisher.class) {};
+            return new Descriptor<>(ResultPublisher.class) {};
         }
     }
 }

--- a/test/src/test/java/hudson/model/UserPropertyTest.java
+++ b/test/src/test/java/hudson/model/UserPropertyTest.java
@@ -91,7 +91,7 @@ public class UserPropertyTest {
     }
 
     public static Matcher<User> nestedUserSet() {
-        return new BaseMatcher<User>() {
+        return new BaseMatcher<>() {
             @Override
             public boolean matches(Object item) {
                 User user = (User) item;

--- a/test/src/test/java/hudson/model/ViewJobTest.java
+++ b/test/src/test/java/hudson/model/ViewJobTest.java
@@ -57,7 +57,7 @@ public class ViewJobTest {
         }
 
         @Override protected void reload() {
-            runs.load(this, new RunMap.Constructor<R>() {
+            runs.load(this, new RunMap.Constructor<>() {
                 @Override public R create(File d) throws IOException {
                     return new R(J.this, d);
                 }

--- a/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
@@ -350,7 +350,7 @@ public class LabelExpressionTest {
 
     @Test
     public void formValidation() throws Exception {
-        j.executeOnServer(new Callable<Object>() {
+        j.executeOnServer(new Callable<>() {
             @Override
             public Object call() throws Exception {
                 Label l = j.jenkins.getLabel("foo");

--- a/test/src/test/java/hudson/tasks/LogRotatorTest.java
+++ b/test/src/test/java/hudson/tasks/LogRotatorTest.java
@@ -220,7 +220,7 @@ public class LogRotatorTest {
 
         @Override
         public Descriptor<Publisher> getDescriptor() {
-            return new Descriptor<Publisher>(TestsFail.class) {};
+            return new Descriptor<>(TestsFail.class) {};
         }
     }
 

--- a/test/src/test/java/jenkins/model/ContextMenuTest.java
+++ b/test/src/test/java/jenkins/model/ContextMenuTest.java
@@ -55,7 +55,7 @@ public class ContextMenuTest {
     @Issue("JENKINS-19173")
     @Test public void contextMenuVisibility() throws Exception {
         final FreeStyleProject p = j.createFreeStyleProject("p");
-        Callable<ContextMenu> doContextMenu = new Callable<ContextMenu>() {
+        Callable<ContextMenu> doContextMenu = new Callable<>() {
             @Override public ContextMenu call() throws Exception {
                 return p.doContextMenu(Stapler.getCurrentRequest(), Stapler.getCurrentResponse());
             }

--- a/test/src/test/java/jenkins/model/ExtensionTypeHierarchyTest.java
+++ b/test/src/test/java/jenkins/model/ExtensionTypeHierarchyTest.java
@@ -51,7 +51,7 @@ public class ExtensionTypeHierarchyTest {
      * Sort by class name
      */
     private <T> T[] sort(T[] a) {
-        Arrays.sort(a, new Comparator<T>() {
+        Arrays.sort(a, new Comparator<>() {
             @Override
             public int compare(T o1, T o2) {
                 return o1.getClass().getName().compareTo(o2.getClass().getName());

--- a/test/src/test/java/jenkins/model/JenkinsManagePermissionTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsManagePermissionTest.java
@@ -203,7 +203,7 @@ public class JenkinsManagePermissionTest {
     }
 
     private static Matcher<WebResponse> hasResponseCode(final int httpStatus) {
-        return new BaseMatcher<WebResponse>() {
+        return new BaseMatcher<>() {
             @Override
             public boolean matches(final Object item) {
                 final WebResponse response = (WebResponse) item;

--- a/test/src/test/java/jenkins/security/SecurityContextExecutorServiceTest.java
+++ b/test/src/test/java/jenkins/security/SecurityContextExecutorServiceTest.java
@@ -111,7 +111,7 @@ public class SecurityContextExecutorServiceTest {
     @Test
     @PresetData(PresetData.DataSet.NO_ANONYMOUS_READACCESS)
     public void testCallableAgainstAllContexts() throws Exception {
-        Callable<SecurityContext> c = new Callable<SecurityContext>() {
+        Callable<SecurityContext> c = new Callable<>() {
             @Override
             public SecurityContext call() {
                 return SecurityContextHolder.getContext();
@@ -137,7 +137,7 @@ public class SecurityContextExecutorServiceTest {
     @PresetData(PresetData.DataSet.NO_ANONYMOUS_READACCESS)
     public void testCallableCollectionAgainstAllContexts() throws Exception {
         Collection<Callable<SecurityContext>> callables = new ArrayList<>();
-        Callable<SecurityContext> c = new Callable<SecurityContext>() {
+        Callable<SecurityContext> c = new Callable<>() {
             @Override
             public SecurityContext call() {
                 return SecurityContextHolder.getContext();


### PR DESCRIPTION
Applies an automated IntelliJ refactoring to the codebase. Apparently Java 9+ improved the diamond operator and allows us to use the diamond operator with anonymous inner classes, which Java 8 couldn't support.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6764"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

