### PR TITLE
Introduced `TriggeredItem` to better abstract `getTriggers`

### DIFF
--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -63,7 +63,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import jenkins.model.ParameterizedJobMixIn;
+import jenkins.triggers.TriggeredItem;
 import jenkins.util.SystemProperties;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -77,6 +77,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * put {@link Extension} on your {@link TriggerDescriptor} class.
  *
  * @author Kohsuke Kawaguchi
+ * @see TriggeredItem
  */
 public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>, ExtensionPoint {
 
@@ -279,9 +280,9 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
         }
 
         // Process all triggers, except SCMTriggers when synchronousPolling is set
-        for (ParameterizedJobMixIn.ParameterizedJob<?, ?> p : inst.allItems(ParameterizedJobMixIn.ParameterizedJob.class)) {
+        for (TriggeredItem p : inst.allItems(TriggeredItem.class)) {
             for (Trigger t : p.getTriggers().values()) {
-                if (!(t instanceof SCMTrigger && scmd.synchronousPolling)) {
+                if (!(p instanceof AbstractProject && t instanceof SCMTrigger && scmd.synchronousPolling)) {
                     if (t != null && t.spec != null && t.tabs != null) {
                         LOGGER.log(Level.FINE, "cron checking {0} with spec ‘{1}’", new Object[]{p, t.spec.trim()});
 

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -49,7 +49,6 @@ import hudson.model.listeners.ItemListener;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.search.SearchIndexBuilder;
 import hudson.triggers.Trigger;
-import hudson.triggers.TriggerDescriptor;
 import hudson.util.AlternativeUiTextProvider;
 import hudson.views.BuildButtonColumn;
 import java.io.IOException;
@@ -57,11 +56,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.ServletException;
 import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.triggers.SCMTriggerItem;
+import jenkins.triggers.TriggeredItem;
 import jenkins.util.TimeDuration;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -321,7 +320,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
     /**
      * Marker for job using this mixin, and default implementations of many methods.
      */
-    public interface ParameterizedJob<JobT extends Job<JobT, RunT> & ParameterizedJobMixIn.ParameterizedJob<JobT, RunT> & Queue.Task, RunT extends Run<JobT, RunT> & Queue.Executable> extends BuildableItem {
+    public interface ParameterizedJob<JobT extends Job<JobT, RunT> & ParameterizedJobMixIn.ParameterizedJob<JobT, RunT> & Queue.Task, RunT extends Run<JobT, RunT> & Queue.Executable> extends BuildableItem, TriggeredItem {
 
         /**
          * Used for CLI binding.
@@ -372,14 +371,6 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         default String getBuildNowText() {
             return getParameterizedJobMixIn().getBuildNowText();
         }
-
-        /**
-         * Gets currently configured triggers.
-         * You may use {@code <p:config-trigger/>} to configure them.
-         * @return a map from trigger kind to instance
-         * @see #getTrigger
-         */
-        Map<TriggerDescriptor, Trigger<?>> getTriggers();
 
         @Override
         default boolean scheduleBuild(Cause c) {

--- a/core/src/main/java/jenkins/triggers/TriggeredItem.java
+++ b/core/src/main/java/jenkins/triggers/TriggeredItem.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.triggers;
+
+import hudson.model.Item;
+import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
+import java.util.Map;
+
+/**
+ * An item which can be configured with {@link Trigger}s.
+ * @since TODO
+ */
+public interface TriggeredItem extends Item {
+
+    /**
+     * Gets currently configured triggers. You may use
+     * {@code <p:config-trigger/>} to configure them.
+     * @return a map from trigger kind to instance
+     */
+    Map<TriggerDescriptor, Trigger<?>> getTriggers();
+
+}


### PR DESCRIPTION
Allows some old tech debt to be cleaned up in https://github.com/jenkinsci/cloudbees-folder-plugin/pull/264.

### Proposed changelog entries

- Introduced a new interface `TriggeredItem`.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7131"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

