### PR TITLE
Docs on linting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,12 @@ which will open the workspace in IntelliJ IDEA using JetBrains Gateway.
 
 For linting we use a number of tools:
 
+- [checkstyle](https://checkstyle.sourceforge.io/)
 - [eslint](https://eslint.org/)
-- [stylelint](https://stylelint.io/)
 - [prettier](https://prettier.io/)
 - [spotless](https://github.com/diffplug/spotless)
+- [stylelint](https://stylelint.io/)
+
 
 These are all configured to run as part of the Maven build, although they will be skipped if you are building with the `quick-build` profile.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,10 @@ which will open the workspace in IntelliJ IDEA using JetBrains Gateway.
 
 For linting we use a number of tools:
 
-- eslint
-- stylelint
-- prettier
-- spotless
+- [eslint](https://eslint.org/)
+- [stylelint](https://stylelint.io/)
+- [prettier](https://prettier.io/)
+- [spotless](https://github.com/diffplug/spotless)
 
 These are all configured to run as part of the Maven build, although they will be skipped if you are building with the `quick-build` profile.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,24 @@ You can use IntelliJ IDEA (preferred) or VS Code (alternate) in the browser.
 If you prefer using IntelliJ IDEA, you can setup Gitpod integration with JetBrains Gateway using the instructions on [gitpod.io](https://www.gitpod.io/docs/ides-and-editors/intellij),
 which will open the workspace in IntelliJ IDEA using JetBrains Gateway.
 
+### Linting
+
+For linting we use a number of tools:
+
+- eslint
+- stylelint
+- prettier
+- spotless
+
+These are all configured to run as part of the Maven build, although they will be skipped if you are building with the `quick-build` profile.
+
+To automatically fix most issues run:
+
+```bash
+mvn spotless:apply
+mvn -pl war frontend:yarn -Dfrontend.yarn.arguments=lint:fix
+```
+
 ## Testing changes
 
 Jenkins core includes unit and functional tests as a part of the repository.
@@ -185,6 +203,11 @@ Pending the merge and release of this patch, IntelliJ IDEA users should work aro
 2. Under "Pass to JUnit process [the] following `maven-surefire-plugin` and `maven-failsafe-plugin` settings", uncheck `argLine`.
 
 Failure to work around the problem as described above will result in a `could not open '{jenkins.addOpens}'` failure when running tests in IntelliJ IDEA.
+
+### Code formatting for frontend files
+
+Install the [Prettier plugin](https://www.jetbrains.com/help/idea/prettier.html).
+Follow the instructions on the above JetBrains page to configure it how you wish. 'On code reformatting' is a good option.
 
 ## Copyright
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,6 @@ For linting we use a number of tools:
 - [spotless](https://github.com/diffplug/spotless)
 - [stylelint](https://stylelint.io/)
 
-
 These are all configured to run as part of the Maven build, although they will be skipped if you are building with the `quick-build` profile.
 
 To automatically fix most issues run:


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->

See https://github.com/jenkinsci/jenkins/pull/6863#issuecomment-1252978467

An option (on top of this) is https://github.com/jenkinsci/jenkins/pull/7075 which makes lint fixing for prettier take ~100ms instead of 7 seconds, as it only runs on changed files

<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

- (skip)
- ...

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [x] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7153"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

