### PR TITLE
[JENKINS-67624] `FileAlreadyExistsException` on startup

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1778,7 +1778,12 @@ public class Util {
             if (Files.isDirectory(dir)) {
                 return dir;
             } else {
-                return Files.createDirectory(dir, attrs);
+                try {
+                    return Files.createDirectory(dir, attrs);
+                } catch (FileAlreadyExistsException e) {
+                    // a concurrent caller won the race
+                    return dir;
+                }
             }
         }
 
@@ -1786,7 +1791,11 @@ public class Util {
         for (Path name : parent.relativize(dir)) {
             child = child.resolve(name);
             if (!Files.isDirectory(child)) {
-                Files.createDirectory(child, attrs);
+                try {
+                    Files.createDirectory(child, attrs);
+                } catch (FileAlreadyExistsException e) {
+                    // a concurrent caller won the race
+                }
             }
         }
 

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1781,7 +1781,7 @@ public class Util {
                 try {
                     return Files.createDirectory(dir, attrs);
                 } catch (FileAlreadyExistsException e) {
-                    if (Files.isDirectory(dir, LinkOption.NOFOLLOW_LINKS)) {
+                    if (Files.isDirectory(dir)) {
                         // a concurrent caller won the race
                         return dir;
                     } else {
@@ -1798,7 +1798,7 @@ public class Util {
                 try {
                     Files.createDirectory(child, attrs);
                 } catch (FileAlreadyExistsException e) {
-                    if (Files.isDirectory(child, LinkOption.NOFOLLOW_LINKS)) {
+                    if (Files.isDirectory(child)) {
                         // a concurrent caller won the race
                     } else {
                         throw e;

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1781,8 +1781,12 @@ public class Util {
                 try {
                     return Files.createDirectory(dir, attrs);
                 } catch (FileAlreadyExistsException e) {
-                    // a concurrent caller won the race
-                    return dir;
+                    if (Files.isDirectory(dir, LinkOption.NOFOLLOW_LINKS)) {
+                        // a concurrent caller won the race
+                        return dir;
+                    } else {
+                        throw e;
+                    }
                 }
             }
         }
@@ -1794,7 +1798,11 @@ public class Util {
                 try {
                     Files.createDirectory(child, attrs);
                 } catch (FileAlreadyExistsException e) {
-                    // a concurrent caller won the race
+                    if (Files.isDirectory(child, LinkOption.NOFOLLOW_LINKS)) {
+                        // a concurrent caller won the race
+                    } else {
+                        throw e;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Steps to reproduce

Patching `Util.java` with …

```
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -75,6 +75,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
@@ -1786,6 +1787,13 @@ public class Util {
         for (Path name : parent.relativize(dir)) {
             child = child.resolve(name);
             if (!Files.isDirectory(child)) {
+                if (new SecureRandom().nextInt(2) == 0) {
+                    try {
+                        Thread.sleep(1000L);
+                    } catch (InterruptedException e) {
+                        // ignore
+                    }
+                }
                 Files.createDirectory(child, attrs);
             }
         }
```

… one can elicit …

```
java.nio.file.FileAlreadyExistsException: /home/basil/jenkins_homes/JENKINS-67624/updates
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:94)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
        at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:389)
        at java.base/java.nio.file.Files.createDirectory(Files.java:690)
        at hudson.Util.createDirectories(Util.java:1802)
        at hudson.util.TextFile.write(TextFile.java:100)
        at hudson.model.UpdateSite.updateData(UpdateSite.java:248)
        at hudson.model.UpdateSite.updateDirectlyNow(UpdateSite.java:219)
        at hudson.model.UpdateSite.updateDirectlyNow(UpdateSite.java:214)
        at hudson.PluginManager.checkUpdatesServer(PluginManager.java:1987)
        at hudson.util.Retrier.start(Retrier.java:62)
        at hudson.PluginManager.doCheckUpdatesServer(PluginManager.java:1958)
        at jenkins.DailyCheck.execute(DailyCheck.java:93)
        at hudson.model.AsyncPeriodicWork.lambda$doRun$0(AsyncPeriodicWork.java:102)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

… at least half the time even on a system with very fast I/O. A probability of 0.5 works well because there are enough racing threads such that at least one of them will hit the sleep.

### Evaluation

Simple race between the thread checking for the existence of a directory and the thread creating it.

### Solution

Let one of the threads win the race and let the other thread accept the result of the race and continue execution. I retained the check for `Files#isDirectory` since there is no point beginning a race when the outcome is already known.

### Testing done

With the above sleep statement I could hit the problem at least half the time even on a system with very fast I/O. With this fix (and the sleep statement retained) I couldn't hit the problem after 5 tries.

### Proposed changelog entries

Fix a potential `FileAlreadyExistsException` error on startup on systems with slow I/O.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  * Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate. 
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7027"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

