### PR TITLE
chore: Add label workflow for conflicting PRs

### DIFF
--- a/.github/workflows/label-conflicting-pr.yml
+++ b/.github/workflows/label-conflicting-pr.yml
@@ -1,0 +1,15 @@
+name: "Label conflicting PRs"
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label conflicting PRs
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "unresolved-merge-conflict"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "Please take a moment and address the merge conflicts of your pull request. Thanks!"

--- a/.github/workflows/label-conflicting-pr.yml
+++ b/.github/workflows/label-conflicting-pr.yml
@@ -17,3 +17,4 @@ jobs:
           dirtyLabel: "unresolved-merge-conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           commentOnDirty: "Please take a moment and address the merge conflicts of your pull request. Thanks!"
+          continueOnMissingPermissions: true

--- a/.github/workflows/label-conflicting-pr.yml
+++ b/.github/workflows/label-conflicting-pr.yml
@@ -1,5 +1,6 @@
 name: "Label conflicting PRs"
 on:
+  push:
   pull_request_target:
     types: [synchronize]
 

--- a/.github/workflows/label-conflicting-pr.yml
+++ b/.github/workflows/label-conflicting-pr.yml
@@ -5,9 +5,7 @@ on:
     types: [synchronize]
     
 permissions:
-  pull-requests: read
-  checks: read
-  statuses: read
+  pull-requests: write
 
 jobs:
   main:

--- a/.github/workflows/label-conflicting-pr.yml
+++ b/.github/workflows/label-conflicting-pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label conflicting PRs
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@v2
         with:
           dirtyLabel: "unresolved-merge-conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label-conflicting-pr.yml
+++ b/.github/workflows/label-conflicting-pr.yml
@@ -3,6 +3,11 @@ on:
   push:
   pull_request_target:
     types: [synchronize]
+    
+permissions:
+  pull-requests: read
+  checks: read
+  statuses: read
 
 jobs:
   main:

--- a/.github/workflows/label-conflicting-pr.yml
+++ b/.github/workflows/label-conflicting-pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label conflicting PRs
-        uses: eps1lon/actions-label-merge-conflict@v2
+        uses: eps1lon/actions-label-merge-conflict@b8bf8341285ec9a4567d4318ba474fee998a6919 # v2.0.1
         with:
           dirtyLabel: "unresolved-merge-conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
If user-submitted PRs conflict with the revision of the master branch, the action lets the PR author know about it and applies our common label. If the conflict is resolved, the label is removed again.

I resolved merge conflicts for PRs on a frequent basis recently, to facilitate a review and/or merge process, considering GH doesn't let you know about conflicts, unless someone tells you or you revisit your PR.
Not that I'm too opposed to the former, but we can auto-notify our contributors about conflicts, encouraging them to resolve those; out of courtesy.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6782"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

