### PR TITLE
build: Update pom to 1.82

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.81</version>
+    <version>1.82</version>
     <relativePath />
   </parent>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -527,13 +527,13 @@ THE SOFTWARE.
             </goals>
             <phase>prepare-package</phase>
             <configuration>
-              <tasks>
+              <target>
                 <move todir="${project.build.directory}/${project.build.finalName}">
                   <fileset dir="${project.build.directory}/classes">
                     <include name="executable/**/*.class" />
                   </fileset>
                 </move>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>
@@ -711,7 +711,7 @@ THE SOFTWARE.
                 </goals>
                 <phase>initialize</phase>
                 <configuration>
-                  <tasks>
+                  <target>
                     <property name="yarn.dest" value="${project.basedir}/.yarn/releases/yarn-${yarn-berry.version}.cjs" />
                     <dirname file="${yarn.dest}" property="yarn.dest.dir" />
                     <mkdir dir="${yarn.dest.dir}" />
@@ -722,7 +722,7 @@ THE SOFTWARE.
                     </condition>
                     <fail if="yarn.checksum.matches.fail">Checksum error</fail>
                     <echo file="${project.basedir}/.yarnrc.yml">yarnPath: ${yarn.dest}</echo>
-                  </tasks>
+                  </target>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Addresses https://github.com/mojohaus/extra-enforcer-rules/issues/225 on our end by using pom 1.82 containing the fix.

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6914"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

