### PR TITLE
[JENKINS-68801] - Fix for Functions#extractPluginNameFromIconSrc

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2341,7 +2341,7 @@ public class Functions {
         String[] arr = iconSrc.split(" ");
         for (String element : arr) {
             if (element.startsWith("plugin-")) {
-                return element.replace("plugin-", "");
+                return element.replaceFirst("plugin-", "");
             }
         }
 

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -400,11 +400,11 @@ public class FunctionsTest {
 
         assertThat(result, is(equalTo("design-library")));
     }
-    
+
     @Test
     public void extractPluginNameFromIconSrcWhichContainsPluginWordInThePluginName() {
         String result = Functions.extractPluginNameFromIconSrc("symbol-padlock plugin-design-library-plugin");
-        
+
         assertThat(result, is(equalTo("design-library-plugin")));
     }
 

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -400,6 +400,13 @@ public class FunctionsTest {
 
         assertThat(result, is(equalTo("design-library")));
     }
+    
+    @Test
+    public void extractPluginNameFromIconSrcWhichContainsPluginWordInThePluginName() {
+        String result = Functions.extractPluginNameFromIconSrc("symbol-padlock plugin-design-library-plugin");
+        
+        assertThat(result, is(equalTo("design-library-plugin")));
+    }
 
     @Issue("JDK-6507809")
     @Test public void printThrowable() {


### PR DESCRIPTION
See [JENKINS-68801](https://issues.jenkins.io/browse/JENKINS-68801).

If our plugin's artifactId will contain "plugin-", then it will replace all "plugin-" occurences instead of first one.
Then it won't be able to correctly extract plugin name

### Proposed changelog

* Use correct icon lookup even when plugin ID includes more than one occurrence of "plugin".

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@timja @janfaracik 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6902"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

