### PR TITLE
Use `Runtime#version` where possible

### DIFF
--- a/core/src/main/java/jenkins/util/java/JavaUtils.java
+++ b/core/src/main/java/jenkins/util/java/JavaUtils.java
@@ -76,7 +76,7 @@ public class JavaUtils {
      * @see System#getProperty(String)
      */
     public static String getCurrentRuntimeJavaVersion() {
-        // TODO: leverage Runtime.version() once on Java 9+
-        return System.getProperty("java.specification.version");
+        Runtime.Version runtimeVersion = Runtime.version();
+        return String.valueOf(runtimeVersion.version().get(0));
     }
 }

--- a/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLogRecordsTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import jenkins.util.java.JavaUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -34,8 +35,8 @@ public class JenkinsLogRecordsTest {
         assertThat("Records are displayed in reverse order",
             logRecords.stream().map(LogRecord::getMessage).collect(Collectors.toList()),
             containsInRelativeOrder("Completed initialization", "Started initialization"));
-        VersionNumber javaVersion = new VersionNumber(System.getProperty("java.specification.version"));
-        if (javaVersion.isOlderThan(new VersionNumber("9")) || javaVersion.isNewerThanOrEqualTo(new VersionNumber("17"))) { // TODO https://github.com/jenkinsci/jenkins-test-harness/issues/359
+        VersionNumber javaVersion = new VersionNumber(JavaUtils.getCurrentRuntimeJavaVersion());
+        if (javaVersion.isNewerThanOrEqualTo(new VersionNumber("17"))) { // TODO https://github.com/jenkinsci/jenkins-test-harness/issues/359
             Object x = new Object() {
                 @Override
                 public String toString() {

--- a/test/src/test/java/jenkins/security/Security637Test.java
+++ b/test/src/test/java/jenkins/security/Security637Test.java
@@ -40,7 +40,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.slaves.DumbSlave;
-import hudson.util.VersionNumber;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -64,10 +63,7 @@ public class Security637Test {
     @Issue("SECURITY-637")
     public void urlSafeDeserialization_handler_inSameJVMRemotingContext() throws Throwable {
         sessions.then(j -> {
-                EnvVars envVars = new VersionNumber(System.getProperty("java.specification.version")).isOlderThan(new VersionNumber("9"))
-                        ? null
-                        : new EnvVars("JAVA_TOOL_OPTIONS", "--add-opens=java.base/java.net=ALL-UNNAMED");
-                DumbSlave slave = j.createOnlineSlave(null, envVars);
+                DumbSlave slave = j.createOnlineSlave(null, new EnvVars("JAVA_TOOL_OPTIONS", "--add-opens=java.base/java.net=ALL-UNNAMED"));
                 String unsafeHandlerClassName = slave.getChannel().call(new URLHandlerCallable(new URL("https://www.google.com/")));
                 assertThat(unsafeHandlerClassName, containsString("SafeURLStreamHandler"));
 


### PR DESCRIPTION
Fixing a TODO that read:

> TODO: leverage Runtime.version() once on Java 9+

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7067"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

