### PR TITLE
De-flake `PingThreadTest`

### DIFF
--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -74,16 +74,6 @@ public class PingThreadTest {
         }
         assertNotNull(pingThread);
 
-        new ProcessBuilder("kill", "-STOP", Long.toString(pid)).redirectErrorStream(true).start().waitFor();
-        Thread.sleep(10000);
-        String status = Files.readString(Paths.get("/proc/" + pid + "/stat"), StandardCharsets.UTF_8);
-        try {
-            assertEquals("basil", status);
-        } finally {
-            new ProcessBuilder("kill", "-CONT", Long.toString(pid)).redirectErrorStream(true).start().waitFor();
-            Thread.sleep(10000);
-        }
-
         // Simulate lost connection
         kill(pid, "-STOP", 'T');
         try {

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -39,6 +39,7 @@ import hudson.remoting.PingThread;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import jenkins.security.MasterToSlaveCallable;
@@ -92,12 +93,15 @@ public class PingThreadTest {
             assertNull(slave.getComputer().getChannel());
             assertNull(computer.getChannel());
         } finally {
-            process = new ProcessBuilder("kill", "-CONT", Long.toString(pid))
-                    .redirectErrorStream(true)
-                    .start();
-            result = process.waitFor();
-            output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            assertEquals(output, 0, result);
+            Optional<ProcessHandle> handle = ProcessHandle.of(pid);
+            if (handle.isPresent()) {
+                process = new ProcessBuilder("kill", "-CONT", Long.toString(pid))
+                        .redirectErrorStream(true)
+                        .start();
+                result = process.waitFor();
+                output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                assertEquals(output, 0, result);
+            }
         }
     }
 

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeFalse;
 
 import hudson.Functions;
+import hudson.Platform;
 import hudson.model.Computer;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelClosedException;
@@ -59,7 +60,7 @@ public class PingThreadTest {
 
     @Test
     public void failedPingThreadResetsComputerChannel() throws Exception {
-        assumeFalse("We simulate hung agent by sending the SIGSTOP signal", Functions.isWindows());
+        assumeFalse("We simulate hung agent by sending the SIGSTOP signal", Functions.isWindows() || Platform.isDarwin());
 
         DumbSlave slave = j.createOnlineSlave();
         Computer computer = slave.toComputer();

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -39,6 +39,8 @@ import hudson.remoting.PingThread;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import jenkins.security.MasterToSlaveCallable;
@@ -78,6 +80,11 @@ public class PingThreadTest {
         int result = process.waitFor();
         String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         assertEquals(output, 0, result);
+
+        await().pollInterval(250, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> Files.readString(Paths.get("/proc/" + pid + "/stat"), StandardCharsets.UTF_8).split(" ")[2].equals("T"));
+
         try {
             // ... do not wait for Ping Thread to notice
             Method onDead = PingThread.class.getDeclaredMethod("onDead", Throwable.class);

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -24,6 +24,7 @@
 
 package hudson.slaves;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -37,6 +38,7 @@ import hudson.remoting.ChannelClosedException;
 import hudson.remoting.PingThread;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import jenkins.security.MasterToSlaveCallable;
 import org.junit.Rule;
@@ -76,6 +78,9 @@ public class PingThreadTest {
             onDead.setAccessible(true);
             onDead.invoke(pingThread, new TimeoutException("No ping"));
 
+            await().pollInterval(250, TimeUnit.MILLISECONDS)
+                    .atMost(10, TimeUnit.SECONDS)
+                    .until(channel::isClosingOrClosed);
             assertThrows(ChannelClosedException.class, () -> channel.call(new GetPid()));
 
             assertNull(slave.getComputer().getChannel());

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -74,6 +74,9 @@ public class PingThreadTest {
         }
         assertNotNull(pingThread);
 
+        String status = Files.readString(Paths.get("/proc/" + pid + "/stat"), StandardCharsets.UTF_8);
+        assertEquals("basil", status);
+
         // Simulate lost connection
         kill(pid, "-TSTP", 'T');
         try {

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -74,8 +74,15 @@ public class PingThreadTest {
         }
         assertNotNull(pingThread);
 
+        new ProcessBuilder("kill", "-TSTP", Long.toString(pid)).redirectErrorStream(true).start().waitFor();
+        Thread.sleep(10000);
         String status = Files.readString(Paths.get("/proc/" + pid + "/stat"), StandardCharsets.UTF_8);
-        assertEquals("basil", status);
+        try {
+            assertEquals("basil", status);
+        } finally {
+            new ProcessBuilder("kill", "-CONT", Long.toString(pid)).redirectErrorStream(true).start().waitFor();
+            Thread.sleep(10000);
+        }
 
         // Simulate lost connection
         kill(pid, "-TSTP", 'T');

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -25,6 +25,7 @@
 package hudson.slaves;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -108,7 +109,7 @@ public class PingThreadTest {
         char actualState = status.charAt(status.lastIndexOf(')') + 2);
         await().pollInterval(250, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
-                .until(() -> actualState == expectedState);
+                .until(() -> actualState, equalTo(expectedState));
     }
 
     private static final class GetPid extends MasterToSlaveCallable<Long, IOException> {

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -39,7 +39,6 @@ import hudson.remoting.PingThread;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import jenkins.security.MasterToSlaveCallable;
@@ -93,15 +92,12 @@ public class PingThreadTest {
             assertNull(slave.getComputer().getChannel());
             assertNull(computer.getChannel());
         } finally {
-            Optional<ProcessHandle> handle = ProcessHandle.of(pid);
-            if (handle.isPresent()) {
-                process = new ProcessBuilder("kill", "-CONT", Long.toString(pid))
-                        .redirectErrorStream(true)
-                        .start();
-                result = process.waitFor();
-                output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-                assertEquals(output, 0, result);
-            }
+            process = new ProcessBuilder("kill", "-CONT", Long.toString(pid))
+                    .redirectErrorStream(true)
+                    .start();
+            result = process.waitFor();
+            output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            assertEquals(output, 0, result);
         }
     }
 

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -59,7 +59,7 @@ public class PingThreadTest {
 
     @Test
     public void failedPingThreadResetsComputerChannel() throws Exception {
-        assumeFalse("We simulate hung agent by sending the SIGTSTP signal", Functions.isWindows());
+        assumeFalse("We simulate hung agent by sending the SIGSTOP signal", Functions.isWindows());
 
         DumbSlave slave = j.createOnlineSlave();
         Computer computer = slave.toComputer();
@@ -74,7 +74,7 @@ public class PingThreadTest {
         }
         assertNotNull(pingThread);
 
-        new ProcessBuilder("kill", "-TSTP", Long.toString(pid)).redirectErrorStream(true).start().waitFor();
+        new ProcessBuilder("kill", "-STOP", Long.toString(pid)).redirectErrorStream(true).start().waitFor();
         Thread.sleep(10000);
         String status = Files.readString(Paths.get("/proc/" + pid + "/stat"), StandardCharsets.UTF_8);
         try {
@@ -85,7 +85,7 @@ public class PingThreadTest {
         }
 
         // Simulate lost connection
-        kill(pid, "-TSTP", 'T');
+        kill(pid, "-STOP", 'T');
         try {
             // ... do not wait for Ping Thread to notice
             Method onDead = PingThread.class.getDeclaredMethod("onDead", Throwable.class);


### PR DESCRIPTION
Flake observed in [this run](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7139/4/testReport/junit/hudson.slaves/PingThreadTest/Linux_jdk17___Linux_Build___Test___failedPingThreadResetsComputerChannel/). I observed that the code being called by the test was asynchronous and could reproduce a hang reliably within

```java
diff --git a/core/src/main/java/hudson/slaves/SlaveComputer.java b/core/src/main/java/hudson/slaves/SlaveComputer.java
index 1b2cc7f562..efa9591510 100644
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -797,6 +797,11 @@ public class SlaveComputer extends Computer {
         return Computer.threadPoolForRemoting.submit(new Runnable() {
             @Override
             public void run() {
+                try {
+                    Thread.sleep(15000);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
                 // do this on another thread so that any lengthy disconnect operation
                 // (which could be typical) won't block UI thread.
                 launcher.beforeDisconnect(SlaveComputer.this, taskListener);
```

In any case the solution is to wait for the asynchronous activity to complete. I verified that the fix in this PR made the hang induced above disappear (modulo adjusting the timing for the artificially long sleep interval).

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7149"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

