### PR TITLE
Discover the reference build before recording code coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,11 +83,11 @@ for (i = 0; i < buildTypes.size(); i++) {
             error 'There were test failures; halting early'
           }
           if (buildType == 'Linux' && jdk == jdks[0]) {
-            publishCoverage calculateDiffForChangeRequests: true, adapters: [jacocoAdapter('coverage/target/site/jacoco-aggregate/jacoco.xml')]
             def folders = env.JOB_NAME.split('/')
             if (folders.length > 1) {
               discoverGitReferenceBuild(scm: folders[1])
             }
+            publishCoverage calculateDiffForChangeRequests: true, adapters: [jacocoAdapter('coverage/target/site/jacoco-aggregate/jacoco.xml')]
 
             echo "Recording static analysis results for '${buildType}'"
             recordIssues(


### PR DESCRIPTION
In [release 3.0.0](https://github.com/jenkinsci/code-coverage-api-plugin/releases/tag/v3.0.0) the code coverage plugin introduces a new feature to compute the delta coverage of pull requests. In order to compute this coverage the reference build must be computed before the coverage recording step. Otherwise we cannot compute the delta coverage of a pull request.

A similar PR has been merged for the `buildPlugin` step, see https://github.com/jenkins-infra/pipeline-library/pull/433

### Desired reviewers

@basil @timja 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6818"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

