### PR TITLE
Better diagnostic when a connection gets EOFException

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -253,8 +253,9 @@ public final class TcpSlaveAgentListener extends Thread {
 
         @Override
         public void run() {
+            String connectionInfo = "#" + id + " from " + s.getRemoteSocketAddress();
             try {
-                LOGGER.log(Level.FINE, "Accepted connection #{0} from {1}", new Object[] {id, s.getRemoteSocketAddress()});
+                LOGGER.log(Level.FINE, () -> "Accepted connection " + connectionInfo);
 
                 DataInputStream in = new DataInputStream(s.getInputStream());
 
@@ -277,7 +278,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     AgentProtocol p = AgentProtocol.of(protocol);
                     if (p != null) {
                         if (Jenkins.get().getAgentProtocols().contains(protocol)) {
-                            LOGGER.log(p instanceof PingAgentProtocol ? Level.FINE : Level.INFO, "Accepted {0} connection #{1} from {2}", new Object[] {protocol, id, this.s.getRemoteSocketAddress()});
+                            LOGGER.log(p instanceof PingAgentProtocol ? Level.FINE : Level.INFO, () -> "Accepted " + protocol + " connection " + connectionInfo);
                             p.handle(this.s);
                         } else {
                             error("Disabled protocol:" + s, this.s);
@@ -288,7 +289,7 @@ public final class TcpSlaveAgentListener extends Thread {
                     error("Unrecognized protocol: " + s, this.s);
                 }
             } catch (InterruptedException e) {
-                LOGGER.log(Level.WARNING, "Connection #" + id + " aborted", e);
+                LOGGER.log(Level.WARNING, e, () -> "Connection " + connectionInfo + " aborted");
                 try {
                     s.close();
                 } catch (IOException ex) {
@@ -296,9 +297,9 @@ public final class TcpSlaveAgentListener extends Thread {
                 }
             } catch (IOException e) {
                 if (e instanceof EOFException) {
-                    LOGGER.log(Level.INFO, "Connection #{0} failed: {1}", new Object[] {id, e});
+                    LOGGER.log(Level.INFO, () -> "Connection " + connectionInfo + " failed: " + e.getMessage());
                 } else {
-                    LOGGER.log(Level.WARNING, "Connection #" + id + " failed", e);
+                    LOGGER.log(Level.WARNING, e, () -> "Connection " + connectionInfo + " failed");
                 }
                 try {
                     s.close();


### PR DESCRIPTION
```
h.TcpSlaveAgentListener$ConnectionHandler#run: Connection #272,607 failed: java.io.EOFException
```

doesn't provide enough context to understand what client is failing to connect.

This change adds information about socket and port attempting to
connect, as well as switching the logging calls in the impacted method
to use the Supplier variant of the method.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

- Provide more information about the agent connection when it fails with `EOFException`

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7053"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

