### PR TITLE
Use a jenkins-button at project creation page

### DIFF
--- a/core/src/main/resources/hudson/model/ListView/newJobButtonBar.jelly
+++ b/core/src/main/resources/hudson/model/ListView/newJobButtonBar.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <button class="jenkins-button jenkins-button--primary" type="submit" id="ok-button">OK</button>
+  <button class="jenkins-button jenkins-button--primary jenkins-buttons-row--equal-width" type="submit" id="ok-button">OK</button>
   <st:nbsp/>
   <f:checkbox title="${%Add to current view}" field="addToCurrentView" checked="${it.addToCurrentView}"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/ListView/newJobButtonBar.jelly
+++ b/core/src/main/resources/hudson/model/ListView/newJobButtonBar.jelly
@@ -24,8 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <span class="yui-button primary large-button">
-    <button type="submit" id="ok-button">OK</button>
-  </span>
+  <button class="jenkins-button jenkins-button--primary" type="submit" id="ok-button">OK</button>
+  <st:nbsp/>
   <f:checkbox title="${%Add to current view}" field="addToCurrentView" checked="${it.addToCurrentView}"/>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/View/newJobButtonBar.jelly
+++ b/core/src/main/resources/hudson/model/View/newJobButtonBar.jelly
@@ -24,7 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <span class="yui-button primary large-button">
-        <button type="submit" id="ok-button">${%OK}</button>
-    </span>
+    <button class="jenkins-button jenkins-button--primary" type="submit" id="ok-button">${%OK}</button>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/View/newJobButtonBar.jelly
+++ b/core/src/main/resources/hudson/model/View/newJobButtonBar.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <button class="jenkins-button jenkins-button--primary" type="submit" id="ok-button">${%OK}</button>
+    <button class="jenkins-button jenkins-button--primary jenkins-buttons-row--equal-width" type="submit" id="ok-button">${%OK}</button>
 </j:jelly>

--- a/war/src/main/less/modules/buttons.less
+++ b/war/src/main/less/modules/buttons.less
@@ -190,6 +190,10 @@
       margin-right: 0 !important;
     }
   }
+
+  &--equal-width {
+    min-width: 5.625rem;
+  }
 }
 
 .jenkins-copy-button {


### PR DESCRIPTION
The title says all; we're on a good way to reduce the overall appearance of standalone yui buttons 🤞🏻 

Before:

![Screenshot 2022-09-29 at 23 13 48](https://user-images.githubusercontent.com/13383509/193143169-72d96b7f-3b36-4379-9bb7-1ff7cbdcedb8.png)

![Screenshot 2022-09-29 at 23 13 58](https://user-images.githubusercontent.com/13383509/193143194-f58bbcda-3f51-486d-804d-21cd1d7981c0.png)

After:

![Screenshot 2022-09-30 at 00 59 22](https://user-images.githubusercontent.com/13383509/193156741-e3211629-2166-4a1c-9cdc-6586aba16848.png)

![Screenshot 2022-09-30 at 00 59 45](https://user-images.githubusercontent.com/13383509/193156781-afe97c80-15a0-4ee3-96f6-b7ff9012e3b3.png)

### Proposed changelog entries

- Entry 1: Issue, Human-readable Text
- ...

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7191"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

