### PR TITLE
De-flake `AbstractItem2Test`

### DIFF
--- a/test/src/test/java/hudson/model/AbstractItem2Test.java
+++ b/test/src/test/java/hudson/model/AbstractItem2Test.java
@@ -62,7 +62,15 @@ public class AbstractItem2Test {
         sessions.then(j -> {
                 FreeStyleProject p1 = j.jenkins.getItemByFullName("p1", FreeStyleProject.class);
                 FreeStyleProject p2 = j.jenkins.getItemByFullName("p2", FreeStyleProject.class);
-                assertEquals(/* does not work yet: p1 */ null, p2.getProperty(BadProperty.class).other);
+                /*
+                 * AbstractItem.Replacer.readResolve() is racy, as its comments acknowledge. Jobs
+                 * are loaded in parallel, and p1 may not have been loaded yet when we are loading
+                 * p2. The only way for this test to work reliably is to reload p2 after p1 has
+                 * already been loaded, thus assuring that p2's reference to p1 can be properly
+                 * deserialized.
+                 */
+                p2.doReload();
+                assertEquals(p1, p2.getProperty(BadProperty.class).other);
         });
     }
 


### PR DESCRIPTION
`AbstractItem2Test.badSerialization` flaked with:

```
02:58:42  [ERROR] hudson.model.AbstractItem2Test.badSerialization  Time elapsed: 35.039 s  <<< FAILURE!
02:58:42  java.lang.AssertionError: expected:<null> but was:<hudson.model.FreeStyleProject@39423854[p1]>
02:58:42        at org.junit.Assert.fail(Assert.java:89)
02:58:42        at org.junit.Assert.failNotEquals(Assert.java:835)
02:58:42        at org.junit.Assert.assertEquals(Assert.java:120)
02:58:42        at org.junit.Assert.assertEquals(Assert.java:146)
02:58:42        at hudson.model.AbstractItem2Test.lambda$badSerialization$1(AbstractItem2Test.java:65)
02:58:42        at org.jvnet.hudson.test.JenkinsSessionRule$2.evaluate(JenkinsSessionRule.java:104)
02:58:42        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:613)
02:58:42        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
02:58:42        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
02:58:42        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
02:58:42        at java.base/java.lang.Thread.run(Thread.java:829)
```

`AbstractItem.Replacer.readResolve()` is racy, as https://github.com/jenkinsci/jenkins/blob/5f57c987a16c860e97960b315c684a9c5356fcd9/core/src/main/java/hudson/model/AbstractItem.java#L644 acknowledges. Jobs are loaded in parallel, and `p1` may not have been loaded yet when we are loading `p2`. The only way for this test to work reliably is to reload `p2` after `p1` has already been loaded, thus assuring that `p2`'s reference to `p1` can be properly deserialized.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] (If applicable) Jira issue is well described
- [ ] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7199"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

