### PR TITLE
De-flake `ProjectTest#testScheduleBuild2`

### DIFF
--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -310,7 +310,7 @@ public class ProjectTest {
     }
 
     @Test
-    public void testScheduleBuild2() throws IOException, InterruptedException {
+    public void testScheduleBuild2() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject("project");
         p.setAssignedLabel(j.jenkins.getLabel("nonExist"));
         p.scheduleBuild(0, new UserIdCause());
@@ -321,7 +321,9 @@ public class ProjectTest {
             Thread.sleep(1000); //give some time to start build
             count++;
         }
-        assertNotNull("Build should be done or in progress.", p.getLastBuild());
+        FreeStyleBuild b = p.getLastBuild();
+        assertNotNull("Build should be done or in progress.", b);
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
     }
 
 


### PR DESCRIPTION
Noticed a flake in `ProjectTest.testScheduleBuild2` on Windows:

```
01:18:37  [WARNING] hudson.model.ProjectTest.testScheduleBuild2
01:18:37  [ERROR]   Run 1: ProjectTest.testScheduleBuild2 » CompositeIO Unable to delete 'C:\Jenkins\workspace\Core_jenkins_master\test\target\j h7877709960004238855'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts.
01:18:37  [INFO]   Run 2: PASS
```

This is because we are starting a build but not waiting for it to complete, resulting in the file being locked in Windows and the teardown failing. Waiting for the build to complete should fix the problem.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7144"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

