### PR TITLE
[JENKINS-69254] Drop down select input is out of style with other drop down select input

### DIFF
--- a/core/src/main/resources/hudson/tools/ToolLocationNodeProperty/config.jelly
+++ b/core/src/main/resources/hudson/tools/ToolLocationNodeProperty/config.jelly
@@ -29,7 +29,7 @@
 			<table width="100%">
 				<f:entry title="${%Name}">
 				        <div class="jenkins-select">
-                  <select class="jenkins-select__input dropdownList" name="locations.key">
+                  <select class="jenkins-select__input" name="locations.key">
                     <j:forEach var="toolDescriptor" items="${descriptor.toolDescriptors}">
                         <j:forEach var="toolInstallation" items="${toolDescriptor.installations}">
                             <f:option selected="${descriptor.getKey(toolInstallation)==location.key}" value="${descriptor.getKey(toolInstallation)}">(${toolDescriptor.displayName}) ${toolInstallation.name}</f:option>

--- a/core/src/main/resources/hudson/tools/ToolLocationNodeProperty/config.jelly
+++ b/core/src/main/resources/hudson/tools/ToolLocationNodeProperty/config.jelly
@@ -28,13 +28,15 @@
 		<f:repeatable var="location" name="locations" items="${instance.locations}">
 			<table width="100%">
 				<f:entry title="${%Name}">
-                  <select class="jenkins-input" name="locations.key">
+				        <div class="jenkins-select">
+                  <select class="jenkins-select__input dropdownList" name="locations.key">
                     <j:forEach var="toolDescriptor" items="${descriptor.toolDescriptors}">
                         <j:forEach var="toolInstallation" items="${toolDescriptor.installations}">
                             <f:option selected="${descriptor.getKey(toolInstallation)==location.key}" value="${descriptor.getKey(toolInstallation)}">(${toolDescriptor.displayName}) ${toolInstallation.name}</f:option>
                         </j:forEach>
                     </j:forEach>
                   </select>
+                </div>
 				</f:entry>
 				<f:entry title="${%Home}">
 					<f:textbox name="locations.home" value="${location.home}" />


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-69254](https://issues.jenkins.io/browse/JENKINS-69254).

### Before
![截圖 2022-08-05 下午12 00 05](https://user-images.githubusercontent.com/92412722/182999512-57d334c2-6c56-49f5-a434-d609f09c2dd2.png)
![截圖 2022-08-05 下午12 00 20](https://user-images.githubusercontent.com/92412722/182999518-e61b67fc-1f33-4e55-b02e-640738701103.png)

### After
![截圖 2022-08-05 下午12 05 54](https://user-images.githubusercontent.com/92412722/182999547-f6c9472c-8852-42ca-bf3d-9528004a3a1b.png)
![截圖 2022-08-05 下午12 06 02](https://user-images.githubusercontent.com/92412722/182999552-75153717-b4e8-4533-9ede-b96786888467.png)


<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

Too minor.

-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6969"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

