### PR TITLE
[JENKINS-69537] Collapsing build history widget throws error

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -93,10 +93,11 @@ THE SOFTWARE.
 
       <st:include page="entries.jelly" it="${page}" />
 
-      <!--The value for `page-next-build` is modified inside of `entries.jelly` on render, so set the attribute-->
-      <!--after that component has been rendered to get the correct value to use in `filter-build-history.js`-->
-      <div id="properties" page-next-build="${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}"/>
     </l:pane>
+
+    <!--The value for `page-next-build` is modified inside of `entries.jelly` on render, so set the attribute-->
+    <!--after that component has been rendered to get the correct value to use in `filter-build-history.js`-->
+    <div id="properties" page-next-build="${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}"/>
   </div>
   <script src="${resURL}/jsbundles/filter-build-history.js" type="text/javascript"/>
 </j:jelly>

--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -518,7 +518,7 @@ const debouncedFilter = debounce(handleFilter, 300);
 
 document.addEventListener("DOMContentLoaded", function () {
   // Apply correct styling upon filter bar text change, call API after wait
-  pageSearchInput.addEventListener("input", function () {
+  pageSearchInput?.addEventListener("input", function () {
     pageSearchInputContainer.classList.add("jenkins-search--loading");
     buildHistoryContainer.classList.add("jenkins-pane--loading");
     noBuildsBanner.style.display = "none";


### PR DESCRIPTION
See [JENKINS-69537](https://issues.jenkins.io/browse/JENKINS-69537).

There are 2 errors occurred after the widget collapsed.
1. As described in the Jira, the `#properties` element was hidden (null) when the widget was collapsed. Therefore, the error which described in the jira was thrown.
2. Since the `.build-search-row` element was hidden when the widget was collaped, the `pageSearchInput` became `undefined`. In order to solved the problem, optional chaining was applied to it. (This error is shown after the first one is fixed, so the issue reporter might not find this then)

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->

<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

- Fix error after collapsing build history widget

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] (If applicable) Jira issue is well described
- [X] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [X] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7121"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

