### PR TITLE
Don't escape special chars in Jelly doc

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractItem/delete.jelly
+++ b/core/src/main/resources/hudson/model/AbstractItem/delete.jelly
@@ -24,8 +24,9 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-	<st:documentation>
-		Deprecated. Instead use a &lt;l:confirmationLink/> directly to /job/*/doDelete.
+	<st:documentation> <![CDATA[
+		Deprecated. Instead use a <l:confirmationLink/> directly to /job/*/doDelete.
+	]]>
 	</st:documentation>
   <l:layout>
 		<st:include page="sidepanel.jelly" />

--- a/core/src/main/resources/hudson/model/AbstractProject/makeDisabled.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/makeDisabled.jelly
@@ -1,7 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:p="/lib/hudson/project" xmlns:st="jelly:stapler">
-    <st:documentation>
-        Deprecated but kept for compatibility. Use &lt;p:makeDisabled/>.
+    <st:documentation> <![CDATA[
+        Deprecated but kept for compatibility. Use <p:makeDisabled/>.
+    ]]>
     </st:documentation>
     <p:makeDisabled/>
 </j:jelly>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
@@ -29,8 +29,9 @@ THE SOFTWARE.
     <st:attribute name="it" use="required" type="hudson.security.HudsonPrivateSecurityRealm">
       Context where the page is loaded.
     </st:attribute>
-    <st:attribute name="title" use="required">
-      Title of the HTML page. Rendered in the page content inside a &lt;h1>.
+    <st:attribute name="title" use="required"> <![CDATA[
+      Title of the HTML page. Rendered in the page content inside a <h1>.
+    ]]>
     </st:attribute>
     <st:attribute name="action" use="required">
       The method to call from within the HudsonPrivateSecurityRealm.

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryFormPage.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryFormPage.jelly
@@ -29,9 +29,10 @@ THE SOFTWARE.
     <st:attribute name="host" use="required" type="hudson.security.HudsonPrivateSecurityRealm">
       Corresponds to the "it" of Jelly, meaning the context where the page is loaded.
     </st:attribute>
-    <st:attribute name="title" use="required">
+    <st:attribute name="title" use="required"> <![CDATA[
       Title of the HTML page. 
-      Rendered into &lt;title> tag, in the page content inside a &lt;h1> and as the label of the submit button.
+      Rendered into <title> tag, in the page content inside a <h1> and as the label of the submit button.
+      ]]>
     </st:attribute>
     <st:attribute name="action" use="required">
       The method to call from within the HudsonPrivateSecurityRealm.

--- a/core/src/main/resources/lib/form/breadcrumb-config-outline.jelly
+++ b/core/src/main/resources/lib/form/breadcrumb-config-outline.jelly
@@ -22,10 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
-  <st:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <st:documentation> <![CDATA[
     Adds one more in-page breadcrumb that jumps to sections in the page.
-    Put this tag right before &lt;l:main-panel>
+    Put this tag right before <l:main-panel>
+    ]]>
     <st:attribute name="title">
       Optional title for this breadcrumb
     </st:attribute>

--- a/core/src/main/resources/lib/form/checkbox.jelly
+++ b/core/src/main/resources/lib/form/checkbox.jelly
@@ -23,9 +23,10 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    &lt;input type="checkbox"> tag that takes true/false for @checked, which is more Jelly friendly.
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    <input type="checkbox"> tag that takes true/false for @checked, which is more Jelly friendly.
+    ]]>
 
     <st:attribute name="name" />
     <st:attribute name="checked" />
@@ -37,7 +38,7 @@ THE SOFTWARE.
       and none otherwise, making the subset selection easier.
     </st:attribute>
     <st:attribute name="default">
-      The default value of the check box, in case both @checked and @instance are null.
+      The default value of the checkbox, in case both @checked and @instance are null.
       If this attribute is unspecified or null, it defaults to unchecked, otherwise checked.
     </st:attribute>
     <st:attribute name="id" />
@@ -50,12 +51,13 @@ THE SOFTWARE.
     </st:attribute>
     <st:attribute name="class" />
     <st:attribute name="negative" />
-    <st:attribute name="readonly" deprecated="true">
+    <st:attribute name="readonly" deprecated="true"> <![CDATA[
       If set to true, this will take precedence over the onclick attribute and prevent the state of the checkbox from being changed.
 
       Note: if you want an actual read only checkbox then add:
-      &lt;j:set var="readOnlyMode" value="true"/&gt; inside your entry tag
+      <j:set var="readOnlyMode" value="true"/> inside your entry tag
       See https://www.jenkins.io/doc/developer/views/read-only/#enabling-read-only-view-support
+      ]]>
     </st:attribute>
     <st:attribute name="field">
       Used for databinding. TBD.

--- a/core/src/main/resources/lib/form/class-entry.jelly
+++ b/core/src/main/resources/lib/form/class-entry.jelly
@@ -22,10 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Invisible &lt;f:entry> type for embedding a descriptor's $class field.
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    Invisible <f:entry> type for embedding a descriptor's $class field.
 
     Most of the time a Descriptor has an unique class name that we can use to instantiate the right Describable
     class, so we use the '$class' to represent that to clarify the intent.
@@ -35,6 +34,7 @@ THE SOFTWARE.
     readers we do not put non-unique '$class'.
 
     See Descriptor.newInstancesFromHeteroList for how the reader side is handled.
+    ]]>
 
     <st:attribute name="clazz">
       The describable class that we are instantiating via structured form submission.

--- a/core/src/main/resources/lib/form/combobox.jelly
+++ b/core/src/main/resources/lib/form/combobox.jelly
@@ -24,24 +24,27 @@ THE SOFTWARE.
 
 <!-- Tomcat doesn't like us using the attribute called 'class' -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
     Editable drop-down combo box that supports the data binding and AJAX updates.
     Your descriptor should have the 'doFillXyzItems' method, which returns a ComboBoxModel
     representation of the items in your combo box, and your instance field should
     hold the current value.
 
-    For a read only input set &lt;j:set var="readOnlyMode" value="true"/&gt; inside your entry tag
+    For a read only input set <j:set var="readOnlyMode" value="true"/> inside your entry tag
     See https://www.jenkins.io/doc/developer/views/read-only/#enabling-read-only-view-support
-    <st:attribute name="name">
-      This becomes @name of the &lt;input> tag.
+    ]]>
+    <st:attribute name="name"> <![CDATA[
+      This becomes @name of the <input> tag.
       If @field is specified, this value is inferred from it.
+    ]]>
     </st:attribute>
-    <st:attribute name="value">
-      The initial value of the field. This becomes the @value of the &lt;input> tag.
+    <st:attribute name="value"> <![CDATA[
+      The initial value of the field. This becomes the @value of the <input> tag.
       If @field is specified, the current property from the "instance" object
       will be set as the initial value automatically,
       which is the recommended approach.
+    ]]>
     </st:attribute>
     <st:attribute name="default">
       The default value of the combo box, in case both @value and 'instance[field]' are null.

--- a/core/src/main/resources/lib/form/descriptorList.jelly
+++ b/core/src/main/resources/lib/form/descriptorList.jelly
@@ -37,26 +37,29 @@ THE SOFTWARE.
     <st:attribute name="descriptors" use="required">
       hudson.model.Descriptor collection whose configuration page is rendered.
     </st:attribute>
-    <st:attribute name="instances">
-      Map&lt;Descriptor,Describable> that defines current instances of those descriptors.
+    <st:attribute name="instances"> <![CDATA[
+      Map<Descriptor,Describable> that defines current instances of those descriptors.
       These are used to fill initial values. Other classes that define the get(Descriptor)
       method works fine, too, such as DescribableList.
+    ]]>
     </st:attribute>
-    <st:attribute name="field">
-      Either @field or @instances are required (or @field may be inherited from the ancestor &lt;entry> element).
+    <st:attribute name="field"> <![CDATA[
+      Either @field or @instances are required (or @field may be inherited from the ancestor <entry> element).
       If field is specified, instances are assumed to be instance[field].
 
       When this attribute is specified, JSON structure is properly set up so that the databinding
       can set the field (or pass this collection as a constructor parameter of the same name.
 
       This is more modern way of doing databinding, and thus preferred approach.
+    ]]>
     </st:attribute>
     <st:attribute name="targetType">
       the type for which descriptors will be configured.
       default to ${it.class}
     </st:attribute>
-    <st:attribute name="forceRowSet">
-      If specified, instead of a sequence of &lt;f:optionalBlock>s, draw a sequence of &lt;rowSet>s.
+    <st:attribute name="forceRowSet"> <![CDATA[
+      If specified, instead of a sequence of <f:optionalBlock>s, draw a sequence of <rowSet>s.
+    ]]>
     </st:attribute>
   </st:documentation>
 

--- a/core/src/main/resources/lib/form/dropdownDescriptorSelector.jelly
+++ b/core/src/main/resources/lib/form/dropdownDescriptorSelector.jelly
@@ -22,11 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Renders a single &lt;select> control for choosing a Describable.
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    Renders a single <select> control for choosing a Describable.
     Depending on the currently selected value, its config.jelly will be
-    rendered below &lt;select>, allowing the user to configure Describable.
+    rendered below <select>, allowing the user to configure Describable.
+    ]]>
 
     <st:attribute name="field" use="required">
       Form field name. Used for databinding.

--- a/core/src/main/resources/lib/form/dropdownList.jelly
+++ b/core/src/main/resources/lib/form/dropdownList.jelly
@@ -26,15 +26,17 @@ THE SOFTWARE.
   <st:documentation>
     Foldable block expanded when the corresponding item is selected in the drop-down list.
 
-    <st:attribute name="title">
+    <st:attribute name="title"> <![CDATA[
       Human readable title text of this drop-down listbox.
-      Shown in the same position as &lt;f:entry title="..." />
+      Shown in the same position as <f:entry title="..." />
+    ]]>
     </st:attribute>
     <st:attribute name="name" use="required">
       name of the drop-down list.
     </st:attribute>
-    <st:attribute name="help">
-      Path to the inline help. See &lt;f:entry help="..." />
+    <st:attribute name="help"> <![CDATA[
+      Path to the inline help. See <f:entry help="..." />
+    ]]>
     </st:attribute>
   </st:documentation>
 

--- a/core/src/main/resources/lib/form/dropdownListBlock.jelly
+++ b/core/src/main/resources/lib/form/dropdownListBlock.jelly
@@ -22,12 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <st:documentation>
     Foldable block expanded when the corresponding item is selected in the drop-down list.
 
-    <st:attribute name="value" use="required">
-      value of the list item. set to &lt;option value="...">
+    <st:attribute name="value" use="required"> <![CDATA[
+      value of the list item. set to <option value="...">
+    ]]>
     </st:attribute>
     <st:attribute name="title" use="required">
       human readable text displayed for this list item.
@@ -39,9 +40,10 @@ THE SOFTWARE.
       provide hint for stapler data binding.
       typically set to ${descriptor.clazz.name} if dropdownList is for a list of descriptors.
     </st:attribute>
-    <st:attribute name="lazy">
+    <st:attribute name="lazy"> <![CDATA[
       If specified, the content of the dropdownListBlock will be rendered lazily when it first becomes visible.
-      The attribute value must be the variables to be captured. See the @capture of &lt;renderOnDemand> tag.
+      The attribute value must be the variables to be captured. See the @capture of <renderOnDemand> tag.
+    ]]>
     </st:attribute>
   </st:documentation>
   <j:choose>

--- a/core/src/main/resources/lib/form/editableComboBox.jelly
+++ b/core/src/main/resources/lib/form/editableComboBox.jelly
@@ -24,15 +24,16 @@ THE SOFTWARE.
 
 <!-- Tomcat doesn't like us using the attribute called 'class' -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
   <st:documentation>
     Editable drop-down combo box. Deprecated as of 1.356. Use f:combobox and databinding instead.
 
     <st:attribute name="clazz">
       Additional CSS classes that the control gets.
     </st:attribute>
-    <st:attribute name="items">
-      List of possible values. Either this or nested &lt;f:editableComboBoxValue/>s are required.
+    <st:attribute name="items"> <![CDATA[
+      List of possible values. Either this or nested <f:editableComboBoxValue/>s are required.
+    ]]>
     </st:attribute>
     <st:attribute name="field">
       Used for databinding.

--- a/core/src/main/resources/lib/form/editableComboBoxValue.jelly
+++ b/core/src/main/resources/lib/form/editableComboBoxValue.jelly
@@ -24,9 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-  <st:documentation>
-    Used inside &lt;f:editableComboBox/> to specify one value of a combobox.
+  <st:documentation> <![CDATA[
+    Used inside <f:editableComboBox/> to specify one value of a combobox.
     Normally one would use multiple values.
+    ]]>
     <st:attribute name="value" use="required" />
   </st:documentation>
   <div value="${value}"/>

--- a/core/src/main/resources/lib/form/entry.jelly
+++ b/core/src/main/resources/lib/form/entry.jelly
@@ -23,13 +23,13 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    An entry of the &lt;f:form>, which is one logical row (that consists of
-    several &lt;TR> tags.
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    An entry of the <f:form>, which is one logical row (that consists of
+    several <TR> tags.
 
     One entry normally host one control.
-
+    ]]>
     <st:attribute name="title">
       Name of the entry. Think of this like a label for the control.
 
@@ -54,14 +54,15 @@ THE SOFTWARE.
     <st:attribute name="class">
       Classes to apply to the form item
     </st:attribute>
-    <st:attribute name="help">
+    <st:attribute name="help"> <![CDATA[
       URL to the HTML page. When this attribute is specified, the entry gets
       a (?) icon on the right, and if the user clicks it, the contents of the
       given URL is rendered as a box below the entry.
 
-      The URL should return an HTML document wrapped in a &lt;div> tag.
+      The URL should return an HTML document wrapped in a <div> tag.
       The URL is interpreted to be rooted at the context path of Hudson,
       so it's normally something like "/plugin/foobar/help/abc.html".
+        ]]>
     </st:attribute>
   </st:documentation>
   <j:if test="${attrs.help==null and attrs.field!=null}">

--- a/core/src/main/resources/lib/form/enum.jelly
+++ b/core/src/main/resources/lib/form/enum.jelly
@@ -23,12 +23,12 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Binds an enum field to a &lt;select> element.
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    Binds an enum field to a <select> element.
     The body of this tag is evaluated for each enum value,
     which is passed as 'it'.
-
+    ]]>
     <st:attribute name="field">
       Used for databinding. TBD.
     </st:attribute>

--- a/core/src/main/resources/lib/form/enumSet.jelly
+++ b/core/src/main/resources/lib/form/enumSet.jelly
@@ -23,10 +23,11 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
     Binds a set of Enum to a list of checkboxes, each with the label taken from enum Enum.toString()
-    Should be used inside an &lt;f:entry field='...'> element.
+    Should be used inside an <f:entry field='...'> element.
+    ]]>
     <st:attribute name="field" implicit="true">
       Used for databinding.
     </st:attribute>

--- a/core/src/main/resources/lib/form/expandableTextbox.jelly
+++ b/core/src/main/resources/lib/form/expandableTextbox.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
   TODO: support @checkUrl
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <st:documentation>
     A single-line textbox that can be expanded into a multi-line textarea.
 
@@ -44,15 +44,17 @@ THE SOFTWARE.
     <st:attribute name="field">
       Used for databinding. TBD.
     </st:attribute>
-    <st:attribute name="name">
-      This becomes @name of the &lt;input> tag.
+    <st:attribute name="name"> <![CDATA[
+      This becomes @name of the <input> tag.
       If @field is specified, this value is inferred from it.
+    ]]>
     </st:attribute>
-    <st:attribute name="value">
-      The initial value of the field. This becomes the @value of the &lt;input> tag.
+    <st:attribute name="value"> <![CDATA[
+      The initial value of the field. This becomes the @value of the <input> tag.
       If @field is specified, the current property from the "instance" object
       will be set as the initial value automatically,
       which is the recommended approach.
+    ]]>
     </st:attribute>
   </st:documentation>
   <f:prepareDatabinding />

--- a/core/src/main/resources/lib/form/form.jelly
+++ b/core/src/main/resources/lib/form/form.jelly
@@ -23,10 +23,10 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Outer-most tag of the entire form taglib, that generates &lt;form> element.
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+  <st:documentation> <![CDATA[
+    Outer-most tag of the entire form taglib, that generates <form> element.
+    ]]>
     <st:attribute name="action" use="required">
       @action of the form field. The URL where the submission is sent.
     </st:attribute>
@@ -41,18 +41,21 @@ THE SOFTWARE.
     <st:attribute name="class">
       Classes to apply to the form
     </st:attribute>
-    <st:attribute name="enctype">
-      @enctype of the &lt;form> HTML element.
+    <st:attribute name="enctype"> <![CDATA[
+      @enctype of the <form> HTML element.
+      ]]>
     </st:attribute>
     <st:attribute name="id">
       ID of the form.
     </st:attribute>
-    <st:attribute name="target">
-      @target of the &lt;form> HTML element. Works like &lt;a target="...">
+    <st:attribute name="target"> <![CDATA[
+      @target of the <form> HTML element. Works like <a target="...">
       and controls which window the result of the submission goes to.
+      ]]>
     </st:attribute>
-    <st:attribute name="tableClass">
-      Optional class attribute for &lt;table> that is created in the form.
+    <st:attribute name="tableClass"> <![CDATA[
+      Optional class attribute for <table> that is created in the form.
+        ]]>
     </st:attribute>
     <st:attribute name="autocomplete">
       Optional attribute for allowing browsers to perform auto complete or pre-fill the form from history.

--- a/core/src/main/resources/lib/form/helpLink.jelly
+++ b/core/src/main/resources/lib/form/helpLink.jelly
@@ -23,14 +23,14 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Outputs an help link for a &lt;f:form> item if help is available or 
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    Outputs a help link for a <f:form> item if help is available or
     a spacer if none is available.
 
     The help link is rendered as a table cell with an (?) icon.
     If the user clicks it, the content of the HTML fragment at the given URL 
-    is rendered in the area designated as &lt;f:helpArea> by the caller,
+    is rendered in the area designated as <f:helpArea> by the caller,
     usually in a row beneath the item with help.
     
     The alternative spacer is just an empty table cell.
@@ -39,12 +39,14 @@ THE SOFTWARE.
     is consistent over the UI whether or not help exists.
 
     @since 1.576
-    <st:attribute name="url">
+    ]]>
+    <st:attribute name="url"> <![CDATA[
       URL to the HTML page. Optional. If not given, no help icon is displayed.
 
-      The URL should return a UTF-8 encoded HTML fragment wrapped in a &lt;div> tag.
+      The URL should return a UTF-8 encoded HTML fragment wrapped in a <div> tag.
       The URL is interpreted to be rooted at the context path of Jenkins,
       so it's normally something like "/plugin/foobar/help/abc.html".
+      ]]>
     </st:attribute>
     <st:attribute name="featureName">
       Name of the feature described by the help text, used for constructing the 

--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -23,15 +23,15 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
-  <st:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:local="local">
+  <st:documentation> <![CDATA[
     Outer most tag for creating a heterogeneous list, where the user can choose arbitrary number of
     arbitrary items from the given list of descriptors, and configure them independently.
 
-    The submission can be data-bound into List&lt;T&gt; where T is the common base type for the describable instances.
+    The submission can be data-bound into List<T> where T is the common base type for the describable instances.
 
-    For databinding use, please use &lt;f:repeatableHeteroProperty /&gt;
-
+    For databinding use, please use <f:repeatableHeteroProperty />
+    ]]>
     <st:attribute name="name" use="required">
       form name that receives an array for all the items in the heterogeneous list.
     </st:attribute>
@@ -50,9 +50,10 @@ THE SOFTWARE.
     <st:attribute name="targetType">
       the type for which descriptors will be configured. Defaults to ${it.class} (optional)
     </st:attribute>
-    <st:attribute name="hasHeader">
+    <st:attribute name="hasHeader"> <![CDATA[
       For each item, add a caption from descriptor.getDisplayName().
-      This also activates drag&amp;drop (where the header is a grip), and help text support.
+      This also activates drag&drop (where the header is a grip), and help text support.
+        ]]>
     </st:attribute>
     <st:attribute name="oneEach">
       If true, only allow up to one instance per descriptor.

--- a/core/src/main/resources/lib/form/invisibleEntry.jelly
+++ b/core/src/main/resources/lib/form/invisibleEntry.jelly
@@ -23,9 +23,10 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Invisible &lt;f:entry> type. Useful for adding hidden field values.
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    Invisible <f:entry> type. Useful for adding hidden field values.
+    ]]>
   </st:documentation>
   <div style="display:none" class='tr'>
     <div>

--- a/core/src/main/resources/lib/form/number.jelly
+++ b/core/src/main/resources/lib/form/number.jelly
@@ -31,34 +31,38 @@ THE SOFTWARE.
     <st:attribute name="field" type="java.lang.String">
       Used for databinding. TBD.
     </st:attribute>
-    <st:attribute name="name" type="java.lang.String">
-      This becomes @name of the &lt;input> tag.
+    <st:attribute name="name" type="java.lang.String"> <![CDATA[
+      This becomes @name of the <input> tag.
       If @field is specified, this value is inferred from it.
+       ]]>
     </st:attribute>
-    <st:attribute name="value">
-      The initial value of the field. This becomes the @value of the &lt;input> tag.
+    <st:attribute name="value"> <![CDATA[
+      The initial value of the field. This becomes the @value of the <input> tag.
       If @field is specified, the current property from the "instance" object
       will be set as the initial value automatically,
       which is the recommended approach.
+      ]]>
     </st:attribute>
     <st:attribute name="default">
       The default value of the text box, in case both @value is and 'instance[field]' is null.
     </st:attribute>
-    <st:attribute name="min">
-      The minimum of the @value. This becomes the @min of the &lt;input> tag.
+    <st:attribute name="min"> <![CDATA[
+      The minimum of the @value. This becomes the @min of the <input> tag.
       This will work only @clazz is 'number', 'number-required', 'non-negative-number-required',
         'positive-number', 'positive-number-required'.
       If specified, the @value should be greater than this value, or errors will be rendered under the text field.
       If this value contains non-digit characters, it will not work.
       If @max is specified and @max is less than this value, both @min and @max will not work.
+      ]]>
     </st:attribute>
-    <st:attribute name="max">
-      The maximum of the @value. This becomes the @max of the &lt;input> tag.
+    <st:attribute name="max"> <![CDATA[
+      The maximum of the @value. This becomes the @max of the <input> tag.
       This will work only @clazz is 'number', 'number-required', 'non-negative-number-required',
         'positive-number', 'positive-number-required'.
       If specified, the @value should be less than this value, or errors will be rendered under the text field.
       If this value contains non-digit characters, it will not work.
       If @min is specified and @min is greater than this value, both @min and @max will not work.
+       ]]>
     </st:attribute>
     <!-- Tomcat doesn't like us using the attribute called 'class' -->
     <st:attribute name="clazz">

--- a/core/src/main/resources/lib/form/option.jelly
+++ b/core/src/main/resources/lib/form/option.jelly
@@ -23,9 +23,9 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
-  <st:documentation>
-    &lt;option> tag for the &lt;select> element that takes true/false for selected.
-
+  <st:documentation> <![CDATA[
+    <option> tag for the <select> element that takes true/false for selected.
+    ]]>
     <st:attribute name="value">
       The value to be sent when the form is submitted.
       If omitted, the body of the tag will be placed in the value attribute as well

--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -23,23 +23,25 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
   <st:documentation>
     Foldable block that can be expanded to show more controls by checking the checkbox.
 
-    <st:attribute name="name">
+    <st:attribute name="name"> <![CDATA[
       Name of the checkbox. Can be used by the server to determine
       if the block is collapsed or expanded at the time of submission.
 
       Note that when the block is collapsed, none of its child controls will send
-      the values to the server (unlike &lt;f:advanced>)
+      the values to the server (unlike <f:advanced>)
+      ]]>
     </st:attribute>
-    <st:attribute name="title">
+    <st:attribute name="title"> <![CDATA[
       Human readable text that follows the checkbox.
 
-      If this field is null, the checkbox degrades to a &lt;f:rowSet>, which provides
+      If this field is null, the checkbox degrades to a <f:rowSet>, which provides
       a grouping at JSON level but on the UI there's no checkbox (and you always see
       the body of it.)
+        ]]>
     </st:attribute>
     <st:attribute name="field">
       Used for databinding. TBD. Either this or @name/@title combo is required.
@@ -47,9 +49,10 @@ THE SOFTWARE.
     <st:attribute name="checked">
       initial checkbox status. true/false.
     </st:attribute>
-    <st:attribute name="help">
+    <st:attribute name="help"> <![CDATA[
       If present, the (?) icon will be rendered on the right to show inline help.
-      See @help for &lt;f:entry>.
+      See @help for <f:entry>.
+      ]]>
     </st:attribute>
     <st:attribute name="negative">
       if present, the foldable section expands when the checkbox is unchecked.

--- a/core/src/main/resources/lib/form/optionalProperty.jelly
+++ b/core/src/main/resources/lib/form/optionalProperty.jelly
@@ -23,14 +23,15 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
     Renders inline an optional single-value nested data-bound property of the current instance,
-    by using a &lt;f:optionalBlock>
+    by using a <f:optionalBlock>
 
     This is useful when your object composes another data-bound object, and when that's optional,
     where the absence of the value is signified as null (in which case the optionalBlock will be drawn unchecked),
     and the presence of the value.
+    ]]>
     <st:attribute name="field" use="required" />
     <st:attribute name="title" use="required" />
     <st:attribute name="help" />

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -24,21 +24,23 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-  <st:documentation>
-    Glorified &lt;input type="password">
-
+  <st:documentation> <![CDATA[
+    Glorified <input type="password">
+    ]]>
     <st:attribute name="field">
       Used for databinding. TBD.
     </st:attribute>
-    <st:attribute name="name">
-      This becomes @name of the &lt;input> tag.
+    <st:attribute name="name"> <![CDATA[
+      This becomes @name of the <input> tag.
       If @field is specified, this value is inferred from it.
+      ]]>
     </st:attribute>
-    <st:attribute name="value">
-      The initial value of the field. This becomes the @value of the &lt;input> tag.
+    <st:attribute name="value"> <![CDATA[
+      The initial value of the field. This becomes the @value of the <input> tag.
       If @field is specified, the current property from the "instance" object
       will be set as the initial value automatically,
       which is the recommended approach.
+      ]]>
     </st:attribute>
     <st:attribute name="clazz">
       Additional CSS class(es) to add (such as client-side validation clazz="required",

--- a/core/src/main/resources/lib/form/prepareDatabinding.jelly
+++ b/core/src/main/resources/lib/form/prepareDatabinding.jelly
@@ -23,10 +23,11 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
-  <st:documentation>
-    Modifies the 'attrs.field' of the parent to inherit @field from the enclosing &lt;f:entry>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <st:documentation> <![CDATA[
+    Modifies the 'attrs.field' of the parent to inherit @field from the enclosing <f:entry>
     if available. Also computes the @checkUrl attribute.
+    ]]>
   </st:documentation>
   <j:set var="pattrs" value="${parentScope.attrs}" />
   <j:if test="${pattrs.field==null}">

--- a/core/src/main/resources/lib/form/radio.jelly
+++ b/core/src/main/resources/lib/form/radio.jelly
@@ -23,16 +23,17 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
- <st:documentation>
-    &lt;input type="radio"> tag that takes true/false for @checked, which is more Jelly friendly.
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+ <st:documentation> <![CDATA[
+    <input type="radio"> tag that takes true/false for @checked, which is more Jelly friendly.
 
-    Note that safari doesn't support onchange.
+    Note that Safari doesn't support onchange.
 
     Beware that the name attribute should be uniquified among all radio blocks on the page, such as by prefixing it with "G0025." or whatever gensym.
 
-    For a read only radio input set &lt;j:set var="readOnlyMode" value="true"/&gt; inside your entry tag
+    For a read only radio input set <j:set var="readOnlyMode" value="true"/> inside your entry tag
     See https://www.jenkins.io/doc/developer/views/read-only/#enabling-read-only-view-support
+    ]]>
     <st:attribute name="name" />
     <st:attribute name="checked" />
     <st:attribute name="value" />

--- a/core/src/main/resources/lib/form/radioBlock.jelly
+++ b/core/src/main/resources/lib/form/radioBlock.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
   <st:documentation>
     Radio button with a label that hides additional controls.
     When checked, those additional controls are displayed. This is useful
@@ -34,8 +34,9 @@ THE SOFTWARE.
       Name of the radio button group. Radio buttons that are mutually exclusive need
       to have the same name.
     </st:attribute>
-    <st:attribute name="value" use="required">
-      @value of the &lt;input> element.
+    <st:attribute name="value" use="required"> <![CDATA[
+      @value of the <input> element.
+    ]]>
     </st:attribute>
     <st:attribute name="title" use="required">
       Human readable label text to be rendered next to the radio button.
@@ -46,9 +47,10 @@ THE SOFTWARE.
     <st:attribute name="inline">
       if present, the folded section will not be grouped into a separate JSON object upon submission.
     </st:attribute>
-    <st:attribute name="help">
+    <st:attribute name="help"> <![CDATA[
       If specified, the (?) help icon will be rendered on the right,
-      for in place help text. See &lt;f:entry> for the details.
+      for in place help text. See <f:entry> for the details.
+    ]]>
     </st:attribute>
   </st:documentation>
 

--- a/core/src/main/resources/lib/form/readOnlyTextbox.jelly
+++ b/core/src/main/resources/lib/form/readOnlyTextbox.jelly
@@ -31,15 +31,17 @@ THE SOFTWARE.
     <st:attribute name="field">
       Used for databinding. TBD.
     </st:attribute>
-    <st:attribute name="name">
-      This becomes @name of the &lt;input> tag.
+    <st:attribute name="name"> <![CDATA[
+      This becomes @name of the <input> tag.
       If @field is specified, this value is inferred from it.
+    ]]>
     </st:attribute>
-    <st:attribute name="value">
-      The initial value of the field. This becomes the @value of the &lt;input> tag.
+    <st:attribute name="value"> <![CDATA[
+      The initial value of the field. This becomes the @value of the <input> tag.
       If @field is specified, the current property from the "instance" object
       will be set as the initial value automatically,
       which is the recommended approach.
+    ]]>
     </st:attribute>
     <st:attribute name="default">
       The default value of the text box, in case both @value is and 'instance[field]' is null.

--- a/core/src/main/resources/lib/form/repeatable.jelly
+++ b/core/src/main/resources/lib/form/repeatable.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" >
   <st:documentation> <![CDATA[
     Repeatable blocks used to present UI where the user can configure multiple entries
     of the same kind (see the Java installations configuration in the system config.)
@@ -102,8 +102,9 @@ THE SOFTWARE.
       minimum="1" is useful to make sure there's always at least one entry for the user to fill in.
     </st:attribute>
     <st:attribute name="header">
-      For each item, add this header.
-      This also activates drag&amp;drop (where the header is a grip).
+      For each item, add this header. <![CDATA[
+      This also activates drag&drop (where the header is a grip).
+      ]]>
     </st:attribute>
     <st:attributeConstraints expr="((var,items,name?)|field),varStatus?,noAddButton?,enableTopButton?,add?,minimum?,header?"/>
   </st:documentation>

--- a/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
+++ b/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
@@ -23,10 +23,10 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Delete button for the &lt;repeatable> tag.
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <st:documentation> <![CDATA[
+    Delete button for the <repeatable> tag.
+    ]]>
     <st:attribute name="value">
       Caption of the button. Defaults to 'Delete'.
     </st:attribute>

--- a/core/src/main/resources/lib/form/repeatableHeteroProperty.jelly
+++ b/core/src/main/resources/lib/form/repeatableHeteroProperty.jelly
@@ -41,9 +41,10 @@ THE SOFTWARE.
     <st:attribute name="targetType">
       the type for which descriptors will be configured. Defaults to ${it.class} (optional)
     </st:attribute>
-    <st:attribute name="hasHeader">
+    <st:attribute name="hasHeader"> <![CDATA[
       For each item, add a caption from descriptor.getDisplayName().
-      This also activates drag&amp;drop (where the header is a grip), and help text support.
+      This also activates drag&drop (where the header is a grip), and help text support.
+       ]]>
     </st:attribute>
     <st:attribute name="oneEach">
       If true, only allow up to one instance per descriptor.

--- a/core/src/main/resources/lib/form/repeatableProperty.jelly
+++ b/core/src/main/resources/lib/form/repeatableProperty.jelly
@@ -68,9 +68,10 @@ THE SOFTWARE.
       At least provide this number of copies initially.
       minimum="1" is useful to make sure there's always at least one entry for the user to fill in.
     </st:attribute>
-    <st:attribute name="header">
+    <st:attribute name="header"> <![CDATA[
       For each item, add this header.
-      This also activates drag&amp;drop (where the header is a grip).
+      This also activates drag&drop (where the header is a grip).
+       ]]>
     </st:attribute>
   </st:documentation>
 

--- a/core/src/main/resources/lib/form/section.jelly
+++ b/core/src/main/resources/lib/form/section.jelly
@@ -23,13 +23,14 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <st:documentation>
     Section header in the form table.
 
-    <st:attribute name="title" use="required">
+    <st:attribute name="title" use="required"> <![CDATA[
       The section header text.
-      If null is given, the entire &lt;f:section> tag becomes no-op.
+      If null is given, the entire <f:section> tag becomes no-op.
+      ]]>
     </st:attribute>
     <st:attribute name="icon">
       Optional attribute to set an icon for the section, this is only visible when using section-to-sidebar-items.js

--- a/core/src/main/resources/lib/form/select.jelly
+++ b/core/src/main/resources/lib/form/select.jelly
@@ -24,13 +24,13 @@ THE SOFTWARE.
 
 <!-- Tomcat doesn't like us using the attribute called 'class' -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Glorified &lt;select> control that supports the data binding and AJAX updates.
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    Glorified <select> control that supports the data binding and AJAX updates.
     Your descriptor should have the 'doFillXyzItems' method, which returns a ListBoxModel
     representation of the items in your drop-down list box, and your instance field should
     hold the current value.
-
+    ]]>
     <st:attribute name="clazz">
       Additional CSS classes that the control gets.
     </st:attribute>

--- a/core/src/main/resources/lib/form/slave-mode.jelly
+++ b/core/src/main/resources/lib/form/slave-mode.jelly
@@ -23,13 +23,13 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   <st:documentation>
     A listbox for choosing the agent's usage.
 
-    <st:attribute name="name">
-      Name of the &lt;select> element.
+    <st:attribute name="name"> <![CDATA[
+      Name of the <select> element.
+    ]]>
     </st:attribute>
     <st:attribute name="node">
       Node object.

--- a/core/src/main/resources/lib/form/submit.jelly
+++ b/core/src/main/resources/lib/form/submit.jelly
@@ -23,11 +23,11 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:s="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
-  <s:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:s="jelly:stapler" >
+  <s:documentation> <![CDATA[
     Submit button themed by YUI. This should be always
-    used instead of the plain &lt;input tag.
-
+    used instead of the plain <input> tag.
+    ]]>
     <s:attribute name="name">
       If specified, becomes the value of the name attribute.
       When you have more than one submit button on the form, this can be used to determine

--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -24,22 +24,24 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-  <st:documentation>
-    &lt;textarea> tag on steroids.
+  <st:documentation> <![CDATA[
+    <textarea> tag on steroids.
     The textarea will be rendered to fit the content. It also gets the resize handle.
-
+    ]]>
     <st:attribute name="field">
       Used for databinding. TBD.
     </st:attribute>
-    <st:attribute name="name">
-      This becomes @name of the &lt;textarea> tag.
+    <st:attribute name="name"> <![CDATA[
+      This becomes @name of the <textarea> tag.
       If @field is specified, this value is inferred from it.
+      ]]>
     </st:attribute>
-    <st:attribute name="value">
-      The initial value of the field. This becomes the value of the &lt;textarea> tag.
+    <st:attribute name="value"> <![CDATA[
+      The initial value of the field. This becomes the value of the <textarea> tag.
       If @field is specified, the current property from the "instance" object
       will be set as the initial value automatically,
       which is the recommended approach.
+       ]]>
     </st:attribute>
     <st:attribute name="default">
       The default value of the text box, in case both @value is and 'instance[field]' is null.

--- a/core/src/main/resources/lib/form/textbox.jelly
+++ b/core/src/main/resources/lib/form/textbox.jelly
@@ -37,15 +37,17 @@ THE SOFTWARE.
       Used for determining the autocomplete URL.
       If @field is specified, that will be used for this.
     </st:attribute>
-    <st:attribute name="name">
-      This becomes @name of the &lt;input> tag.
+    <st:attribute name="name"> <![CDATA[
+      This becomes @name of the <input> tag.
       If @field is specified, this value is inferred from it.
+      ]]>
     </st:attribute>
-    <st:attribute name="value">
-      The initial value of the field. This becomes the @value of the &lt;input> tag.
+    <st:attribute name="value"> <![CDATA[
+      The initial value of the field. This becomes the @value of the <input> tag.
       If @field is specified, the current property from the "instance" object
       will be set as the initial value automatically,
       which is the recommended approach.
+       ]]>
     </st:attribute>
     <st:attribute name="default">
       The default value of the text box, in case both @value is and 'instance[field]' is null.

--- a/core/src/main/resources/lib/form/toggleSwitch.jelly
+++ b/core/src/main/resources/lib/form/toggleSwitch.jelly
@@ -23,11 +23,10 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    &lt;input type="checkbox"> tag that takes true/false for @checked, which is more Jelly friendly.
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    <input type="checkbox"> tag that takes true/false for @checked, which is more Jelly friendly.
+    ]]>
     <st:attribute name="name"/>
     <st:attribute name="checked"/>
     <st:attribute name="value"/>

--- a/core/src/main/resources/lib/hudson/newFromList/form.jelly
+++ b/core/src/main/resources/lib/hudson/newFromList/form.jelly
@@ -23,11 +23,11 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-  <st:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:s="/lib/form">
+  <st:documentation> <![CDATA[
     Generates a form for creating something out of descriptors by (1) selecting a descriptor and specifying a name.
-    This also presents a copy option. This should be placed inside &lt;l:main-panel>.
-
+    This also presents a copy option. This should be placed inside <l:main-panel>.
+    ]]>
     <st:attribute name="action">
       Specify where the form will be submitted to. Defaults to 'createItem'.
     </st:attribute>

--- a/core/src/main/resources/lib/hudson/project/config-publishers.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-publishers.jelly
@@ -26,10 +26,11 @@ THE SOFTWARE.
   Publisher config pane
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
-  <st:documentation>
-    Deprecated as of 1.463. Use &lt;config-publishers2> and update your code to do
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    Deprecated as of 1.463. Use <config-publishers2> and update your code to do
     publishers.rebuildHetero(req, json, Publisher.all(), "publisher");
+    ]]>
   </st:documentation>
   <f:descriptorList title="${%Post-build Actions}"
                     descriptors="${h.getPublisherDescriptors(it)}"

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -23,10 +23,10 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <st:documentation>
-    Displays the build queue as &lt;l:pane>
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation> <![CDATA[
+    Displays the build queue as <l:pane>
+    ]]>
     <st:attribute name="items" use="required">
       Queue items to be displayed. Normally you should specify ${app.queue.items},
       but for example you can specify a sublist after some filtering to narrow down

--- a/core/src/main/resources/lib/hudson/rssBar-with-iconSize.jelly
+++ b/core/src/main/resources/lib/hudson/rssBar-with-iconSize.jelly
@@ -24,8 +24,9 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
-  <st:documentation>
-    Deprecated since 1.345: use &lt;t:iconSize>&lt;t:rssBar/>&lt;/t:iconSize>
+  <st:documentation> <![CDATA[
+    Deprecated since 1.345: use <t:iconSize><t:rssBar/></t:iconSize>
+    ]]>
   </st:documentation>
   <t:iconSize><t:rssBar/></t:iconSize>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -22,10 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
-  <st:documentation>
-    Used inside &lt;l:layout> to render additional breadcrumb items.
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <st:documentation> <![CDATA[
+    Used inside <l:layout> to render additional breadcrumb items.
+    ]]>
     <st:attribute name="title" use="required">
       Display name of the breadcrumb.
     </st:attribute>

--- a/core/src/main/resources/lib/layout/breadcrumbBar.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumbBar.jelly
@@ -24,14 +24,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
-  <st:documentation>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
+  <st:documentation> <![CDATA[
     Generates the bar that shows breadcrumbs, along with its associated dynamic behaviours.
     This tag is used by l:layout and not expected to be used by anyone else,
     but it's written as separate tag for better readability of code.
 
     To render additional breadcrumb items (for example to provide in-page navigations),
-    use the &lt;l:breadcrumb> tag.
+    use the <l:breadcrumb> tag.
+    ]]>
   </st:documentation>
 
   <st:adjunct includes="lib.layout.breadcrumbs" />

--- a/core/src/main/resources/lib/layout/header.jelly
+++ b/core/src/main/resources/lib/layout/header.jelly
@@ -24,12 +24,13 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="jelly:stapler" xmlns:d="jelly:define">
-  <s:documentation>
-    Header portion of the HTML page, that gets rendered into the &lt;head> tag.
-    Multiple &lt;l:header> elements can be specified, and can even come after
-    &lt;l:main-panel>.
+  <s:documentation> <![CDATA[
+    Header portion of the HTML page, that gets rendered into the <head> tag.
+    Multiple <l:header> elements can be specified, and can even come after
+    <l:main-panel>.
 
-    This tag can be placed inside &lt;l:layout>.
+    This tag can be placed inside <l:layout>.
+    ]]>
   </s:documentation>
   <j:if test="${mode=='header'}">
     <d:invokeBody />

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -25,27 +25,29 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
-  <st:documentation>
+  <st:documentation> <![CDATA[
     Outer-most tag for a normal (non-AJAX) HTML rendering.
-    This is used with nested &lt;header>, &lt;side-panel>, and &lt;main-panel>
+    This is used with nested <header>, <side-panel>, and <main-panel>
     to form Jenkins's basic HTML layout.
-
-    <st:attribute name="title" use="required">
-      Title of the HTML page. Rendered into &lt;title> tag.
+    ]]>
+    <st:attribute name="title" use="required"> <![CDATA[
+      Title of the HTML page. Rendered into <title> tag.
+      ]]>
     </st:attribute>
     <st:attribute name="norefresh">
       Deprecated: Used to disable auto refresh for a page. The feature has been removed.
     </st:attribute>
-    <st:attribute name="css" deprecated="true">
+    <st:attribute name="css" deprecated="true"> <![CDATA[
       specify path that starts from "/" for loading additional CSS stylesheet.
       path is interpreted as relative to the context root. e.g.,
 
-      {noformat}&lt;l:layout css="/plugin/mysuperplugin/css/myneatstyle.css">{noformat}
+      {noformat}<l:layout css="/plugin/mysuperplugin/css/myneatstyle.css">{noformat}
 
       This was originally added to allow plugins to load their stylesheets, but
       *the use of the attribute is discouraged now.*
-      plugins should now do so by inserting &lt;style> elements and/or &lt;script> elements
-      in &lt;l:header/> tag.
+      plugins should now do so by inserting <style> elements and/or <script> elements
+      in <l:header/> tag.
+       ]]>
     </st:attribute>
     <st:attribute name="permission">
       If given, this page is only made available to users who have the specified permission.

--- a/core/src/main/resources/lib/layout/pane.jelly
+++ b/core/src/main/resources/lib/layout/pane.jelly
@@ -24,13 +24,13 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-  <st:documentation>
-    Used in the &lt;l:side-panel> to draw a box with a title.
+  <st:documentation> <![CDATA[
+    Used in the <l:side-panel> to draw a box with a title.
 
     The box is drawn as a table, and the body of this tag
-    is expected to draw a series of &lt;TR>s to fill in the contents
+    is expected to draw a series of <TR>s to fill in the contents
     of the box.
-
+    ]]>
     <st:attribute name="title" use="required">
       Title of the box. Can include HTML.
     </st:attribute>

--- a/core/src/main/resources/lib/layout/progressAnimation.jelly
+++ b/core/src/main/resources/lib/layout/progressAnimation.jelly
@@ -1,14 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-  <st:documentation>
+  <st:documentation> <![CDATA[
     Display a CSS animation for progressive logging. This tag supersedes spinner.gif and is a drop in replacement:
 
     From
-    {noformat}&lt;img src="${imagesURL}/spinner.gif" alt=""/>{noformat}
+    {noformat}<img src="${imagesURL}/spinner.gif" alt=""/>{noformat}
     to
-    {noformat}&lt;l:progressAnimation/>{noformat}
+    {noformat}<l:progressAnimation/>{noformat}
 
     @since 2.320
+    ]]>
   </st:documentation>
 
 <style>

--- a/core/src/main/resources/lib/layout/svgIcon.jelly
+++ b/core/src/main/resources/lib/layout/svgIcon.jelly
@@ -1,15 +1,16 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:d="jelly:define">
-    <st:documentation>
+    <st:documentation> <![CDATA[
 
-        Opinionated helper to use icons via &lt;svg> tags. Can be used by passing a href or a body:
+        Opinionated helper to use icons via <svg> tags. Can be used by passing a href or a body:
 
         {noformat}
-        # &lt;l:svgIcon href="/path/to/my/sprite.svg#my-icon" />
-        # &lt;l:svgIcon>&lt;path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z">&lt;/path>&lt;/l:svgIcon>
+        # <l:svgIcon href="/path/to/my/sprite.svg#my-icon" />
+        # <l:svgIcon><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path></l:svgIcon>
         {noformat}
 
         @since 2.222
+        ]]>
         <st:attribute name="class">
             Extra CSS classes passed to the icon. Currently only the 'svg-icon' class is applied by default.
         </st:attribute>

--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
-  <st:documentation>
-    This tag inside &lt;l:tasks> tag renders the left navigation bar of Hudson.
-    Each &lt;task> tag gets an icon and link.
-
+  <st:documentation> <![CDATA[
+    This tag inside <l:tasks> tag renders the left navigation bar of Jenkins.
+    Each <task> tag gets an icon and link.
+    ]]>
     <st:attribute name="href" use="required">
       Link target. Relative to the current page.
     </st:attribute>


### PR DESCRIPTION
Special chars need to be escaped in order to not interpret them as Jelly syntax, but we can provide instructions to treat documentation as character data, not markup.

A minor QoL change to improve readability.

Additionally, I got a rid of a few unused namespaces.

### Proposed changelog entries

- Entry 1: Issue, Human-readable Text
- ...

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

