### PR TITLE
Delete dead code to invoke `maven-stapler-plugin`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -745,35 +745,6 @@ THE SOFTWARE.
       </activation>
     </profile>
     <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <!--
-              generate jelly taglib docs from src/main/resources.
-              this is necessary in addition to the <reporting> configuration
-              to get the results deployed.
-            -->
-            <groupId>org.kohsuke.stapler</groupId>
-            <artifactId>maven-stapler-plugin</artifactId>
-            <!-- version specified in grandparent pom -->
-            <executions>
-              <execution>
-                <goals>
-                  <goal>jelly-taglibdoc</goal>
-                </goals>
-                <configuration>
-                  <patterns>
-                    <pattern>/lib/.*</pattern>
-                  </patterns>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <!-- Run SpotBugs for better error detection. Run as "mvn -Pspotbugs verify". -->
       <!-- SpotBugs has been moved to the default build flow, but here we fail the build on errors-->
       <id>spotbugs</id>


### PR DESCRIPTION
### Problem

If you have access to it, take a look at e.g. https://release.ci.jenkins.io/job/core/job/release/job/master/169/consoleFull and search for the strings `maven-stapler-plugin`, `jellydoc`, or `taglibdoc`. You won't find them anywhere in the console output! That's because this is dead code that is not being invoked. Dead code is a maintenance burden, as frequently discussed in programming style guides.

### Evaluation

The code comment states:

> this is necessary in addition to the <reporting> configuration to get the results deployed.

This dates back to commit f0a8b41a7df7a233e21e7c3211b57c14c8f1b71a from 2009 and is now outdated. Since 2017, the deployment takes place via https://github.com/jenkins-infra/core-taglibs-report-generator but this dead code remains.

### Solution

[Flense](https://en.wikipedia.org/wiki/Flensing) it.

### Testing done

Searched for the strings `maven-stapler-plugin`, `jellydoc`, and `taglibdoc` in https://release.ci.jenkins.io/job/core/job/release/job/master/169/consoleFull unsuccessfully. This confirms the code is not being executed and is safe to remove.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7058"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

