### PR TITLE
De-flake `DefaultCrumbIssuerTest`

### DIFF
--- a/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerTest.java
+++ b/test/src/test/java/hudson/security/csrf/DefaultCrumbIssuerTest.java
@@ -38,6 +38,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.recipes.PresetData;
+import org.jvnet.hudson.test.recipes.WithTimeout;
 
 /**
  * @author dty
@@ -169,6 +170,7 @@ public class DefaultCrumbIssuerTest {
 
     @Test
     @Issue("SECURITY-626")
+    @WithTimeout(300)
     public void crumbOnlyValidForOneSession() throws Exception {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         DefaultCrumbIssuer issuer = new DefaultCrumbIssuer(false);


### PR DESCRIPTION
I noticed a fair number of timeouts of this test:

```
00:23:46  [WARNING] hudson.security.csrf.DefaultCrumbIssuerTest.crumbOnlyValidForOneSession
00:23:46  [ERROR]   Run 1: DefaultCrumbIssuerTest.crumbOnlyValidForOneSession:183->compareDifferentSessions_tokenAreEqual:197 » TestTimedOut test timed out after 180 seconds
00:23:46  [INFO]   Run 2: PASS
```

Like #7146 I suspect much of this is due to the slow nature of parsing and rendering with HtmlUnit, particularly on Windows. To give us more breathing room I am adding a `@WithTimeout` annotation to increase the timeout from its default value of 180 seconds to 300 seconds as in #7146.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7150"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

