### PR TITLE
Update Javadoc links

### DIFF
--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -179,8 +179,8 @@ public abstract class ExtensionFinder implements ExtensionPoint {
      * from here.
      *
      * <p>
-     * See https://bugs.openjdk.java.net/browse/JDK-4993813 for how to force a class initialization.
-     * Also see http://kohsuke.org/2010/09/01/deadlock-that-you-cant-avoid/ for how class initialization
+     * See <a href="https://bugs.openjdk.org/browse/JDK-4993813">JDK-4993813</a> for how to force a class initialization.
+     * Also see <a href="https://kohsuke.org/2010/09/01/deadlock-that-you-cant-avoid/">this blog post</a> for how class initialization
      * can results in a dead lock.
      */
     public void scout(Class extensionType, Hudson hudson) {

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1845,7 +1845,7 @@ public class Functions {
 
     /**
      * Escapes the character unsafe for e-mail address.
-     * See http://en.wikipedia.org/wiki/E-mail_address for the details,
+     * See <a href="https://en.wikipedia.org/wiki/Email_address">the Wikipedia page</a> for the details,
      * but here the vocabulary is even more restricted.
      */
     public static String toEmailSafeString(String projectName) {

--- a/core/src/main/java/hudson/StructuredForm.java
+++ b/core/src/main/java/hudson/StructuredForm.java
@@ -33,7 +33,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Obtains the structured form data from {@link StaplerRequest}.
- * See https://www.jenkins.io/doc/developer/forms/structured-form-submission/
+ * See <a href="https://www.jenkins.io/doc/developer/forms/structured-form-submission/">the developer documentation</a>.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/model/DependencyGraph.java
+++ b/core/src/main/java/hudson/model/DependencyGraph.java
@@ -100,7 +100,7 @@ public class DependencyGraph implements Comparator<AbstractProject> {
     /**
      *
      *
-     * See https://en.wikipedia.org/wiki/Tarjan's_strongly_connected_components_algorithm
+     * See <a href="https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm">Tarjan's strongly connected components algorithm</a>
      */
     private void topologicalDagSort() {
         DirectedGraph<AbstractProject> g = new DirectedGraph<AbstractProject>() {

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -568,7 +568,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      *      Always non-null (see note above.) This object includes represents the entire submission.
      * @param formData
      *      The JSON object that captures the configuration data for this {@link Descriptor}.
-     *      See https://www.jenkins.io/doc/developer/forms/structured-form-submission/
+     *      See <a href="https://www.jenkins.io/doc/developer/forms/structured-form-submission/">the developer documentation</a>.
      *      Always non-null.
      *
      * @throws FormException
@@ -820,7 +820,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable, 
      *
      * @param json
      *      The JSON object that captures the configuration data for this {@link Descriptor}.
-     *      See https://www.jenkins.io/doc/developer/forms/structured-form-submission/
+     *      See <a href="https://www.jenkins.io/doc/developer/forms/structured-form-submission/">the developer documentation</a>.
      * @return false
      *      to keep the client in the same config page.
      */

--- a/core/src/main/java/hudson/os/WindowsUtil.java
+++ b/core/src/main/java/hudson/os/WindowsUtil.java
@@ -36,7 +36,7 @@ import org.apache.commons.io.IOUtils;
 /**
  * Utilities for the Windows Platform.
  * Adapted from:
- * https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+ * <a href="https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way">Everyone quotes command line arguments the wrong way</a>
  *
  * @since 2.183
  */

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -908,7 +908,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
         /**
          * Returns true if the supplied hash looks like a bcrypt encoded hash value, based off of the
-         * implementation defined in jBCrypt and: https://en.wikipedia.org/wiki/Bcrypt.
+         * implementation defined in jBCrypt and <a href="https://en.wikipedia.org/wiki/Bcrypt">the Wikipedia page</a>.
          *
          */
         public boolean isHashValid(String hash) {

--- a/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
+++ b/core/src/main/java/hudson/tools/DownloadFromUrlInstaller.java
@@ -103,7 +103,7 @@ public abstract class DownloadFromUrlInstaller extends ToolInstaller {
      * @param root
      *      The directory that contains the extracted archive. This directory contains nothing but the
      *      extracted archive. For example, if the user installed
-     *      https://archive.apache.org/dist/ant/binaries/jakarta-ant-1.1.zip , this directory would contain
+     *      <a href="https://archive.apache.org/dist/ant/binaries/jakarta-ant-1.1.zip">jakarta-ant-1.1.zip</a> , this directory would contain
      *      a single directory "jakarta-ant".
      *
      * @return

--- a/core/src/main/java/hudson/util/ConsistentHash.java
+++ b/core/src/main/java/hudson/util/ConsistentHash.java
@@ -54,8 +54,8 @@ import java.util.NoSuchElementException;
  * as increase/decrease of the replicas.
  *
  * <p>
- * See http://en.wikipedia.org/wiki/Consistent_hashing for references, and
- * http://tom-e-white.com/2007/11/consistent-hashing.html is probably a reasonable depiction.
+ * See <a href="https://en.wikipedia.org/wiki/Consistent_hashing">the Wikipedia page</a> for references, and
+ * <a href="https://tom-e-white.com/2007/11/consistent-hashing.html">this blog post</a> is probably a reasonable depiction.
  * If we trust his experiments, creating 100 replicas will reduce the stddev to 10% of the mean for 10 nodes.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/hudson/util/HeapSpaceStringConverter.java
+++ b/core/src/main/java/hudson/util/HeapSpaceStringConverter.java
@@ -34,7 +34,7 @@ import com.thoughtworks.xstream.converters.basic.StringConverter;
  *
  * Since XStream 1.3 it use a WeakHashMap cache to always use the same String instances, but
  * this has also major problems with a single long living XStream instance (as we have in Jenkins)
- * See https://x-stream.github.io/jira/604/
+ * See <a href="https://x-stream.github.io/jira/604/">XSTR-604</a>.
  *
  * <p>
  * Use this to avoid that (instead those strings will

--- a/core/src/main/java/hudson/util/Secret.java
+++ b/core/src/main/java/hudson/util/Secret.java
@@ -229,7 +229,7 @@ public final class Secret implements Serializable {
     }
 
     /**
-     * Workaround for JENKINS-6459 / http://java.net/jira/browse/GLASSFISH-11862
+     * Workaround for <a href="https://issues.jenkins.io/browse/JENKINS-6459">JENKINS-6459</a> / <a href="https://web.archive.org/web/20110107095054/http://java.net/jira/browse/GLASSFISH-11862">GLASSFISH-11862</a>
      * This method uses specific provider selected via hudson.util.Secret.provider system property
      * to provide a workaround for the above bug where default provide gives an unusable instance.
      * (Glassfish Enterprise users should set value of this property to "SunJCE")
@@ -286,7 +286,7 @@ public final class Secret implements Serializable {
     }
 
     /**
-     * Workaround for JENKINS-6459 / http://java.net/jira/browse/GLASSFISH-11862
+     * Workaround for <a href="https://issues.jenkins.io/browse/JENKINS-6459">JENKINS-6459</a> / <a href="https://web.archive.org/web/20110107095054/http://java.net/jira/browse/GLASSFISH-11862">GLASSFISH-11862</a>
      * @see #getCipher(String)
      */
     private static final String PROVIDER = SystemProperties.getString(Secret.class.getName() + ".provider");

--- a/core/src/main/java/hudson/util/TagCloud.java
+++ b/core/src/main/java/hudson/util/TagCloud.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Represents an order-preserving tag cloud (http://en.wikipedia.org/wiki/Tag_cloud)
+ * Represents an order-preserving <a href="https://en.wikipedia.org/wiki/Tag_cloud">tag cloud</a>
  * where each keyword gets a weight and displayed according to their weight.
  *
  * TODO: define a view on its own.

--- a/core/src/main/java/hudson/util/TextFile.java
+++ b/core/src/main/java/hudson/util/TextFile.java
@@ -135,7 +135,7 @@ public class TextFile {
      * necessary chunk.
      *
      * <p>
-     * Some multi-byte encoding, such as Shift-JIS (http://en.wikipedia.org/wiki/Shift_JIS) doesn't
+     * Some multi-byte encoding, such as <a href="https://en.wikipedia.org/wiki/Shift_JIS">Shift-JIS</a>, doesn't
      * allow the first byte and the second byte of a single char to be unambiguously identified,
      * so it is possible that we end up decoding incorrectly if we start reading in the middle of a multi-byte
      * character. All the CJK multi-byte encodings that I know of are self-correcting; as they are ASCII-compatible,

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -96,7 +96,7 @@ public class XStream2 extends XStream {
     private static final Logger LOGGER = Logger.getLogger(XStream2.class.getName());
     /**
      * Determine what is the value (in seconds) of the "collectionUpdateLimit" added by XStream
-     * to protect against http://x-stream.github.io/CVE-2021-43859.html.
+     * to protect against <a href="http://x-stream.github.io/CVE-2021-43859.html">CVE-2021-43859</a>.
      * It corresponds to the accumulated timeout when adding an item to a collection.
      *
      * Default: 5 seconds (in contrary to XStream default to 20 which is a bit too tolerant)

--- a/core/src/main/java/hudson/util/jna/Advapi32.java
+++ b/core/src/main/java/hudson/util/jna/Advapi32.java
@@ -41,7 +41,7 @@ public interface Advapi32  extends StdCallLibrary {
      * Retrieves the name of the user associated with the current thread.
      *
      * <p>
-     * See http://msdn.microsoft.com/en-us/library/ms724432(VS.85).aspx
+     * See <a href="https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getusernamea">GetUserNameA function (winbase.h)</a>
      */
     boolean GetUserName(char[] buffer, IntByReference lpnSize);
 

--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -128,7 +128,7 @@ public interface GNUCLibrary extends Library {
     /**
      * Creates a symlink.
      *
-     * See http://linux.die.net/man/3/symlink
+     * See <a href="https://linux.die.net/man/3/symlink">symlink(3)</a>
      */
     int symlink(String oldname, String newname);
 

--- a/core/src/main/java/hudson/util/jna/Kernel32.java
+++ b/core/src/main/java/hudson/util/jna/Kernel32.java
@@ -38,7 +38,7 @@ public interface Kernel32 extends StdCallLibrary {
     Kernel32 INSTANCE = Kernel32Utils.load();
 
     /**
-     * See http://msdn.microsoft.com/en-us/library/aa365240(VS.85).aspx
+     * See <a href="https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexa">MoveFileExA function (winbase.h)</a>
      */
     boolean MoveFileExA(String existingFileName, String newFileName, int flags);
 

--- a/core/src/main/java/hudson/util/jna/Kernel32Utils.java
+++ b/core/src/main/java/hudson/util/jna/Kernel32Utils.java
@@ -91,7 +91,7 @@ public class Kernel32Utils {
      *      If absolute, it's absolute.
      * @throws UnsatisfiedLinkError
      *      If the function is not exported by kernel32.
-     *      See http://msdn.microsoft.com/en-us/library/windows/desktop/aa363866(v=vs.85).aspx
+     *      See <a href="https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinka">CreateSymbolicLinkA function (winbase.h)</a>
      *      for compatibility info.
      * @deprecated Use {@link Util#createSymlink} instead.
      */

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1487,7 +1487,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * <p>
      * This form of identifier is weak in that it can be impersonated by others. See
-     * https://github.com/jenkinsci/instance-identity-plugin for more modern form of instance ID
+     * <a href="https://github.com/jenkinsci/instance-identity-plugin">the Instance Identity plugin</a> for more modern form of instance ID
      * that can be challenged and verified.
      *
      * @since 1.498
@@ -5544,7 +5544,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *
      * The default value is true.
      *
-     * For detailed documentation: https://docs.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/file-folder-name-whitespace-characters
+     * For detailed documentation: <a href="https://docs.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/file-folder-name-whitespace-characters">Support for Whitespace characters in File and Folder names for Windows</a>
      * @see #checkGoodName(String)
      */
     @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/security/HMACConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/HMACConfidentialKey.java
@@ -17,7 +17,7 @@ import javax.crypto.spec.SecretKeySpec;
  *
  * <p>
  * This provides more secure version of it by using HMAC.
- * See http://rdist.root.org/2009/10/29/stop-using-unsafe-keyed-hashes-use-hmac/ for background.
+ * See <a href="https://rdist.root.org/2009/10/29/stop-using-unsafe-keyed-hashes-use-hmac/">this blog post</a> for background.
  * This implementation also never leaks the secret value to outside, so it makes it impossible
  * for the careless caller to misuse the key (thus protecting ourselves from our own stupidity!)
  *

--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -81,7 +81,7 @@ public abstract class Telemetry implements ExtensionPoint {
      *
      * Good IDs are globally unique and human readable (i.e. no UUIDs).
      *
-     * For a periodically updated list of all public implementations, see https://www.jenkins.io/doc/developer/extensions/jenkins-core/#telemetry
+     * For a periodically updated list of all public implementations, see <a href="https://www.jenkins.io/doc/developer/extensions/jenkins-core/#telemetry">the developer documentation</a>.
      *
      * @return ID of the collector, never null or empty
      */

--- a/core/src/main/java/jenkins/util/DirectedGraph.java
+++ b/core/src/main/java/jenkins/util/DirectedGraph.java
@@ -93,7 +93,7 @@ public abstract class DirectedGraph<N> {
      * Performs the Tarjan's algorithm and computes strongly-connected components from the
      * sink to source order.
      *
-     * See https://en.wikipedia.org/wiki/Tarjan's_strongly_connected_components_algorithm
+     * See <a href="https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm">the Wikipedia page</a>.
      */
     public List<SCC<N>> getStronglyConnectedComponents() {
         final Map<N, Node> nodes = new HashMap<>();

--- a/core/src/main/java/jenkins/util/java/JavaUtils.java
+++ b/core/src/main/java/jenkins/util/java/JavaUtils.java
@@ -67,7 +67,7 @@ public class JavaUtils {
 
     /**
      * Returns the JVM's current version as a {@link String}.
-     * See https://openjdk.java.net/jeps/223 for the expected format.
+     * See <a href="https://openjdk.org/jeps/223">JEP 223</a> for the expected format.
      * <ul>
      *     <li>Until Java 8 included, the expected format should be starting with {@code 1.x}</li>
      *     <li>Starting with Java 9, cf. JEP-223 linked above, the version got simplified in 9.x, 10.x, etc.</li>


### PR DESCRIPTION
Adds links in the Javadocs where the link tags were missing and also updates some broken links to working versions for the benefit of those reading Javadocs in their web browser.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6767"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

