### PR TITLE
In the security warnings popup, show recommended actions

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1047,6 +1047,13 @@ public class UpdateSite {
             }
         }
 
+        /**
+         * Returns whether this warning is fixable by updating the affected component.
+         * @return {@code true} if the warning does not apply to the latest offered version of core or the affected plugin;
+         * {@code false} if it does; and {@code null} when the affected component isn't being offered, or it's a warning
+         * for something other than core or a plugin.
+         */
+        @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL")
         public Boolean isFixable() {
             final Data data = UpdateSite.this.data;
             if (data == null) {
@@ -1069,9 +1076,9 @@ public class UpdateSite {
                     final VersionNumber latestCoreVersion = new VersionNumber(plugin.version);
                     return !isRelevantToVersion(latestCoreVersion);
                 }
-                // No handling for 'OTHER'
+                default:
+                    return null;
             }
-            return null;
         }
 
         public boolean isRelevantToVersion(@NonNull VersionNumber version) {

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsConfiguration.java
@@ -76,7 +76,7 @@ public class UpdateSiteWarningsConfiguration extends GlobalConfiguration impleme
 
     @CheckForNull
     public PluginWrapper getPlugin(@NonNull UpdateSite.Warning warning) {
-        if (warning.type != UpdateSite.Warning.Type.PLUGIN) {
+        if (warning.type != UpdateSite.WarningType.PLUGIN) {
             return null;
         }
         return Jenkins.get().getPluginManager().getPlugin(warning.component);

--- a/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
+++ b/core/src/main/java/jenkins/security/UpdateSiteWarningsMonitor.java
@@ -96,7 +96,7 @@ public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
         List<UpdateSite.Warning> CoreWarnings = new ArrayList<>();
 
         for (UpdateSite.Warning warning : getActiveWarnings()) {
-            if (warning.type != UpdateSite.Warning.Type.CORE) {
+            if (warning.type != UpdateSite.WarningType.CORE) {
                 // this is not a core warning
                 continue;
             }
@@ -109,7 +109,7 @@ public class UpdateSiteWarningsMonitor extends AdministrativeMonitor {
         Map<PluginWrapper, List<UpdateSite.Warning>> activePluginWarningsByPlugin = new HashMap<>();
 
         for (UpdateSite.Warning warning : getActiveWarnings()) {
-            if (warning.type != UpdateSite.Warning.Type.PLUGIN) {
+            if (warning.type != UpdateSite.WarningType.PLUGIN) {
                 // this is not a plugin warning
                 continue;
             }

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
@@ -47,14 +47,14 @@ def listWarnings(warnings) {
     if (fixables == warnings.size) {
         dd {
             if (fixables == 1) {
-                raw(_("allFixable1"))
+                raw(_("allFixable1", rootURL))
             } else {
-                raw(_("allFixable"))
+                raw(_("allFixable", rootURL))
             }
         }
     } else if (fixables > 0) {
         dd {
-            raw(_("someFixable"))
+            raw(_("someFixable", rootURL))
         }
     } else {
         dd {

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
@@ -28,17 +28,37 @@ def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 
 def listWarnings(warnings) {
+    def fixables = 0
+    def unfixables = 0
     warnings.each { warning ->
         dd {
             a(warning.message, href: warning.url, rel: 'noopener noreferrer', target: "_blank")
             def fixable = warning.isFixable()
             if (fixable != null) {
                 if (fixable) {
-                    raw(_("fixable", rootURL))
+                    fixables++
                 } else {
-                    raw(_("unfixable", rootURL))
+                    unfixables++
+                    raw(_("unfixable"))
                 }
             }
+        }
+    }
+    if (fixables == warnings.size) {
+        dd {
+            if (fixables == 1) {
+                raw(_("allFixable1"))
+            } else {
+                raw(_("allFixable"))
+            }
+        }
+    } else if (fixables > 0) {
+        dd {
+            raw(_("someFixable"))
+        }
+    } else {
+        dd {
+            raw(_("noneFixable"))
         }
     }
 }

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
@@ -29,7 +29,6 @@ def l = namespace(lib.LayoutTagLib)
 
 def listWarnings(warnings) {
     def fixables = 0
-    def unfixables = 0
     warnings.each { warning ->
         dd {
             a(warning.message, href: warning.url, rel: 'noopener noreferrer', target: "_blank")
@@ -38,7 +37,6 @@ def listWarnings(warnings) {
                 if (fixable) {
                     fixables++
                 } else {
-                    unfixables++
                     raw(_("unfixable"))
                 }
             }

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
@@ -31,6 +31,14 @@ def listWarnings(warnings) {
     warnings.each { warning ->
         dd {
             a(warning.message, href: warning.url, rel: 'noopener noreferrer', target: "_blank")
+            def fixable = warning.isFixable()
+            if (fixable != null) {
+                if (fixable) {
+                    raw(_("fixable", rootURL))
+                } else {
+                    raw(_("unfixable", rootURL))
+                }
+            }
         }
     }
 }

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
@@ -26,10 +26,17 @@ coreTitle = Jenkins {0} core and libraries
 blurb = Warnings have been published for the following currently installed components:
 more = Additional warnings are hidden due to the current security configuration.
 
-fixable = : A fix for this issue is available. \
-  Go to the <a href="{0}/pluginManager">plugin manager</a> to install it.
-unfixable = : A fix for this issue is not available. \
-  It is recommended that you review the security advisory and, if you're affected, implement workarounds or uninstall the plugin.
+allFixable = Fixes for all of these issues are available. \
+  Go to the <a href="{0}/pluginManager">plugin manager</a> to update the plugin.
+allFixable1 = A fix for this issue is available. \
+  Go to the <a href="{0}/pluginManager">plugin manager</a> to update the plugin.
+someFixable = Fixes for some of these issues are available. \
+  Go to the <a href="{0}/pluginManager">plugin manager</a> to update the plugin. \
+  For issues without a fix, it is recommended that you review the security advisory and apply mitigations if possible, or uninstall this plugin.
+noneFixable = No fixes for these issues are available. \
+  It is recommended that you review the security advisory and apply mitigations if possible, or uninstall this plugin.
+# Leading space to separate from link
+unfixable = \u0020(no fix available)
 
 pluginManager.link = Go to plugin manager
 configureSecurity.link = Configure which of these warnings are shown

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.properties
@@ -26,6 +26,10 @@ coreTitle = Jenkins {0} core and libraries
 blurb = Warnings have been published for the following currently installed components:
 more = Additional warnings are hidden due to the current security configuration.
 
+fixable = : A fix for this issue is available. \
+  Go to the <a href="{0}/pluginManager">plugin manager</a> to install it.
+unfixable = : A fix for this issue is not available. \
+  It is recommended that you review the security advisory and, if you're affected, implement workarounds or uninstall the plugin.
 
 pluginManager.link = Go to plugin manager
 configureSecurity.link = Configure which of these warnings are shown


### PR DESCRIPTION
This adds information about the (un)availability of fixes to the security warning popup.

The warnings are changed into an inner class to have a reference to the related update site to check whether an update fixing the issue is being offered. We're not bothering with understanding the semantics of plugin updates offered across different update sites here, which might be the correct thing to do or not, unsure. I expect this is very unusual, so we have very little data to reason about the optimal behavior, and it's probably not worth the time either.

Screenshot:

### Before

> <img width="1596" alt="Screenshot 2022-08-31 at 13 57 12" src="https://user-images.githubusercontent.com/1831569/187673150-3269f466-e554-44a7-b229-7d0306702bb9.png">


### After

> <img width="2320" alt="Screenshot 2022-08-31 at 13 53 12" src="https://user-images.githubusercontent.com/1831569/187672525-e5a8e344-3957-468a-a908-74e2790504f1.png">


### Proposed changelog entries

* Show recommended actions (e.g., to update affected plugins) in security warnings popup.

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7046"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

