### PR TITLE
Enable Dependabot security updates on LTS line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,3 +56,10 @@ updates:
       # Contains incompatible API changes and needs compatibility work. See:
       # https://github.com/jenkinsci/jenkins/pull/4224
       - dependency-name: "org.jfree:jfreechart"
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "stable-2.361"
+    schedule:
+      interval: "daily"
+    # Include only security updates and exclude version updates.
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,7 @@ updates:
     target-branch: "stable-2.361"
     labels:
       - "into-lts"
+      - "needs-justification"
     schedule:
       interval: "daily"
     # Include only security updates and exclude version updates.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,8 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     target-branch: "stable-2.361"
+    labels:
+      - "into-lts"
     schedule:
       interval: "daily"
     # Include only security updates and exclude version updates.


### PR DESCRIPTION
This PR enables Dependabot security updates (but not regular dependency updates) on the stable LTS line. Per [the documentation](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file):

> If you only require security updates and want to exclude version updates, you can set `open-pull-request-limit` to 0 in order to prevent version updates for a given `package-ecosystem`.

And [also](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit):

> [The `open-pull-requests-limit`] option has no impact on security updates, which have a separate, internal limit of ten open pull requests.

### Expected process

Suppose a new version of a dependency is released that fixes a CVE but is not exploitable (if it is exploitable, the standard CERT process would apply instead). Dependabot would open a PR against the main branch, which we would presumably merge and release in the next weekly. As of this PR, Dependabot would also open a backport PR against the stable LTS branch. (Well, it wouldn't be a "backport" per se until after the corresponding PR on the main branch has been merged, but presumably that would happen very quickly.) ~After the update is shipped in a weekly and verified to not have any problems, the backport PR could be accepted. This eliminates the need for a human to create a backport ticket with the lts-candidate label for such changes.~ Our existing criteria for acceptance or rejection of the proposed backport would then apply. If accepted, the net result would be eliminating the need for a human to create a backport ticket with the `lts-candidate` label for such changes and therefore making it less likely that they will slip through the cracks, ultimately benefiting users for whom scanner compliance is a goal.

### Future work

If accepted, there would be two additional action items after merging this PR:

- Update the release lead guide to include instructions on bumping this number when a new LTS branch is created.
- Ensure that Dependabot security updates are enabled [here](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#enabling-or-disabling-dependabot-security-updates-for-an-individual-repository). I lack the administrative access to check this setting; it may already be enabled.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7026"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

