### PR TITLE
[JENKINS-69650] Fix test reporting of Security2779Test

### DIFF
--- a/test/src/test/java/jenkins/security/Security2779Test.java
+++ b/test/src/test/java/jenkins/security/Security2779Test.java
@@ -27,7 +27,11 @@ public class Security2779Test {
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    @Parameterized.Parameters
+    // Dynamic tests are not fully supported by the maven surefire plugin
+    // Failures of one parameter are treated as "flakes" of the named test
+    // instead of being treated as failures.
+    // Test output includes the test number and argument to make it a little easier to diagnose
+    @Parameterized.Parameters(name = "test:{index}  arg:\"{0}\"")
     public static Collection<String> getSelectors() {
         return Arrays.asList("#link-panel a", "#icon-panel svg");
     }
@@ -47,7 +51,8 @@ public class Security2779Test {
         assertThat(eventResult, instanceOf(boolean.class));
         Assert.assertTrue((boolean) eventResult);
         webClient.waitForBackgroundJavaScript(2000);
-        Assert.assertEquals(0, alerts.get());
+        // Assertion includes the selector for easier diagnosis
+        Assert.assertEquals("Alert with selector '" + selector + "'", 0, alerts.get());
 
         final ScriptResult innerHtmlScript = page.executeJavaScript("document.querySelector('#tt').innerHTML");
         Object jsResult = innerHtmlScript.getJavaScriptResult();

--- a/test/src/test/java/jenkins/security/Security2779Test.java
+++ b/test/src/test/java/jenkins/security/Security2779Test.java
@@ -9,39 +9,30 @@ import com.gargoylesoftware.htmlunit.AlertHandler;
 import com.gargoylesoftware.htmlunit.ScriptResult;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.UnprotectedRootAction;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 
-@RunWith(Parameterized.class)
 public class Security2779Test {
     public static final String URL_NAME = "security2779";
-    private final String selector;
+
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-    // Dynamic tests are not fully supported by the maven surefire plugin
-    // Failures of one parameter are treated as "flakes" of the named test
-    // instead of being treated as failures.
-    // Test output includes the test number and argument to make it a little easier to diagnose
-    @Parameterized.Parameters(name = "test:{index}  arg:\"{0}\"")
-    public static Collection<String> getSelectors() {
-        return Arrays.asList("#link-panel a", "#icon-panel svg");
-    }
-
-    public Security2779Test(String selector) {
-        this.selector = selector;
+    @Test
+    public void noXssInHelpLinkPanel() throws Exception {
+        noCrossSiteScriptingInHelp("#link-panel a");
     }
 
     @Test
-    public void noXssInHelp() throws Exception {
+    public void noXssInHelpIconPanel() throws Exception {
+        noCrossSiteScriptingInHelp("#icon-panel svg");
+    }
+
+    private void noCrossSiteScriptingInHelp(String selector) throws Exception {
         final AtomicInteger alerts = new AtomicInteger();
         final JenkinsRule.WebClient webClient = j.createWebClient();
         webClient.setAlertHandler((AlertHandler) (p, s) -> alerts.addAndGet(1));


### PR DESCRIPTION
# [JENKINS-69650](https://issues.jenkins.io/browse/JENKINS-69650) Fix test reporting of Security2779Test

Apache Maven surefire plugin does not seem to fully support parameterized JUnit 4 tests.  See https://github.com/junit-team/junit5/issues/990 for discussion of the issue.

The surefire plugin acts as though the Security2779Test is being run multiple times with the same argument and treats a failure of one argument as a "flaky test".  In this case, the test is not flaky as far as I can tell, it is showing a real failure when the argument is "#icon-panel svg".

The test passes consistently when the argument is "#link-panel a".

The consistent failures that I've seen were on Red Hat Enterprise Linux 8.6 with Eclipse Temurin Java 11.0.16.1.  The same failure was seen in the Jenkins 2.369 weekly build.

This commit does not fix the failure, it just makes it easier to see that there is a failure.

It appears that the parameterized test started failing for the '#icon-panel svg' with commit 3923e45a3be592b7ce3cf93f25c30ec606a7d2d7 in pull request #7052.  See the bisection command used in [JENKINS-69650](https://issues.jenkins.io/browse/JENKINS-69650)

### Proposed changelog entries

* No changelog - test related only

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

### Desired reviewers

@NotMyFault, @daniel-beck

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- ~~If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))~~
- ~~If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).~~


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7134"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

