### PR TITLE
[JENKINS-69269] There is no space between the text and the button

### DIFF
--- a/core/src/main/resources/lib/form/block.jelly
+++ b/core/src/main/resources/lib/form/block.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <st:documentation>
     Full-width space in the form table that can be filled with arbitrary HTML.
   </st:documentation>
-	<div class='tr' style="margin-bottom: 1rem">
+	<div class='tr jenkins-!-margin-bottom-2'>
 	  <div colspan="4">
 	    <d:invokeBody />
 	  </div>

--- a/core/src/main/resources/lib/form/block.jelly
+++ b/core/src/main/resources/lib/form/block.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <st:documentation>
     Full-width space in the form table that can be filled with arbitrary HTML.
   </st:documentation>
-	<div class='tr'>
+	<div class='tr' style="margin-bottom: 1rem">
 	  <div colspan="4">
 	    <d:invokeBody />
 	  </div>


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-69269](https://issues.jenkins.io/browse/JENKINS-69269).
### Before 
<img width="963" alt="截圖 2022-08-06 上午11 46 24" src="https://user-images.githubusercontent.com/92412722/183232774-27c417be-5cfb-471a-9540-786c54437b1d.png">

### After
<img width="947" alt="截圖 2022-08-06 上午11 56 30" src="https://user-images.githubusercontent.com/92412722/183232783-4f0788a9-d72e-44f8-8606-27c5a1415b05.png">

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Too minor

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6972"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

