### PR TITLE
[JENKINS-60866] Extract inline JS for optional blocks in configuration

### DIFF
--- a/core/src/main/resources/lib/form/checkbox.jelly
+++ b/core/src/main/resources/lib/form/checkbox.jelly
@@ -41,10 +41,10 @@ THE SOFTWARE.
       If this attribute is unspecified or null, it defaults to unchecked, otherwise checked.
     </st:attribute>
     <st:attribute name="id" />
-    <st:attribute name="onclick" />
+    <st:attribute name="onclick" deprecated="true" />
     <st:attribute name="class" />
     <st:attribute name="negative" />
-    <st:attribute name="readonly">
+    <st:attribute name="readonly" deprecated="true">
       If set to true, this will take precedence over the onclick attribute and prevent the state of the checkbox from being changed.
 
       Note: if you want an actual read only checkbox then add:

--- a/core/src/main/resources/lib/form/checkbox.jelly
+++ b/core/src/main/resources/lib/form/checkbox.jelly
@@ -41,7 +41,13 @@ THE SOFTWARE.
       If this attribute is unspecified or null, it defaults to unchecked, otherwise checked.
     </st:attribute>
     <st:attribute name="id" />
-    <st:attribute name="onclick" deprecated="true" />
+    <st:attribute name="onclick" deprecated="true">
+      Inline JavaScript to execute when the checkbox is clicked.
+      Deprecated because this attribute is incompatible with adding Content-Security-Policy to the Jenkins UI in the future.
+      Set 'id' or 'class' attributes as appropriate to look up this element in external Javascript files (e.g. adjuncts)
+      to add the desired behavior there (DOMContentLoaded event in static forms, Behaviour.specify if this element may be
+      dynamically added). See https://github.com/jenkinsci/jenkins/pull/6852 for an example.
+    </st:attribute>
     <st:attribute name="class" />
     <st:attribute name="negative" />
     <st:attribute name="readonly" deprecated="true">

--- a/core/src/main/resources/lib/form/optional-block.js
+++ b/core/src/main/resources/lib/form/optional-block.js
@@ -1,7 +1,0 @@
-document.addEventListener('DOMContentLoaded', function() {
-  document.querySelectorAll('input.optional-block-event-item').forEach(function(el) {
-    el.addEventListener('click', function(e) {
-      updateOptionalBlock(el, true);
-    });
-  });
-});

--- a/core/src/main/resources/lib/form/optional-block.js
+++ b/core/src/main/resources/lib/form/optional-block.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('input.optional-block-event-item').forEach(function(el) {
+    el.addEventListener('click', function(e) {
+      updateOptionalBlock(el, true);
+    });
+  });
+});

--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -69,7 +69,6 @@ THE SOFTWARE.
       <div class="optionalBlock-container jenkins-form-item">
         <div class="help-sibling tr optional-block-start row-group-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
           <div class="jenkins-checkbox-help-wrapper">
-            <st:adjunct includes="lib.form.optional-block"/>
             <f:checkbox name="${attrs.name}" class="optional-block-control block-control optional-block-event-item"
                         negative="${attrs.negative}" checked="${attrs.checked}" field="${attrs.field}" title="${title}" />
             <f:helpLink url="${attrs.help}" featureName="${title}"/>

--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -69,7 +69,8 @@ THE SOFTWARE.
       <div class="optionalBlock-container jenkins-form-item">
         <div class="help-sibling tr optional-block-start row-group-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
           <div class="jenkins-checkbox-help-wrapper">
-            <f:checkbox name="${attrs.name}" class="optional-block-control block-control" onclick="javascript:updateOptionalBlock(this,true)"
+            <st:adjunct includes="lib.form.optional-block"/>
+            <f:checkbox name="${attrs.name}" class="optional-block-control block-control optional-block-event-item"
                         negative="${attrs.negative}" checked="${attrs.checked}" field="${attrs.field}" title="${title}" />
             <f:helpLink url="${attrs.help}" featureName="${title}"/>
           </div>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1296,6 +1296,12 @@ function rowvgStartEachRow(recursive,f) {
         };
     });
 
+    Behaviour.specify("INPUT.optional-block-event-item", "input-optional-block-event-item", ++p, function(e) {
+      e.addEventListener('click', function() {
+        updateOptionalBlock(e, true);
+      });
+    });
+
     Behaviour.specify("TR.row-set-end,DIV.tr.row-set-end", "tr-row-set-end-div-tr-row-set-end", ++p, function(e) { // see rowSet.jelly and optionalBlock.jelly
         // figure out the corresponding start block
         e = $(e);


### PR DESCRIPTION
See [JENKINS-60866](https://issues.jenkins.io/browse/JENKINS-60866).

Also deprecates some attributes of `f:checkbox` that probably should not be used anymore.

### Proposed changelog entries

Too minor

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6852"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

