### PR TITLE
Fix Plugin Manager selection controller buttons appearance

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -68,7 +68,7 @@ THE SOFTWARE.
                 <th data-sort-disable="true">
                   <l:rowSelectionController>
                     <j:if test="${app.updateCenter.hasIncompatibleUpdates(cache)}">
-                      <button tooltip="${%CompatibleTooltip}" type="button" data-select="compatible" class="jenkins-button jenkins-button--transparent">
+                      <button tooltip="${%CompatibleTooltip}" type="button" data-select="compatible" class="jenkins-button jenkins-button--tertiary">
                         <div class="jenkins-table__checkbox-dropdown__icon">
                           <l:icon src="symbol-compatible" />
                         </div>

--- a/core/src/main/resources/lib/layout/rowSelectionController.jelly
+++ b/core/src/main/resources/lib/layout/rowSelectionController.jelly
@@ -39,20 +39,20 @@ THE SOFTWARE.
     </j:set>
 
     <j:if test="${contents.length() != 0}">
-      <button type="button" class="jenkins-button jenkins-button--transparent jenkins-table__checkbox-options">
+      <button type="button" class="jenkins-button jenkins-button--tertiary jenkins-table__checkbox-options">
         <l:icon src="symbol-chevron-down" />
       </button>
 
       <div class="jenkins-table__checkbox-dropdown">
         <span>${%Select}</span>
-        <button type="button" data-select="all" class="jenkins-button jenkins-button--transparent">
+        <button type="button" data-select="all" class="jenkins-button jenkins-button--tertiary">
           <div class="jenkins-table__checkbox-dropdown__icon">
             <l:icon src="symbol-check" />
           </div>
           ${%All}
         </button>
         <j:out value="${contents}" />
-        <button type="button" data-select="none" class="jenkins-button jenkins-button--transparent">
+        <button type="button" data-select="none" class="jenkins-button jenkins-button--tertiary">
           <div class="jenkins-table__checkbox-dropdown__icon">
             <l:icon src="symbol-close" />
           </div>

--- a/war/src/main/less/modules/row-selection-controller.less
+++ b/war/src/main/less/modules/row-selection-controller.less
@@ -104,6 +104,11 @@
     }
   }
 
+  &::before,
+  &::after {
+    border-radius: 0.33rem;
+  }
+
   &:hover {
     svg {
       color: var(--input-border-hover);
@@ -131,7 +136,7 @@
   left: 1.375rem;
   display: flex;
   flex-direction: column;
-  border-radius: 10px;
+  border-radius: 0.8rem;
   z-index: 999;
   padding: 0.4rem;
   box-shadow: inset 0 0 0 2px rgba(white, 0.05), 0 0 0 1px rgba(black, 0.05),


### PR DESCRIPTION
Small bug that cropped up as a result of #6799, the class for transparent buttons was renamed but I had missed this.

**Before**
<img width="232" alt="Screenshot 2022-08-29 at 22 09 52" src="https://user-images.githubusercontent.com/43062514/187299486-e8ee8ede-0c06-48de-9f92-809b4b581ee3.png">

**After**
<img width="218" alt="Screenshot 2022-08-29 at 22 03 21" src="https://user-images.githubusercontent.com/43062514/187298453-d0a1855e-59a7-4ac6-a886-b491d6a3befe.png">


### Proposed changelog entries

- N/A (too small)

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7045"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

