### PR TITLE
[JENKINS-69627] Fix CGS form when unsafe plugins are installed

### DIFF
--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsConfiguration/config.groovy
@@ -52,12 +52,12 @@ f.section(title:_("Hidden security warnings")) {
             table(width:"100%") {
 
                 descriptor.applicableWarnings.each { warning ->
-                    if (warning.type == hudson.model.UpdateSite.Warning.Type.CORE) {
+                    if (warning.type == hudson.model.UpdateSite.WarningType.CORE) {
                         printEntry(warning,
                                 _("warning.core", warning.message),
                                 !descriptor.isIgnored(warning))
                     }
-                    else if (warning.type == hudson.model.UpdateSite.Warning.Type.PLUGIN) {
+                    else if (warning.type == hudson.model.UpdateSite.WarningType.PLUGIN) {
                         def plugin = descriptor.getPlugin(warning)
                         printEntry(warning,
                                 _("warning.plugin", plugin.displayName, warning.message),


### PR DESCRIPTION
See [JENKINS-69627](https://issues.jenkins.io/browse/JENKINS-69627).

Amends #7046.

<!-- If someone tells Jesse about this PR, he'll probably link to the type-safe UI proposal again. 😁 -->

### Proposed changelog entries

* Fix broken UI on Configure Global Security form when plugins with active security warnings are installed (regression in 2.368).


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
