### PR TITLE
Add configuration for `comment-ops`

### DIFF
--- a/.github/comment-ops.yml
+++ b/.github/comment-ops.yml
@@ -1,0 +1,7 @@
+commands:
+  label:
+    enabled: true
+  removeLabel:
+    enabled: true
+  reviewer:
+    enabled: true


### PR DESCRIPTION
With https://github.com/timja/github-comment-ops/issues/69 commands are being switched to off by default so let's explicitly enable what we want here

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6985"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

