### PR TITLE
Forward compatibility with Servlet 4.0: `getTrailerFields()`

### DIFF
--- a/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
+++ b/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
@@ -11,9 +11,7 @@ import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.ServletException;
@@ -498,8 +496,6 @@ public class DoActionFilterTest extends StaplerAbstractTest {
 
         public void doWithResponseImpl(ResponseImpl response) { replyOk(); }
 
-        public void doWithRequestAndResponse(RequestAndResponse requestAndResponse) { replyOk(); }
-
         // special case to keep Groovy parameter name, but does not seem to indicate it's automatically a web method
         @CapturedParameterNames("req")
         public void doAnnotatedResponseSuccess(Object req) { replyOk(); }
@@ -507,21 +503,6 @@ public class DoActionFilterTest extends StaplerAbstractTest {
 //        // as mentioned in its documentation, it requires to have JavaScriptMethod, that has its own test
 //        @JsonOutputFilter
 //        public void doAnnotatedJsonOutputFilter() { replyOk(); }
-    }
-
-    public abstract static class RequestAndResponse implements StaplerRequest, StaplerResponse {
-        @Override
-        public CollectionAndEnumeration getHeaderNames() {
-            return null;
-        }
-
-        @Override
-        public CollectionAndEnumeration getHeaders(String name) {
-            return null;
-        }
-
-        public abstract static class CollectionAndEnumeration implements Collection, Enumeration {
-        }
     }
 
     @Test
@@ -545,12 +526,6 @@ public class DoActionFilterTest extends StaplerAbstractTest {
     @Test
     public void testNotOkSpecialCases_withResponseImpl() throws Exception {
         assertNotReachable("testNewRulesNotOkSpecialCases/withResponseImpl/");
-        assertDoActionRequestWasBlockedAndResetFlag();
-    }
-
-    @Test
-    public void testNotOkSpecialCases_withRequestAndResponse() throws Exception {
-        assertNotReachable("testNewRulesNotOkSpecialCases/withRequestAndResponse/");
         assertDoActionRequestWasBlockedAndResetFlag();
     }
 


### PR DESCRIPTION
Noticed when testing core with a Servlet 4.0-based `JenkinsRule` in #6802: core stopped compiling with

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:testCompile (default-testCompile) on project jenkins-test: Compilation failure
[ERROR] /home/basil/src/jenkinsci/jenkins/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java:[512,27] error: types HttpServletResponse and HttpServletRequest are incompatible;
[ERROR]   both define getTrailerFields(), but with unrelated return types
```

The cause of the compilation error is a new default method introduced in Servlet 4.0:

- https://github.com/jakartaee/servlet/blob/4b93fb2e230ab68fd62a80526f69859d6af6ddd9/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java#L654-L679=
- https://github.com/jakartaee/servlet/blob/4b93fb2e230ab68fd62a80526f69859d6af6ddd9/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java#L366-L377=

As you can see, the method has a different return type in each class, making it no longer possible to implement both `HttpServletRequest` and `HttpServletResponse` in a single class, as this test is doing. I looked for any code in the Jenkins ecosystem that did this and did not find any such code beside this test, and I cannot think of a valid use case for wanting to implement both a request and a response in a single class, so I am just deleting this test. Doing so has no effect on Servlet 3, but it does allow us to be compatible with Servlet 4 in the future at compile time.

### Testing done

On trunk (Servlet 3), verified that the test passes. In #6802 (Servlet 4), verified that the test failed to compile before this change and successfully compiled after this change.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6804"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

