### PR TITLE
[JENKINS-60866] Remove attributes from `f:toggleSwitch`

### DIFF
--- a/core/src/main/resources/lib/form/toggleSwitch.jelly
+++ b/core/src/main/resources/lib/form/toggleSwitch.jelly
@@ -42,18 +42,9 @@ THE SOFTWARE.
       If this attribute is unspecified or null, it defaults to unchecked, otherwise checked.
     </st:attribute>
     <st:attribute name="id"/>
-    <st:attribute name="onclick"/>
     <st:attribute name="class"/>
     <st:attribute name="invertLabel">
       Move the label of the toggle switch to the opposite side
-    </st:attribute>
-    <st:attribute name="readonly">
-      If set to true, this will take precedence over the onclick attribute and prevent the state of the checkbox from
-      being changed.
-
-      Note: if you want an actual read only checkbox then add:
-      &lt;j:set var="readOnlyMode" value="true"/&gt; inside your entry tag
-      See https://www.jenkins.io/doc/developer/views/read-only/#enabling-read-only-view-support
     </st:attribute>
     <st:attribute name="field">
       Used for databinding. TBD.
@@ -80,7 +71,6 @@ THE SOFTWARE.
            name="${name}"
            value="${value}"
            id="${id}"
-           onclick="${readonly=='true' ? 'return false;' : onclick}"
            class="jenkins-toggle-switch__input ${attrs.class} ${checkUrl!=null?'validated':''}"
            checkUrl="${checkUrl}"
            checkDependsOn="${checkDependsOn}" json="${json}"


### PR DESCRIPTION
See [JENKINS-60866](https://issues.jenkins.io/browse/JENKINS-60866).

A quick GH search indicates that nobody uses this element yet (it was introduced only in https://github.com/jenkinsci/jenkins/pull/5923, apparently as an indiscriminate copy & paste from existing controls), so now's a good time to remove attributes that will be annoying to support. https://github.com/jenkinsci/jenkins/pull/6852 deprecates the same attributes in `f:checkbox`.

### Proposed changelog entries

* Remove `onclick` and `disabled` attributes from `f:toggleSwitch`.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6871"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

