### PR TITLE
Skip building on Windows machines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,8 @@ properties([
   disableConcurrentBuilds(abortPrevious: true)
 ])
 
-def buildTypes = ['Linux', 'Windows']
+// TODO Restore Windows once https://github.com/jenkins-infra/helpdesk/issues/3117 finds a suitable solution
+def buildTypes = ['Linux']
 def jdks = [11, 17]
 
 def builds = [:]
@@ -20,15 +21,9 @@ for (i = 0; i < buildTypes.size(); i++) {
   for (j = 0; j < jdks.size(); j++) {
     def buildType = buildTypes[i]
     def jdk = jdks[j]
-    if (buildType == 'Windows' && jdk == 17) {
-      continue // TODO pending jenkins-infra/helpdesk#2822
-    }
     builds["${buildType}-jdk${jdk}"] = {
       // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#node-labels for information on what node types are available
       def agentContainerLabel = 'maven-' + jdk
-      if (buildType == 'Windows') {
-        agentContainerLabel += '-windows'
-      }
       node(agentContainerLabel) {
         // First stage is actually checking out the source. Since we're using Multibranch
         // currently, we can use "checkout scm".


### PR DESCRIPTION
Building on Windows machines takes a long time, and exceeds the configured timeout of 6h on a very frequent base.

Waiting 6h or more for incrementals or to get a green light is too long. For comparison, Linux builds are typically done in less than 2h, sometimes even less than 1 1/2 h.

I suggest we pause building on Windows machines for now, until https://github.com/jenkins-infra/helpdesk/issues/3117 finds a suitable solution.

To name a few examples from the past 7 days, [#7095](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7095/), [#7094](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7094/), [#7090](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7090/), [#7091](https://ci.jenkins.io/job/Core/job/jenkins/view/change-requests/job/PR-7091/), and more, the list is long if you increase the timeframe.

### Proposed changelog entries

- N/A, skip changelog

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7103"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

