### PR TITLE
More informative error message when `ViewDescriptorTest` fails

### DIFF
--- a/test/src/test/java/hudson/model/ViewDescriptorTest.java
+++ b/test/src/test/java/hudson/model/ViewDescriptorTest.java
@@ -24,6 +24,8 @@
 
 package hudson.model;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -35,7 +37,6 @@ import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import net.sf.json.JSONObject;
-import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -111,8 +112,7 @@ public class ViewDescriptorTest {
                         .getSomeProperty());
 
         //WHEN the users goes with "Edit View" on the configure page
-        JenkinsRule.WebClient webClient = r.createWebClient();
-        HtmlPage editViewPage = webClient.getPage(myListView, "configure");
+        HtmlPage editViewPage = r.createWebClient().getPage(myListView, "configure");
 
         //THEN the invisible property is not displayed on page
         assertFalse("CustomInvisibleProperty should not be displayed on the View edition page UI.",
@@ -124,10 +124,9 @@ public class ViewDescriptorTest {
         r.submit(editViewForm);
 
         //Check that the description is updated on view
-        Awaitility.waitAtMost(10, TimeUnit.SECONDS).until(() -> webClient.getPage(myListView)
-                                                                        .asNormalizedText()
-                                                                        .contains("This list view is awesome !"));
-
+        await().pollInterval(1, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> r.createWebClient().getPage(myListView).asNormalizedText(), containsString("This list view is awesome !"));
 
         //AND THEN after View save, the invisible property is still persisted with the View.
         assertNotNull("The CustomInvisibleProperty should be persisted on the View.",


### PR DESCRIPTION
### Problem

`ViewDescriptorTest#invisiblePropertiesOnViewShoudBePersisted` flaked with:

```
09:35:21  [ERROR] hudson.model.ViewDescriptorTest.invisiblePropertiesOnViewShoudBePersisted  Time elapsed: 71.599 s  <<< ERROR!
09:35:21  org.awaitility.core.ConditionTimeoutException: Condition with lambda expression in hudson.model.ViewDescriptorTest that uses org.jvnet.hudson.test.JenkinsRule$WebClient, org.jvnet.hudson.test.JenkinsRule$WebClienthudson.model.ListView was not fulfilled within 10 seconds.
09:35:21        at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
09:35:21        at org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
09:35:21        at org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
09:35:21        at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:985)
09:35:21        at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:954)
09:35:21        at hudson.model.ViewDescriptorTest.invisiblePropertiesOnViewShoudBePersisted(ViewDescriptorTest.java:127)
09:35:21        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
09:35:21        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
09:35:21        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
09:35:21        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
09:35:21        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
09:35:21        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
09:35:21        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
09:35:21        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
09:35:21        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:613)
09:35:21        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
09:35:21        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
09:35:21        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
09:35:21        at java.base/java.lang.Thread.run(Thread.java:829)
09:35:21  Caused by: java.util.concurrent.TimeoutException
09:35:21        at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:204)
09:35:21        at org.awaitility.core.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:101)
```

Unfortunately, the error message was not very informative because the assertion doesn't print the actual value when the expected value is not present.

### Solution

This PR uses Hamcrest Matchers to improve the error message to read:

```
org.awaitility.core.ConditionTimeoutException: Lambda expression in hudson.model.ViewDescriptorTest that uses org.jvnet.hudson.test.JenkinsRule$WebClient, org.jvnet.hudson.test.JenkinsRule$WebClienthudson.model.ListView: expected a string containing "This list view is awesome !" but was "Rock [Jenkins]
Skip to content
2
Dashboard
Rock
New Item
People
Build History
Edit View
Delete View
Manage Jenkins
Build Queue
No builds in the queue.
Build Executor Status
1	Idle		
2	Idle		
Expand
Logger Console
Pause Clear
checkedcheckedcheckedcheckedchecked
checkedcheckedcheckedcheckedcheckedcheckedcheckedcheckedcheckedcheckedcheckedchecked
This list view is not awesome !
Edit description
This view has no jobs associated with it. You can either add some existing jobs to this view or create a new job in this view.
REST APIJenkins 2.372-SNAPSHOT" within 10 seconds.
```

### Bonus

While I was here I lowered the polling interval to one second. This loop is doing a heavyweight HTTP download and parsing operation, so no need to hammer the system while we're waiting. I also used a different `WebClient` for each request in case they were interfering with each other for some reason.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7186"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

