### PR TITLE
Use 'jenkins-button' for session termination

### DIFF
--- a/core/src/main/resources/jenkins/security/seed/UserSeedProperty/config.jelly
+++ b/core/src/main/resources/jenkins/security/seed/UserSeedProperty/config.jelly
@@ -9,25 +9,21 @@
         <div class="user-seed-panel" name="OK">
             <j:choose>
                 <j:when test="${descriptor.isCurrentUser(it)}">
-                    <span class="yui-button">
-                        <button type="button" name="reset-seed"
-                                onclick="return resetSeed(this)"
-                                data-target-url="${descriptor.descriptorFullUrl}/renewSessionSeed"
-                                data-confirm="${%resetSeed.confirmation}"
-                                data-redirect-url="${request.contextPath}/">
-                            ${%resetSeed.button}
-                        </button>
-                    </span>
+                    <button class="jenkins-button" type="button" name="reset-seed"
+                            onclick="return resetSeed(this)"
+                            data-target-url="${descriptor.descriptorFullUrl}/renewSessionSeed"
+                            data-confirm="${%resetSeed.confirmation}"
+                            data-redirect-url="${request.contextPath}/">
+                        ${%resetSeed.button}
+                    </button>
                 </j:when>
                 <j:otherwise>
-                    <span class="yui-button">
-                        <button type="button" name="reset-seed"
-                                onclick="return resetSeed(this)"
-                                data-target-url="${descriptor.descriptorFullUrl}/renewSessionSeed"
-                                data-confirm="${%resetSeed.confirmation}">
-                            ${%resetSeed.button}
-                        </button>
-                    </span>
+                    <button class="jenkins-button" type="button" name="reset-seed"
+                            onclick="return resetSeed(this)"
+                            data-target-url="${descriptor.descriptorFullUrl}/renewSessionSeed"
+                            data-confirm="${%resetSeed.confirmation}">
+                        ${%resetSeed.button}
+                    </button>
                 </j:otherwise>
             </j:choose>
             <div class="display-after-reset">${%resetSeed.result}</div>

--- a/core/src/main/resources/jenkins/security/seed/UserSeedProperty/config.jelly
+++ b/core/src/main/resources/jenkins/security/seed/UserSeedProperty/config.jelly
@@ -9,7 +9,7 @@
         <div class="user-seed-panel" name="OK">
             <j:choose>
                 <j:when test="${descriptor.isCurrentUser(it)}">
-                    <button class="jenkins-button" type="button" name="reset-seed"
+                    <button class="jenkins-button jenkins-!-destructive-color" type="button" name="reset-seed"
                             onclick="return resetSeed(this)"
                             data-target-url="${descriptor.descriptorFullUrl}/renewSessionSeed"
                             data-confirm="${%resetSeed.confirmation}"
@@ -18,7 +18,7 @@
                     </button>
                 </j:when>
                 <j:otherwise>
-                    <button class="jenkins-button" type="button" name="reset-seed"
+                    <button class="jenkins-button jenkins-!-destructive-color" type="button" name="reset-seed"
                             onclick="return resetSeed(this)"
                             data-target-url="${descriptor.descriptorFullUrl}/renewSessionSeed"
                             data-confirm="${%resetSeed.confirmation}">


### PR DESCRIPTION
The change proposed replaces the session termination button with a destructive`jenkins-button`.

Before:
![Screenshot 2022-09-28 at 22 42 00](https://user-images.githubusercontent.com/13383509/192884590-87b556b6-2bc0-4a8a-b1ef-c2631a4654d7.png)

After:
![Screenshot 2022-09-29 at 09 53 29](https://user-images.githubusercontent.com/13383509/192973281-8fd945c1-f41e-4348-8fcf-9493b45d5a85.png)

### Proposed changelog entries

- Modernize session termination button.

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7182"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

