### PR TITLE
Added individual suppression to spotbugs false positives

### DIFF
--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -212,6 +212,7 @@ public class SetupWizard extends PageDecorator {
         }
     }
 
+    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "only checked against true")
     private void createInitialApiToken(User user) throws IOException, InterruptedException {
         ApiTokenProperty apiTokenProperty = user.getProperty(ApiTokenProperty.class);
 

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -175,7 +175,7 @@ public class ApiTokenProperty extends UserProperty {
 
     @NonNull
     @Restricted(NoExternalUse.class)
-    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "Only used to generate new token.")
+    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "Used to prevent use of pre-2013 API tokens, then returning the API token value")
     /*package*/ String getApiTokenInsecure() {
         if (apiToken == null) {
             return Messages.ApiTokenProperty_NoLegacyToken();

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -175,6 +175,7 @@ public class ApiTokenProperty extends UserProperty {
 
     @NonNull
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "Only used to generate new token.")
     /*package*/ String getApiTokenInsecure() {
         if (apiToken == null) {
             return Messages.ApiTokenProperty_NoLegacyToken();

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
@@ -194,7 +194,7 @@ public class ApiTokenStore {
      * Be careful with this method. Depending on how the tokenPlainValue was stored/sent to this method,
      * it could be a good idea to generate a new token randomly and revoke this one.
      */
-    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "Only used to generate a new token.")
+    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "Comparison only validates version of the specified token")
     public synchronized @NonNull String addFixedNewToken(@NonNull String name, @NonNull String tokenPlainValue) {
         if (tokenPlainValue.length() != VERSION_LENGTH + HEX_CHAR_LENGTH) {
             LOGGER.log(Level.INFO, "addFixedNewToken, length received: {0}" + tokenPlainValue.length());

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
@@ -27,6 +27,7 @@ package jenkins.security.apitoken;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
 import hudson.util.Secret;
 import java.io.Serializable;
@@ -193,6 +194,7 @@ public class ApiTokenStore {
      * Be careful with this method. Depending on how the tokenPlainValue was stored/sent to this method,
      * it could be a good idea to generate a new token randomly and revoke this one.
      */
+    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "Only used to generate a new token.")
     public synchronized @NonNull String addFixedNewToken(@NonNull String name, @NonNull String tokenPlainValue) {
         if (tokenPlainValue.length() != VERSION_LENGTH + HEX_CHAR_LENGTH) {
             LOGGER.log(Level.INFO, "addFixedNewToken, length received: {0}" + tokenPlainValue.length());
@@ -303,6 +305,7 @@ public class ApiTokenStore {
      * @param tokenUuid The identifier of the token, could be retrieved directly from the {@link HashedToken#getUuid()}
      * @return the revoked token corresponding to the given {@code tokenUuid} if one was found, otherwise {@code null}
      */
+    @SuppressFBWarnings(value = "UNSAFE_HASH_EQUALS", justification = "Only used during revocation.")
     public synchronized @CheckForNull HashedToken revokeToken(@NonNull String tokenUuid) {
         for (Iterator<HashedToken> iterator = tokenList.iterator(); iterator.hasNext(); ) {
             HashedToken token = iterator.next();

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -779,16 +779,6 @@
         </Or>
       </And>
       <And>
-        <Bug pattern="UNSAFE_HASH_EQUALS"/>
-        <Or>
-          <Class name="jenkins.install.SetupWizard"/>
-          <Class name="jenkins.security.apitoken.ApiTokenStore"/>
-          <Class name="jenkins.security.ApiTokenProperty"/>
-          <Class name="jenkins.security.ApiTokenProperty$DescriptorImpl"/>
-          <Class name="jenkins.util.SystemProperties"/>
-        </Or>
-      </And>
-      <And>
         <Bug pattern="URLCONNECTION_SSRF_FD"/>
         <Or>
           <Class name="hudson.FilePath"/>


### PR DESCRIPTION
Added individual suppression to spotbugs false positives of type `UNSAFE_HASH_EQUALS`

### Proposed changelog entries

- N/A

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7124"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

