### PR TITLE
De-flake `ResponseTimeMonitorTest`

### DIFF
--- a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
@@ -1,5 +1,7 @@
 package hudson.node_monitors;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -14,6 +16,7 @@ import hudson.slaves.OfflineCause;
 import hudson.slaves.RetentionStrategy;
 import hudson.slaves.SlaveComputer;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -58,7 +61,11 @@ public class ResponseTimeMonitorTest {
         j.jenkins.addNode(slave);
         Computer c = slave.toComputer();
         assertNotNull(c);
+        await().pollInterval(250, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> c.getOfflineCause(), notNullValue());
         OfflineCause originalOfflineCause = c.getOfflineCause();
+        assertNotNull(originalOfflineCause);
 
         ResponseTimeMonitor rtm = ComputerSet.getMonitors().get(ResponseTimeMonitor.class);
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
Observed in [this test run](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7139/12/testReport/junit/hudson.node_monitors/ResponseTimeMonitorTest/Linux_jdk11___Linux_Build___Test___doNotDisconnectBeforeLaunched/):

```
java.lang.AssertionError: expected:<null> but was:<This agent is offline because Jenkins failed to launch the agent process on it.>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at hudson.node_monitors.ResponseTimeMonitorTest.doNotDisconnectBeforeLaunched(ResponseTimeMonitorTest.java:67)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:613)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

Can reproduce consistently with

```java
diff --git a/core/src/main/java/hudson/slaves/SlaveComputer.java b/core/src/main/java/hudson/slaves/SlaveComputer.java
index 1b2cc7f562..9a7cd18d75 100644
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -316,6 +316,7 @@ public class SlaveComputer extends Computer {
                 }
             } finally {
                 if (channel == null && offlineCause == null) {
+                    Thread.sleep(10000);
                     offlineCause = new OfflineCause.LaunchFailed();
                     for (ComputerListener cl : ComputerListener.all())
                         cl.onLaunchFailure(SlaveComputer.this, taskListener);
diff --git a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
index c985068259..12d11aa470 100644
--- a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
@@ -64,6 +64,9 @@ public class ResponseTimeMonitorTest {
         for (int i = 0; i < 10; i++) {
             rtm.triggerUpdate().join();
             System.out.println(rtm.getDescriptor().get(c));
+            if (i == 5) {
+                Thread.sleep(15000);
+            }
             assertEquals(originalOfflineCause, c.getOfflineCause());
         }
     }
```

As with other flakes I have been investigating, this is a classic case of starting asynchronous activity and not waiting for it to complete before proceeding in the test. The asynchronous activity in this case is setting a non-null offline cause in `SlaveComputer#_connect`. This PR corrects the problem by waiting for the asynchronous activity to complete. With this fix I can no longer reproduce the problem with the above synthetic sleeps (modulo adjusting the test for the longer synthetic timing interval).

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7163"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

