### PR TITLE
[JENKINS-60866] Remove inline JS for plugin deploy URL validation

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1869,7 +1869,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     @Restricted(NoExternalUse.class)
-    @RequirePOST public FormValidation doCheckPluginUrl(StaplerRequest request, @QueryParameter("pluginUrl") String value) throws IOException {
+    @RequirePOST public FormValidation doCheckPluginUrl(StaplerRequest request, @QueryParameter String value) throws IOException {
         if (StringUtils.isNotBlank(value)) {
             try {
                 URL url = new URL(value);

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1869,7 +1869,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     @Restricted(NoExternalUse.class)
-    @RequirePOST public FormValidation doCheckPluginUrl(StaplerRequest request, @QueryParameter String value) throws IOException {
+    @RequirePOST public FormValidation doCheckPluginUrl(StaplerRequest request, @QueryParameter("pluginUrl") String value) throws IOException {
         if (StringUtils.isNotBlank(value)) {
             try {
                 URL url = new URL(value);

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -67,7 +67,7 @@ THE SOFTWARE.
                         <p>${%Or}</p>
                         <f:entry title="${%URL}">
                             <f:textbox name="pluginUrl"
-                                       class="jenkins-input validated" checkUrl="'checkPluginUrl?value='+this.value"/>
+                                       class="jenkins-input validated" checkUrl="checkPluginUrl" checkDependsOn="pluginUrl"/>
                         </f:entry>
                         <f:submit value="${%Deploy}"/>
                     </f:form>

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -67,7 +67,7 @@ THE SOFTWARE.
                         <p>${%Or}</p>
                         <f:entry title="${%URL}">
                             <f:textbox name="pluginUrl"
-                                       class="jenkins-input validated" checkUrl="checkPluginUrl" checkDependsOn="pluginUrl"/>
+                                       class="jenkins-input validated" checkUrl="checkPluginUrl" checkDependsOn="" />
                         </f:entry>
                         <f:submit value="${%Deploy}"/>
                     </f:form>


### PR DESCRIPTION
See [JENKINS-60866](https://issues.jenkins.io/browse/JENKINS-60866).

This is fairly recent code and probably should not have been written with this legacy form validation method in the first place. Oh well, I asked for it, kind of 😓 Amends #5862.

This is slightly awkward, because "modern" form validation (not JS) requires `checkDependsOn` to be defined, otherwise `registerValidator` in `hudson-behavior.js` thinks it _should_ be JS, and if it's not, logs a warning, and does not add the `value` argument.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

Too minor

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6853"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

