### PR TITLE
[JENKINS-68750] sorting by timestamp list of installed plugins in plugin manager 

### DIFF
--- a/war/src/main/js/templates/plugin-manager/available.hbs
+++ b/war/src/main/js/templates/plugin-manager/available.hbs
@@ -71,6 +71,8 @@
                     {{ this.releaseTimestamp.displayValue }}
                 </time>
             </td>
+        {{else}}
+            <td width="25%"></td>
         {{/if}}
     </tr>
 {{/each}}

--- a/war/src/main/js/templates/plugin-manager/available.hbs
+++ b/war/src/main/js/templates/plugin-manager/available.hbs
@@ -66,13 +66,13 @@
             {{/if}}
         </td>
         {{#if this.releaseTimestamp }}
-            <td width="25%" data="{{ this.releaseTimestamp.iso8601 }}">
+            <td style="width: 25%" data="{{ this.releaseTimestamp.iso8601 }}">
                 <time datetime="{{ this.releaseTimestamp.iso8601 }}">
                     {{ this.releaseTimestamp.displayValue }}
                 </time>
             </td>
         {{else}}
-            <td width="25%"></td>
+            <td style="width: 25%"></td>
         {{/if}}
     </tr>
 {{/each}}

--- a/war/src/main/js/templates/plugin-manager/available.hbs
+++ b/war/src/main/js/templates/plugin-manager/available.hbs
@@ -65,12 +65,12 @@
                 </div>
             {{/if}}
         </td>
-        <td width="25%">
-            {{#if this.releaseTimestamp }}
+        {{#if this.releaseTimestamp }}
+            <td width="25%" data="{{ this.releaseTimestamp.iso8601 }}">
                 <time datetime="{{ this.releaseTimestamp.iso8601 }}">
                     {{ this.releaseTimestamp.displayValue }}
                 </time>
-            {{/if}}
-        </td>
+            </td>
+        {{/if}}
     </tr>
 {{/each}}


### PR DESCRIPTION
### Description 

Until now displayValue was used to compare against.
Format of this value is not sort-able at all.
I was wondering why in `available` plugin manager tab sorting was working fine.
Thanks table.jelly i was able to find bug.
My change adds possibility to sort by attribute, before it even starts sorting by displayValue.

I'm not web programmer so if somebody is willing to help me add test here It will more than appreciate. 
As reference I was using this lines:
https://github.com/jenkinsci/jenkins/blob/315b2f410cd8c2551d9d65482d93432ace09ba77/core/src/main/resources/hudson/PluginManager/table.jelly#L223-L230

### Linked issues

See:
* [JENKINS-68750](https://issues.jenkins.io/browse/JENKINS-68750)
* [JENKINS-69126](https://issues.jenkins.io/browse/JENKINS-69126)

### Proposed changelog entries

* Fix sorting by timestamp list of installed plugins in plugin manager.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6929"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

