### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -854,7 +854,7 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
             String encoding = configFile.sniffEncoding();
             String xml = Files.readString(Util.fileToPath(configFile.getFile()), Charset.forName(encoding));
             Matcher matcher = SECRET_PATTERN.matcher(xml);
-            StringBuffer cleanXml = new StringBuffer();
+            StringBuilder cleanXml = new StringBuilder();
             while (matcher.find()) {
                 if (Secret.decrypt(matcher.group(1)) != null) {
                     matcher.appendReplacement(cleanXml, ">********<");

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -666,7 +666,7 @@ public class SlaveComputer extends Computer {
                         "Rejecting the connection because the Remoting version is older than the"
                             + " minimum required version (%s). To allow the connection anyway, set"
                             + " the hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions"
-                            + " system property to true.%n",
+                            + " system property to true.",
                         RemotingVersionInfo.getMinimumSupportedVersion());
                 disconnect(new OfflineCause.LaunchFailed());
                 return;
@@ -674,7 +674,7 @@ public class SlaveComputer extends Computer {
                 taskListener.error(
                         "The Remoting version is older than the minimum required version (%s)."
                             + " The connection will be allowed, but compatibility is NOT"
-                            + " guaranteed.%n",
+                            + " guaranteed.",
                         RemotingVersionInfo.getMinimumSupportedVersion());
             }
         }

--- a/test/src/test/java/hudson/model/ParametersTest.java
+++ b/test/src/test/java/hudson/model/ParametersTest.java
@@ -270,7 +270,7 @@ public class ParametersTest {
         @Override
         public void translate(String markup, @NonNull Writer output) throws IOException {
             Matcher m = Pattern.compile("[<>]").matcher(markup);
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             while (m.find()) {
                 m.appendReplacement(buf, m.group().equals("<") ? "<b>[</b>" : "<b>]</b>");
             }

--- a/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
+++ b/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
@@ -87,7 +87,7 @@ public class JnlpSlaveRestarterInstallerTest {
                 ).stdout(System.out).start());
                 r.waitOnline(s);
                 assertEquals(1, s.getChannel().call(new JVMCount()).intValue());
-                while (!logging.getMessages().stream().anyMatch(msg -> msg.contains("Effective SlaveRestarter on remote:"))) {
+                while (logging.getMessages().stream().noneMatch(msg -> msg.contains("Effective SlaveRestarter on remote:"))) {
                     Thread.sleep(100);
                 }
                 // Likely true on Unix, likely false on Windows (not under winsw):


### PR DESCRIPTION
Odds and ends that I've been collecting on a branch that didn't feel like they belonged in any other PR.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6940"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

