### PR TITLE
De-emphasize label for generic tool installers

### DIFF
--- a/core/src/main/resources/hudson/tools/AbstractCommandInstaller/config.jelly
+++ b/core/src/main/resources/hudson/tools/AbstractCommandInstaller/config.jelly
@@ -23,11 +23,11 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:t="/hudson/tools">
-    <t:label />
     <f:entry title="${%Command}" field="command">
         <f:textarea checkMethod="post"/>
     </f:entry>
     <f:entry title="${%Tool Home}" field="toolHome">
         <f:textbox/>
     </f:entry>
+    <t:label />
 </j:jelly>

--- a/core/src/main/resources/hudson/tools/ZipExtractionInstaller/config.jelly
+++ b/core/src/main/resources/hudson/tools/ZipExtractionInstaller/config.jelly
@@ -23,11 +23,13 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:t="/hudson/tools">
-    <t:label />
     <f:entry title="${%Download URL for binary archive}" field="url">
         <f:textbox checkMethod="post"/>
     </f:entry>
     <f:entry title="${%Subdirectory of extracted archive}" field="subdir">
         <f:textbox/>
     </f:entry>
+  <f:advanced>
+    <t:label />
+  </f:advanced>
 </j:jelly>


### PR DESCRIPTION
This change moves the label field for the generic tool installers to the bottom, even hiding it behind an Advanced button in the case of the "download zip/gz" installer (because it's not needed for platform-independent downloads like most Java tools).

Motivation: I'm regularly confused that this is the most prominent field, and keep entering the URL there.

I'm less confident about the change to the script installer, but even there it makes sense to me that you write a script first and then think about exactly which nodes it works with. Could go either way though.

<details>
<summary>Screenshots</summary>

### Before

<img width="981" alt="Screenshot 2022-07-05 at 22 55 19" src="https://user-images.githubusercontent.com/1831569/177415227-55a1e0fd-0643-46a1-b60c-9a3b14a5af97.png">

### After

<img width="988" alt="Screenshot 2022-07-05 at 22 54 37" src="https://user-images.githubusercontent.com/1831569/177415212-70d16adc-4b43-46f0-a45e-8467c29ffdcd.png">

</details>


### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6784"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

