### PR TITLE
Revert "Bump junit from 1119.1121.vc43d0fc45561 to 1143.v8d9a_e3355270"

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -160,7 +160,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1143.v8d9a_e3355270</version>
+      <version>1119.1121.vc43d0fc45561</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Somehow managed to pass its PR build, but fails locally for me with the same error as in https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7139/13/testReport/junit/jenkins.model/StartupTest/Linux_jdk17___Linux_Build___Test___noWarnings/

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7164"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

