### PR TITLE
New symbol for ParametersAction

### DIFF
--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -208,7 +208,7 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
 
     @Override
     public String getIconFileName() {
-        return "document-properties.png";
+        return "symbol-parameters";
     }
 
     @Override

--- a/core/src/main/java/org/jenkins/ui/icon/IconSet.java
+++ b/core/src/main/java/org/jenkins/ui/icon/IconSet.java
@@ -597,6 +597,7 @@ public class IconSet {
         translations.put("icon-user", "symbol-people");
         translations.put("icon-undo", "symbol-undo");
         translations.put("icon-redo", "symbol-redo");
+        translations.put("icon-document-properties", "symbol-parameters");
         ICON_TO_SYMBOL_TRANSLATIONS = translations;
     }
 

--- a/core/src/main/java/org/jenkins/ui/icon/IconSet.java
+++ b/core/src/main/java/org/jenkins/ui/icon/IconSet.java
@@ -597,7 +597,6 @@ public class IconSet {
         translations.put("icon-user", "symbol-people");
         translations.put("icon-undo", "symbol-undo");
         translations.put("icon-redo", "symbol-redo");
-        translations.put("icon-document-properties", "symbol-parameters");
         ICON_TO_SYMBOL_TRANSLATIONS = translations;
     }
 

--- a/war/src/main/resources/images/symbols/parameters.svg
+++ b/war/src/main/resources/images/symbols/parameters.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><title>Parameters</title>
+<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32" d="M368 96h80M64 96h240M368 416h80M64 416h240M208 256h240M64 256h80"/>
+<circle cx="336" cy="96" r="32" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+<circle cx="176" cy="256" r="32" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+<circle cx="336" cy="416" r="32" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+</svg>


### PR DESCRIPTION
Replace the old style document-properties svg for the parameters action with the slightly
modified options icon from ionicons as symbol-parameters.
Add a translation for the document-properties to the parameters symbol.
A search in the sources of the jenkinsci org revealed only 3 other
plugins using the document-properties icon:
- jobrevision
- envinject (but deprecated)
- envinject-lib

Before: 
![image](https://user-images.githubusercontent.com/17767050/179356398-9f4bbd6b-3304-48f7-8b46-cb850ad321fe.png)

After: 
![image](https://user-images.githubusercontent.com/17767050/179356416-c8c56bd0-6bee-4f83-a445-368c91ca592d.png)

<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: UI: New symbol for the Parameters action of builds

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6862"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

