### PR TITLE
Remove inline SVG of 'concealed' field

### DIFF
--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   <st:documentation>
     Glorified &lt;input type="password">
 
@@ -85,28 +85,7 @@ THE SOFTWARE.
                          ATTRIBUTES="${attrs}" EXCEPT="field clazz value"/>
                 <div class="hidden-password-placeholder">
                   <div class="hidden-password-legend">
-                    <svg width="20px" height="25px" viewBox="0 0 25 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                      <!--
-                          Based on Material Design.
-
-                          Licensed under the Apache License, Version 2.0 (the "License");
-                          you may not use this file except in compliance with the License.
-                          You may obtain a copy of the License at
-
-                              http://www.apache.org/licenses/LICENSE-2.0
-
-                          Unless required by applicable law or agreed to in writing, software
-                          distributed under the License is distributed on an "AS IS" BASIS,
-                          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                          See the License for the specific language governing permissions and
-                          limitations under the License.
-                      -->
-                      <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                        <g transform="translate(-504.000000, -199.000000)" fill="#788594">
-                          <path d="M520.914667,209.666667 L511.466667,209.666667 L511.466667,206.619333 C511.466667,204.014 513.584667,201.895333 516.190667,201.895333 C518.796667,201.895333 520.914667,204.014 520.914667,206.619333 L520.914667,209.666667 Z M516.190667,223.381333 C514.514,223.381333 513.143333,222.01 513.143333,220.333333 C513.143333,218.657333 514.514,217.286 516.190667,217.286 C517.867333,217.286 519.238,218.657333 519.238,220.333333 C519.238,222.01 517.867333,223.381333 516.190667,223.381333 Z M516.190667,199 C511.984667,199 508.571333,202.414 508.571333,206.619333 L508.571333,209.666667 L507.048,209.666667 C505.372,209.666667 504,211.038 504,212.714667 L504,227.952667 C504,229.628667 505.372,231 507.048,231 L525.334,231 C527.01,231 528.380667,229.628667 528.380667,227.952667 L528.380667,212.714667 C528.380667,211.038 527.01,209.666667 525.334,209.666667 L523.81,209.666667 L523.81,206.619333 C523.81,202.414 520.396667,199 516.190667,199 Z"/>
-                        </g>
-                      </g>
-                    </svg>
+                    <l:icon src="symbol-lock-closed" class="icon-md"/>
                     <span>${%Concealed}</span>
                   </div>
                   <div class="hidden-password-update">

--- a/core/src/main/resources/lib/form/secretTextarea.jelly
+++ b/core/src/main/resources/lib/form/secretTextarea.jelly
@@ -23,7 +23,7 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout">
     <st:documentation><![CDATA[
 Enhanced version of <f:textarea/> for editing multi-line secrets.
 
@@ -73,28 +73,7 @@ Example usage:
                         <span>${%NoStoredValue}</span>
                     </j:when>
                     <j:otherwise>
-                        <svg width="25px" height="32px" viewBox="0 0 25 32" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                            <!--
-                                Based on Material Design.
-
-                                Licensed under the Apache License, Version 2.0 (the "License");
-                                you may not use this file except in compliance with the License.
-                                You may obtain a copy of the License at
-
-                                    http://www.apache.org/licenses/LICENSE-2.0
-
-                                Unless required by applicable law or agreed to in writing, software
-                                distributed under the License is distributed on an "AS IS" BASIS,
-                                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                See the License for the specific language governing permissions and
-                                limitations under the License.
-                            -->
-                            <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                                <g transform="translate(-504.000000, -199.000000)" fill="#788594">
-                                    <path d="M520.914667,209.666667 L511.466667,209.666667 L511.466667,206.619333 C511.466667,204.014 513.584667,201.895333 516.190667,201.895333 C518.796667,201.895333 520.914667,204.014 520.914667,206.619333 L520.914667,209.666667 Z M516.190667,223.381333 C514.514,223.381333 513.143333,222.01 513.143333,220.333333 C513.143333,218.657333 514.514,217.286 516.190667,217.286 C517.867333,217.286 519.238,218.657333 519.238,220.333333 C519.238,222.01 517.867333,223.381333 516.190667,223.381333 Z M516.190667,199 C511.984667,199 508.571333,202.414 508.571333,206.619333 L508.571333,209.666667 L507.048,209.666667 C505.372,209.666667 504,211.038 504,212.714667 L504,227.952667 C504,229.628667 505.372,231 507.048,231 L525.334,231 C527.01,231 528.380667,229.628667 528.380667,227.952667 L528.380667,212.714667 C528.380667,211.038 527.01,209.666667 525.334,209.666667 L523.81,209.666667 L523.81,206.619333 C523.81,202.414 520.396667,199 516.190667,199 Z"/>
-                                </g>
-                            </g>
-                        </svg>
+                        <l:icon src="symbol-lock-closed" class="icon-md"/>
                         <span>${%Concealed}</span>
                         <input type="hidden" name="${name}" value="${value}"/>
                     </j:otherwise>


### PR DESCRIPTION
This PR removes the inline SVG of the padlock icon on concealed fields, in favor of a symbol reference using the familiar padlock symbol matching our symbol scheme.

<details>
<summary>Current implementation</summary>

![Screenshot 2022-09-01 at 23 02 25](https://user-images.githubusercontent.com/13383509/188012797-53f4b9f6-8eb2-4291-95b3-e6a9e03a0ac6.png)

</details>

<details>
<summary>Current implementation - dark theme</summary>

![Screenshot 2022-09-01 at 23 02 09](https://user-images.githubusercontent.com/13383509/188012904-cee2e1de-992f-4390-8948-3f5077a6386a.png)

</details>

<details>
<summary>Proposed change</summary>

![Screenshot 2022-09-01 at 22 53 55](https://user-images.githubusercontent.com/13383509/188012706-3ebb2cb7-6191-45f4-b28d-7fa106c26812.png)

</details>

<details>
<summary>Proposed change - dark theme</summary>

![Screenshot 2022-09-01 at 22 53 37](https://user-images.githubusercontent.com/13383509/188012748-cea3f27b-51e4-4989-b339-6c8f83e28af7.png)

</details>


### Proposed changelog entries

- N/A, skip changelog

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7050"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

