### PR TITLE
Fill in recent 'since' annotations

### DIFF
--- a/core/src/main/java/jenkins/util/SetContextClassLoader.java
+++ b/core/src/main/java/jenkins/util/SetContextClassLoader.java
@@ -48,7 +48,7 @@ import java.io.ObjectInputStream;
  * href="https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#context-class-loaders">the
  * developer documentation</a> for more information.
  *
- * @since TODO
+ * @since 2.362
  */
 public final class SetContextClassLoader implements AutoCloseable {
 
@@ -59,7 +59,7 @@ public final class SetContextClassLoader implements AutoCloseable {
      * Change the {@link Thread#getContextClassLoader} associated with the current thread to that of
      * the calling class.
      *
-     * @since TODO
+     * @since 2.362
      */
     public SetContextClassLoader() {
         this(StackWalker.getInstance().getCallerClass());
@@ -70,7 +70,7 @@ public final class SetContextClassLoader implements AutoCloseable {
      * the specified class.
      *
      * @param clazz The {@link Class} whose {@link ClassLoader} to use.
-     * @since TODO
+     * @since 2.362
      */
     public SetContextClassLoader(Class<?> clazz) {
         this(clazz.getClassLoader());
@@ -81,7 +81,7 @@ public final class SetContextClassLoader implements AutoCloseable {
      * specified {@link ClassLoader}.
      *
      * @param cl The {@link ClassLoader} to use.
-     * @since TODO
+     * @since 2.362
      */
     public SetContextClassLoader(ClassLoader cl) {
         t = Thread.currentThread();

--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -89,7 +89,7 @@ public class Main {
      * In such case it becomes configurable via
      * <a href="http://www.eclipse.org/jetty/documentation/9.4.x/jetty-xml-config.html">Jetty XML Config file</a>>
      * or via system properties.
-     * @since 2.358
+     * @since 2.66
      */
     private static final boolean DISABLE_CUSTOM_JSESSIONID_COOKIE_NAME =
             Boolean.getBoolean("executableWar.jetty.disableCustomSessionIdCookieName");

--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -78,7 +78,7 @@ public class Main {
      * Sets custom session cookie name.
      * It may be used to prevent randomization of JSESSIONID cookies and issues like
      * <a href="https://issues.jenkins-ci.org/browse/JENKINS-25046">JENKINS-25046</a>.
-     * @since 2.358
+     * @since 2.66
      */
     private static final String JSESSIONID_COOKIE_NAME =
             System.getProperty("executableWar.jetty.sessionIdCookieName");

--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -78,7 +78,7 @@ public class Main {
      * Sets custom session cookie name.
      * It may be used to prevent randomization of JSESSIONID cookies and issues like
      * <a href="https://issues.jenkins-ci.org/browse/JENKINS-25046">JENKINS-25046</a>.
-     * @since TODO
+     * @since 2.358
      */
     private static final String JSESSIONID_COOKIE_NAME =
             System.getProperty("executableWar.jetty.sessionIdCookieName");
@@ -89,7 +89,7 @@ public class Main {
      * In such case it becomes configurable via
      * <a href="http://www.eclipse.org/jetty/documentation/9.4.x/jetty-xml-config.html">Jetty XML Config file</a>>
      * or via system properties.
-     * @since TODO
+     * @since 2.358
      */
     private static final boolean DISABLE_CUSTOM_JSESSIONID_COOKIE_NAME =
             Boolean.getBoolean("executableWar.jetty.disableCustomSessionIdCookieName");


### PR DESCRIPTION
```
Analyzing core/src/main/java/jenkins/util/SetContextClassLoader.java:51
        first sha: f77a28b37adcacdce40ffecc0544df104d708d55
        first tag was jenkins-2.362
        Updating file in place
Analyzing core/src/main/java/jenkins/util/SetContextClassLoader.java:62
        first sha: f77a28b37adcacdce40ffecc0544df104d708d55
        first tag was jenkins-2.362
        Updating file in place
Analyzing core/src/main/java/jenkins/util/SetContextClassLoader.java:73
        first sha: f77a28b37adcacdce40ffecc0544df104d708d55
        first tag was jenkins-2.362
        Updating file in place
Analyzing core/src/main/java/jenkins/util/SetContextClassLoader.java:84
        first sha: f77a28b37adcacdce40ffecc0544df104d708d55
        first tag was jenkins-2.362
        Updating file in place
Analyzing war/src/main/java/executable/Main.java:81
        first sha: ed0ce3877c1d1ee5d078f48a87dbe958514a48ff
        first tag was jenkins-2.358
        Updating file in place
Analyzing war/src/main/java/executable/Main.java:92
        first sha: ed0ce3877c1d1ee5d078f48a87dbe958514a48ff
        first tag was jenkins-2.358
        Updating file in place

List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.358
  - https://github.com/jenkinsci/jenkins/commit/ed0ce3877c1d1ee5d078f48a87dbe958514a48ff
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.362
  - https://github.com/jenkinsci/jenkins/commit/f77a28b37adcacdce40ffecc0544df104d708d55
```

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7059"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

