### PR TITLE
Clean up `HistoryPageFilter` tests

### DIFF
--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -43,6 +43,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -497,13 +498,10 @@ public class HistoryPageFilterTest {
             return this;
         }
 
-        //TODO: Rewrite in functional style when Java 8 is available
         private List<ParameterValue> buildPropertiesMapToParameterValues(Map<String, String> buildParametersAsMap) {
-            List<ParameterValue> parameterValues = new ArrayList<>();
-            for (Map.Entry<String, String> parameter : buildParametersAsMap.entrySet()) {
-                parameterValues.add(new StringParameterValue(parameter.getKey(), parameter.getValue()));
-            }
-            return parameterValues;
+            return buildParametersAsMap.entrySet().stream()
+                    .map(parameter -> new StringParameterValue(parameter.getKey(), parameter.getValue()))
+                    .collect(Collectors.toList());
         }
 
         MockBuild withSensitiveBuildParameters(String paramName, String paramValue) {

--- a/test/src/test/java/jenkins/widgets/HistoryPageFilterCaseSensitiveSearchTest.java
+++ b/test/src/test/java/jenkins/widgets/HistoryPageFilterCaseSensitiveSearchTest.java
@@ -12,6 +12,7 @@ import hudson.security.AuthorizationStrategy;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Consumer;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,27 +36,20 @@ public class HistoryPageFilterCaseSensitiveSearchTest {
 
     @Test
     public void should_search_case_sensitively_when_enabled_for_user() throws IOException {
-        setCaseSensitiveSearchForUserAndCheckAssertionForGivenSearchString("FAILURE", new SearchResultAssertFunction() {
-            @Override
-            public void doAssertion(HistoryPageFilter<ModelObject> historyPageFilter) {
+        setCaseSensitiveSearchForUserAndCheckAssertionForGivenSearchString("FAILURE", historyPageFilter -> {
                 Assert.assertEquals(1, historyPageFilter.runs.size());
                 Assert.assertEquals(HistoryPageEntry.getEntryId(2), historyPageFilter.runs.get(0).getEntryId());
-            }
         });
     }
 
     @Test
     public void should_skip_result_with_different_capitalization_when_case_sensitively_search_is_enabled_for_user() throws IOException {
-        setCaseSensitiveSearchForUserAndCheckAssertionForGivenSearchString("failure", new SearchResultAssertFunction() {
-            @Override
-            public void doAssertion(HistoryPageFilter<ModelObject> historyPageFilter) {
-                Assert.assertEquals(0, historyPageFilter.runs.size());
-            }
-        });
+        setCaseSensitiveSearchForUserAndCheckAssertionForGivenSearchString(
+                "failure", historyPageFilter -> Assert.assertEquals(0, historyPageFilter.runs.size()));
     }
 
     private void setCaseSensitiveSearchForUserAndCheckAssertionForGivenSearchString(final String searchString,
-                                                                                    SearchResultAssertFunction assertionOnSearchResults) throws IOException {
+                                                                                    Consumer<HistoryPageFilter<ModelObject>> assertionOnSearchResults) throws IOException {
         AuthorizationStrategy.Unsecured strategy = new AuthorizationStrategy.Unsecured();
         j.jenkins.setAuthorizationStrategy(strategy);
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -72,7 +66,7 @@ public class HistoryPageFilterCaseSensitiveSearchTest {
     }
 
     private void assertNoMatchingBuildsForGivenSearchStringAndRunItems(String searchString, Iterable<ModelObject> runs,
-                                                                       SearchResultAssertFunction assertionOnSearchResults) {
+                                                                       Consumer<HistoryPageFilter<ModelObject>> assertionOnSearchResults) {
         //given
         HistoryPageFilter<ModelObject> historyPageFilter = new HistoryPageFilter<>(5);
         //and
@@ -82,7 +76,7 @@ public class HistoryPageFilterCaseSensitiveSearchTest {
         historyPageFilter.add(runs, Collections.emptyList());
 
         //then
-        assertionOnSearchResults.doAssertion(historyPageFilter);
+        assertionOnSearchResults.accept(historyPageFilter);
     }
 
     @SuppressWarnings("unchecked")
@@ -123,10 +117,5 @@ public class HistoryPageFilterCaseSensitiveSearchTest {
         public int getNumber() {
             return (int) queueId;
         }
-    }
-
-    //Waiting for Java 8... - coming soon - April 2017?
-    private interface SearchResultAssertFunction {
-        void doAssertion(HistoryPageFilter<ModelObject> historyPageFilter);
     }
 }


### PR DESCRIPTION
These tests had a TODO stating:

> Waiting for Java 8... - coming soon - April 2017?

Needless to say, that is long overdue.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7065"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

