### PR TITLE
[JENKINS-69714] Use new jenkins-table for slow trigger admin monitor

### DIFF
--- a/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
+++ b/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
@@ -15,12 +15,14 @@ dl {
 
         text(_("blurb"))
 
-        table(class: "pane sortable bigtable", width: "100%") {
-            tr {
-                th(_("Trigger"))
-                th(_("Most Recent Occurrence"))
-                th(_("Most Recently Occurring Job"))
-                th(_("Duration"))
+        table(class: "sortable jenkins-table jenkins-!-margin-top-2", width: "100%") {
+            thead {
+                tr {
+                    th(_("Trigger"))
+                    th(_("Most Recent Occurrence"))
+                    th(_("Most Recently Occurring Job"))
+                    th(_("Duration"))
+                }
             }
 
             tam.errors.each { trigger, val ->


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://www.jenkins.io/download/lts/#backporting-process for more.
-->

See [JENKINS-69714](https://issues.jenkins.io/browse/JENKINS-69714).

No tests are included in the pull request because it is difficult to assert table layout from an automated test.

### Before
![image](https://user-images.githubusercontent.com/5103752/193477372-e31d83c3-e2b2-47bb-b8c8-551857d8779d.png)


### After
![image](https://user-images.githubusercontent.com/5103752/194141812-f1eae24e-ccf3-4bdc-9cc3-2cbfc6cae590.png)


<!-- Comment:
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

Replace the old Jenkins table layout in the slow trigger admin monitor with the new Jenkins table layout

<!-- Comment:
The changelogs will be integrated by the core maintainers after the merge.
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] (If applicable) Jira issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change) and are in the imperative mood. [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
  - Fill-in the `Proposed changelog entries` section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadoc, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content-Security-Policy directives (see [documentation on jenkins.io](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] Changelog entries in the PR title and/or `Proposed changelog entries` are accurate, human-readable, and in the imperative mood
- [ ] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional upgrade steps from users, `upgrade-guide-needed` label is set and there is a `Proposed upgrade guidelines` section in the PR title. ([example](https://github.com/jenkinsci/jenkins/pull/4387))
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7205"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

