### PR TITLE
Clarify safe restart won't wait for Pipeline jobs

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
     You can cancel this mode by sending a POST request to <a href="../cancelQuietDown">this URL</a>. On environments
     where Jenkins can restart itself (such as when Jenkins is installed as a Windows service), POSTing to
     <a href="../restart">this URL</a> will start the restart sequence, or
-    <a href="../safeRestart">this URL</a> to restart once no jobs (Pipeline jobs excepted) are running.
+    <a href="../safeRestart">this URL</a> to restart once no jobs are running. (Pipeline builds may prevent Jenkins from restarting for a short period of time in some cases, but if so, they will be paused at the next available opportunity and then resumed after Jenkins restarts.)
     All these URLs need Overall/Manage permission (typically granted via Overall/Administer).
   </p>
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
     You can cancel this mode by sending a POST request to <a href="../cancelQuietDown">this URL</a>. On environments
     where Jenkins can restart itself (such as when Jenkins is installed as a Windows service), POSTing to
     <a href="../restart">this URL</a> will start the restart sequence, or
-    <a href="../safeRestart">this URL</a> to restart once no jobs are running.
+    <a href="../safeRestart">this URL</a> to restart once no jobs (Pipeline jobs excepted) are running.
     All these URLs need Overall/Manage permission (typically granted via Overall/Administer).
   </p>
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 			<j:choose>
 				<j:when test="${app.lifecycle.canRestart()}">
 					<form method="post" action="safeRestart">
-						${%Are you sure you want to restart Jenkins? Jenkins will restart once all running jobs are finished.}
+						${%Are you sure you want to restart Jenkins? Jenkins will restart once all running jobs (Pipeline jobs excepted) are finished.}
 						<f:submit value="${%Yes}" />
 					</form>
 				</j:when>

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 			<j:choose>
 				<j:when test="${app.lifecycle.canRestart()}">
 					<form method="post" action="safeRestart">
-						${%Are you sure you want to restart Jenkins? Jenkins will restart once all running jobs (Pipeline jobs excepted) are finished.}
+						${%Are you sure you want to restart Jenkins? Jenkins will restart once all running jobs are finished. (Pipeline builds may prevent Jenkins from restarting for a short period of time in some cases, but if so, they will be paused at the next available opportunity and then resumed after Jenkins restarts.) }
 						<f:submit value="${%Yes}" />
 					</form>
 				</j:when>


### PR DESCRIPTION
A customer raised the fact that this text was a little confusing, as the service will restart even when Pipeline jobs are running - it only waits for Freestyle etc. jobs.

### Proposed changelog entries

Clarify safe restart won't wait for Pipeline jobs.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7091"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

