### PR TITLE
Revert #6694

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       # Provided by Jetty and should be aligned with the version provided by the
       # version of Jetty we deliver. See:
       # https://github.com/jenkinsci/jenkins/pull/5211
-      - dependency-name: "jakarta.servlet:jakarta.servlet-api"
+      - dependency-name: "javax.servlet:javax.servlet-api"
 
       # Jetty Maven Plugin and Winstone should be upgraded in lockstep in order
       # to keep their corresponding Jetty versions aligned.

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
   <properties>
     <asm.version>9.3</asm.version>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <stapler.version>1711.v5b_1b_03f0fcf2</stapler.version>
+    <stapler.version>1685.v3b_5035c4ce05</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -468,9 +468,9 @@ THE SOFTWARE.
       <version>1.1.4c</version>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>4.0.4</version>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -86,8 +86,8 @@ THE SOFTWARE.
           jars that are not needed in war. most of the exclusions should happen in the core, to make IDEs happy, not here.
         -->
         <exclusion>
-          <groupId>jakarta.servlet.jsp</groupId>
-          <artifactId>jakarta.servlet.jsp-api</artifactId>
+          <groupId>javax.servlet.jsp</groupId>
+          <artifactId>javax.servlet.jsp-api</artifactId>
         </exclusion>
         <!-- Stapler 1.195 fails to declare this as optional, and the 1.1 version lacks a license: -->
         <exclusion>
@@ -132,7 +132,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>6.0</version>
+      <version>5.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -172,12 +172,8 @@ THE SOFTWARE.
                 <enforceBytecodeVersion>
                   <maxJdkVersion>1.8</maxJdkVersion>
                   <excludes>
-                    <exclude>org.jenkins-ci:commons-jelly</exclude>
                     <exclude>org.jenkins-ci.main:cli</exclude>
                     <exclude>org.jenkins-ci.main:jenkins-core</exclude>
-                    <exclude>org.kohsuke.stapler:stapler</exclude>
-                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
-                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
                   </excludes>
                 </enforceBytecodeVersion>
               </rules>
@@ -564,7 +560,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>10.0.11</version>
+        <version>9.4.46.v20220331</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
The core and BOM/PCT testing done in #6694 was done with the standard test harness, whose `JenkinsRule`-based tests use their own copy of Jetty 9 rather than the bundled Winstone used by the `RealJenkinsRule`-based tests. Since the vast majority of our tests are based on `JenkinsRule`, this meant that we were not actually testing with Jetty 10 as intended. If we had run `jenkins.agents.WebSocketAgentsTest` with a Jetty 10 based `JenkinsRule`, we would have discovered that there is no way the existing code in `jenkins.websocket.WebSockets` could work without extensive changes to adapt to new Jetty APIs. (We also did not notice this at compile time because all of this code is written using reflection.) That being the case, this PR reverts #6694 to restore stability on trunk. We can then work on adapting `jenkins.websocket.WebSockets` to the new Jetty APIs, and when that is done we can re-run the core and BOM/PCT tests using a modified `JenkinsRule` based on Jetty 10 to achieve the originally intended test scenario.

### Proposed changelog entries

N/A, #6694 was never released.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6781"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

