### PR TITLE
Retry build on agent error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,39 +29,41 @@ for (i = 0; i < buildTypes.size(); i++) {
       if (buildType == 'Windows') {
         agentContainerLabel += '-windows'
       }
-      node(agentContainerLabel) {
-        // First stage is actually checking out the source. Since we're using Multibranch
-        // currently, we can use "checkout scm".
-        stage('Checkout') {
-          infra.checkoutSCM()
-        }
+      retry(conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2) {
+        node(agentContainerLabel) {
+          // First stage is actually checking out the source. Since we're using Multibranch
+          // currently, we can use "checkout scm".
+          stage('Checkout') {
+            infra.checkoutSCM()
+          }
 
-        def changelistF = "${pwd tmp: true}/changelist"
-        def m2repo = "${pwd tmp: true}/m2repo"
+          def changelistF = "${pwd tmp: true}/changelist"
+          def m2repo = "${pwd tmp: true}/m2repo"
 
-        // Now run the actual build.
-        stage("${buildType} Build / Test") {
-          timeout(time: 6, unit: 'HOURS') {
-            realtimeJUnit(healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml') {
-              def mavenOptions = [
-                '-Pdebug',
-                '-Penable-jacoco',
-                '--update-snapshots',
-                "-Dmaven.repo.local=$m2repo",
-                '-Dmaven.test.failure.ignore',
-                '-DforkCount=2',
-                '-Dspotbugs.failOnError=false',
-                '-Dcheckstyle.failOnViolation=false',
-                '-Dset.changelist',
-                'help:evaluate',
-                '-Dexpression=changelist',
-                "-Doutput=$changelistF",
-                'clean',
-                'install',
-              ]
-              infra.runMaven(mavenOptions, jdk)
-              if (isUnix()) {
-                sh 'git add . && git diff --exit-code HEAD'
+          // Now run the actual build.
+          stage("${buildType} Build / Test") {
+            timeout(time: 6, unit: 'HOURS') {
+              realtimeJUnit(healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml') {
+                def mavenOptions = [
+                  '-Pdebug',
+                  '-Penable-jacoco',
+                  '--update-snapshots',
+                  "-Dmaven.repo.local=$m2repo",
+                  '-Dmaven.test.failure.ignore',
+                  '-DforkCount=2',
+                  '-Dspotbugs.failOnError=false',
+                  '-Dcheckstyle.failOnViolation=false',
+                  '-Dset.changelist',
+                  'help:evaluate',
+                  '-Dexpression=changelist',
+                  "-Doutput=$changelistF",
+                  'clean',
+                  'install',
+                ]
+                infra.runMaven(mavenOptions, jdk)
+                if (isUnix()) {
+                  sh 'git add . && git diff --exit-code HEAD'
+                }
               }
             }
           }
@@ -145,29 +147,31 @@ for (i = 0; i < buildTypes.size(); i++) {
 }
 
 builds.ath = {
-  node('docker-highmem') {
-    // Just to be safe
-    deleteDir()
-    def fileUri
-    def metadataPath
-    dir('sources') {
-      checkout scm
-      def mavenOptions = [
-        '-Pquick-build',
-        '-Dmaven.repo.local=$WORKSPACE_TMP/m2repo',
-        '-am',
-        '-pl',
-        'war',
-        'package',
-      ]
-      infra.runMaven(mavenOptions, 11)
-      dir('war/target') {
-        fileUri = 'file://' + pwd() + '/jenkins.war'
+  retry(conditions: [agent(), nonresumable()], count: 2) {
+    node('docker-highmem') {
+      // Just to be safe
+      deleteDir()
+      def fileUri
+      def metadataPath
+      dir('sources') {
+        checkout scm
+        def mavenOptions = [
+          '-Pquick-build',
+          '-Dmaven.repo.local=$WORKSPACE_TMP/m2repo',
+          '-am',
+          '-pl',
+          'war',
+          'package',
+        ]
+        infra.runMaven(mavenOptions, 11)
+        dir('war/target') {
+          fileUri = 'file://' + pwd() + '/jenkins.war'
+        }
+        metadataPath = pwd() + '/essentials.yml'
       }
-      metadataPath = pwd() + '/essentials.yml'
-    }
-    dir('ath') {
-      runATH jenkins: fileUri, metadataFile: metadataPath
+      dir('ath') {
+        runATH jenkins: fileUri, metadataFile: metadataPath
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,13 +59,9 @@ for (i = 0; i < buildTypes.size(); i++) {
                 'clean',
                 'install',
               ]
-              try {
-                infra.runMaven(mavenOptions, jdk)
-                if (isUnix()) {
-                  sh 'git add . && git diff --exit-code HEAD'
-                }
-              } finally {
-                archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
+              infra.runMaven(mavenOptions, jdk)
+              if (isUnix()) {
+                sh 'git add . && git diff --exit-code HEAD'
               }
             }
           }
@@ -73,6 +69,7 @@ for (i = 0; i < buildTypes.size(); i++) {
 
         // Once we've built, archive the artifacts and the test results.
         stage("${buildType} Publishing") {
+          archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
           if (!fileExists('core/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
             error 'JUnit 4 tests are no longer being run for the core package'
           }


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

Noticed a flakey build in: https://ci.jenkins.io/blue/organizations/jenkins/Core%2Fjenkins/detail/PR-7203/5/pipeline

Haven't investigated widely but I think it's happening a fair bit

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Proposed changelog entries

- (skip changelog)
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7220"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

