### PR TITLE
Allow `yarn.lint.skip` to be set by `-Pquick-build`

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -52,7 +52,6 @@ THE SOFTWARE.
     <!-- maven-antrun-plugin will download this Yarn version. -->
     <yarn-berry.version>3.2.3</yarn-berry.version>
     <yarn-berry.sha256sum>311cd84f5f144680cc21b4bbbdeba97d1a5f32ee8a2eae7037ccbdeff8a3c1ce</yarn-berry.sha256sum>
-    <yarn.lint.skip />
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
https://github.com/jenkinsci/pom/pull/280 did not actually work here in https://github.com/jenkinsci/jenkins/blob/7521f353ad2844f195e0b745d688a7683a93a063/war/pom.xml#L752-L761 because the profile definition was overridden.

AFAICT it is fine to leave it undefined: then the variable is null and the lint target gets run.

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7057"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

