### PR TITLE
Upgrade Winstone from 6.4 to 6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@ THE SOFTWARE.
     <access-modifier.version>1.27</access-modifier.version>
     <bridge-method-injector.version>1.23</bridge-method-injector.version>
     <spotless.version>2.27.1</spotless.version>
+    <winstone.version>6.5</winstone.version>
   </properties>
 
   <dependencyManagement>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -146,7 +146,7 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
       <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
-      <version>6.4</version>
+      <version>${winstone.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/websocket/jetty10/pom.xml
+++ b/websocket/jetty10/pom.xml
@@ -52,7 +52,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>6.4</version>
+      <version>${winstone.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade Winstone from 6.4 to 6.5 ([release notes](https://github.com/jenkinsci/winstone/releases/tag/winstone-6.5), [diff](https://github.com/jenkinsci/winstone/compare/winstone-6.4...winstone-6.5)). As a bonus I also pulled out this version to a Maven property so it is easier to bump in the future.

### Testing done

Ran `java -jar war/target/jenkins.war --help` and verified that the removed options were no longer present.

### Proposed changelog entries

- Deprecate the `--extraLibFolder` option for removal on or after January 1, 2023 (https://github.com/jenkinsci/winstone/pull/290)
- Remove the `--toolsJar` and `--useJasper` options without replacement (https://github.com/jenkinsci/winstone/pull/287)

### Proposed upgrade guidelines

The `--extraLibFolder` option, which is no longer necessary for HTTP/2 support, has been deprecated for removal on or after January 1, 2023. The `--toolsJar` and `--useJasper` options, which are no longer relevant on Java 11 and 17, have been removed without replacement. Ensure you are not using any of the above options prior to upgrading.

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7223"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

