### PR TITLE
First backporting for LTS 2.361.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       # Provided by Jetty and should be aligned with the version provided by the
       # version of Jetty we deliver. See:
       # https://github.com/jenkinsci/jenkins/pull/5211
+      - dependency-name: "jakarta.servlet:jakarta.servlet-api"
       - dependency-name: "javax.servlet:javax.servlet-api"
 
       # Jetty Maven Plugin and Winstone should be upgraded in lockstep in order

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -29,6 +29,9 @@
     <file url="file://$PROJECT_DIR$/war/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/war/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/war/src/test/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/websocket/jetty10/src/filter/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/websocket/jetty10/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/websocket/jetty10/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/jetty9/src/filter/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/jetty9/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/jetty9/src/main/resources" charset="UTF-8" />

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
   <properties>
     <asm.version>9.3</asm.version>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <stapler.version>1685.v3b_5035c4ce05</stapler.version>
+    <stapler.version>1711.v5b_1b_03f0fcf2</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -477,9 +477,9 @@ THE SOFTWARE.
       <version>1.1.4c</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>4.0.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2341,7 +2341,7 @@ public class Functions {
         String[] arr = iconSrc.split(" ");
         for (String element : arr) {
             if (element.startsWith("plugin-")) {
-                return element.replace("plugin-", "");
+                return element.replaceFirst("plugin-", "");
             }
         }
 

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -28,6 +28,7 @@ package hudson.triggers;
 import static java.util.logging.Level.WARNING;
 
 import antlr.ANTLRException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
@@ -711,6 +712,7 @@ public class SCMTrigger extends Trigger<Item> {
          * Only used while ths cause is in the queue.
          * Once attached to the build, we'll move this into a file to reduce the memory footprint.
          */
+        @CheckForNull
         private String pollingLog;
 
         private transient Run run;
@@ -743,7 +745,10 @@ public class SCMTrigger extends Trigger<Item> {
             this.run = build;
             try {
                 BuildAction a = new BuildAction(build);
-                Files.writeString(Util.fileToPath(a.getPollingLogFile()), pollingLog, Charset.defaultCharset());
+                // pollingLog can be null when rebuilding a job that was initially triggered by polling.
+                if (pollingLog != null) {
+                    Files.writeString(Util.fileToPath(a.getPollingLogFile()), pollingLog, Charset.defaultCharset());
+                }
                 build.replaceAction(a);
             } catch (IOException e) {
                 LOGGER.log(WARNING, "Failed to persist the polling log", e);

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
         <l:main-panel>
             <local:tabBar page="advanced" xmlns:local="/hudson/PluginManager"/>
 
-            <section class="jenkins-section">
+            <section class="jenkins-section jenkins-!-margin-bottom-5">
                 <h2 class="jenkins-section__title">${%HTTP Proxy Configuration}</h2>
                 <f:form method="post" action="proxyConfigure" name="proxyConfigure">
                     <j:scope>
@@ -55,7 +55,7 @@ THE SOFTWARE.
             </section>
 
             <l:isAdmin>
-                <section class="jenkins-section">
+                <section class="jenkins-section jenkins-!-margin-bottom-5">
                     <h2 class="jenkins-section__title">${%Deploy Plugin}</h2>
                     <f:form method="post" action="uploadPlugin" name="uploadPlugin" enctype="multipart/form-data">
                         <div style="margin-bottom: 1em;">
@@ -74,7 +74,7 @@ THE SOFTWARE.
                 </section>
             </l:isAdmin>
 
-            <section class="jenkins-section">
+            <section class="jenkins-section jenkins-!-margin-bottom-5">
                 <h2 class="jenkins-section__title">${%Update Site}</h2>
                 <f:form method="post" action="siteConfigure" name="siteConfigure">
                     <f:entry title="${%URL}">
@@ -96,7 +96,7 @@ THE SOFTWARE.
             </section>
 
             <j:if test="${hasNonDefault}">
-                <section class="jenkins-section">
+                <section class="jenkins-section jenkins-!-margin-bottom-5">
                     <h2 class="jenkins-section__title">${%Other Sites}</h2>
                     <ul>
                         <j:forEach var="site" items="${app.updateCenter.sites}">

--- a/core/src/main/resources/hudson/tools/DownloadFromUrlInstaller/config.jelly
+++ b/core/src/main/resources/hudson/tools/DownloadFromUrlInstaller/config.jelly
@@ -31,11 +31,13 @@ THE SOFTWARE.
         <f:textbox />
       </j:when>
       <j:otherwise>
-        <select name="_.id" disabled="${readOnlyMode ? 'true' : null}">
+      <div class="jenkins-select">
+        <select class="jenkins-select__input" name="_.id" disabled="${readOnlyMode ? 'true' : null}">
           <j:forEach var="tool" items="${tools}">
             <f:option value="${tool.id}" selected="${tool.id==instance.id}">${tool.name}</f:option>
           </j:forEach>
         </select>
+      </div>
       </j:otherwise>
     </j:choose>
   </f:entry>

--- a/core/src/main/resources/lib/form/filter-menu-button/filter-menu-button.js
+++ b/core/src/main/resources/lib/form/filter-menu-button/filter-menu-button.js
@@ -31,6 +31,11 @@ function _createFilterMenuButton(menu) {
   filterInput.setAttribute("type", "search");
 
   filterInput.addEventListener('input', (event) => _applyFilterKeyword(menu, event.currentTarget));
+  filterInput.addEventListener("keypress", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+    }
+  });
 
   const filterContainer = document.createElement("div");
   filterContainer.appendChild(filterInput);

--- a/core/src/main/resources/lib/form/radioBlock/radioBlock.js
+++ b/core/src/main/resources/lib/form/radioBlock/radioBlock.js
@@ -20,8 +20,10 @@ var radioBlockSupport = {
         while((n = n.next()) != blockEnd) {
             if (show) {
                 n.classList.remove("form-container--hidden")
+                n.style.position = "";
             } else {
                 n.classList.add("form-container--hidden")
+                n.style.position = "absolute";
             }
         }
         layoutUpdateCallback.call();

--- a/core/src/main/resources/lib/test/bar.jelly
+++ b/core/src/main/resources/lib/test/bar.jelly
@@ -54,11 +54,11 @@ THE SOFTWARE.
             </j:if>
           </j:if>
         </div>
-        <div style="width:100%; height:1em; background-color: #729FCF">
+        <div style="width:100%; height:1em; background-color: #729FCF; border-radius: 6px; overflow: hidden;">
           <!-- Failed tests part of the bar. -->
-          <div style="width:${it.failCount*100/it.totalCount}%; height: 1em; background-color: #EF2929; float: left"></div>
+          <div style="width:${it.failCount*100/it.totalCount}%; height: 1em; background-color: #EF2929; float: left; border-top-left-radius: 6px; border-bottom-left-radius: 6px;"></div>
           <!-- Skipped tests part of the bar. -->
-          <div style="width:${it.skipCount*100/it.totalCount}%; height: 1em; background-color: #FCE94F; float: left"></div>
+          <div style="width:${it.skipCount*100/it.totalCount}%; height: 1em; background-color: #FCE94F; float: left;"></div>
         </div>
         <div align="right">
           ${%tests(it.totalCount)}

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -401,6 +401,13 @@ public class FunctionsTest {
         assertThat(result, is(equalTo("design-library")));
     }
 
+    @Test
+    public void extractPluginNameFromIconSrcWhichContainsPluginWordInThePluginName() {
+        String result = Functions.extractPluginNameFromIconSrc("symbol-padlock plugin-design-library-plugin");
+
+        assertThat(result, is(equalTo("design-library-plugin")));
+    }
+
     @Issue("JDK-6507809")
     @Test public void printThrowable() {
         // Basics: a single exception. No change.

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.84</version>
+    <version>1.85</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@ THE SOFTWARE.
     <module>bom</module>
     <module>websocket/spi</module>
     <module>websocket/jetty9</module>
+    <module>websocket/jetty10</module>
     <module>core</module>
     <module>war</module>
     <module>test</module>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3028.va_a_436db_35078</remoting.version>
+    <remoting.version>3044.vb_940a_a_e4f72e</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.2.1</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.82</version>
+    <version>1.84</version>
     <relativePath />
   </parent>
 

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -659,6 +659,7 @@
           <Class name="jenkins.slaves.StandardOutputSwapper$ChannelSwapper"/>
           <Class name="jenkins.util.ProgressiveRendering"/>
           <Class name="jenkins.websocket.Jetty9Provider"/>
+          <Class name="jenkins.websocket.Jetty10Provider"/>
           <Class name="jenkins.websocket.Provider"/>
           <Class name="jenkins.websocket.WebSockets"/>
           <Class name="jenkins.websocket.WebSocketSession"/>

--- a/test/src/test/java/hudson/security/csrf/CrumbExclusionTest.java
+++ b/test/src/test/java/hudson/security/csrf/CrumbExclusionTest.java
@@ -69,7 +69,7 @@ public class CrumbExclusionTest {
                     assertThat("error message using " + path, x.getResponse().getContentAsString(), containsString("No valid crumb was included in the request"));
                     break;
                 case 400: // from Jetty
-                    assertThat("error message using " + path, x.getResponse().getContentAsString(), containsString("Ambiguous path parameter"));
+                    assertThat("error message using " + path, x.getResponse().getContentAsString(), containsString("path parameter"));
                     break;
                 default:
                     fail("unexpected error code");

--- a/test/src/test/java/jenkins/security/SuspiciousRequestFilterTest.java
+++ b/test/src/test/java/jenkins/security/SuspiciousRequestFilterTest.java
@@ -40,7 +40,7 @@ public class SuspiciousRequestFilterTest {
         assertThat(Foo.getInstance().baz, is(nullValue()));
         assertThat(response.getStatusCode(), is(HttpServletResponse.SC_BAD_REQUEST));
         // Actually served by Jetty; never even gets as far as SuspiciousRequestFilter.
-        assertThat(response.getContentAsString(), containsString("Ambiguous path parameter"));
+        assertThat(response.getContentAsString(), containsString("path parameter"));
     }
 
     @Ignore("No longer passes Jetty")

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -171,6 +171,7 @@ THE SOFTWARE.
                   <excludes>
                     <exclude>org.jenkins-ci.main:cli</exclude>
                     <exclude>org.jenkins-ci.main:jenkins-core</exclude>
+                    <exclude>org.jenkins-ci.main:remoting</exclude>
                     <exclude>org.jenkins-ci.main:websocket-jetty9</exclude>
                     <exclude>org.jenkins-ci.main:websocket-spi</exclude>
                   </excludes>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -91,8 +91,8 @@ THE SOFTWARE.
           jars that are not needed in war. most of the exclusions should happen in the core, to make IDEs happy, not here.
         -->
         <exclusion>
-          <groupId>javax.servlet.jsp</groupId>
-          <artifactId>javax.servlet.jsp-api</artifactId>
+          <groupId>jakarta.servlet.jsp</groupId>
+          <artifactId>jakarta.servlet.jsp-api</artifactId>
         </exclusion>
         <!-- Stapler 1.195 fails to declare this as optional, and the 1.1 version lacks a license: -->
         <exclusion>
@@ -100,6 +100,11 @@ THE SOFTWARE.
           <artifactId>metainf-services</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>websocket-jetty10</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
@@ -142,7 +147,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>5.25</version>
+      <version>6.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -169,11 +174,16 @@ THE SOFTWARE.
                 <enforceBytecodeVersion>
                   <maxJdkVersion>1.8</maxJdkVersion>
                   <excludes>
+                    <exclude>org.jenkins-ci:commons-jelly</exclude>
                     <exclude>org.jenkins-ci.main:cli</exclude>
                     <exclude>org.jenkins-ci.main:jenkins-core</exclude>
                     <exclude>org.jenkins-ci.main:remoting</exclude>
                     <exclude>org.jenkins-ci.main:websocket-jetty9</exclude>
+                    <exclude>org.jenkins-ci.main:websocket-jetty10</exclude>
                     <exclude>org.jenkins-ci.main:websocket-spi</exclude>
+                    <exclude>org.kohsuke.stapler:stapler</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
                   </excludes>
                 </enforceBytecodeVersion>
               </rules>
@@ -560,7 +570,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.4.46.v20220331</version>
+        <version>10.0.11</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)
@@ -577,54 +587,27 @@ THE SOFTWARE.
             </loginService>
           </loginServices>
           <systemProperties>
-            <systemProperty>
-              <name>JENKINS_HOME</name>
-              <value>${JENKINS_HOME}</value>
-            </systemProperty>
-            <systemProperty>
-              <!-- always reload views during debugging -->
-              <name>stapler.jelly.noCache</name>
-              <value>true</value>
-            </systemProperty>
-            <systemProperty>
-              <!-- show the stapler evaluation during execution -->
-              <name>stapler.trace</name>
-              <value>true</value>
-            </systemProperty>
-            <systemProperty>
-              <!-- show the full stack trace on errors (the oops page) -->
-              <name>jenkins.model.Jenkins.SHOW_STACK_TRACE</name>
-              <value>true</value>
-            </systemProperty>
-            <systemProperty>
-              <!-- always reload scripts during debugging -->
-              <name>hudson.script.noCache</name>
-              <value>true</value>
-            </systemProperty>
-            <systemProperty>
-              <!-- load view resources from the source directly, again for real time change -->
-              <name>stapler.resourcePath</name>
-              <value>../core/src/main/resources;</value>
-            </systemProperty>
-            <systemProperty>
-              <!-- enable the plugins in main by default -->
-              <name>hudson.bundled.plugins</name>
-              <!-- run "mvn install" once will generate the.hpl -->
-              <value>${project.build.directory}/${project.build.finalName}/WEB-INF/plugins/*.hpi</value>
-            </systemProperty>
-            <systemProperty>
-              <!-- stat collection pointless -->
-              <name>hudson.model.UsageStatistics.disabled</name>
-              <value>true</value>
-            </systemProperty>
-            <systemProperty>
-              <name>hudson.Main.development</name>
-              <value>true</value>
-            </systemProperty>
+            <JENKINS_HOME>${JENKINS_HOME}</JENKINS_HOME>
+            <!-- always reload views during debugging -->
+            <stapler.jelly.noCache>true</stapler.jelly.noCache>
+            <!-- show the stapler evaluation during execution -->
+            <stapler.trace>true</stapler.trace>
+            <!-- show the full stack trace on errors (the oops page) -->
+            <jenkins.model.Jenkins.SHOW_STACK_TRACE>true</jenkins.model.Jenkins.SHOW_STACK_TRACE>
+            <!-- always reload scripts during debugging -->
+            <hudson.script.noCache>true</hudson.script.noCache>
+            <!-- load view resources from the source directly, again for real time change -->
+            <stapler.resourcePath>../core/src/main/resources;</stapler.resourcePath>
+            <!-- enable the plugins in main by default -->
+            <!-- run "mvn install" once will generate the.hpl -->
+            <hudson.bundled.plugins>${project.build.directory}/${project.build.finalName}/WEB-INF/plugins/*.hpi</hudson.bundled.plugins>
+            <!-- stat collection pointless -->
+            <hudson.model.UsageStatistics.disabled>true</hudson.model.UsageStatistics.disabled>
+            <hudson.Main.development>true</hudson.Main.development>
           </systemProperties>
           <webApp>
             <!-- Allows resources to be reloaded, and enable nicer console logging. -->
-            <extraClasspath>${project.basedir}/../core/src/main/resources,${project.basedir}/../core/target/classes,${project.build.directory}/support-log-formatter.jar</extraClasspath>
+            <!-- TODO eclipse/jetty.project#7970 <extraClasspath>${project.basedir}/../core/src/main/resources,${project.basedir}/../core/target/classes,${project.build.directory}/support-log-formatter.jar</extraClasspath> -->
             <contextPath>${contextPath}</contextPath>
             <configurationDiscovered>false</configurationDiscovered>
             <!-- see https://wiki.eclipse.org/Jetty/Howto/Avoid_slow_deployment -->

--- a/war/src/main/js/templates/plugin-manager/available.hbs
+++ b/war/src/main/js/templates/plugin-manager/available.hbs
@@ -65,12 +65,14 @@
                 </div>
             {{/if}}
         </td>
-        <td width="25%">
-            {{#if this.releaseTimestamp }}
+        {{#if this.releaseTimestamp }}
+            <td style="width: 25%" data="{{ this.releaseTimestamp.iso8601 }}">
                 <time datetime="{{ this.releaseTimestamp.iso8601 }}">
                     {{ this.releaseTimestamp.displayValue }}
                 </time>
-            {{/if}}
-        </td>
+            </td>
+        {{else}}
+            <td style="width: 25%"></td>
+        {{/if}}
     </tr>
 {{/each}}

--- a/war/src/main/less/form/reorderable-list.less
+++ b/war/src/main/less/form/reorderable-list.less
@@ -6,6 +6,7 @@
   padding: 1rem;
   border-radius: 10px;
   margin-bottom: 1rem;
+  margin-top: 1rem;
 }
 
 .repeated-chunk .show-if-last { visibility: hidden; }

--- a/websocket/jetty10/pom.xml
+++ b/websocket/jetty10/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright (c) 2019, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.main</groupId>
+    <artifactId>jenkins-parent</artifactId>
+    <version>${revision}${changelist}</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>websocket-jetty10</artifactId>
+  <name>Jetty 10 implementation for WebSocket</name>
+  <description>An implementation of the WebSocket handler that works with Jetty 10.</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>winstone</artifactId>
+      <version>6.1</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>websocket-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-annotation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke.metainf-services</groupId>
+      <artifactId>metainf-services</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
+++ b/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
@@ -1,0 +1,162 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.websocket;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
+import org.eclipse.jetty.websocket.api.WriteCallback;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
+import org.kohsuke.MetaInfServices;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+@MetaInfServices(Provider.class)
+public class Jetty10Provider implements Provider {
+
+    private static final String ATTR_LISTENER = Jetty10Provider.class.getName() + ".listener";
+
+    // TODO does not seem possible to use HttpServletRequest.get/setAttribute for this
+    private static final Map<Listener, Session> sessions = new WeakHashMap<>();
+
+    public Jetty10Provider() {
+        JettyWebSocketServerContainer.class.hashCode();
+    }
+
+    @Override
+    public Handler handle(HttpServletRequest req, HttpServletResponse rsp, Listener listener) throws Exception {
+        req.setAttribute(ATTR_LISTENER, listener);
+        // TODO Jetty 10 has no obvious equivalent to WebSocketServerFactory.isUpgradeRequest; RFC6455Negotiation?
+        if (!"websocket".equalsIgnoreCase(req.getHeader("Upgrade"))) {
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, "only WS connections accepted here");
+            return null;
+        }
+        if (!JettyWebSocketServerContainer.getContainer(req.getServletContext()).upgrade(Jetty10Provider::createWebSocket, req, rsp)) {
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, "did not manage to upgrade");
+            return null;
+        }
+        return new Handler() {
+            @Override
+            public Future<Void> sendBinary(ByteBuffer data) throws IOException {
+                CompletableFuture<Void> f = new CompletableFuture<>();
+                session().getRemote().sendBytes(data, new WriteCallbackImpl(f));
+                return f;
+            }
+
+            @Override
+            public void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
+                session().getRemote().sendPartialBytes(partialByte, isLast);
+            }
+
+            @Override
+            public Future<Void> sendText(String text) throws IOException {
+                CompletableFuture<Void> f = new CompletableFuture<>();
+                session().getRemote().sendString(text, new WriteCallbackImpl(f));
+                return f;
+            }
+
+            @Override
+            public void sendPing(ByteBuffer applicationData) throws IOException {
+                session().getRemote().sendPing(applicationData);
+            }
+
+            @Override
+            public void close() throws IOException {
+                session().close();
+            }
+
+            private Session session() {
+                Session session = sessions.get(listener);
+                if (session == null) {
+                    throw new IllegalStateException("missing session");
+                }
+                return session;
+            }
+        };
+    }
+
+    private static final class WriteCallbackImpl implements WriteCallback {
+        private final CompletableFuture<Void> f;
+
+        WriteCallbackImpl(CompletableFuture<Void> f) {
+            this.f = f;
+        }
+
+        @Override
+        public void writeSuccess() {
+            f.complete(null);
+        }
+
+        @Override
+        public void writeFailed(Throwable x) {
+            f.completeExceptionally(x);
+        }
+    }
+
+    private static Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp) {
+        Listener listener = (Listener) req.getHttpServletRequest().getAttribute(ATTR_LISTENER);
+        if (listener == null) {
+            throw new IllegalStateException("missing listener attribute");
+        }
+        return new WebSocketListener() {
+            @Override
+            public void onWebSocketBinary(byte[] payload, int offset, int length) {
+                listener.onWebSocketBinary(payload, offset, length);
+            }
+
+            @Override
+            public void onWebSocketText(String message) {
+                listener.onWebSocketText(message);
+            }
+
+            @Override
+            public void onWebSocketClose(int statusCode, String reason) {
+                listener.onWebSocketClose(statusCode, reason);
+            }
+
+            @Override
+            public void onWebSocketConnect(Session session) {
+                sessions.put(listener, session);
+                listener.onWebSocketConnect();
+            }
+
+            @Override
+            public void onWebSocketError(Throwable cause) {
+                listener.onWebSocketError(cause);
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->
<!--See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).-->

### Summary
This is the first **backporting** PR for LTS 2.361.1

```
Latest core version: jenkins-2.363

Fixed
-----

JENKINS-69240           Minor                   2.363
        Version select input is out of style with other drop down select input
        https://issues.jenkins.io/browse/JENKINS-69240

JENKINS-69230           Minor                   2.363
        There is no space between the form and the button
        https://issues.jenkins.io/browse/JENKINS-69230

JENKINS-69211           Minor                   2.363
        There is no space between the line and the button
        https://issues.jenkins.io/browse/JENKINS-69211

JENKINS-69210           Blocker                 2.363
        Unable to rebuild a job triggered by polling (regression in 2.358)
        regression
        https://issues.jenkins.io/browse/JENKINS-69210

JENKINS-69198           Major                   2.362
        Jenkins 2.361 core sources & javadoc not on repo.jenkins-ci.org
        regression
        https://issues.jenkins.io/browse/JENKINS-69198

JENKINS-68957           Minor                   2.363
        Job configuration page SCM radio buttons have an odd selection animation
        https://issues.jenkins.io/browse/JENKINS-68957

JENKINS-68851           Minor                   2.362
        Press enter in the filter box of dropdown lists leads to other pages
        https://issues.jenkins.io/browse/JENKINS-68851

JENKINS-68801           Minor                   2.362
        Symbol framework doesn't work properly if plugin's artifactId contains word "plugin-"
        https://issues.jenkins.io/browse/JENKINS-68801

JENKINS-68750           Minor                   2.362
        Plugin Manager does not sort by timestamp (regression in 2.274)
        regression
        https://issues.jenkins.io/browse/JENKINS-68750

JENKINS-68694           Major                   2.363
        Winstone 6.1: Upgrade Jetty from 9.4.46.v20220331 to 10.0.11
        https://issues.jenkins.io/browse/JENKINS-68694

JENKINS-68578           Minor                   2.362
        Test overview bar is out of style with other Jenkins components
        https://issues.jenkins.io/browse/JENKINS-68578

JENKINS-68390           Minor                   2.361
        Build number cut off on safari (regression in 2.344)
        regression
        https://issues.jenkins.io/browse/JENKINS-68390

JENKINS-68380           Minor                   2.357
        Script console input box is not sizeable, yet the box looks like it is (regression in 2.321)
        regression
        https://issues.jenkins.io/browse/JENKINS-68380

JENKINS-65873           Major                   2.362
        java.lang.OutOfMemoryError: unable to create new native thread
        https://issues.jenkins.io/browse/JENKINS-65873
```

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

<!--### Proposed changelog entries-->

<!--* Entry 1: Issue, Human-readable Text-->
<!--* ...-->

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

<!--### Proposed upgrade guidelines-->

<!--N/A-->

### Submitter checklist

- [x] (If applicable) Jira issue is well described. (N/A)
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml) (N/A)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade.
- [x] Appropriate autotests or explanation to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. (N/A)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable. (N/A)
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)). (N/A)
- [x] For dependency updates: links to external changelogs and, if possible, full diffs. (N/A)

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@basil @alecharp @timja @NotMyFault

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6993"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

