### PR TITLE
Prefer `assertThrows` to try/fail

### DIFF
--- a/core/src/test/java/hudson/util/RobustCollectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustCollectionConverterTest.java
@@ -26,8 +26,8 @@ package hudson.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.thoughtworks.xstream.security.InputManipulationException;
 import java.time.Instant;
@@ -82,16 +82,12 @@ public class RobustCollectionConverterTest {
 
         xstream2.setCollectionUpdateLimit(3);
         final String xml = xstream2.toXML(set);
-        try {
-            xstream2.fromXML(xml);
-            fail("Thrown " + CriticalXStreamException.class.getName() + " expected");
-        } catch (final CriticalXStreamException e) {
-            Throwable cause = e.getCause();
-            assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
-            assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
-            InputManipulationException ime = (InputManipulationException) cause;
-            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 3 seconds"));
-        }
+        CriticalXStreamException e = assertThrows(CriticalXStreamException.class, () -> xstream2.fromXML(xml));
+        Throwable cause = e.getCause();
+        assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
+        assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
+        InputManipulationException ime = (InputManipulationException) cause;
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 3 seconds"));
     }
 
     @Test(timeout = 30 * 1000)
@@ -106,16 +102,12 @@ public class RobustCollectionConverterTest {
             Set<Object> set = preparePayload();
 
             final String xml = xstream2.toXML(set);
-            try {
-                xstream2.fromXML(xml);
-                fail("Thrown " + CriticalXStreamException.class.getName() + " expected");
-            } catch (final CriticalXStreamException e) {
-                Throwable cause = e.getCause();
-                assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
-                assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
-                InputManipulationException ime = (InputManipulationException) cause;
-                assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 4 seconds"));
-            }
+            CriticalXStreamException e = assertThrows(CriticalXStreamException.class, () -> xstream2.fromXML(xml));
+            Throwable cause = e.getCause();
+            assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
+            assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
+            InputManipulationException ime = (InputManipulationException) cause;
+            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 4 seconds"));
         } finally {
             if (currentValue == null) {
                 System.clearProperty(XStream2.COLLECTION_UPDATE_LIMIT_PROPERTY_NAME);
@@ -134,16 +126,12 @@ public class RobustCollectionConverterTest {
         Set<Object> set = preparePayload();
 
         final String xml = xstream2.toXML(set);
-        try {
-            xstream2.fromXML(xml);
-            fail("Thrown " + CriticalXStreamException.class.getName() + " expected");
-        } catch (final CriticalXStreamException e) {
-            Throwable cause = e.getCause();
-            assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
-            assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
-            InputManipulationException ime = (InputManipulationException) cause;
-            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
-        }
+        CriticalXStreamException e = assertThrows(CriticalXStreamException.class, () -> xstream2.fromXML(xml));
+        Throwable cause = e.getCause();
+        assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
+        assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
+        InputManipulationException ime = (InputManipulationException) cause;
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
     }
 
     // Inspired by https://github.com/x-stream/xstream/commit/e8e88621ba1c85ac3b8620337dd672e0c0c3a846#diff-9fde4ecf1bb4dc9850c031cb161960d2e61e069b386fa0b3db0d57e0e9f5baa

--- a/core/src/test/java/hudson/util/RobustMapConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustMapConverterTest.java
@@ -25,8 +25,8 @@
 package hudson.util;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.thoughtworks.xstream.security.InputManipulationException;
 import java.util.HashMap;
@@ -51,16 +51,12 @@ public class RobustMapConverterTest {
 
         xstream2.setCollectionUpdateLimit(3);
         final String xml = xstream2.toXML(map);
-        try {
-            xstream2.fromXML(xml);
-            fail("Thrown " + CriticalXStreamException.class.getName() + " expected");
-        } catch (final CriticalXStreamException e) {
-            Throwable cause = e.getCause();
-            assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
-            assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
-            InputManipulationException ime = (InputManipulationException) cause;
-            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 3 seconds"));
-        }
+        CriticalXStreamException e = assertThrows(CriticalXStreamException.class, () -> xstream2.fromXML(xml));
+        Throwable cause = e.getCause();
+        assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
+        assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
+        InputManipulationException ime = (InputManipulationException) cause;
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 3 seconds"));
     }
 
     @Test(timeout = 30 * 1000)
@@ -75,16 +71,12 @@ public class RobustMapConverterTest {
             Map<Object, Object> map = preparePayload();
 
             final String xml = xstream2.toXML(map);
-            try {
-                xstream2.fromXML(xml);
-                fail("Thrown " + CriticalXStreamException.class.getName() + " expected");
-            } catch (final CriticalXStreamException e) {
-                Throwable cause = e.getCause();
-                assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
-                assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
-                InputManipulationException ime = (InputManipulationException) cause;
-                assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 4 seconds"));
-            }
+            CriticalXStreamException e = assertThrows(CriticalXStreamException.class, () -> xstream2.fromXML(xml));
+            Throwable cause = e.getCause();
+            assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
+            assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
+            InputManipulationException ime = (InputManipulationException) cause;
+            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 4 seconds"));
         } finally {
             if (currentValue == null) {
                 System.clearProperty(XStream2.COLLECTION_UPDATE_LIMIT_PROPERTY_NAME);
@@ -103,16 +95,12 @@ public class RobustMapConverterTest {
         Map<Object, Object> map = preparePayload();
 
         final String xml = xstream2.toXML(map);
-        try {
-            xstream2.fromXML(xml);
-            fail("Thrown " + CriticalXStreamException.class.getName() + " expected");
-        } catch (final CriticalXStreamException e) {
-            Throwable cause = e.getCause();
-            assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
-            assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
-            InputManipulationException ime = (InputManipulationException) cause;
-            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
-        }
+        CriticalXStreamException e = assertThrows(CriticalXStreamException.class, () -> xstream2.fromXML(xml));
+        Throwable cause = e.getCause();
+        assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
+        assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
+        InputManipulationException ime = (InputManipulationException) cause;
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
     }
 
     // Inspired by https://github.com/x-stream/xstream/commit/e8e88621ba1c85ac3b8620337dd672e0c0c3a846#diff-9fde4ecf1bb4dc9850c031cb161960d2e61e069b386fa0b3db0d57e0e9f5baa

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
@@ -194,16 +193,12 @@ public class RobustReflectionConverterTest {
 
         final String xml = xstream2.toXML(parentItem);
 
-        try {
-            xstream2.fromXML(xml);
-            fail("Thrown " + CriticalXStreamException.class.getName() + " expected");
-        } catch (final CriticalXStreamException e) {
-            Throwable cause = e.getCause();
-            assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
-            assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
-            InputManipulationException ime = (InputManipulationException) cause;
-            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
-        }
+        CriticalXStreamException e = assertThrows(CriticalXStreamException.class, () -> xstream2.fromXML(xml));
+        Throwable cause = e.getCause();
+        assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
+        assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
+        InputManipulationException ime = (InputManipulationException) cause;
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
     }
 
     @Test(timeout = 30 * 1000)
@@ -216,12 +211,8 @@ public class RobustReflectionConverterTest {
         // Will use the ConverterImpl without going with RobustReflectionConverter
         final String xml = xstream2.toXML(customSet);
 
-        try {
-            xstream2.fromXML(xml);
-            fail("Thrown " + InputManipulationException.class.getName() + " expected");
-        } catch (final InputManipulationException e) {
-            assertTrue("Limit expected in message", e.getMessage().contains("exceeds 5 seconds"));
-        }
+        InputManipulationException e = assertThrows(InputManipulationException.class, () -> xstream2.fromXML(xml));
+        assertTrue("Limit expected in message", e.getMessage().contains("exceeds 5 seconds"));
     }
 
     @Test(timeout = 30 * 1000)
@@ -239,18 +230,14 @@ public class RobustReflectionConverterTest {
 
         final String xml = xstream2.toXML(parentObject);
 
-        try {
-            xstream2.fromXML(xml);
-            // Without the InputManipulationException catch in RobustReflectionConverter,
-            // the parsing is continued despite the DoS prevention being triggered due to the robustness
-            fail("Thrown " + CriticalXStreamException.class.getName() + " expected");
-        } catch (final CriticalXStreamException e) {
-            Throwable cause = e.getCause();
-            assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
-            assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
-            InputManipulationException ime = (InputManipulationException) cause;
-            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
-        }
+        // Without the InputManipulationException catch in RobustReflectionConverter,
+        // the parsing is continued despite the DoS prevention being triggered due to the robustness
+        CriticalXStreamException e = assertThrows(CriticalXStreamException.class, () -> xstream2.fromXML(xml));
+        Throwable cause = e.getCause();
+        assertNotNull("A non-null cause of CriticalXStreamException is expected", cause);
+        assertTrue("Cause of CriticalXStreamException is expected to be InputManipulationException", cause instanceof InputManipulationException);
+        InputManipulationException ime = (InputManipulationException) cause;
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
     }
 
     private Set<Object> preparePayload() {

--- a/core/src/test/java/jenkins/model/Security2424Test.java
+++ b/core/src/test/java/jenkins/model/Security2424Test.java
@@ -25,7 +25,7 @@
 package jenkins.model;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import hudson.model.Failure;
 import hudson.model.Messages;
@@ -36,23 +36,21 @@ public class Security2424Test {
     @Test
     @Issue("SECURITY-2424")
     public void doesNotAcceptNameWithTrailingDot_regular() {
-        try {
-            Jenkins.checkGoodName("job.");
-            fail("Names with dot should not be accepted");
-        } catch (Failure e) {
-            assertEquals(Messages.Hudson_TrailingDot(), e.getMessage());
-        }
+        Failure e = assertThrows(
+                "Names with dot should not be accepted",
+                Failure.class,
+                () -> Jenkins.checkGoodName("job."));
+        assertEquals(Messages.Hudson_TrailingDot(), e.getMessage());
     }
 
     @Test
     @Issue("SECURITY-2424")
     public void doesNotAcceptNameWithTrailingDot_withSpaces() {
-        try {
-            Jenkins.checkGoodName("job.   ");
-            fail("Names with dot should not be accepted");
-        } catch (Failure e) {
-            assertEquals(Messages.Hudson_TrailingDot(), e.getMessage());
-        }
+        Failure e = assertThrows(
+                "Names with dot should not be accepted",
+                Failure.class,
+                () -> Jenkins.checkGoodName("job.   "));
+        assertEquals(Messages.Hudson_TrailingDot(), e.getMessage());
     }
 
     @Test

--- a/test/src/test/java/hudson/cli/ComputerStateTest.java
+++ b/test/src/test/java/hudson/cli/ComputerStateTest.java
@@ -31,8 +31,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -165,9 +165,9 @@ public class ComputerStateTest {
     }
 
     private void assertLinkDoesNotExist(HtmlPage page, String text) {
-        try {
-            page.getAnchorByText(text);
-            fail(text + " link should not exist");
-        } catch (ElementNotFoundException ex) { /*expected*/ }
+        assertThrows(
+                text + " link should not exist",
+                ElementNotFoundException.class,
+                () -> page.getAnchorByText(text));
     }
 }

--- a/test/src/test/java/hudson/diagnosis/HudsonHomeDiskUsageMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/HudsonHomeDiskUsageMonitorTest.java
@@ -2,8 +2,8 @@ package hudson.diagnosis;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
@@ -50,11 +50,7 @@ public class HudsonHomeDiskUsageMonitorTest {
         assertFalse(mon.isEnabled());
 
         // and make sure it's gone
-        try {
-            fail(getForm(mon) + " shouldn't be there");
-        } catch (ElementNotFoundException e) {
-            // as expected
-        }
+        assertThrows(ElementNotFoundException.class, () -> getForm(mon));
     }
 
     @Issue("SECURITY-371")

--- a/test/src/test/java/hudson/diagnosis/TooManyJobsButNoViewTest.java
+++ b/test/src/test/java/hudson/diagnosis/TooManyJobsButNoViewTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.html.DomElement;
@@ -47,12 +47,7 @@ public class TooManyJobsButNoViewTest {
 
     private void verifyNoForm() throws IOException, SAXException {
         HtmlPage p = r.createWebClient().goTo("manage");
-        try {
-            p.getFormByName(mon.id);
-            fail();
-        } catch (ElementNotFoundException e) {
-            // shouldn't find it
-        }
+        assertThrows(ElementNotFoundException.class, () -> p.getFormByName(mon.id));
     }
 
     /**

--- a/test/src/test/java/hudson/model/FingerprintTest.java
+++ b/test/src/test/java/hudson/model/FingerprintTest.java
@@ -35,8 +35,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.Page;
@@ -193,13 +193,8 @@ public class FingerprintTest {
     public void shouldThrowIOExceptionWhenFileIsInvalid() throws Exception {
         XmlFile f = new XmlFile(new File(rule.jenkins.getRootDir(), "foo.xml"));
         f.write("Hello, world!");
-        try {
-            FileFingerprintStorage.load(f.getFile());
-        } catch (IOException ex) {
-            assertThat(ex.getMessage(), containsString("Unexpected Fingerprint type"));
-            return;
-        }
-        fail("Expected IOException");
+        IOException e = assertThrows(IOException.class, () -> FileFingerprintStorage.load(f.getFile()));
+        assertThat(e.getMessage(), containsString("Unexpected Fingerprint type"));
     }
 
     @Test

--- a/test/src/test/java/hudson/model/FreeStyleProjectTest.java
+++ b/test/src/test/java/hudson/model/FreeStyleProjectTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
@@ -253,13 +252,11 @@ public class FreeStyleProjectTest {
     @Issue("SECURITY-2424")
     public void cannotCreateJobWithTrailingDot_withoutOtherJob() throws Exception {
         assertThat(j.jenkins.getItems(), hasSize(0));
-        try {
-            j.jenkins.createProjectFromXML("jobA.", new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8)));
-            fail("Adding the job should have thrown an exception during checkGoodName");
-        }
-        catch (Failure e) {
-            assertEquals(Messages.Hudson_TrailingDot(), e.getMessage());
-        }
+        Failure e = assertThrows(
+                "Adding the job should have thrown an exception during checkGoodName",
+                Failure.class,
+                () -> j.jenkins.createProjectFromXML("jobA.", new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8))));
+        assertEquals(Messages.Hudson_TrailingDot(), e.getMessage());
         assertThat(j.jenkins.getItems(), hasSize(0));
     }
 
@@ -269,13 +266,11 @@ public class FreeStyleProjectTest {
         assertThat(j.jenkins.getItems(), hasSize(0));
         j.createFreeStyleProject("jobA");
         assertThat(j.jenkins.getItems(), hasSize(1));
-        try {
-            j.jenkins.createProjectFromXML("jobA.", new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8)));
-            fail("Adding the job should have thrown an exception during checkGoodName");
-        }
-        catch (Failure e) {
-            assertEquals(Messages.Hudson_TrailingDot(), e.getMessage());
-        }
+        Failure e = assertThrows(
+                "Adding the job should have thrown an exception during checkGoodName",
+                Failure.class,
+                () -> j.jenkins.createProjectFromXML("jobA.", new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8))));
+        assertEquals(Messages.Hudson_TrailingDot(), e.getMessage());
         assertThat(j.jenkins.getItems(), hasSize(1));
     }
 

--- a/test/src/test/java/hudson/model/SlaveTest.java
+++ b/test/src/test/java/hudson/model/SlaveTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeThat;
 
 import com.gargoylesoftware.htmlunit.Page;
@@ -160,13 +160,7 @@ public class SlaveTest {
     private void assertJnlpJarUrlFails(@NonNull Slave slave, @NonNull String url) throws Exception {
         // Raw access to API
         Slave.JnlpJar jnlpJar = slave.getComputer().getJnlpJars(url);
-        try {
-            jnlpJar.getURL();
-        } catch (MalformedURLException ex) {
-            // we expect the exception here
-            return;
-        }
-        fail("Expected the MalformedURLException for " + url);
+        assertThrows(MalformedURLException.class, () -> jnlpJar.getURL());
     }
 
     private void assertJnlpJarUrlIsAllowed(@NonNull Slave slave, @NonNull String url) throws Exception {

--- a/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelExpressionTest.java
@@ -28,8 +28,8 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 import antlr.ANTLRException;
@@ -340,12 +340,10 @@ public class LabelExpressionTest {
     }
 
     private void parseShouldFail(String expr) {
-        try {
-            Label.parseExpression(expr);
-            fail(expr + " should fail to parse");
-        } catch (ANTLRException e) {
-            // expected
-        }
+        assertThrows(
+                expr + " should fail to parse",
+                ANTLRException.class,
+                () -> Label.parseExpression(expr));
     }
 
     @Test

--- a/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerTest.java
+++ b/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerTest.java
@@ -12,8 +12,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
@@ -21,6 +21,7 @@ import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.User;
 import java.net.HttpURLConnection;
@@ -199,18 +200,15 @@ public class DefaultCrumbIssuerTest {
 
         assertEquals(crumb1.equals(crumb2), areEqual);
 
+        HtmlForm config = p.getFormByName("config");
         if (areEqual) {
-            r.submit(p.getFormByName("config"));
+            r.submit(config);
         } else {
             replaceAllCrumbInPageBy(p, crumb1);
-            try {
-                // submit the form with previous session crumb
-                r.submit(p.getFormByName("config"));
-                fail();
-            } catch (FailingHttpStatusCodeException e) {
-                assertEquals(HttpServletResponse.SC_FORBIDDEN, e.getStatusCode());
-                assertThat(e.getResponse().getContentAsString(), containsString("No valid crumb"));
-            }
+            // submit the form with previous session crumb
+            FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> r.submit(config));
+            assertEquals(HttpServletResponse.SC_FORBIDDEN, e.getStatusCode());
+            assertThat(e.getResponse().getContentAsString(), containsString("No valid crumb"));
         }
     }
 
@@ -257,13 +255,9 @@ public class DefaultCrumbIssuerTest {
         String jobName2 = namePrefix + "-test2";
 
         WebRequest request1 = createRequestForJobCreation(jobName1);
-        try {
-            r.createWebClient().getPage(request1);
-            fail();
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(HttpServletResponse.SC_FORBIDDEN, e.getStatusCode());
-            assertThat(e.getResponse().getContentAsString(), containsString("No valid crumb"));
-        }
+        FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> r.createWebClient().getPage(request1));
+        assertEquals(HttpServletResponse.SC_FORBIDDEN, e.getStatusCode());
+        assertThat(e.getResponse().getContentAsString(), containsString("No valid crumb"));
         // cannot create new job due to missing crumb
         assertNull(r.jenkins.getItem(jobName1));
 
@@ -274,14 +268,13 @@ public class DefaultCrumbIssuerTest {
 
             assertNotNull(r.jenkins.getItem(jobName2));
         } else {
-            try {
-                r.createWebClient().getPage(request2);
-                fail("Should have failed due to invalid crumb");
-            } catch (FailingHttpStatusCodeException e) {
-                assertEquals(HttpURLConnection.HTTP_FORBIDDEN, e.getStatusCode());
-                // cannot create new job due to invalid crumb
-                assertNull(r.jenkins.getItem(jobName2));
-            }
+            e = assertThrows(
+                    "Should have failed due to invalid crumb",
+                    FailingHttpStatusCodeException.class,
+                    () -> r.createWebClient().getPage(request2));
+            assertEquals(HttpURLConnection.HTTP_FORBIDDEN, e.getStatusCode());
+            // cannot create new job due to invalid crumb
+            assertNull(r.jenkins.getItem(jobName2));
         }
     }
 

--- a/test/src/test/java/jenkins/model/NodesTest.java
+++ b/test/src/test/java/jenkins/model/NodesTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
@@ -59,7 +58,10 @@ public class NodesTest {
     @Issue("JENKINS-50599")
     public void addNodeShouldFailAtomically() throws Exception {
         InvalidNode node = new InvalidNode("foo", "temp", r.createComputerLauncher(null));
-        IOException e = assertThrows("Adding the node should have thrown an exception during serialization", IOException.class, () -> r.jenkins.addNode(node));
+        IOException e = assertThrows(
+                "Adding the node should have thrown an exception during serialization",
+                IOException.class,
+                () -> r.jenkins.addNode(node));
         String className = InvalidNode.class.getName();
         assertThat("The exception should be from failing to serialize the node",
                 e.getMessage(), containsString("Failed to serialize " + className + "#cl for class " + className));
@@ -73,7 +75,10 @@ public class NodesTest {
         Node oldNode = r.createSlave("foo", "", null);
         r.jenkins.addNode(oldNode);
         InvalidNode newNode = new InvalidNode("foo", "temp", r.createComputerLauncher(null));
-        IOException e = assertThrows("Adding the node should have thrown an exception during serialization", IOException.class, () -> r.jenkins.addNode(newNode));
+        IOException e = assertThrows(
+                "Adding the node should have thrown an exception during serialization",
+                IOException.class,
+                () -> r.jenkins.addNode(newNode));
         String className = InvalidNode.class.getName();
         assertThat("The exception should be from failing to serialize the node",
                 e.getMessage(), containsString("Failed to serialize " + className + "#cl for class " + className));
@@ -152,12 +157,11 @@ public class NodesTest {
         assertThat(r.jenkins.getNodes(), hasSize(0));
 
         DumbSlave node = new DumbSlave("nodeA.", "temp", r.createComputerLauncher(null));
-        try {
-            r.jenkins.addNode(node);
-            fail("Adding the node should have thrown an exception during checkGoodName");
-        } catch (Failure e) {
-            assertEquals(hudson.model.Messages.Hudson_TrailingDot(), e.getMessage());
-        }
+        Failure e = assertThrows(
+                "Adding the node should have thrown an exception during checkGoodName",
+                Failure.class,
+                () -> r.jenkins.addNode(node));
+        assertEquals(hudson.model.Messages.Hudson_TrailingDot(), e.getMessage());
 
         assertThat(r.jenkins.getNodes(), hasSize(0));
     }
@@ -170,12 +174,11 @@ public class NodesTest {
         assertThat(r.jenkins.getNodes(), hasSize(1));
 
         DumbSlave node = new DumbSlave("nodeA.", "temp", r.createComputerLauncher(null));
-        try {
-            r.jenkins.addNode(node);
-            fail("Adding the node should have thrown an exception during checkGoodName");
-        } catch (Failure e) {
-            assertEquals(hudson.model.Messages.Hudson_TrailingDot(), e.getMessage());
-        }
+        Failure e = assertThrows(
+                "Adding the node should have thrown an exception during checkGoodName",
+                Failure.class,
+                () -> r.jenkins.addNode(node));
+        assertEquals(hudson.model.Messages.Hudson_TrailingDot(), e.getMessage());
 
         assertThat(r.jenkins.getNodes(), hasSize(1));
     }

--- a/test/src/test/java/jenkins/security/ApiTokenPropertyTest.java
+++ b/test/src/test/java/jenkins/security/ApiTokenPropertyTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
@@ -286,13 +286,8 @@ public class ApiTokenPropertyTest {
     }
 
     private void checkUserIsNotConnected(WebClient wc) throws Exception {
-        try {
-            wc.goToXml("whoAmI/api/xml");
-            fail();
-        }
-        catch (FailingHttpStatusCodeException e) {
-            assertEquals(401, e.getStatusCode());
-        }
+        FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> wc.goToXml("whoAmI/api/xml"));
+        assertEquals(401, e.getStatusCode());
     }
 
     @Test
@@ -659,13 +654,10 @@ public class ApiTokenPropertyTest {
     }
 
     private void checkInvalidTokenValue(ApiTokenProperty apiTokenProperty, String tokenName, String tokenValue) throws Exception {
-        try {
-            apiTokenProperty.addFixedNewToken(tokenName, tokenValue);
-            fail("The invalid token " + tokenName + " with value " + tokenValue + " was accepted but it should have been rejected.");
-        }
-        catch (IllegalArgumentException iae) {
-            // no care about the exception
-        }
+        assertThrows(
+                "The invalid token " + tokenName + " with value " + tokenValue + " was accepted but it should have been rejected.",
+                IllegalArgumentException.class,
+                () -> apiTokenProperty.addFixedNewToken(tokenName, tokenValue));
     }
 
     // test no token are generated for new user with the global configuration set to false

--- a/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
+++ b/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
@@ -1,7 +1,7 @@
 package jenkins.security;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.Page;
@@ -164,12 +164,10 @@ public class BasicHeaderProcessorTest {
     }
 
     private void makeRequestWithAuthCodeAndFail(String authCode) throws IOException {
-        try {
-            makeRequestWithAuthCodeAndVerify(authCode, "-");
-            fail();
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(401, e.getStatusCode());
-        }
+        FailingHttpStatusCodeException e = assertThrows(
+                FailingHttpStatusCodeException.class,
+                () -> makeRequestWithAuthCodeAndVerify(authCode, "-"));
+        assertEquals(401, e.getStatusCode());
     }
 
     @TestExtension

--- a/test/src/test/java/jenkins/security/Security218Test.java
+++ b/test/src/test/java/jenkins/security/Security218Test.java
@@ -2,7 +2,7 @@ package jenkins.security;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import hudson.model.Node.Mode;
 import hudson.model.Slave;
@@ -11,6 +11,7 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.RetentionStrategy;
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.logging.Level;
@@ -72,12 +73,11 @@ public class Security218Test implements Serializable {
      */
     @SuppressWarnings("ConstantConditions")
     private void check(DumbSlave s) {
-        try {
-            Object o = s.getComputer().getChannel().call(new EvilReturnValue());
-            fail("Expected the connection to die: " + o);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), containsString(MethodClosure.class.getName()));
-        }
+        IOException e = assertThrows(
+                "Expected the connection to die",
+                IOException.class,
+                () -> s.getComputer().getChannel().call(new EvilReturnValue()));
+        assertThat(e.getMessage(), containsString(MethodClosure.class.getName()));
     }
 
     private static class EvilReturnValue extends MasterToSlaveCallable<Object, RuntimeException> {

--- a/test/src/test/java/jenkins/security/apitoken/ApiTokenStatsRestartTest.java
+++ b/test/src/test/java/jenkins/security/apitoken/ApiTokenStatsRestartTest.java
@@ -31,8 +31,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.xml.HasXPath.hasXPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
@@ -159,12 +159,8 @@ public class ApiTokenStatsRestartTest {
     }
 
     private static void checkUserIsNotConnected(WebClient wc) throws Exception {
-        try {
-            wc.goToXml("whoAmI/api/xml");
-            fail();
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(401, e.getStatusCode());
-        }
+        FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> wc.goToXml("whoAmI/api/xml"));
+        assertEquals(401, e.getStatusCode());
     }
 
     private static void revokeToken(JenkinsRule j, WebClient wc, String login, String tokenUuid) throws Exception {

--- a/test/src/test/java/jenkins/security/apitoken/ApiTokenStatsTest.java
+++ b/test/src/test/java/jenkins/security/apitoken/ApiTokenStatsTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.xml.HasXPath.hasXPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.HttpMethod;
@@ -126,12 +126,8 @@ public class ApiTokenStatsTest {
     }
 
     private void checkUserIsNotConnected(WebClient wc) throws Exception {
-        try {
-            wc.goToXml("whoAmI/api/xml");
-            fail();
-        } catch (FailingHttpStatusCodeException e) {
-            assertEquals(401, e.getStatusCode());
-        }
+        FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> wc.goToXml("whoAmI/api/xml"));
+        assertEquals(401, e.getStatusCode());
     }
 
     private void revokeToken(WebClient wc, String login, String tokenUuid) throws Exception {

--- a/test/src/test/java/org/kohsuke/stapler/Security1097Test.java
+++ b/test/src/test/java/org/kohsuke/stapler/Security1097Test.java
@@ -1,11 +1,15 @@
 package org.kohsuke.stapler;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.Extension;
 import hudson.model.InvisibleAction;
 import hudson.model.RootAction;
 import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.List;
 import javax.servlet.ServletException;
@@ -29,18 +33,20 @@ public class Security1097Test {
         j.submit(htmlPage2.getFormByName("config"));
     }
 
-    @Test(expected = FailingHttpStatusCodeException.class)
+    @Test
     public void testGet1Fails() throws Exception {
         final JenkinsRule.WebClient webClient = j.createWebClient();
         final HtmlPage htmlPage = webClient.goTo("security1097/get1");
-        j.submit(htmlPage.getFormByName("config"));
+        FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> j.submit(htmlPage.getFormByName("config")));
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, e.getStatusCode());
     }
 
-    @Test(expected = FailingHttpStatusCodeException.class)
+    @Test
     public void testGet2Fails() throws Exception {
         final JenkinsRule.WebClient webClient = j.createWebClient();
         final HtmlPage htmlPage = webClient.goTo("security1097/get2");
-        j.submit(htmlPage.getFormByName("config"));
+        FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> j.submit(htmlPage.getFormByName("config")));
+        assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, e.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
Continuation of #5734. Some test cleanup, mainly eliminating usages of try/fail in favor of the more legible alternative offered by JUnit 4.13 in the form of `Assert#assertThrows`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7114"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

