### PR TITLE
JENKINS-67554: Make ArtifactManager an interface

### DIFF
--- a/core/src/main/java/jenkins/model/ArtifactManager.java
+++ b/core/src/main/java/jenkins/model/ArtifactManager.java
@@ -41,14 +41,14 @@ import jenkins.util.VirtualFile;
  * @see ArtifactManagerFactory
  * @since 1.532
  */
-public abstract class ArtifactManager {
+public interface ArtifactManager {
 
     /**
      * Called when this manager is loaded from disk.
      * The selected manager will be persisted inside a build, so the build reference should be {@code transient} (quasi-{@code final}) and restored here.
      * @param build a historical build with which this manager was associated
      */
-    public abstract void onLoad(@NonNull Run<?, ?> build);
+    void onLoad(@NonNull Run<?, ?> build);
 
     /**
      * Archive all configured artifacts from a build.
@@ -65,7 +65,7 @@ public abstract class ArtifactManager {
      * @throws InterruptedException if transfer was interrupted
      * @see ArtifactArchiver#perform(Run, FilePath, Launcher, TaskListener)
      */
-    public abstract void archive(FilePath workspace, Launcher launcher, BuildListener listener, Map<String, String> artifacts) throws IOException, InterruptedException;
+    void archive(FilePath workspace, Launcher launcher, BuildListener listener, Map<String, String> artifacts) throws IOException, InterruptedException;
 
     /**
      * Delete all artifacts associated with an earlier build (if any).
@@ -73,12 +73,12 @@ public abstract class ArtifactManager {
      * @throws IOException if deletion could not be completed
      * @throws InterruptedException if deletion was interrupted
      */
-    public abstract boolean delete() throws IOException, InterruptedException;
+    boolean delete() throws IOException, InterruptedException;
 
     /**
      * Returns a representation of the root directory of archived artifacts.
      * @return the archive root
      */
-    public abstract VirtualFile root();
+    VirtualFile root();
 
 }

--- a/core/src/main/java/jenkins/model/StandardArtifactManager.java
+++ b/core/src/main/java/jenkins/model/StandardArtifactManager.java
@@ -46,7 +46,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * May be subclassed to provide an artifact manager which uses the standard storage but which only overrides {@link #archive}.
  * @since 1.532
  */
-public class StandardArtifactManager extends ArtifactManager {
+public class StandardArtifactManager implements ArtifactManager {
 
     private static final Logger LOG = Logger.getLogger(StandardArtifactManager.class.getName());
 

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -395,7 +395,7 @@ public class DirectoryBrowserSupportTest {
         public static final class DescriptorImpl extends ArtifactManagerFactoryDescriptor {}
     }
 
-    private static final class ExternalArtifactManager extends ArtifactManager {
+    private static final class ExternalArtifactManager implements ArtifactManager {
         String hash;
 
         @Override
@@ -1162,7 +1162,7 @@ public class DirectoryBrowserSupportTest {
         public static final class DescriptorImpl extends ArtifactManagerFactoryDescriptor {}
     }
 
-    private static final class SimulatedExternalArtifactManager extends ArtifactManager {
+    private static final class SimulatedExternalArtifactManager implements ArtifactManager {
         String hash;
 
         @Override

--- a/test/src/test/java/hudson/model/RunTest.java
+++ b/test/src/test/java/hudson/model/RunTest.java
@@ -222,7 +222,7 @@ public class RunTest  {
         }
     }
 
-    public static final class Mgr extends ArtifactManager {
+    public static final class Mgr implements ArtifactManager {
         static final AtomicBoolean deleted = new AtomicBoolean();
 
         @Override public boolean delete() {


### PR DESCRIPTION
See [JENKINS-67554](https://issues.jenkins.io/browse/JENKINS-67554).

No runtime tests because it's a compile time change affecting plugin developers.

### Proposed changelog entries

* Entry 1: JENKINS-67554: make ArtifactManager an interface

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6990"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

