### PR TITLE
Improve `InitMilestoneTest` error message

### DIFF
--- a/test/src/test/java/hudson/init/InitMilestoneTest.java
+++ b/test/src/test/java/hudson/init/InitMilestoneTest.java
@@ -1,8 +1,9 @@
 package hudson.init;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.junit.Rule;
@@ -18,9 +19,9 @@ public class InitMilestoneTest {
     @Test
     public void testInitMilestones() {
 
-        Queue<InitMilestone> attained = r.jenkins.getExtensionList(Initializers.class).get(0).getAttained();
+        List<InitMilestone> attained = r.jenkins.getExtensionList(Initializers.class).get(0).getAttained();
 
-        assertThat(attained, contains(
+        assertEquals(attained, List.of(
                 InitMilestone.EXTENSIONS_AUGMENTED,
                 InitMilestone.SYSTEM_CONFIG_LOADED,
                 InitMilestone.SYSTEM_CONFIG_ADAPTED,
@@ -59,8 +60,8 @@ public class InitMilestoneTest {
             attained.offer(InitMilestone.JOB_CONFIG_ADAPTED);
         }
 
-        public Queue<InitMilestone> getAttained() {
-            return attained;
+        public List<InitMilestone> getAttained() {
+            return new ArrayList<>(attained);
         }
     }
 


### PR DESCRIPTION
`InitMilestoneTest` flaked again with

```
13:21:02  [WARNING] hudson.init.InitMilestoneTest.testInitMilestones
13:21:02  [ERROR]   Run 1: InitMilestoneTest.testInitMilestones:23 
13:21:02  Expected: iterable containing [<Augmented all extensions>, <System config loaded>, <System config adapted>, <Loaded all jobs>, <Configuration for all jobs updated>]
13:21:02       but: item 2: was <Loaded all jobs>
13:21:02  [INFO]   Run 2: PASS
```

but the error message wasn't great because it didn't show the rest of the list of the actual output. This PR improves the error message to read something like this:

```
[ERROR]   InitMilestoneTest.testInitMilestones:24 expected:<[Augmented all extensions, System config adapted, System config loaded, Loaded all jobs, Configuration for all jobs updated]> but was:<[Augmented all extensions, System config loaded, System config adapted, Loaded all jobs, Configuration for all jobs updated]>
```

Hopefully with a better error message it will be easier to understand the cause of the next flake.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7166"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

