### PR TITLE
[JENKINS-69624] [JENKINS-69638] Winstone 6.4: Upgrade Jetty from 10.0.11 to 10.0.12

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -146,7 +146,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>6.2</version>
+      <version>6.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -571,7 +571,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>10.0.11</version>
+        <version>10.0.12</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)
@@ -608,7 +608,7 @@ THE SOFTWARE.
           </systemProperties>
           <webApp>
             <!-- Allows resources to be reloaded, and enable nicer console logging. -->
-            <!-- TODO eclipse/jetty.project#7970 <extraClasspath>${project.basedir}/../core/src/main/resources,${project.basedir}/../core/target/classes,${project.build.directory}/support-log-formatter.jar</extraClasspath> -->
+            <extraClasspath>${project.basedir}/../core/src/main/resources,${project.basedir}/../core/target/classes,${project.build.directory}/support-log-formatter.jar</extraClasspath>
             <contextPath>${contextPath}</contextPath>
             <configurationDiscovered>false</configurationDiscovered>
             <!-- see https://wiki.eclipse.org/Jetty/Howto/Avoid_slow_deployment -->

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -146,7 +146,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>6.3</version>
+      <version>6.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/websocket/jetty10/pom.xml
+++ b/websocket/jetty10/pom.xml
@@ -52,7 +52,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>6.3</version>
+      <version>6.4</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/websocket/jetty10/pom.xml
+++ b/websocket/jetty10/pom.xml
@@ -52,7 +52,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>6.2</version>
+      <version>6.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
See [JENKINS-69624](https://issues.jenkins.io/browse/JENKINS-69624) and [JENKINS-69638](https://issues.jenkins.io/browse/JENKINS-69638).

- Jetty: [changelog](https://github.com/eclipse/jetty.project/releases/jetty-10.0.12), [compare view](https://github.com/eclipse/jetty.project/compare/jetty-10.0.11...jetty-10.0.12)
- Winstone: [6.3 changelog](https://github.com/jenkinsci/winstone/releases/winstone-6.3), [6.4 changelog](https://github.com/jenkinsci/winstone/releases/winstone-6.4), [compare view](https://github.com/jenkinsci/winstone/compare/winstone-6.2...winstone-6.4)

### Testing done

- WebSocket: Ran `mvn clean verify -Dtest=hudson.slaves.JNLPLauncherRealTest` on both Java 11 and Java 17.
- HTTP/2: Ran Jenkins with `--http2Port=80 --httpsKeyStore=[…] --httpsKeyStorePassword=[…]`. Successfully ran `curl --http2 --insecure https://127.0.0.1:80`. Also connected to Jenkins in Firefox and verified in the Developer Tools that HTTP/2 was being used successfully.
- Ran `mvn -pl war jetty:run` 10 times in a row without any failures.
- Inspected `winstone.jar` before and after this change; verified that no unexpected files had been added to or removed from the JAR archive.

### Proposed changelog entries

* Winstone 6.4: Upgrade Jetty from 10.0.11 to 10.0.12 ([Jetty 10.0.12 changelog](https://github.com/eclipse/jetty.project/releases/jetty-10.0.12), [Winstone 6.3 changelog](https://github.com/jenkinsci/winstone/releases/winstone-6.3), [Winstone 6.4 changelog](https://github.com/jenkinsci/winstone/releases/winstone-6.4))
* Support HTTP/2 without the use of a custom `--extraLibFolder` option.

### Proposed upgrade guidelines

If you previously added an `--extraLibFolder` option for use with HTTP/2, this option can now be removed.

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7117"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

