### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,8 +9,15 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   update_draft_release:
+    permissions:
+      pull-requests: write # to add label to PR (release-drafter/release-drafter)
+      contents: write # to create a github release (release-drafter/release-drafter)
+
     if: github.repository_owner == 'jenkinsci'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   determine-version:
     runs-on: ubuntu-latest
@@ -35,6 +38,9 @@ jobs:
           echo "::set-output name=is-lts::${is_lts}"
           echo "::set-output name=project-version::$version"
   war:
+    permissions:
+      contents: write # to upload release asset (actions/upload-release-asset)
+
     runs-on: ubuntu-latest
     needs: determine-version
     steps:
@@ -67,6 +73,9 @@ jobs:
           asset_name: ${{ steps.fetch-war.outputs.file-name }}
           asset_content_type: application/java-archive
   debian:
+    permissions:
+      contents: write # to upload release asset (actions/upload-release-asset)
+
     runs-on: ubuntu-latest
     needs: determine-version
     steps:
@@ -101,6 +110,9 @@ jobs:
           asset_name: ${{ steps.fetch-deb.outputs.file-name }}
           asset_content_type: application/vnd.debian.binary-package
   redhat:
+    permissions:
+      contents: write # to upload release asset (actions/upload-release-asset)
+
     runs-on: ubuntu-latest
     needs: determine-version
     steps:
@@ -136,6 +148,9 @@ jobs:
           asset_name: ${{ steps.fetch-rpm.outputs.file-name }}
           asset_content_type: application/x-redhat-package-manager
   windows:
+    permissions:
+      contents: write # to upload release asset (actions/upload-release-asset)
+
     runs-on: ubuntu-latest
     needs: determine-version
     steps:
@@ -171,6 +186,9 @@ jobs:
           asset_name: ${{ steps.fetch-msi.outputs.file-name }}
           asset_content_type: application/octet-stream
   suse:
+    permissions:
+      contents: write # to upload release asset (actions/upload-release-asset)
+
     runs-on: ubuntu-latest
     needs: determine-version
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7128"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

