### PR TITLE
[JENKINS-60866][JENKINS-69030] Extract inline JS from 'new-from-list'

### DIFF
--- a/core/src/main/resources/lib/hudson/newFromList/form.jelly
+++ b/core/src/main/resources/lib/hudson/newFromList/form.jelly
@@ -85,7 +85,7 @@ THE SOFTWARE.
 
         <j:if test="${!empty(attrs.copyNames) or attrs.showCopyOption}">
           <div class="jenkins-radio">
-            <input class="jenkins-radio__input" type="radio" id="copy" name="mode" value="copy"  />
+            <input class="jenkins-radio__input mode-selection" type="radio" id="copy" name="mode" value="copy"  />
             <label class="jenkins-radio__label" for="copy">${attrs.copyTitle}</label>
             <div class="jenkins-radio__children">
               <j:set var="descriptor" value="${it.descriptor}" />

--- a/core/src/main/resources/lib/hudson/newFromList/form.jelly
+++ b/core/src/main/resources/lib/hudson/newFromList/form.jelly
@@ -62,7 +62,7 @@ THE SOFTWARE.
 
   <s:form class="jenkins-form" method="post" id="createItemForm" action="${attrs.action?:'createItem'}" name="createItem">
     <s:entry title="${attrs.nameTitle}" class="jenkins-form-item--medium">
-      <s:textbox id="name" name="name" checkUrl="'${h.jsStringEscape(attrs.checkUrl)}?value='+encodeURIComponent(this.value)"
+      <s:textbox id="name" name="name" checkUrl="${attrs.checkUrl}" checkDependsOn=""
                  onchange="updateOk(this.form)" onkeyup="updateOk(this.form)" />
       <script>$('name').focus();</script>
     </s:entry>

--- a/core/src/main/resources/lib/hudson/newFromList/form.jelly
+++ b/core/src/main/resources/lib/hudson/newFromList/form.jelly
@@ -62,9 +62,7 @@ THE SOFTWARE.
 
   <s:form class="jenkins-form" method="post" id="createItemForm" action="${attrs.action?:'createItem'}" name="createItem">
     <s:entry title="${attrs.nameTitle}" class="jenkins-form-item--medium">
-      <s:textbox id="name" name="name" checkUrl="${attrs.checkUrl}" checkDependsOn=""
-                 onchange="updateOk(this.form)" onkeyup="updateOk(this.form)" />
-      <script>$('name').focus();</script>
+      <s:textbox id="name" name="name" checkUrl="${attrs.checkUrl}" checkDependsOn=""/>
     </s:entry>
 
     <div class="jenkins-form-item jenkins-form-item--medium">
@@ -75,7 +73,7 @@ THE SOFTWARE.
 
         <j:forEach var="descriptor" items="${descriptors}">
           <div class="jenkins-radio">
-            <input class="jenkins-radio__input" type="radio" name="mode" id="${descriptor.id}" value="${descriptor.id}" onchange="updateOk()" onclick="updateOk()" />
+            <input class="jenkins-radio__input mode-selection" type="radio" name="mode" id="${descriptor.id}" value="${descriptor.id}"/>
             <label for="${descriptor.id}" class="jenkins-radio__label">
               ${descriptor.displayName}
             </label>
@@ -87,12 +85,12 @@ THE SOFTWARE.
 
         <j:if test="${!empty(attrs.copyNames) or attrs.showCopyOption}">
           <div class="jenkins-radio">
-            <input class="jenkins-radio__input" type="radio" id="copy" name="mode" value="copy" onchange="updateOk()" onclick="updateOk()" />
+            <input class="jenkins-radio__input" type="radio" id="copy" name="mode" value="copy"  />
             <label class="jenkins-radio__label" for="copy">${attrs.copyTitle}</label>
             <div class="jenkins-radio__children">
               <j:set var="descriptor" value="${it.descriptor}" />
               <div class="jenkins-search">
-                <s:textbox placeholder="${%Type for suggestions}" clazz="jenkins-search__input"  name="from" field="copyNewItemFrom" onfocus="$('copy').click()" />
+                <s:textbox placeholder="${%Type for suggestions}" clazz="jenkins-search__input copy-field" name="from" field="copyNewItemFrom" />
                 <div class="jenkins-search__icon">
                   <l:icon src="symbol-search" />
                 </div>

--- a/core/src/main/resources/lib/hudson/newFromList/validation.js
+++ b/core/src/main/resources/lib/hudson/newFromList/validation.js
@@ -26,3 +26,39 @@ function updateOk() {
 }
 
 updateOk();
+
+document.addEventListener('DOMContentLoaded', function() {
+  let nameField = document.getElementById('name');
+  nameField.focus();
+  nameField.addEventListener('change', function () {
+    updateOk();
+  });
+  nameField.addEventListener('keyup', function () {
+    updateOk();
+  });
+
+  document.querySelectorAll('.mode-selection').forEach(function(el) {
+    el.addEventListener('change', function () {
+      updateOk();
+    });
+    el.addEventListener('click', function () {
+      updateOk();
+    });
+  });
+
+  let copyRadio = document.getElementById('copy');
+  if (copyRadio !== null) {
+    copyRadio.addEventListener('change', function () {
+      updateOk();
+    });
+    copyRadio.addEventListener('keyup', function () {
+      updateOk();
+    });
+
+    document.getElementById('copy').addEventListener('click', function (e) {
+      window.setTimeout(function() {
+        document.querySelector('.copy-field').focus();
+      }, 100);
+    });
+  }
+});

--- a/core/src/main/resources/lib/hudson/newFromList/validation.js
+++ b/core/src/main/resources/lib/hudson/newFromList/validation.js
@@ -45,17 +45,9 @@ document.addEventListener('DOMContentLoaded', function() {
       updateOk();
     });
   });
-
   let copyRadio = document.getElementById('copy');
   if (copyRadio !== null) {
-    copyRadio.addEventListener('change', function () {
-      updateOk();
-    });
-    copyRadio.addEventListener('keyup', function () {
-      updateOk();
-    });
-
-    document.getElementById('copy').addEventListener('click', function (e) {
+    copyRadio.addEventListener('click', function () {
       window.setTimeout(function() {
         document.querySelector('.copy-field').focus();
       }, 100);


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-60866](https://issues.jenkins.io/browse/JENKINS-60866).

Applying the trick described in https://github.com/jenkinsci/jenkins/pull/6853 without depending on https://github.com/jenkinsci/jenkins/pull/6855.

Also addresses the regression [JENKINS-69030](https://issues.jenkins.io/browse/JENKINS-69030) introduced in #5842 by reverting the behavior before 2.320: Previously, selecting the 'copy' text field automatically selected the 'copy' radio button. Now, selecting the 'copy' radio button reveals (added in #5842) and then selects (new in this PR) the text field.


### Proposed changelog entries

Too minor

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6858"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

