### PR TITLE
[JENKINS-69676] Status filter dropdown icon is out of style with other

### DIFF
--- a/core/src/main/resources/hudson/views/StatusFilter/config.jelly
+++ b/core/src/main/resources/hudson/views/StatusFilter/config.jelly
@@ -26,9 +26,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="${%Status Filter}" help="/help/view-config/statusFilter.html">
-        <select name="statusFilter" class="jenkins-input">
-            <f:option value="1" selected="${it.statusFilter==true}">${%Enabled jobs only}</f:option>
-            <f:option value="2" selected="${it.statusFilter==false}">${%Disabled jobs only}</f:option>
-        </select>
+        <div class="jenkins-select">
+            <select name="statusFilter" class="jenkins-select__input">
+                <f:option value="1" selected="${it.statusFilter==true}">${%Enabled jobs only}</f:option>
+                <f:option value="2" selected="${it.statusFilter==false}">${%Disabled jobs only}</f:option>
+            </select>
+        </div>
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->

See [JENKINS-69676](https://issues.jenkins.io/browse/JENKINS-69676).
### Before
<img width="949" alt="截圖 2022-09-23 上午9 19 03" src="https://user-images.githubusercontent.com/92412722/191878983-79811946-bdd2-407a-8a32-89644e45161d.png">

### After
<img width="955" alt="截圖 2022-09-23 上午9 44 52" src="https://user-images.githubusercontent.com/92412722/191879002-1bb031cc-5efb-48f5-8f56-4dcc8b2996e5.png">

<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

- Status filter dropdown icon is out of style with other

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7152"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

