### PR TITLE
Fill in since annotations

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -273,7 +273,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P, R>, R extends A
      * {@link #getDisplayName()}.
      * @deprecated navigation through a hierarchy should be done through breadcrumbs, do not add a link using this method
      */
-    @Deprecated(since = "TODO")
+    @Deprecated(since = "2.364")
     public String getUpUrl() {
         return Functions.getNearestAncestorUrl(Stapler.getCurrentRequest(), getParent()) + '/';
     }

--- a/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
+++ b/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
@@ -83,7 +83,7 @@ public abstract class ProjectNamingStrategy implements Describable<ProjectNaming
      * @throws Failure
      *             if the user has to be informed about an illegal name, forces the user to change the name before submitting. The message of the failure will be presented to the user.
      *
-     * @since TODO
+     * @since 2.367
      */
     public void checkName(String parentName, String name) throws Failure {
         checkName(name);

--- a/core/src/main/java/jenkins/triggers/TriggeredItem.java
+++ b/core/src/main/java/jenkins/triggers/TriggeredItem.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 /**
  * An item which can be configured with {@link Trigger}s.
- * @since TODO
+ * @since 2.372
  */
 public interface TriggeredItem extends Item {
 

--- a/core/src/main/resources/lib/layout/search-bar.jelly
+++ b/core/src/main/resources/lib/layout/search-bar.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     </st:attribute>
     Creates a search input
 
-    @since TODO
+    @since 2.369
   </st:documentation>
 
   <div class="jenkins-search ${attrs.clazz}">


### PR DESCRIPTION
Analyzing core/src/main/java/hudson/model/AbstractBuild.java:276
        first sha: 26c924b39d59f986e73156ba6f2c8a01afd789af
        first tag was jenkins-2.364
Analyzing core/src/main/java/jenkins/model/ProjectNamingStrategy.java:86
        first sha: f93ee622a0eb64b3dd23826f39f92f79bee7c55e
        first tag was jenkins-2.367
Analyzing core/src/main/java/jenkins/triggers/TriggeredItem.java:34
        first sha: d5d518e91a5fbf981b17ce924ccc03e976fe3771
        first tag was jenkins-2.372
Analyzing core/src/main/resources/lib/layout/search-bar.jelly:38
        first sha: 8ab0519089bc2e3dd5a97910a04e97b0665c1cf4
        first tag was jenkins-2.369

List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.364
  - https://github.com/jenkinsci/jenkins/commit/26c924b39d59f986e73156ba6f2c8a01afd789af
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.367
  - https://github.com/jenkinsci/jenkins/commit/f93ee622a0eb64b3dd23826f39f92f79bee7c55e
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.369
  - https://github.com/jenkinsci/jenkins/commit/8ab0519089bc2e3dd5a97910a04e97b0665c1cf4
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.372
  - https://github.com/jenkinsci/jenkins/commit/d5d518e91a5fbf981b17ce924ccc03e976fe3771

### Testing done

Unneeded.

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7239"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

