### PR TITLE
De-flake `InitMilestoneTest`

### DIFF
--- a/test/src/test/java/hudson/init/InitMilestoneTest.java
+++ b/test/src/test/java/hudson/init/InitMilestoneTest.java
@@ -1,9 +1,10 @@
 package hudson.init;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -17,48 +18,48 @@ public class InitMilestoneTest {
     @Test
     public void testInitMilestones() {
 
-        List<InitMilestone> attained = r.jenkins.getExtensionList(Initializers.class).get(0).getAttained();
+        Queue<InitMilestone> attained = r.jenkins.getExtensionList(Initializers.class).get(0).getAttained();
 
-        assertEquals(InitMilestone.EXTENSIONS_AUGMENTED, attained.get(0));
-        assertEquals(InitMilestone.SYSTEM_CONFIG_LOADED, attained.get(1));
-        assertEquals(InitMilestone.SYSTEM_CONFIG_ADAPTED, attained.get(2));
-        assertEquals(InitMilestone.JOB_LOADED, attained.get(3));
-        assertEquals(InitMilestone.JOB_CONFIG_ADAPTED, attained.get(4));
+        assertThat(attained, contains(
+                InitMilestone.EXTENSIONS_AUGMENTED,
+                InitMilestone.SYSTEM_CONFIG_LOADED,
+                InitMilestone.SYSTEM_CONFIG_ADAPTED,
+                InitMilestone.JOB_LOADED,
+                InitMilestone.JOB_CONFIG_ADAPTED));
     }
 
     // Using @Initializer in static methods to check all the InitMilestones are loaded in all tests instances and make them fail,
     // so using a TestExtension and checking only the InitMilestone after EXTENSION_AUGMENTED
     @TestExtension("testInitMilestones")
     public static class Initializers {
-        private int order = 0;
-        private List<InitMilestone> attained = new ArrayList<>();
+        private Queue<InitMilestone> attained = new ConcurrentLinkedQueue<>();
 
         @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
         public void extensionsAugmented() {
-            attained.add(order++, InitMilestone.EXTENSIONS_AUGMENTED);
+            attained.offer(InitMilestone.EXTENSIONS_AUGMENTED);
         }
 
         @Initializer(after = InitMilestone.SYSTEM_CONFIG_LOADED)
         public void pluginsSystemConfigLoaded() {
-            attained.add(order++, InitMilestone.SYSTEM_CONFIG_LOADED);
+            attained.offer(InitMilestone.SYSTEM_CONFIG_LOADED);
         }
 
         @Initializer(after = InitMilestone.SYSTEM_CONFIG_ADAPTED)
         public void pluginsSystemConfigAdapted() {
-            attained.add(order++, InitMilestone.SYSTEM_CONFIG_ADAPTED);
+            attained.offer(InitMilestone.SYSTEM_CONFIG_ADAPTED);
         }
 
         @Initializer(after = InitMilestone.JOB_LOADED)
         public void jobLoaded() {
-            attained.add(order++, InitMilestone.JOB_LOADED);
+            attained.offer(InitMilestone.JOB_LOADED);
         }
 
         @Initializer(after = InitMilestone.JOB_CONFIG_ADAPTED)
         public void jobConfigAdapted() {
-            attained.add(order++, InitMilestone.JOB_CONFIG_ADAPTED);
+            attained.offer(InitMilestone.JOB_CONFIG_ADAPTED);
         }
 
-        public List<InitMilestone> getAttained() {
+        public Queue<InitMilestone> getAttained() {
             return attained;
         }
     }


### PR DESCRIPTION
Saw this test flake with:

```
12:01:27  [WARNING] Flakes: 
12:01:27  [WARNING] hudson.init.InitMilestoneTest.testInitMilestones
12:01:27  [ERROR]   Run 1: InitMilestoneTest.testInitMilestones:23 expected:<System config loaded> but was:<System config adapted>
12:01:27  [INFO]   Run 2: PASS
```

The test was not thread-safe, which I fixed by using a concurrent data structure. Also converted the test to use Hamcrest matchers to make future failures easier to understand.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7151"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

