### PR TITLE
Remove .jelly from editorconfig rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{jelly, js, less, css, hbs}]
+[*.{js, less, css, hbs}]
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true


### PR DESCRIPTION
While there are hundreds of Jelly files not compliant with this rule, it makes editing them in a manner consistent with existing content unnecessarily cumbersome.

Amends #5916.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7070"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

