### PR TITLE
[JENKINS-60866] Extract inline JS for sidepanel widget refresh

### DIFF
--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -159,8 +159,7 @@ THE SOFTWARE.
     </l:pane>
     <!-- schedule updates only for the full page reload -->
     <j:if test="${ajax==null and h.hasPermission(app.READ)}">
-      <script defer="defer">
-        refreshPart('executors',"${rootURL}/${h.hasView(it,'ajaxExecutors')?it.url:''}ajaxExecutors");
-      </script>
+      <div class="widget-refresh-reference" data-id="executors" data-url="${rootURL}/${h.hasView(it,'ajaxExecutors')?it.url:''}ajaxExecutors"/>
+      <st:adjunct includes="lib.hudson.widget-refresh"/>
     </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -103,8 +103,7 @@ THE SOFTWARE.
   </l:pane>
   <!-- schedule updates only for the full page reload -->
   <j:if test="${ajax==null and h.hasPermission(app.READ)}">
-    <script defer="defer">
-      refreshPart('buildQueue',"${rootURL}/${h.hasView(it,'ajaxBuildQueue')?it.url:''}ajaxBuildQueue");
-    </script>
+    <div class="widget-refresh-reference" data-id="buildQueue" data-url="${rootURL}/${h.hasView(it,'ajaxBuildQueue')?it.url:''}ajaxBuildQueue"/>
+    <st:adjunct includes="lib.hudson.widget-refresh"/>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/widget-refresh.js
+++ b/core/src/main/resources/lib/hudson/widget-refresh.js
@@ -1,0 +1,5 @@
+Behaviour.specify(".widget-refresh-reference", 'widget-refresh', 0, function(e) {
+  var id = e.getAttribute('data-id');
+  var url = e.getAttribute('data-url');
+  refreshPart(id, url);
+});


### PR DESCRIPTION
See [JENKINS-60866](https://issues.jenkins.io/browse/JENKINS-60866).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

Too minor

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6847"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

