### PR TITLE
De-flake `BuildCommandTest#executorsAliveOnParameterWithNullDefaultValue`

### DIFF
--- a/test/src/test/java/hudson/cli/BuildCommandTest.java
+++ b/test/src/test/java/hudson/cli/BuildCommandTest.java
@@ -26,6 +26,7 @@ package hudson.cli;
 
 import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
 import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -62,6 +63,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import net.sf.json.JSONObject;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -241,7 +243,9 @@ public class BuildCommandTest {
         j.buildAndAssertSuccess(project);
 
         for (Executor exec : slave.toComputer().getExecutors()) {
-            assertTrue("Executor has died before the test start: " + exec, exec.isActive());
+            await().pollInterval(250, TimeUnit.MILLISECONDS)
+                    .atMost(10, TimeUnit.SECONDS)
+                    .until(exec::isActive);
         }
 
         // Create CLI & run command


### PR DESCRIPTION
Observed in both a CI build and a release build:

```
15:13:04  [ERROR] hudson.cli.BuildCommandTest.executorsAliveOnParameterWithNullDefaultValue  Time elapsed: 9.634 s  <<< FAILURE!
15:13:04  java.lang.AssertionError: Executor has died before the test start: Thread[Executor #0 for slave0 : executing foo #1,5,]
15:13:04  	at org.junit.Assert.fail(Assert.java:89)
15:13:04  	at org.junit.Assert.assertTrue(Assert.java:42)
15:13:04  	at hudson.cli.BuildCommandTest.executorsAliveOnParameterWithNullDefaultValue(BuildCommandTest.java:244)
15:13:04  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
15:13:04  	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
15:13:04  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
15:13:04  	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
15:13:04  	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
15:13:04  	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
15:13:04  	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
15:13:04  	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
15:13:04  	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:613)
15:13:04  	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
15:13:04  	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
15:13:04  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
15:13:04  	at java.base/java.lang.Thread.run(Thread.java:829)
```

Since the build is ostensibly complete but we see the executor running "executing foo #1" this must mean that we didn't wait long enough for the executor to be returned back to the available pool. This PR corrects the bug in the test by adding a short loop to wait for the expected condition to be true before proceeding with the next portion of the test.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7147"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

