### PR TITLE
Tabs powered by `section-to-tabs.js` appear above its sections, rather than at the very top of the page

### DIFF
--- a/war/src/main/js/section-to-tabs.js
+++ b/war/src/main/js/section-to-tabs.js
@@ -45,4 +45,4 @@ tabPanes.forEach((tabPane, index) => {
   tabBar.append(tab)
 })
 
-content.insertBefore(tabBar, content.children[0])
+content.insertBefore(tabBar, tabPanes[0])


### PR DESCRIPTION
Tiny fix to make tabs powered by `section-to-tabs.js` appear above its sections, rather than at the very top of the page. This fix is necessary for some work I'm doing on the [Design Library](http://github.com/jenkinsci/design-library-plugin).

**Before**
<img width="750" alt="image" src="https://user-images.githubusercontent.com/43062514/179483289-64b87dea-0182-4600-8ca6-a2b67098c7fa.png">

**After**
<img width="762" alt="image" src="https://user-images.githubusercontent.com/43062514/179483213-467da9f5-d31b-42ac-9eb2-6d9b0169038e.png">

_Test page - notice how the tabs are no longer at the top of the page_

### Proposed changelog entries

* Tabs now appear above their respective sections, not at the top of the page.

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6873"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

