### PR TITLE
[JENKINS-69543] Fix thread safety in websockets handling.

### DIFF
--- a/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
+++ b/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
@@ -26,6 +26,7 @@ package jenkins.websocket;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
@@ -49,7 +50,7 @@ public class Jetty10Provider implements Provider {
     private static final String ATTR_LISTENER = Jetty10Provider.class.getName() + ".listener";
 
     // TODO does not seem possible to use HttpServletRequest.get/setAttribute for this
-    private static final Map<Listener, Session> sessions = new WeakHashMap<>();
+    private static final Map<Listener, Session> sessions = Collections.synchronizedMap(new WeakHashMap<>());
 
     public Jetty10Provider() {
         JettyWebSocketServerContainer.class.hashCode();

--- a/websocket/jetty9/src/main/java/jenkins/websocket/Jetty9Provider.java
+++ b/websocket/jetty9/src/main/java/jenkins/websocket/Jetty9Provider.java
@@ -26,6 +26,7 @@ package jenkins.websocket;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.Future;
@@ -48,7 +49,7 @@ public class Jetty9Provider implements Provider {
     private static final String ATTR_LISTENER = Jetty9Provider.class.getName() + ".listener";
 
     // TODO does not seem possible to use HttpServletRequest.get/setAttribute for this
-    private static final Map<Listener, Session> sessions = new WeakHashMap<>();
+    private static final Map<Listener, Session> sessions = Collections.synchronizedMap(new WeakHashMap<>());
 
     private WebSocketServletFactory factory;
 


### PR DESCRIPTION
Follow-up of #6780, #6801

Session-holding maps are accessed by multiple threads.

Even though some concurrent access version of this would perform better it should be safe to access sessions in a synchronized way.

`org.springframework.util.ConcurrentReferenceHashMap` could be an alternative if synchronized access is too slow.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->

See [JENKINS-69543](https://issues.jenkins.io/browse/JENKINS-69543).

<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

- Fix thread safety in websockets handling.

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7076"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

