### PR TITLE
Remove workaround for JENKINS-68887

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,8 +15,7 @@
 *.json          text
 *.jelly         text
 *.jellytag      text
-# JENKINS-68887: postcss-less fails to properly parse .less files with Windows line breaks
-*.less          text eol=lf
+*.less          text
 *.properties    text
 *.rb            text
 *.sh            text

--- a/war/.stylelintrc.js
+++ b/war/.stylelintrc.js
@@ -3,7 +3,6 @@ module.exports = {
   customSyntax: "postcss-less",
   rules: {
     "indentation": null,
-    "linebreaks": "unix",
     "max-line-length": 150,
     "selector-list-comma-newline-after": null,
     "selector-list-comma-space-after": null,


### PR DESCRIPTION
In https://github.com/jenkinsci/jenkins/pull/6744 I wrote:

> While it is arguably a bug in `postcss-less` that it cannot produce a proper parse tree in this scenario, I lack the motivation to whip up a minimal reproducible example (MRE) and submit an upstream bug report.

It is a good thing I did not bother spending the time to do this, since whatever bug we were encountering must have already been fixed in recent versions of `postcss-less`, because after the recent work done to modernize the frontend dependency tree this problem no longer occurs. As a result, the workaround is no longer necessary and can be removed.

### Testing done

Checked out this PR, then refreshed my line endings as described in [Refreshing a repository after changing line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings) and ran the build on Windows. At the time I opened #6744, this would have resulted in failures (due to the older version of `postcss-less` we were using at the time), but now it passes.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6949"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

