### PR TITLE
Document missing options

### DIFF
--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -315,6 +315,8 @@ public class Main {
                 "   --extractedFilesFolder   = folder where extracted files are to be located. Default is the temp folder\n" +
                 "   --logfile                = redirect log messages to this file\n" +
                 "   " + ENABLE_FUTURE_JAVA_CLI_SWITCH + "     = allows running with Java versions which are not fully supported\n" +
+                "   --paramsFromStdIn        = Read parameters from standard input (stdin)\n" +
+                "   --version                = Print version to standard output (stdout) and exit\n" +
                 "{OPTIONS}");
 
         if (!DISABLE_CUSTOM_JSESSIONID_COOKIE_NAME) {


### PR DESCRIPTION
When running `java -jar jenkins.war` I noticed that these Jenkins-specific extensions to Winstone were undocumented. See also https://github.com/jenkins-infra/jenkins.io/pull/5575.

### Testing done

```bash
$ java -jar war/target/jenkins.war --help | head -15
Running from: /home/basil/src/jenkinsci/jenkins/war/target/jenkins.war
webroot: $user.home/.jenkins
Jenkins Automation Server Engine 2.373-SNAPSHOT
Usage: java -jar jenkins.war [--option=value] [--option=value]

Options:
   --webroot                = folder where the WAR file is expanded into. Default is ${JENKINS_HOME}/war
   --pluginroot             = folder where the plugin archives are expanded into. Default is ${JENKINS_HOME}/plugins
                              (NOTE: this option does not change the directory where the plugin archives are stored)
   --extractedFilesFolder   = folder where extracted files are to be located. Default is the temp folder
   --logfile                = redirect log messages to this file
   --enable-future-java     = allows running with Java versions which are not fully supported
   --paramsFromStdIn        = Read parameters from standard input (stdin)
   --version                = Print version to standard output (stdout) and exit
   --javaHome               = Override the JAVA_HOME variable
```

### Proposed changelog entries

Add documentation for the `--paramsFromStdIn` and `--version` command-line options.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7246"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

