### PR TITLE
Remove custom arguments from Maven Release Plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,8 +425,6 @@ THE SOFTWARE.
         <artifactId>maven-release-plugin</artifactId>
         <!-- Version specified in parent POM -->
         <configuration>
-          <!-- enable release profile during the release, create IPS package, and sign bits. -->
-          <arguments>-P release,sign</arguments>
           <!-- work around for a bug in javadoc plugin that causes the release to fail. see MRELEASE-271 -->
           <preparationGoals>clean install</preparationGoals>
           <goals>-DskipTests -Dspotbugs.skip -Dmaven.checkstyle.skip -Dspotless.check.skip generate-resources javadoc:javadoc deploy</goals>


### PR DESCRIPTION
Fixes a regression exposed by jenkinsci/pom#281 and #6914. In order for release artifacts to be signed by `maven-gpg-plugin` and `maven-jarsigner-plugin` during the `release:prepare` goal, we rely on https://github.com/jenkinsci/jenkins/blob/d25704cfbc929bca3bd5e5675e1fe1aa1a58928c/pom.xml#L521-L540 and https://github.com/jenkinsci/jenkins/blob/d25704cfbc929bca3bd5e5675e1fe1aa1a58928c/war/pom.xml#L623-L648, activated by the `release` and `sign` profiles respectively. To activate these profiles during the `release:prepare` goal we currently rely on https://github.com/jenkinsci/jenkins/blob/d25704cfbc929bca3bd5e5675e1fe1aa1a58928c/pom.xml#L428-L429, which happens to expose a serious bug in recent versions of Maven Release Plugin as explained in https://github.com/jenkins-infra/helpdesk/issues/3143#issuecomment-1254040470. Fortunately for us, we can work around the problem by omitting any custom arguments from our Maven Release Plugin configuration as in https://github.com/jenkins-infra/release/pull/291 and this PR, instead enabling these profiles via an `<activeProfiles>` setting in [`settings-release.xml`](https://github.com/jenkins-infra/release/blob/29865baf0d90bf30885f81413bf7dbb36dd36582/utils/release.bash#L152-L237). Note that we cannot enable these profiles using [`releaseProfiles`](https://maven.apache.org/maven-release/maven-release-plugin/stage-mojo.html#releaseProfiles) because that setting only applies to the `release:stage` and `release:perform` goals, not the `release:prepare` goal.

### Proposed changelog entries

Support staging of releases (regression in 2.361).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7138"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

