### PR TITLE
Backporting for LTS 2.346.3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>5.3.19</version>
+        <version>5.3.20</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -1265,7 +1265,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     public ModelObjectWithContextMenu.ContextMenu doChildrenContextMenu(StaplerRequest request, StaplerResponse response) throws Exception {
         ModelObjectWithContextMenu.ContextMenu m = new ModelObjectWithContextMenu.ContextMenu();
         for (TopLevelItem i : getItems())
-            m.add(i.getShortUrl(), i.getDisplayName());
+            m.add(Functions.getRelativeLinkTo(i), Functions.getRelativeDisplayNameFrom(i, getOwner().getItemGroup()));
         return m;
     }
 

--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -24,13 +24,9 @@
 
 package hudson.util;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.lang.ref.SoftReference;
 import java.util.AbstractList;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Handler;
-import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 /**
@@ -38,28 +34,12 @@ import java.util.logging.LogRecord;
  *
  * @author Kohsuke Kawaguchi
  */
-@SuppressFBWarnings(
-        value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
-        justification = "to guard against potential future compiler optimizations")
 public class RingBufferLogHandler extends Handler {
 
     private static final int DEFAULT_RING_BUFFER_SIZE = Integer.getInteger(RingBufferLogHandler.class.getName() + ".defaultSize", 256);
 
-    private static final class LogRecordRef extends SoftReference<LogRecord> {
-        LogRecordRef(LogRecord referent) {
-            super(referent);
-        }
-    }
-
-    static {
-        // Preload the LogRecordRef class to avoid an ABBA deadlock between agent class loading and logging.
-        LogRecord r = new LogRecord(Level.INFO, "<preloading>");
-        // We call Objects.hash() to guard against potential future compiler optimizations.
-        Objects.hash(new LogRecordRef(r).get());
-    }
-
     private int start = 0;
-    private final LogRecordRef[] records;
+    private final LogRecord[] records;
     private int size;
 
     /**
@@ -73,7 +53,7 @@ public class RingBufferLogHandler extends Handler {
     }
 
     public RingBufferLogHandler(int ringSize) {
-        records = new LogRecordRef[ringSize];
+        records = new LogRecord[ringSize];
     }
 
     /**
@@ -86,13 +66,18 @@ public class RingBufferLogHandler extends Handler {
     }
 
     @Override
-    public synchronized void publish(LogRecord record) {
-        int len = records.length;
-        records[(start + size) % len] = new LogRecordRef(record);
-        if (size == len) {
-            start = (start + 1) % len;
-        } else {
-            size++;
+    public void publish(LogRecord record) {
+        if (record == null) {
+            return;
+        }
+        synchronized (this) {
+            int len = records.length;
+            records[(start + size) % len] = record;
+            if (size == len) {
+                start = (start + 1) % len;
+            } else {
+                size++;
+            }
         }
     }
 
@@ -114,9 +99,7 @@ public class RingBufferLogHandler extends Handler {
             public LogRecord get(int index) {
                 // flip the order
                 synchronized (RingBufferLogHandler.this) {
-                    LogRecord r = records[(start + (size - (index + 1))) % records.length].get();
-                    // We cannot just omit collected entries due to the List interface.
-                    return r != null ? r : new LogRecord(Level.OFF, "<discarded>");
+                    return records[(start + (size - (index + 1))) % records.length];
                 }
             }
 

--- a/test/src/test/java/hudson/util/RingBufferLogHandlerTest.java
+++ b/test/src/test/java/hudson/util/RingBufferLogHandlerTest.java
@@ -24,6 +24,8 @@
 
 package hudson.util;
 
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -33,10 +35,10 @@ public class RingBufferLogHandlerTest {
     @Issue("JENKINS-9120")
     public void tooMuchRecordsShouldNotCrashHandler() {
         final RingBufferLogHandler handler = new RingBufferLogHandler();
-
+        LogRecord lr = new LogRecord(Level.INFO, "xxx");
         for (long i = 0; i < (long) Integer.MAX_VALUE + 300; i++) {
             // throws ArrayIndexOutOfBoundsException after int-overflow
-            handler.publish(null);
+            handler.publish(lr);
         }
     }
 }

--- a/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.not;
 import hudson.util.VersionNumber;
 import java.lang.ref.WeakReference;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -37,14 +36,24 @@ public class JenkinsLogRecordsTest {
             containsInRelativeOrder("Completed initialization", "Started initialization"));
         VersionNumber javaVersion = new VersionNumber(System.getProperty("java.specification.version"));
         if (javaVersion.isOlderThan(new VersionNumber("9")) || javaVersion.isNewerThanOrEqualTo(new VersionNumber("17"))) { // TODO https://github.com/jenkinsci/jenkins-test-harness/issues/359
-            LogRecord lr = new LogRecord(Level.INFO, "collect me");
-            Logger.getLogger(Jenkins.class.getName()).log(lr);
-            WeakReference<LogRecord> ref = new WeakReference<>(lr);
-            lr = null;
+            Object x = new Object() {
+                @Override
+                public String toString() {
+                    return "collect me";
+                }
+            };
+            use(x);
+            WeakReference<Object> ref = new WeakReference<>(x);
+            x = null;
             MemoryAssert.assertGC(ref, true);
-            assertThat("Records collected",
+            assertThat("Record parameters formatted before collection",
                 logRecords.stream().map(LogRecord::getMessage).collect(Collectors.toList()),
-                hasItem("<discarded>"));
+                hasItem("formatting collect me"));
         }
     }
+
+    private static void use(Object x) {
+        Logger.getLogger(Jenkins.class.getName()).info(() -> "formatting " + x);
+    }
+
 }

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1241,7 +1241,7 @@ td.progress-bar-done {
 }
 
 td.progress-bar-left {
-  background-color: #EBECF0;
+  background-color: #bababa;
 }
 
 table.progress-bar.red {


### PR DESCRIPTION
```
Latest core version: jenkins-2.360

Fixed
-----

JENKINS-68417           Major                   2.358
        System log no longer usable as soon as it is full of "<discarded>" messages (regression in 2.325)
        regression
        https://issues.jenkins.io/browse/JENKINS-68417

JENKINS-68906           Minor                   2.358
        Children context menu is broken when view shows items other than children
        https://issues.jenkins.io/browse/JENKINS-68906           

JENKINS-68672           Minor                   2.360
        Total length of progress bar still difficult to see in shaded rows
        https://issues.jenkins.io/browse/JENKINS-68672

JENKINS-68854           Minor                   2.348
        Upgrade Spring core to 5.3.20 or newer
        https://issues.jenkins.io/browse/JENKINS-68854
```