### PR TITLE
Keep Jelly samples as-is

### DIFF
--- a/core/src/main/resources/lib/form/repeatableProperty.jelly
+++ b/core/src/main/resources/lib/form/repeatableProperty.jelly
@@ -30,11 +30,13 @@ THE SOFTWARE.
 
     Unless that nested config.jelly already adds a delete button (deprecated), you should normally put the following inside this tag:
 
+      	{noformat}
       	<f:block>
           <div align="right">
             <f:repeatableDeleteButton />
           </div>
         </f:block>
+        {noformat}
 
     Due to a bug in Stapler data binding the model elements are only set if they consist of one or more values.
     If all values have been removed in the user interface (i.e. the associated form is empty), then the setter is not

--- a/core/src/main/resources/lib/form/secretTextarea.jelly
+++ b/core/src/main/resources/lib/form/secretTextarea.jelly
@@ -28,7 +28,7 @@
 Enhanced version of <f:textarea/> for editing multi-line secrets.
 
 Example usage:
-
+{noformat}
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="Secret" field="secret">
         <f:secretTextarea/>
@@ -40,6 +40,7 @@ Example usage:
         <f:secretTextarea name="foo" value="${it.foo}"/>
     </f:entry>
 </j:jelly>
+{noformat}
     ]]>
         <st:attribute name="field">
             Used for databinding. Must be compatible with hudson.util.Secret for round-trip ciphertext.

--- a/core/src/main/resources/lib/layout/svgIcon.jelly
+++ b/core/src/main/resources/lib/layout/svgIcon.jelly
@@ -2,10 +2,12 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:d="jelly:define">
     <st:documentation>
 
-        Opinionated helper to use icons via &lt;svg> tags. Can be used by passing an href or a body:
+        Opinionated helper to use icons via &lt;svg> tags. Can be used by passing a href or a body:
 
+        {noformat}
         # &lt;l:svgIcon href="/path/to/my/sprite.svg#my-icon" />
         # &lt;l:svgIcon>&lt;path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z">&lt;/path>&lt;/l:svgIcon>
+        {noformat}
 
         @since 2.222
         <st:attribute name="class">


### PR DESCRIPTION
Minor change to ensure Jelly code samples stay as-is and are treated as plain text.

See https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html#form:secretTextarea for an example of the current state.

The change proposed ensures the samples stay the way they are:

<details>
<summary>taglib generator</summary>

![Screenshot 2022-09-12 at 20 54 19](https://user-images.githubusercontent.com/13383509/189733482-162e8d98-9f93-45f2-b300-c9e756027aff.png)

</details>

<details>
<summary>IDEA stapler plugin</summary>

![Screenshot 2022-09-12 at 20 55 22](https://user-images.githubusercontent.com/13383509/189733640-b5fa5e91-c960-43d4-961e-ab7e699cc24d.png)

</details>

### Proposed changelog entries

- N/A, skip changelog

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7096"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

