### PR TITLE
Update Maven Jellydoc and Stapler plugins

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
   <properties>
     <asm.version>9.3</asm.version>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <stapler.version>1728.v56ec83576669</stapler.version>
+    <stapler.version>1730.v43d2c7b_11a_27</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.85</version>
+    <version>1.86</version>
     <relativePath />
   </parent>
 
@@ -295,7 +295,7 @@ THE SOFTWARE.
             <dependency>
               <groupId>org.jvnet.maven-jellydoc-plugin</groupId>
               <artifactId>maven-jellydoc-plugin</artifactId>
-              <version>1.5</version>
+              <version>1.9</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Updates to the latest parent POM (which contains the new Maven 3 based release of Maven Stapler Plugin 1.19) and the latest version of Stapler (which depends on the new Maven 3 based release of Maven Jellydoc Plugin 1.9) and Maven Jellydoc Plugin 1.9. Note that Maven Stapler Plugin 1.19 depends on Maven Jellydoc Plugin 1.9.

### Testing done

With Java 11, ran in `core/`

```
$ mvn -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site
[…]
[INFO] <<< maven-stapler-plugin:1.19:jelly-taglibdoc < generate-sources @ jenkins-core <<<
[INFO] 
[INFO] 'generate-sources' forked phase execution for maven-stapler-plugin:jelly-taglibdoc report preparation done
[INFO] 1 report detected for maven-stapler-plugin:1.19: jelly-taglibdoc
[INFO] configuring report plugin org.apache.maven.plugins:maven-project-info-reports-plugin:3.4.1
[INFO] 15 reports detected for maven-project-info-reports-plugin:3.4.1: ci-management, dependencies, dependency-info, dependency-management, distribution-management, index, issue-management, licenses, mailing-lists, modules, plugin-management, plugins, scm, summary, team
[INFO] Rendering site with default locale English (en)
[INFO] Relativizing decoration links with respect to localized project URL: https://github.com/jenkinsci/jenkins
[INFO] Rendering content with org.apache.maven.skins:maven-fluido-skin:jar:1.11.1 skin.
[INFO] Skipped "About" report (maven-project-info-reports-plugin:3.4.1:index), file "index.html" already exists.
[INFO] Rendering 1 Doxia document: 1 markdown
[INFO] Generating "Jelly taglib reference" report --- maven-stapler-plugin:1.19:jelly-taglibdoc
[INFO] Processing /home/basil/src/jenkinsci/jenkins/core/src/main/resources/lib/form
[INFO] Processing /home/basil/src/jenkinsci/jenkins/core/src/main/resources/lib/test
[INFO] Processing /home/basil/src/jenkinsci/jenkins/core/src/main/resources/lib/layout
[INFO] Processing /home/basil/src/jenkinsci/jenkins/core/src/main/resources/lib/hudson
[INFO] Processing /home/basil/src/jenkinsci/jenkins/core/src/main/resources/lib/hudson/project
[INFO] Processing /home/basil/src/jenkinsci/jenkins/core/src/main/resources/lib/hudson/newFromList
[info] Generating XML Schema
[INFO] Generating "CI Management" report --- maven-project-info-reports-plugin:3.4.1:ci-management
[INFO] Generating "Dependencies" report  --- maven-project-info-reports-plugin:3.4.1:dependencies
[INFO] Generating "Dependency Information" report --- maven-project-info-reports-plugin:3.4.1:dependency-info
[INFO] Generating "Dependency Management" report --- maven-project-info-reports-plugin:3.4.1:dependency-management
[INFO] Generating "Distribution Management" report --- maven-project-info-reports-plugin:3.4.1:distribution-management
[INFO] Generating "Issue Management" report --- maven-project-info-reports-plugin:3.4.1:issue-management
[INFO] Generating "Licenses" report      --- maven-project-info-reports-plugin:3.4.1:licenses
[INFO] Generating "Mailing Lists" report --- maven-project-info-reports-plugin:3.4.1:mailing-lists
[INFO] Generating "Plugin Management" report --- maven-project-info-reports-plugin:3.4.1:plugin-management
[INFO] Could not build project for lifecycle-mapping
```

and then viewed the core tag library report successfully.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/6998"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

