### PR TITLE
Replace static icon references with symbol API

### DIFF
--- a/core/src/main/resources/hudson/model/AllView/noJob.groovy
+++ b/core/src/main/resources/hudson/model/AllView/noJob.groovy
@@ -31,9 +31,9 @@ div {
                             a(href: "newJob", class: "content-block__link") {
                                 span(_("createJob"))
                                 span(class: "trailing-icon") {
-                                    l.svgIcon(
-                                            class: "icon-sm",
-                                            href: "${resURL}/images/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px")
+                                    l.icon(
+                                            class: "icon-md",
+                                            src: "symbol-arrow-right")
                                 }
                             }
                         }
@@ -48,9 +48,9 @@ div {
                                 a(href: "computer/new", class: "content-block__link") {
                                     span(_("setUpAgent"))
                                     span(class: "trailing-icon") {
-                                        l.svgIcon(
-                                                class: "icon-sm",
-                                                href: "${resURL}/images/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px")
+                                        l.icon(
+                                                class: "icon-md",
+                                                src: "symbol-arrow-right")
                                     }
                                 }
                             }
@@ -60,9 +60,9 @@ div {
                                     a(href: "configureClouds", class: "content-block__link") {
                                         span(_("setUpCloud"))
                                         span(class: "trailing-icon") {
-                                            l.svgIcon(
-                                                    class: "icon-sm",
-                                                    href: "${resURL}/images/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px")
+                                            l.icon(
+                                                    class: "icon-md",
+                                                    src: "symbol-arrow-right")
                                         }
                                     }
                                 }
@@ -96,9 +96,9 @@ div {
                         a(href: "newJob", class: "content-block__link") {
                             span(_("createJob"))
                             span(class: "trailing-icon") {
-                                l.svgIcon(
-                                        class: "icon-sm",
-                                        href: "${resURL}/images/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px")
+                                l.icon(
+                                        class: "icon-md",
+                                        src: "symbol-arrow-right")
                             }
                         }
                     }
@@ -125,9 +125,9 @@ div {
                                 class: "content-block__link") {
                             span(_("Log in to Jenkins"))
                             span(class: "trailing-icon") {
-                                l.svgIcon(
-                                        class: "icon-sm",
-                                        href: "${resURL}/images/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px")
+                                l.icon(
+                                        class: "icon-md",
+                                        src: "symbol-arrow-right")
                             }
                         }
                     }
@@ -137,9 +137,9 @@ div {
                             a(href: "signup", class: "content-block__link") {
                                 span(_("Sign up for Jenkins"))
                                 span(class: "trailing-icon") {
-                                    l.svgIcon(
-                                            class: "icon-sm",
-                                            href: "${resURL}/images/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px")
+                                    l.icon(
+                                            class: "icon-md",
+                                            src: "symbol-arrow-right")
                                 }
 
                             }

--- a/core/src/main/resources/hudson/util/JenkinsReloadFailed/index.groovy
+++ b/core/src/main/resources/hudson/util/JenkinsReloadFailed/index.groovy
@@ -9,8 +9,6 @@ l.layout {
     l.header(title:"Jenkins")
     l.main_panel {
         h1 {
-            l.icon(class: 'icon-error icon-xlg')
-            text(" ")
             text(_("Error"))
         }
         p(_("msg"))

--- a/core/src/main/resources/jenkins/views/JenkinsHeader/headerContent.jelly
+++ b/core/src/main/resources/jenkins/views/JenkinsHeader/headerContent.jelly
@@ -57,10 +57,7 @@
                             </j:otherwise>
                         </j:choose>
                         <a href="${rootURL}/${user.url}" class="model-link">
-                            <l:svgIcon
-                                       class="am-monitor-icon" >
-                                <use href="${resURL}/images/material-icons/svg-sprite-social-symbol.svg#ic_person_24px"></use>
-                            </l:svgIcon>
+                            <l:icon src="symbol-person-circle" class="icon-md"/>
                             <span class="hidden-xs hidden-sm">${userName}</span>
                         </a>
                         <j:if test="${app.securityRealm.canLogOut()}">

--- a/core/src/main/resources/lib/layout/helpIcon.jelly
+++ b/core/src/main/resources/lib/layout/helpIcon.jelly
@@ -4,7 +4,7 @@
     Outputs a help icon
 
     The help link is rendered as an SVG with an (?) icon.
-    
+
     @since 2.234
     <st:attribute name="iconSize">
       Icon size, available are: small, medium, large, xlarge
@@ -19,7 +19,7 @@
   <j:if test="${attrs.iconSize != null}">
     <j:set var="iconSize" value="icon-${iconSize}"/>
   </j:if>
-  <l:svgIcon tooltip="${tooltip}"
+  <l:icon tooltip="${tooltip}"
              class="${class} ${iconSize}"
-             href="${resURL}/images/material-icons/svg-sprite-action-symbol.svg#ic_help_24px" />
+             src="symbol-help-circle" />
 </j:jelly>


### PR DESCRIPTION
This PR replaces a few static icon references with already used symbols through the symbol API. I plan to create a follow-up PR to address the leftover ones by adding the corresponding symbols.

noJob.groovy - the arrow shape change is marginal
<details>
<summary>Before</summary>

![Screenshot 2022-09-03 at 22 28 29](https://user-images.githubusercontent.com/13383509/188286759-8633bce9-3e4f-463a-9e71-39c907c15b3c.png)

</details>

<details>
<summary>After</summary>

![Screenshot 2022-09-03 at 21 10 42](https://user-images.githubusercontent.com/13383509/188284826-7fbc85f8-f061-4bf0-977e-b8dd7c7f3eee.png)

</details>

headerContent.jelly - Same symbol like on the profile page header
<details>
<summary>Before</summary>

![Screenshot 2022-09-03 at 22 29 09](https://user-images.githubusercontent.com/13383509/188286776-7fbf036d-0a19-40a1-8821-e8abf8ba9386.png)

</details>

<details>
<summary>After</summary>

![Screenshot 2022-09-03 at 21 11 24](https://user-images.githubusercontent.com/13383509/188284849-4995dcc2-1788-4dfd-b787-505c0562d7b8.png)
</details>

<l:helpIcon>
<details>
<summary>Before</summary>

![Screenshot 2022-09-03 at 22 30 59](https://user-images.githubusercontent.com/13383509/188286811-3bc49c3c-56ad-435d-a35d-623f110336a9.png)

</details>

<details>
<summary>After</summary>

https://github.com/jenkinsci/jenkins/blob/master/war/src/main/resources/images/symbols/help-circle.svg

</details>

### Proposed changelog entries

- Minor changes to empty state arrow icon and header user profile icon

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7052"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

