### PR TITLE
Revise curl example for inbound agent

### DIFF
--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -58,7 +58,7 @@ java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenki
             </j:otherwise>
           </j:choose>
           <p>
-            ${%Note: PowerShell users must use curl.exe instead of curl due to the default PowerShell cmdlet alias for curl}
+            ${%Note: PowerShell users must use curl.exe instead of curl because curl is a default PowerShell cmdlet alias for Invoke-WebRequest.}
           </p>
       </j:if>
     </j:when>

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -57,9 +57,9 @@ curl -sO ${jenkinsURL}jnlpJars/agent.jar
 java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenkinsURL}${it.url}jenkins-agent.jnlp -secret @secret-file ${it.launcher.getWorkDirOptions(it)}</pre>
             </j:otherwise>
           </j:choose>
-               <p>
-                 ${%Please note: Powershell users must use curl.exe instead of curl due to the default Powershell cmd-let alias for curl}
-               </p>
+          <p>
+            ${%Please note: Powershell users must use curl.exe instead of curl due to the default Powershell cmd-let alias for curl}
+          </p>
       </j:if>
     </j:when>
     <j:otherwise>

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
                 <p>
                   ${%Run from agent command line:}
                 </p>
-                <pre>curl -sO ${jenkinsURL}jnlpJars/agent.jar
+                <pre>curl.exe -sO ${jenkinsURL}jnlpJars/agent.jar
 java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenkinsURL}${it.url}jenkins-agent.jnlp ${it.launcher.getWorkDirOptions(it)}</pre>
             </j:when>
             <j:otherwise>
@@ -47,7 +47,7 @@ java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenki
                   ${%Run from agent command line:}
                 </p>
                 <!-- TODO conceal secret w/ JS if possible -->
-                <pre>curl -sO ${jenkinsURL}jnlpJars/agent.jar
+                <pre>curl.exe -sO ${jenkinsURL}jnlpJars/agent.jar
 java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenkinsURL}${it.url}jenkins-agent.jnlp -secret ${it.jnlpMac} ${it.launcher.getWorkDirOptions(it)}</pre>
                 <p>
                   ${%Or run from agent command line, with the secret stored in a file:}

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -58,7 +58,7 @@ java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenki
             </j:otherwise>
           </j:choose>
           <p>
-            ${%Please note: PowerShell users must use curl.exe instead of curl due to the default PowerShell cmdlet alias for curl}
+            ${%Note: PowerShell users must use curl.exe instead of curl due to the default PowerShell cmdlet alias for curl}
           </p>
       </j:if>
     </j:when>

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -58,7 +58,7 @@ java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenki
             </j:otherwise>
           </j:choose>
           <p>
-            ${%Please note: Powershell users must use curl.exe instead of curl due to the default Powershell cmd-let alias for curl}
+            ${%Please note: PowerShell users must use curl.exe instead of curl due to the default PowerShell cmd-let alias for curl}
           </p>
       </j:if>
     </j:when>

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
                 <p>
                   ${%Run from agent command line:}
                 </p>
-                <pre>curl.exe -sO ${jenkinsURL}jnlpJars/agent.jar
+                <pre>curl -sO ${jenkinsURL}jnlpJars/agent.jar
 java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenkinsURL}${it.url}jenkins-agent.jnlp ${it.launcher.getWorkDirOptions(it)}</pre>
             </j:when>
             <j:otherwise>
@@ -47,7 +47,7 @@ java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenki
                   ${%Run from agent command line:}
                 </p>
                 <!-- TODO conceal secret w/ JS if possible -->
-                <pre>curl.exe -sO ${jenkinsURL}jnlpJars/agent.jar
+                <pre>curl -sO ${jenkinsURL}jnlpJars/agent.jar
 java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenkinsURL}${it.url}jenkins-agent.jnlp -secret ${it.jnlpMac} ${it.launcher.getWorkDirOptions(it)}</pre>
                 <p>
                   ${%Or run from agent command line, with the secret stored in a file:}
@@ -57,6 +57,9 @@ curl -sO ${jenkinsURL}jnlpJars/agent.jar
 java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenkinsURL}${it.url}jenkins-agent.jnlp -secret @secret-file ${it.launcher.getWorkDirOptions(it)}</pre>
             </j:otherwise>
           </j:choose>
+               <p>
+                 ${%Please note: Powershell users must use curl.exe instead of curl due to the default Powershell cmd-let alias for curl}
+               </p>
       </j:if>
     </j:when>
     <j:otherwise>

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -58,7 +58,7 @@ java -jar <a href="${rootURL}/jnlpJars/agent.jar">agent.jar</a> -jnlpUrl ${jenki
             </j:otherwise>
           </j:choose>
           <p>
-            ${%Please note: PowerShell users must use curl.exe instead of curl due to the default PowerShell cmd-let alias for curl}
+            ${%Please note: PowerShell users must use curl.exe instead of curl due to the default PowerShell cmdlet alias for curl}
           </p>
       </j:if>
     </j:when>


### PR DESCRIPTION
`curl` in powershell is a `cmd-let` and the `-sO` flags don't working with it. If you change it to `curl.exe` it will work with the flags. 

Reference: https://curl.se/windows/microsoft.html


### Proposed changelog entries

- Changed the hint command for `curl.exe` instead of the `cmd-let` of `curl`


### Submitter checklist

- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7142"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

