### PR TITLE
De-flake `NodeProvisionerRule`-based tests

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -160,7 +160,7 @@ import org.springframework.security.core.Authentication;
  */
 public class QueueTest {
 
-    @Rule public JenkinsRule r = new NodeProvisionerRule(-1, 0, 10);
+    @Rule public JenkinsRule r = new NodeProvisionerRule(/* run 10x the regular speed to speed up the test */ 1000, 10000, 1000);
 
     @Rule
     public LoggerRule logging = new LoggerRule().record(Queue.class, Level.FINE);

--- a/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
+++ b/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
@@ -63,7 +63,7 @@ import org.jvnet.hudson.test.SleepBuilder;
  */
 public class NodeProvisionerTest {
 
-    @Rule public JenkinsRule r = new NodeProvisionerRule(/* run x1000 the regular speed to speed up the test */10, 100, 10);
+    @Rule public JenkinsRule r = new NodeProvisionerRule(/* run 10x the regular speed to speed up the test */ 1000, 10000, 1000);
 
     /**
      * Latch synchronization primitive that waits for N thread to pass the checkpoint.


### PR DESCRIPTION
Our two `NodeProvisionerRule`-based tests (`QueueTest` and `NodeProvisionerTest`) reschedule `NodeProvisionerInvoker` from once every 10 seconds to once every 10 milliseconds (!). The comment states that the intention was to speed up the test by 1000x, but the arithmetic is faulty. My theory is that such an aggressive recurrence period causes excessive scheduling and ultimately CPU exhaustion. In this PR I attempt to mitigate the problem by choosing values that are only 10x faster than production. That should be plenty fast to fit within our 180-second test execution budget while still being close enough to production to be realistic, including not exhausting the CPU. And of course the arithmetic is now correct.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7148"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

