### PR TITLE
Improve error message when running on unsupported Java version

### DIFF
--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -63,10 +63,8 @@ import java.util.logging.Logger;
  */
 public class Main {
 
-    private static final int MINIMUM_JAVA_VERSION = 11;
-    private static final int MAXIMUM_JAVA_VERSION = 17;
     private static final NavigableSet<Integer> SUPPORTED_JAVA_VERSIONS =
-            new TreeSet<>(Arrays.asList(MINIMUM_JAVA_VERSION, MAXIMUM_JAVA_VERSION));
+            new TreeSet<>(Arrays.asList(11, 17));
 
     private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
 
@@ -98,11 +96,11 @@ public class Main {
     /*package*/ static void verifyJavaVersion(int releaseVersion, boolean enableFutureJava) {
         if (SUPPORTED_JAVA_VERSIONS.contains(releaseVersion)) {
             // Great!
-        } else if (releaseVersion >= MINIMUM_JAVA_VERSION) {
+        } else if (releaseVersion >= SUPPORTED_JAVA_VERSIONS.first()) {
             if (enableFutureJava) {
                 LOGGER.log(
                         Level.WARNING,
-                        "Running with Java {0} from {1}, which is not yet fully supported."
+                        "Running with Java {0} from {1}, which is not fully supported."
                             + " Continuing because {2} is set."
                             + " Supported Java versions are: {3}."
                             + " See https://jenkins.io/redirect/java-support/ for more information.",
@@ -112,11 +110,21 @@ public class Main {
                             ENABLE_FUTURE_JAVA_CLI_SWITCH,
                             SUPPORTED_JAVA_VERSIONS,
                         });
-            } else {
+            } else if (releaseVersion > SUPPORTED_JAVA_VERSIONS.last()) {
                 throw new UnsupportedClassVersionError(
                         String.format(
                                 "Running with Java %d from %s, which is not yet fully supported.%n"
                                         + "Run the command again with the %s flag to enable preview support for future Java versions.%n"
+                                        + "Supported Java versions are: %s",
+                                releaseVersion,
+                                System.getProperty("java.home"),
+                                ENABLE_FUTURE_JAVA_CLI_SWITCH,
+                                SUPPORTED_JAVA_VERSIONS));
+            } else {
+                throw new UnsupportedClassVersionError(
+                        String.format(
+                                "Running with Java %d from %s, which is not fully supported.%n"
+                                        + "Run the command again with the %s flag to bypass this error.%n"
                                         + "Supported Java versions are: %s",
                                 releaseVersion,
                                 System.getProperty("java.home"),
@@ -130,7 +138,7 @@ public class Main {
                                     + "Supported Java versions are: %s",
                             releaseVersion,
                             System.getProperty("java.home"),
-                            MINIMUM_JAVA_VERSION,
+                            SUPPORTED_JAVA_VERSIONS.first(),
                             SUPPORTED_JAVA_VERSIONS));
         }
     }
@@ -306,7 +314,7 @@ public class Main {
                 "                              (NOTE: this option does not change the directory where the plugin archives are stored)\n" +
                 "   --extractedFilesFolder   = folder where extracted files are to be located. Default is the temp folder\n" +
                 "   --logfile                = redirect log messages to this file\n" +
-                "   " + ENABLE_FUTURE_JAVA_CLI_SWITCH + "     = allows running with newer Java versions which are not yet fully supported\n" +
+                "   " + ENABLE_FUTURE_JAVA_CLI_SWITCH + "     = allows running with Java versions which are not fully supported\n" +
                 "{OPTIONS}");
 
         if (!DISABLE_CUSTOM_JSESSIONID_COOKIE_NAME) {

--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -45,10 +45,10 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.MissingResourceException;
-import java.util.Set;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -65,12 +65,8 @@ public class Main {
 
     private static final int MINIMUM_JAVA_VERSION = 11;
     private static final int MAXIMUM_JAVA_VERSION = 17;
-    private static final Set<Integer> SUPPORTED_JAVA_VERSIONS =
-            new HashSet<>(Arrays.asList(MINIMUM_JAVA_VERSION, MAXIMUM_JAVA_VERSION));
-    private static final int MINIMUM_JAVA_CLASS_VERSION = 55;
-    private static final int MAXIMUM_JAVA_CLASS_VERSION = 61;
-    private static final Set<Integer> SUPPORTED_JAVA_CLASS_VERSIONS =
-            new HashSet<>(Arrays.asList(MINIMUM_JAVA_CLASS_VERSION, MAXIMUM_JAVA_CLASS_VERSION));
+    private static final NavigableSet<Integer> SUPPORTED_JAVA_VERSIONS =
+            new TreeSet<>(Arrays.asList(MINIMUM_JAVA_VERSION, MAXIMUM_JAVA_VERSION));
 
     private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
 
@@ -99,56 +95,63 @@ public class Main {
      */
     private static final String ENABLE_FUTURE_JAVA_CLI_SWITCH = "--enable-future-java";
 
-    public static void main(String[] args) throws IllegalAccessException {
-        try {
-            String v = System.getProperty("java.class.version");
-            if (v != null) {
-                String classVersionString = v.split("\\.")[0];
-                try {
-                    int javaVersion = Integer.parseInt(classVersionString);
-                    verifyJavaVersion(javaVersion, isFutureJavaEnabled(args));
-                } catch (NumberFormatException e) {
-                    // err on the safe side and keep on going
-                    LOGGER.log(Level.WARNING, "Failed to parse java.class.version: {0}. Will continue execution", v);
-                }
+    /*package*/ static void verifyJavaVersion(int releaseVersion, boolean enableFutureJava) {
+        if (SUPPORTED_JAVA_VERSIONS.contains(releaseVersion)) {
+            // Great!
+        } else if (releaseVersion >= MINIMUM_JAVA_VERSION) {
+            if (enableFutureJava) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Running with Java {0} from {1}, which is not yet fully supported."
+                            + " Continuing because {2} is set."
+                            + " Supported Java versions are: {3}."
+                            + " See https://jenkins.io/redirect/java-support/ for more information.",
+                        new Object[] {
+                            releaseVersion,
+                            System.getProperty("java.home"),
+                            ENABLE_FUTURE_JAVA_CLI_SWITCH,
+                            SUPPORTED_JAVA_VERSIONS,
+                        });
+            } else {
+                throw new UnsupportedClassVersionError(
+                        String.format(
+                                "Running with Java %d from %s, which is not yet fully supported.%n"
+                                        + "Run the command again with the %s flag to enable preview support for future Java versions.%n"
+                                        + "Supported Java versions are: %s",
+                                releaseVersion,
+                                System.getProperty("java.home"),
+                                ENABLE_FUTURE_JAVA_CLI_SWITCH,
+                                SUPPORTED_JAVA_VERSIONS));
             }
-
-            _main(args);
-        } catch (UnsupportedClassVersionError e) {
-            System.err.printf(
-                    "Jenkins requires Java versions %s but you are running with Java %s from %s%n",
-                    SUPPORTED_JAVA_VERSIONS, System.getProperty("java.specification.version"), System.getProperty("java.home"));
-            e.printStackTrace();
+        } else {
+            throw new UnsupportedClassVersionError(
+                    String.format(
+                            "Running with Java %d from %s, which is older than the minimum required version (Java %d).%n"
+                                    + "Supported Java versions are: %s",
+                            releaseVersion,
+                            System.getProperty("java.home"),
+                            MINIMUM_JAVA_VERSION,
+                            SUPPORTED_JAVA_VERSIONS));
         }
     }
 
-    /*package*/ static void verifyJavaVersion(int javaClassVersion, boolean enableFutureJava) {
-        final String displayVersion = String.format("%d.0", javaClassVersion);
-        if (SUPPORTED_JAVA_CLASS_VERSIONS.contains(javaClassVersion)) {
-            // Great!
-        } else if (javaClassVersion > MINIMUM_JAVA_CLASS_VERSION) {
-            if (enableFutureJava) {
-                LOGGER.log(Level.WARNING,
-                        String.format("Running with Java class version %s which is not in the list of supported versions: %s. " +
-                                        "Argument %s is set, so will continue. " +
-                                        "See https://jenkins.io/redirect/java-support/",
-                                javaClassVersion, SUPPORTED_JAVA_CLASS_VERSIONS, ENABLE_FUTURE_JAVA_CLI_SWITCH));
-            } else {
-                Error error = new UnsupportedClassVersionError(displayVersion);
-                LOGGER.log(Level.SEVERE, String.format("Running with Java class version %s which is not in the list of supported versions: %s. " +
-                                "Run with the " + ENABLE_FUTURE_JAVA_CLI_SWITCH + " flag to enable such behavior. " +
-                                "See https://jenkins.io/redirect/java-support/",
-                        javaClassVersion, SUPPORTED_JAVA_CLASS_VERSIONS), error);
-                throw error;
+    /**
+     * Get the release version of the current JVM.
+     *
+     * @return The release version of the current JVM; e.g., 8, 11, or 17.
+     * @throws NumberFormatException If the release version could not be parsed.
+     */
+    private static int getReleaseVersion() {
+        String version = System.getProperty("java.specification.version");
+        version = version.trim();
+        if (version.startsWith("1.")) {
+            String[] split = version.split("\\.");
+            if (split.length != 2) {
+                throw new NumberFormatException("Invalid Java specification version: " + version);
             }
-        } else {
-            Error error = new UnsupportedClassVersionError(displayVersion);
-            LOGGER.log(Level.SEVERE,
-                    String.format("Running with Java class version %s, which is older than the Minimum required version %s. " +
-                                    "See https://jenkins.io/redirect/java-support/",
-                            javaClassVersion, MINIMUM_JAVA_CLASS_VERSION), error);
-            throw error;
+            version = split[1];
         }
+        return Integer.parseInt(version);
     }
 
     /**
@@ -173,7 +176,15 @@ public class Main {
     @SuppressFBWarnings(
             value = {"PATH_TRAVERSAL_IN", "THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"},
             justification = "User provided values for running the program and intentional propagation of reflection errors")
-    private static void _main(String[] args) throws IllegalAccessException {
+    public static void main(String[] args) throws IllegalAccessException {
+        try {
+            verifyJavaVersion(getReleaseVersion(), isFutureJavaEnabled(args));
+        } catch (UnsupportedClassVersionError e) {
+            System.err.println(e.getMessage());
+            System.err.println("See https://jenkins.io/redirect/java-support/ for more information.");
+            System.exit(1);
+        }
+
         //Allows to pass arguments through stdin to "hide" sensitive parameters like httpsKeyStorePassword
         //to achieve this use --paramsFromStdIn
         if (hasArgument("--paramsFromStdIn", args)) {
@@ -295,7 +306,7 @@ public class Main {
                 "                              (NOTE: this option does not change the directory where the plugin archives are stored)\n" +
                 "   --extractedFilesFolder   = folder where extracted files are to be located. Default is the temp folder\n" +
                 "   --logfile                = redirect log messages to this file\n" +
-                "   " + ENABLE_FUTURE_JAVA_CLI_SWITCH + "     = allows running with new Java versions which are not fully supported (class version " + MINIMUM_JAVA_CLASS_VERSION + " and above)\n" +
+                "   " + ENABLE_FUTURE_JAVA_CLI_SWITCH + "     = allows running with newer Java versions which are not yet fully supported\n" +
                 "{OPTIONS}");
 
         if (!DISABLE_CUSTOM_JSESSIONID_COOKIE_NAME) {

--- a/war/src/test/java/executable/MainTest.java
+++ b/war/src/test/java/executable/MainTest.java
@@ -1,84 +1,82 @@
 package executable;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class MainTest {
 
     @Test
-    void shouldFailForOldJava() {
-        assertJavaCheckFails(52, false);
-        assertJavaCheckFails(52, true);
+    void unsupported() {
+        assertJavaCheckFails(8, false);
+        assertJavaCheckFails(8, true);
     }
 
     @Test
-    void shouldBeOkForJava11() {
-        assertJavaCheckPasses(55, false);
-        assertJavaCheckPasses(55, true);
+    void supported() {
+        assertJavaCheckPasses(11, false);
+        assertJavaCheckPasses(11, true);
+        assertJavaCheckPasses(17, false);
+        assertJavaCheckPasses(17, true);
     }
 
     @Test
-    void shouldFailForMidJavaVersionsIfNoFlag() {
-        assertJavaCheckFails(56, false);
-        assertJavaCheckPasses(56, true);
-        assertJavaCheckFails(57, false);
-        assertJavaCheckPasses(57, true);
-        assertJavaCheckFails(58, false);
-        assertJavaCheckPasses(58, true);
-        assertJavaCheckFails(59, false);
-        assertJavaCheckPasses(59, true);
-        assertJavaCheckFails(60, false);
-        assertJavaCheckPasses(60, true);
+    void future() {
+        assertJavaCheckFails(12, false);
+        assertJavaCheckFails(13, false);
+        assertJavaCheckFails(14, false);
+        assertJavaCheckFails(15, false);
+        assertJavaCheckFails(16, false);
+        assertJavaCheckFails(18, false);
+        assertJavaCheckFails(19, false);
+        assertJavaCheckPasses(12, true);
+        assertJavaCheckPasses(13, true);
+        assertJavaCheckPasses(14, true);
+        assertJavaCheckPasses(15, true);
+        assertJavaCheckPasses(16, true);
+        assertJavaCheckPasses(18, true);
+        assertJavaCheckPasses(19, true);
     }
 
-    @Test
-    void shouldBeOkForJava17() {
-        assertJavaCheckPasses(61, false);
-        assertJavaCheckPasses(61, true);
+    private static void assertJavaCheckFails(int releaseVersion, boolean enableFutureJava) {
+        assertJavaCheckFails(null, releaseVersion, enableFutureJava);
     }
 
-    @Test
-    void shouldFailForNewJavaVersionsIfNoFlag() {
-        assertJavaCheckFails(62, false);
-        assertJavaCheckPasses(62, true);
-        assertJavaCheckFails(63, false);
-        assertJavaCheckPasses(63, true);
-    }
+    private static void assertJavaCheckFails(
+            @CheckForNull String message, int releaseVersion, boolean enableFutureJava) {
+        if (message == null) {
+            message = String.format(
+                    "Java version check should have failed for Java version %d and enableFutureJava=%b",
+                    releaseVersion, enableFutureJava);
+        }
 
-    private static void assertJavaCheckFails(int classVersion, boolean enableFutureJava) {
-        assertJavaCheckFails(null, classVersion, enableFutureJava);
-    }
-
-    private static void assertJavaCheckFails(@CheckForNull String message, int classVersion, boolean enableFutureJava) {
-        boolean failed = false;
+        // TODO use assertThrows once we drop support for Java 8 in this module
+        boolean failed;
         try {
-            Main.verifyJavaVersion(classVersion, enableFutureJava);
-        } catch (Error error) {
+            Main.verifyJavaVersion(releaseVersion, enableFutureJava);
+            failed = false;
+        } catch (UnsupportedClassVersionError error) {
             failed = true;
-            System.out.printf("Java class version check failed as it was expected for Java class version %s.0 and enableFutureJava=%s%n",
-                classVersion, enableFutureJava);
-            error.printStackTrace(System.out);
         }
-
         if (!failed) {
-            Assertions.fail(message != null ? message :
-                    String.format("Java version Check should have failed for Java class version %s.0 and enableFutureJava=%s",
-                            classVersion, enableFutureJava));
+            throw new AssertionError(message);
         }
     }
 
-    private static void assertJavaCheckPasses(int classVersion, boolean enableFutureJava) {
-        assertJavaCheckPasses(null, classVersion, enableFutureJava);
+    private static void assertJavaCheckPasses(int releaseVersion, boolean enableFutureJava) {
+        assertJavaCheckPasses(null, releaseVersion, enableFutureJava);
     }
 
-    private static void assertJavaCheckPasses(@CheckForNull String message, int classVersion, boolean enableFutureJava) {
+    private static void assertJavaCheckPasses(
+            @CheckForNull String message, int releaseVersion, boolean enableFutureJava) {
+        if (message == null) {
+            message = String.format(
+                    "Java version check should have passed for Java version %d and enableFutureJava=%b",
+                    releaseVersion, enableFutureJava);
+        }
         try {
-            Main.verifyJavaVersion(classVersion, enableFutureJava);
-        } catch (Error error) {
-            throw new AssertionError(message != null ? message :
-                    String.format("Java version Check should have passed for Java class version %s.0 and enableFutureJava=%s",
-                            classVersion, enableFutureJava), error);
+            Main.verifyJavaVersion(releaseVersion, enableFutureJava);
+        } catch (UnsupportedClassVersionError e) {
+            throw new AssertionError(message, e);
         }
     }
 }


### PR DESCRIPTION
The error messages printed when running on an unsupported version of Java had a very poor user experience (UX): multiple message being printed for the same error, unnecessary mentioning of class versions, and unnecessary stack traces. This PR simplifies the error messages to the minimum needed to convey the necessary information to the user.

### Testing done

#### Java 8

```
$ java -jar war/target/jenkins.war
Running with Java 8 from /usr/lib/jvm/java-8-openjdk-amd64/jre, which is older than the minimum required version (Java 11).
Supported Java versions are: [11, 17]
See https://jenkins.io/redirect/java-support/ for more information.
$ echo $?
1
```

#### Java 11 and 17

Started without logging anything special, as expected.

#### Java 18

```
$ java -jar war/target/jenkins.war                     
Running with Java 18 from /usr/lib/jvm/java-18-openjdk-amd64, which is not yet fully supported.
Run the command again with the --enable-future-java flag to enable preview support for future Java versions.
Supported Java versions are: [11, 17]
See https://jenkins.io/redirect/java-support/ for more information.
$ echo $?
1
$ java -jar war/target/jenkins.war --enable-future-java
Sep 28, 2022 2:35:23 PM executable.Main verifyJavaVersion
WARNING: Running with Java 18 from /usr/lib/jvm/java-18-openjdk-amd64, which is not yet fully supported. Continuing because --enable-future-java is set. Supported Java versions are: [11, 17]. See https://jenkins.io/redirect/java-support/ for more information.
Running from: /home/basil/src/jenkinsci/jenkins/war/target/jenkins.war
webroot: $user.home/.jenkins
```

### Proposed changelog entries

Improve the error message when running the controller on unsupported Java version.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7185"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

