### PR TITLE
Bump `tyrus-standalone-client-jdk` from 2.0.1 to 2.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,10 +52,6 @@ updates:
       # https://github.com/jenkinsci/jenkins/pull/5184
       - dependency-name: "org.fusesource.jansi:jansi"
 
-      # Requires Java 11 starting with version 2.0.2.
-      - dependency-name: "org.glassfish.tyrus.bundles:tyrus-standalone-client-jdk"
-        versions: [">=2.0.2"]
-
       # Contains incompatible API changes and needs compatibility work. See:
       # https://github.com/jenkinsci/jenkins/pull/4224
       - dependency-name: "org.jfree:jfreechart"

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client-jdk</artifactId>
-      <version>2.0.1</version>
+      <version>2.1.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -129,10 +129,6 @@
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <relocations>
-                <relocation>
-                  <pattern>javax.websocket</pattern>
-                  <shadedPattern>io.jenkins.cli.shaded.javax.websocket</shadedPattern>
-                </relocation>
                 <relocation>
                   <pattern>org</pattern>
                   <shadedPattern>io.jenkins.cli.shaded.org</shadedPattern>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <!-- TODO https://github.com/jenkinsci/remoting/pull/564 -->
-    <remoting.version>3047.v7a_7b_149d151f</remoting.version>
+    <remoting.version>3046.v38db_38a_b_7a_86</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.2.1</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,8 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3044.vb_940a_a_e4f72e</remoting.version>
+    <!-- TODO https://github.com/jenkinsci/remoting/pull/564 -->
+    <remoting.version>3047.v7a_7b_149d151f</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.2.1</remoting.minimum.supported.version>
 


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/remoting/pull/564, which adapts to the new version's use of Jakarta imports.

[Compare view](https://github.com/eclipse-ee4j/tyrus/compare/2.0.1...2.1.0)

### Proposed changelog entries

Upgrade [Eclipse Tyrus](https://github.com/eclipse-ee4j/tyrus) from 2.0.1 to 2.1.0.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6939"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

