### PR TITLE
ci: Publish ESLint results for builds on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ for (i = 0; i < buildTypes.size(); i++) {
               skipBlames: true,
               trendChartType: 'TOOLS_ONLY',
               qualityGates: [
-                [threshold: 1, type: 'NEW', unstable: true],
+                [threshold: 1, type: 'TOTAL', unstable: true],
               ]])
             if (failFast && currentBuild.result == 'UNSTABLE') {
               error 'Static analysis quality gates not passed; halting early'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,6 +112,13 @@ for (i = 0; i < buildTypes.size(); i++) {
               qualityGates: [
                 [threshold: 1, type: 'TOTAL', unstable: true],
               ]])
+             recordIssues([tool: esLint(pattern: '**/target/eslint-warnings.xml'),
+              sourceCodeEncoding: 'UTF-8',
+              skipBlames: true,
+              trendChartType: 'TOOLS_ONLY',
+              qualityGates: [
+                [threshold: 1, type: 'NEW', unstable: true],
+              ]])
             if (failFast && currentBuild.result == 'UNSTABLE') {
               error 'Static analysis quality gates not passed; halting early'
             }

--- a/war/package.json
+++ b/war/package.json
@@ -15,7 +15,7 @@
     "build": "yarn prod",
     "start": "yarn dev --watch",
     "test": "jest --ci --config=jest.config.json --reporters=jest-standard-reporter --reporters=jest-junit",
-    "lint:js": "eslint . --ext js",
+    "lint:js": "eslint . --ext js -f checkstyle > target/eslint-warnings.xml",
     "lint:css": "stylelint src/main/less",
     "lint:css:fix": "stylelint src/main/less --fix",
     "lint": "yarn lint:js && yarn lint:css"

--- a/war/package.json
+++ b/war/package.json
@@ -15,7 +15,7 @@
     "build": "yarn prod",
     "start": "yarn dev --watch",
     "test": "jest --ci --config=jest.config.json --reporters=jest-standard-reporter --reporters=jest-junit",
-    "lint:js": "eslint . --ext js -f checkstyle > target/eslint-warnings.xml",
+    "lint:js": "eslint . --ext js -f checkstyle -o target/eslint-warnings.xml",
     "lint:css": "stylelint src/main/less",
     "lint:css:fix": "stylelint src/main/less --fix",
     "lint": "yarn lint:js && yarn lint:css"


### PR DESCRIPTION
Warnings ng, more specifically, analysis-model, is able to render ESLint warnings and results on the web UI:

<details>
<summary>Issues recorded</summary>

![Screenshot 2022-07-08 at 23 11 50](https://user-images.githubusercontent.com/13383509/178071106-9bb0466c-742b-4ae0-9658-96a49db8f910.png)

</details>

<details>
<summary>Job overview</summary>

![Screenshot 2022-07-08 at 22 24 32](https://user-images.githubusercontent.com/13383509/178071155-aa657378-29a8-4be2-b2f4-dadde4e9dac5.png)

</details>

The overview is pretty handy, if you want to view failures and warnings outside the build log in a more appealing way.

### Proposed changelog entries

* N/A

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6817"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

