### PR TITLE
De-flake `RepeatableTest`

### DIFF
--- a/test/src/test/java/lib/form/RepeatableTest.java
+++ b/test/src/test/java/lib/form/RepeatableTest.java
@@ -30,12 +30,11 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
-import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClientUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSelect;
-import com.gargoylesoftware.htmlunit.javascript.background.JavaScriptJob;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -74,11 +73,11 @@ public class RepeatableTest {
 
     // ========================================================================
 
-    private void doTestSimple(HtmlForm f) throws Exception {
+    private void doTestSimple(HtmlForm f, JenkinsRule.WebClient wc) throws Exception {
         f.getInputByValue("").setValueAttribute("value one");
-        getHtmlButton(f, "Add", false).click();
+        clickButton(wc, f, "Add", false);
         f.getInputByValue("").setValueAttribute("value two");
-        getHtmlButton(f, "Add", false).click();
+        clickButton(wc, f, "Add", false);
         f.getInputByValue("").setValueAttribute("value three");
         f.getInputsByName("bool").get(2).click();
         j.submit(f);
@@ -86,10 +85,11 @@ public class RepeatableTest {
 
     @Test
     public void testSimple() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testSimple");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testSimple");
         HtmlForm f = p.getFormByName("config");
-        getHtmlButton(f, "Add", true).click();
-        doTestSimple(f);
+        clickButton(wc, f, "Add", true);
+        doTestSimple(f, wc);
 
         assertEqualsJsonArray("[{\"bool\":false,\"txt\":\"value one\"},"
             + "{\"bool\":false,\"txt\":\"value two\"},{\"bool\":true,\"txt\":\"value three\"}]",
@@ -101,15 +101,14 @@ public class RepeatableTest {
      */
     @Test
     public void testSimpleCheckNumberOfButtons() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testSimpleWithDeleteButton");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testSimpleWithDeleteButton");
         HtmlForm f = p.getFormByName("config");
         String buttonCaption = "Add";
         assertEquals(1, getButtonsList(f, buttonCaption).size());
-        getHtmlButton(f, buttonCaption, true).click(); // click Add button
-        waitForJavaScript(p);
+        clickButton(wc, f, buttonCaption, true); // click Add button
         assertEquals(1, getButtonsList(f, buttonCaption).size()); // check that second Add button is not present
-        getHtmlButton(f, "Delete", true).click(); // click Delete button
-        waitForJavaScript(p);
+        clickButton(wc, f, "Delete", true); // click Delete button
         assertEquals(1, getButtonsList(f, buttonCaption).size()); // check that only one Add button is in form
     }
 
@@ -118,15 +117,14 @@ public class RepeatableTest {
      */
     @Test
     public void testSimpleCheckNumberOfButtonsEnabledTopButton() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testSimpleWithDeleteButtonTopButton");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testSimpleWithDeleteButtonTopButton");
         HtmlForm f = p.getFormByName("config");
         String buttonCaption = "Add";
         assertEquals(1, getButtonsList(f, buttonCaption).size());
-        getHtmlButton(f, buttonCaption, true).click(); // click Add button
-        waitForJavaScript(p);
+        clickButton(wc, f, buttonCaption, true); // click Add button
         assertEquals(2, getButtonsList(f, buttonCaption).size()); // check that second Add button was added into form
-        getHtmlButton(f, "Delete", true).click(); // click Delete button
-        waitForJavaScript(p);
+        clickButton(wc, f, "Delete", true); // click Delete button
         assertEquals(1, getButtonsList(f, buttonCaption).size()); // check that only one Add button is in form
     }
 
@@ -153,10 +151,11 @@ public class RepeatableTest {
     @Test
     public void testSimple_ExistingData() throws Exception {
         addData();
-        HtmlPage p = j.createWebClient().goTo("self/testSimple");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testSimple");
         HtmlForm f = p.getFormByName("config");
-        getHtmlButton(f, "Add", false).click();
-        doTestSimple(f);
+        clickButton(wc, f, "Add", false);
+        doTestSimple(f, wc);
         assertEqualsJsonArray("[{\"bool\":true,\"txt\":\"existing one\"},"
             + "{\"bool\":false,\"txt\":\"existing two\"},{\"bool\":true,\"txt\":\"value one\"},"
             + "{\"bool\":false,\"txt\":\"value two\"},{\"bool\":false,\"txt\":\"value three\"}]",
@@ -166,7 +165,8 @@ public class RepeatableTest {
     @Test
     public void testMinimum() throws Exception {
         rootAction.minimum = 3;
-        HtmlPage p = j.createWebClient().goTo("self/testSimple");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testSimple");
         HtmlForm f = p.getFormByName("config");
         f.getInputByValue("").setValueAttribute("value one");
         f.getInputByValue("").setValueAttribute("value two");
@@ -183,7 +183,8 @@ public class RepeatableTest {
     public void testMinimum_ExistingData() throws Exception {
         addData();
         rootAction.minimum = 3;
-        HtmlPage p = j.createWebClient().goTo("self/testSimple");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testSimple");
         HtmlForm f = p.getFormByName("config");
         f.getInputByValue("").setValueAttribute("new one");
         assertThrows(ElementNotFoundException.class, () -> f.getInputByValue(""));
@@ -198,31 +199,36 @@ public class RepeatableTest {
     public void testNoData() throws Exception {
         rootAction.list = null;
         rootAction.defaults = null;
-        gotoAndSubmitConfig("defaultForField");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        gotoAndSubmitConfig("defaultForField", wc);
         assertNull(rootAction.formData.get("list"));
 
-        gotoAndSubmitConfig("defaultForItems");
+        gotoAndSubmitConfig("defaultForItems", wc);
         assertNull(rootAction.formData.get("list"));
     }
 
     @Test
     public void testItemsWithDefaults() throws Exception {
-        assertWithDefaults("defaultForItems");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        assertWithDefaults("defaultForItems", wc);
     }
 
     @Test
     public void testItemsDefaultsIgnoredIfFieldHasData() throws Exception {
-        assertDefaultsIgnoredIfHaveData("defaultForItems");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        assertDefaultsIgnoredIfHaveData("defaultForItems", wc);
     }
 
     @Test
     public void testFieldWithDefaults() throws Exception {
-        assertWithDefaults("defaultForField");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        assertWithDefaults("defaultForField", wc);
     }
 
     @Test
     public void testFieldDefaultsIgnoredIfFieldHasData() throws Exception {
-        assertDefaultsIgnoredIfHaveData("defaultForField");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        assertDefaultsIgnoredIfHaveData("defaultForField", wc);
     }
 
     private void addDefaults() {
@@ -231,26 +237,26 @@ public class RepeatableTest {
         rootAction.defaults.add(new Foo("default two", false));
     }
 
-    private void assertWithDefaults(final String viewName) throws Exception {
+    private void assertWithDefaults(final String viewName, final JenkinsRule.WebClient wc) throws Exception {
         rootAction.list = null;
         addDefaults();
-        gotoAndSubmitConfig(viewName);
+        gotoAndSubmitConfig(viewName, wc);
         assertNotNull(rootAction.formData.get("list"));
         assertEqualsJsonArray("[{\"bool\":true,\"txt\":\"default one\"},{\"bool\":false,\"txt\":\"default two\"}]",
                 rootAction.formData.get("list"));
     }
 
-    private void assertDefaultsIgnoredIfHaveData(final String viewName) throws Exception {
+    private void assertDefaultsIgnoredIfHaveData(final String viewName, final JenkinsRule.WebClient wc) throws Exception {
         addData();
         addDefaults();
-        gotoAndSubmitConfig(viewName);
+        gotoAndSubmitConfig(viewName, wc);
         assertNotNull(rootAction.formData.get("list"));
         assertEqualsJsonArray("[{\"bool\":true,\"txt\":\"existing one\"},{\"bool\":false,\"txt\":\"existing two\"}]",
                 rootAction.formData.get("list"));
     }
 
-    private void gotoAndSubmitConfig(final String viewName) throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/" + viewName);
+    private void gotoAndSubmitConfig(final String viewName, final JenkinsRule.WebClient wc) throws Exception {
+        HtmlPage p = wc.goTo("self/" + viewName);
         HtmlForm f = p.getFormByName("config");
         j.submit(f);
     }
@@ -261,12 +267,13 @@ public class RepeatableTest {
     // then converts back to original names when submitting form.
     @Test
     public void testRadio() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testRadio");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testRadio");
         HtmlForm f = p.getFormByName("config");
-        getHtmlButton(f, "Add", true).click();
+        clickButton(wc, f, "Add", true);
         f.getInputByValue("").setValueAttribute("txt one");
         f.getElementsByAttribute("INPUT", "type", "radio").get(1).click();
-        getHtmlButton(f, "Add", false).click();
+        clickButton(wc, f, "Add", false);
         f.getInputByValue("").setValueAttribute("txt two");
         f.getElementsByAttribute("INPUT", "type", "radio").get(3).click();
         j.submit(f);
@@ -289,9 +296,10 @@ public class RepeatableTest {
         rootAction.list.add(new FooRadio("1", "one"));
         rootAction.list.add(new FooRadio("2", "two"));
         rootAction.list.add(new FooRadio("three", "one"));
-        HtmlPage p = j.createWebClient().goTo("self/testRadio");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testRadio");
         HtmlForm f = p.getFormByName("config");
-        getHtmlButton(f, "Add", false).click();
+        clickButton(wc, f, "Add", false);
         f.getInputByValue("").setValueAttribute("txt 4");
         f.getElementsByAttribute("INPUT", "type", "radio").get(7).click();
         j.submit(f);
@@ -304,14 +312,15 @@ public class RepeatableTest {
     // then converts back to original names when submitting form.
     @Test
     public void testRadioBlock() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testRadioBlock");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testRadioBlock");
         HtmlForm f = p.getFormByName("config");
-        getHtmlButton(f, "Add", true).click();
+        clickButton(wc, f, "Add", true);
         f.getInputByValue("").setValueAttribute("txt one");
         f.getInputByValue("").setValueAttribute("avalue do not send");
         f.getElementsByAttribute("INPUT", "type", "radio").get(1).click();
         f.getInputByValue("").setValueAttribute("bvalue");
-        getHtmlButton(f, "Add", false).click();
+        clickButton(wc, f, "Add", false);
         f.getInputByValue("").setValueAttribute("txt two");
         f.getElementsByAttribute("INPUT", "type", "radio").get(2).click();
         f.getInputByValue("").setValueAttribute("avalue two");
@@ -380,14 +389,13 @@ public class RepeatableTest {
 
     @Test
     public void testDropdownList() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testDropdownList");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testDropdownList");
         HtmlForm f = p.getFormByName("config");
-        getHtmlButton(f, "Add", true).click();
-        waitForJavaScript(p);
+        clickButton(wc, f, "Add", true);
         f.getInputByValue("").setValueAttribute("17"); // seeds
         f.getInputByValue("").setValueAttribute("pie"); // word
-        getHtmlButton(f, "Add", false).click();
-        waitForJavaScript(p);
+        clickButton(wc, f, "Add", false);
         // select banana in 2nd select element:
         ((HtmlSelect) f.getElementsByTagName("select").get(1)).getOption(1).click();
         f.getInputsByName("yellow").get(1).click(); // checkbox
@@ -424,19 +432,21 @@ public class RepeatableTest {
     /** Tests nested repeatable and use of @DataBoundConstructor to process formData */
     @Test
     public void testNested() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testNested");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testNested");
         HtmlForm f = p.getFormByName("config");
         try {
-            clickButton(p, f, "Add", true);
+            clickButton(wc, f, "Add", true);
             f.getInputByValue("").setValueAttribute("title one");
-            clickButton(p, f, "Add Foo", true);
+            clickButton(wc, f, "Add Foo", true);
             f.getInputByValue("").setValueAttribute("txt one");
-            clickButton(p, f, "Add Foo", false);
+            clickButton(wc, f, "Add Foo", false);
             f.getInputByValue("").setValueAttribute("txt two");
             f.getInputsByName("bool").get(1).click();
-            clickButton(p, f, "Add", false);
+            clickButton(wc, f, "Add", false);
             f.getInputByValue("").setValueAttribute("title two");
             f.getElementsByTagName("button").get(1).click(); // 2nd "Add Foo" button
+            WebClientUtil.waitForJSExec(wc);
             f.getInputByValue("").setValueAttribute("txt 2.1");
         } catch (Exception e) {
             System.err.println("HTML at time of failure:\n" + p.getBody().asXml());
@@ -451,19 +461,21 @@ public class RepeatableTest {
     /** Tests nested repeatable and use of @DataBoundConstructor to process formData */
     @Test
     public void testNestedEnabledTopButton() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testNestedTopButton");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testNestedTopButton");
         HtmlForm f = p.getFormByName("config");
         try {
-            clickButton(p, f, "Add", true);
+            clickButton(wc, f, "Add", true);
             f.getInputByValue("").setValueAttribute("title one");
-            clickButton(p, f, "Add Foo", true);
+            clickButton(wc, f, "Add Foo", true);
             f.getInputByValue("").setValueAttribute("txt one");
-            clickButton(p, f, "Add Foo", false);
+            clickButton(wc, f, "Add Foo", false);
             f.getInputByValue("").setValueAttribute("txt two");
             f.getInputsByName("bool").get(1).click();
-            clickButton(p, f, "Add", false);
+            clickButton(wc, f, "Add", false);
             f.getInputByValue("").setValueAttribute("title two");
             f.getElementsByTagName("button").get(3).click(); // 2nd "Add Foo" button
+            WebClientUtil.waitForJSExec(wc);
             f.getInputByValue("").setValueAttribute("txt 2.1");
         } catch (Exception e) {
             System.err.println("HTML at time of failure:\n" + p.getBody().asXml());
@@ -478,19 +490,21 @@ public class RepeatableTest {
     /** Tests nested repeatable and use of @DataBoundConstructor to process formData */
     @Test
     public void testNestedEnabledTopButtonInner() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testNestedTopButtonInner");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testNestedTopButtonInner");
         HtmlForm f = p.getFormByName("config");
         try {
-            clickButton(p, f, "Add", true);
+            clickButton(wc, f, "Add", true);
             f.getInputByValue("").setValueAttribute("title one");
-            clickButton(p, f, "Add Foo", true);
+            clickButton(wc, f, "Add Foo", true);
             f.getInputByValue("").setValueAttribute("txt one");
-            clickButton(p, f, "Add Foo", false);
+            clickButton(wc, f, "Add Foo", false);
             f.getInputByValue("").setValueAttribute("txt two");
             f.getInputsByName("bool").get(1).click();
-            clickButton(p, f, "Add", false);
+            clickButton(wc, f, "Add", false);
             f.getInputByValue("").setValueAttribute("title two");
             f.getElementsByTagName("button").get(2).click(); // 2nd "Add Foo" button
+            WebClientUtil.waitForJSExec(wc);
             f.getInputByValue("").setValueAttribute("txt 2.1");
         } catch (Exception e) {
             System.err.println("HTML at time of failure:\n" + p.getBody().asXml());
@@ -505,19 +519,21 @@ public class RepeatableTest {
     /** Tests nested repeatable and use of @DataBoundConstructor to process formData */
     @Test
     public void testNestedEnabledTopButtonOuter() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testNestedTopButtonOuter");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testNestedTopButtonOuter");
         HtmlForm f = p.getFormByName("config");
         try {
-            clickButton(p, f, "Add", true);
+            clickButton(wc, f, "Add", true);
             f.getInputByValue("").setValueAttribute("title one");
-            clickButton(p, f, "Add Foo", true);
+            clickButton(wc, f, "Add Foo", true);
             f.getInputByValue("").setValueAttribute("txt one");
-            clickButton(p, f, "Add Foo", false);
+            clickButton(wc, f, "Add Foo", false);
             f.getInputByValue("").setValueAttribute("txt two");
             f.getInputsByName("bool").get(1).click();
-            clickButton(p, f, "Add", false);
+            clickButton(wc, f, "Add", false);
             f.getInputByValue("").setValueAttribute("title two");
             f.getElementsByTagName("button").get(2).click(); // 2nd "Add Foo" button
+            WebClientUtil.waitForJSExec(wc);
             f.getInputByValue("").setValueAttribute("txt 2.1");
         } catch (Exception e) {
             System.err.println("HTML at time of failure:\n" + p.getBody().asXml());
@@ -529,28 +545,29 @@ public class RepeatableTest {
                      + "FooList:title two:[foo:txt 2.1:false]]", rootAction.bindResult.toString());
     }
 
-    private void clickButton(HtmlPage p, HtmlForm f, String caption, boolean isTopButton) throws IOException {
+    private static void clickButton(JenkinsRule.WebClient wc, HtmlForm f, String caption, boolean isTopButton) throws IOException {
         getHtmlButton(f, caption, isTopButton).click();
-        waitForJavaScript(p);
+        WebClientUtil.waitForJSExec(wc);
     }
 
     @Test
     public void testNestedRadio() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testNestedRadio");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testNestedRadio");
         HtmlForm f = p.getFormByName("config");
         try {
-            clickButton(p, f, "Add", true);
+            clickButton(wc, f, "Add", true);
             f.getElementsByAttribute("input", "type", "radio").get(1).click(); // outer=two
-            clickButton(p, f, "Add Moo", true);
+            clickButton(wc, f, "Add Moo", true);
             f.getElementsByAttribute("input", "type", "radio").get(2).click(); // inner=inone
-            clickButton(p, f, "Add", false);
+            clickButton(wc, f, "Add", false);
             f.getElementsByAttribute("input", "type", "radio").get(4).click(); // outer=one
             Thread.sleep(500);
             f.getElementsByTagName("button").get(1).click(); // 2nd "Add Moo" button
-            waitForJavaScript(p);
+            WebClientUtil.waitForJSExec(wc);
             f.getElementsByAttribute("input", "type", "radio").get(7).click(); // inner=intwo
             f.getElementsByTagName("button").get(1).click();
-            waitForJavaScript(p);
+            WebClientUtil.waitForJSExec(wc);
             f.getElementsByAttribute("input", "type", "radio").get(8).click(); // inner=inone
         } catch (Exception e) {
             System.err.println("HTML at time of failure:\n" + p.getBody().asXml());
@@ -564,21 +581,22 @@ public class RepeatableTest {
 
     @Test
     public void testNestedRadioEnabledTopButton() throws Exception {
-        HtmlPage p = j.createWebClient().goTo("self/testNestedRadioTopButton");
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage p = wc.goTo("self/testNestedRadioTopButton");
         HtmlForm f = p.getFormByName("config");
         try {
-            clickButton(p, f, "Add", true);
+            clickButton(wc, f, "Add", true);
             f.getElementsByAttribute("input", "type", "radio").get(1).click(); // outer=two
-            clickButton(p, f, "Add Moo", true);
+            clickButton(wc, f, "Add Moo", true);
             f.getElementsByAttribute("input", "type", "radio").get(2).click(); // inner=inone
-            clickButton(p, f, "Add", false);
+            clickButton(wc, f, "Add", false);
             f.getElementsByAttribute("input", "type", "radio").get(4).click(); // outer=one
             Thread.sleep(500);
             f.getElementsByTagName("button").get(3).click(); // 2nd "Add Moo" button
-            waitForJavaScript(p);
+            WebClientUtil.waitForJSExec(wc);
             f.getElementsByAttribute("input", "type", "radio").get(7).click(); // inner=intwo
             f.getElementsByTagName("button").get(4).click();
-            waitForJavaScript(p);
+            WebClientUtil.waitForJSExec(wc);
             f.getElementsByAttribute("input", "type", "radio").get(8).click(); // inner=inone
         } catch (Exception e) {
             System.err.println("HTML at time of failure:\n" + p.getBody().asXml());
@@ -595,19 +613,6 @@ public class RepeatableTest {
     }
 
     /**
-     * YUI internally partially relies on setTimeout/setInterval when we add a new chunk of HTML
-     * to the page. So wait for the completion of it.
-     *
-     * <p>
-     * To see where such asynchronous activity is happening, set a breakpoint to
-     * {@link JavaScriptJobManagerImpl#addJob(JavaScriptJob, Page)} and look at the call stack.
-     * Also see {@link #jsDebugger} at that time to see the JavaScript callstack.
-     */
-    private void waitForJavaScript(HtmlPage p) {
-        p.getEnclosingWindow().getJobManager().waitForJobsStartingBefore(500);
-    }
-
-    /**
      * Get one of HTML button from a form
      *
      * @param form form element
@@ -618,7 +623,7 @@ public class RepeatableTest {
      * if there is only one button, it will be returned
      * @return HTMLButton - one of Add buttons
      */
-    private HtmlButton getHtmlButton(HtmlForm form, String buttonCaption, boolean isTopButton) {
+    private static HtmlButton getHtmlButton(HtmlForm form, String buttonCaption, boolean isTopButton) {
         List<?> buttons = getButtonsList(form, buttonCaption);
         if (buttons.size() == 1) {
             return (HtmlButton) buttons.get(0);
@@ -632,7 +637,7 @@ public class RepeatableTest {
      * @param buttonCaption button caption you are looking for
      * @return list of buttons
      */
-    private List<?> getButtonsList(HtmlForm form, String buttonCaption) {
+    private static List<?> getButtonsList(HtmlForm form, String buttonCaption) {
         return form.getByXPath(
                 String.format("//button[text() = '%s'] | //button[@title = '%s']", buttonCaption, buttonCaption
                 )


### PR DESCRIPTION
`RepeatableTest` flaked with:

```
22:07:12  [ERROR] lib.form.RepeatableTest.testSimpleCheckNumberOfButtonsEnabledTopButton  Time elapsed: 49.673 s  <<< FAILURE!
22:07:12  java.lang.AssertionError: expected:<1> but was:<2>
22:07:12        at org.junit.Assert.fail(Assert.java:89)
22:07:12        at org.junit.Assert.failNotEquals(Assert.java:835)
22:07:12        at org.junit.Assert.assertEquals(Assert.java:647)
22:07:12        at org.junit.Assert.assertEquals(Assert.java:633)
22:07:12        at lib.form.RepeatableTest.testSimpleCheckNumberOfButtonsEnabledTopButton(RepeatableTest.java:130)
22:07:12        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
22:07:12        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
22:07:12        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
22:07:12        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
22:07:12        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
22:07:12        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
22:07:12        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
22:07:12        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
22:07:12        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
22:07:12        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:613)
22:07:12        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
22:07:12        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
22:07:12        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
22:07:12        at java.base/java.lang.Thread.run(Thread.java:829)
```

Examining the failure I can see that some asynchronous JavaScript code had not yet executed as we expected it to. This test had a custom `waitForJavaScript` method rather than using the test harness's `WebClientUtil#waitForJSExec` method. The custom method was only waiting up to 500 milliseconds while the official method waits up to 10 seconds. Switching to the latter seems like it will make this test more reliable on our CI servers where multiple tests are executing concurrently (and competing for CPU), as well as removing duplicate code. In this PR I refactored the test to call `WebClientUtil#waitForJSExec` whenever we click on a form (not radio!) button in the test.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7170"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

