### PR TITLE
Ping asynchronously in `Jetty10Provider`

### DIFF
--- a/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
+++ b/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
@@ -90,7 +90,9 @@ public class Jetty10Provider implements Provider {
 
             @Override
             public void sendPing(ByteBuffer applicationData) throws IOException {
-                session().getRemote().sendPing(applicationData);
+                CompletableFuture<Void> f = new CompletableFuture<>();
+                session().getRemote().sendPing(applicationData, new WriteCallbackImpl(f));
+                // TODO return f;
             }
 
             @Override


### PR DESCRIPTION
Users have been complaining about unstable WebSocket connections since the upgrade to Jetty 10, for example in [JENKINS-69509](https://issues.jenkins.io/browse/JENKINS-69509).

`Jetty9Provider`'s `#sendPing` method starts an asynchronous write operation to send the ping request, but it does not await confirmation that the write request succeeded or failed, most likely because of the Jetty 9 interface it is using, which creates a future but does not return it. That is, the Jetty 9 interface looks like a blocking method, because it returns void rather than a `Future`, but it is actually an asynchronous method that discards the future before returning. The caller of `#sendPing`, the ping thread started in `WebSocketSession#startPings`, catches any exception and cancels the ping thread if an exception occurs. But since the `Jetty9Provider`'s `#sendPing` method never called `Future#get` (because the Jetty 9 API never returned the `Future` in the first place), it never threw any exceptions, effectively behaving like a UDP transmission with no concern for acknowledgement.

Jetty 10 fixes the API problem by providing both synchronous and asynchronous methods, with the synchronous version returning void and the asynchronous version returning a `Future` as you would expect. The trouble is that `Jetty10Provider` invokes the blocking version, technically a change in behavior. And the blocking version is subject to the HTTP keep-alive idle timeout value, which Winstone happens to tune down from its default of 30 seconds to 5 seconds. So this means that we start an asynchronous write operation to send the ping request, but if it fails within 5 seconds or takes longer than 5 seconds to succeed, `#sendPing` will now throw an exception, which will result in the cancellation of the ping thread. While a WebSocket ping taking over five seconds is not common, there are reasons why it could occur in practice: networking delays, temporary CPU spikes causing the TCP stack to be delayed in processing packets, etc. When the controller isn't pinging regularly, and the agent is not generating any data (such as when a build is not producing output for a long time), then the HTTP keep-alive idle timeout (which we observed above is 5 seconds in Winstone) is likely to expire. Jenkins used to be resilient to this situation, but that is no longer the case.

This PR applies the most expedient hotfix by restoring the old Jetty 9 behavior: firing off an asynchronous ping request and not waiting for the result.

A more comprehensive fix that could be considered in the future is to adjust `jenkins.websocket.Provider.Handler#sendPing` to return a `Future`, which is implementable with the improved Jetty 10 APIs. The caller in the ping thread could be adjusted to check the `Future` from the last ping before pinging again, logging any errors returned by the future if there were any but _not_ cancelling the ping thread. I deemed this outside the scope of this immediate regression fix.

### Testing done

This is a completely speculative fix. I plan on asking end users to test this and see if it helps alleviate their pain.

### Proposed changelog entries

Ensure that temporary network partitions do not cancel the WebSocket ping thread (regression in 2.363).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

