### PR TITLE
Correctly encode pound sign in `sortable.js`

### DIFF
--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -383,7 +383,7 @@ var Sortable = (function () {
     determine: function (itm) {
       var sortfn = this.caseInsensitive;
       if (itm.match(date_pattern)) sortfn = this.date;
-      if (itm.match(/^[�$]/)) sortfn = this.currency;
+      if (itm.match(/^[£$]/)) sortfn = this.currency;
       if (itm.match(/\%$/)) sortfn = this.percent;
       if (itm.match(/^-?[\d]+(\.[\d]+)?$/)) sortfn = this.numeric;
       return sortfn;


### PR DESCRIPTION
commit 8a0dc230f44e84e5a7f7920cf9a31f09a54999ac checked in an ISO-8859-1-encoded pound sign (£) to `war/resources/scripts/sortable.js`, but commit 4c00dac67b2d3af7a021948ef040d36fe1a586ca (which was changing the next line below) accidentally corrupted the symbol into Mojibake. This commit restores a pound sign as originally intended, though the file is now encoded in UTF-8.

### Testing done

The Jenkins UI does not display currencies anywhere, so the main concern when testing this change is ensuring that existing code has not regressed. To verify this, I sorted a few columns in a list of builds with a debugger set to the line being changed in this PR. I verified that we executed the code at this stack trace and that it continued to work as before:

```
determine (http://127.0.0.1/static/b8cb6a6d/scripts/sortable.js#386)
getSorter (http://127.0.0.1/static/b8cb6a6d/scripts/sortable.js#168)
refresh (http://127.0.0.1/static/b8cb6a6d/scripts/sortable.js#205)
onClicked (http://127.0.0.1/static/b8cb6a6d/scripts/sortable.js#191)
onclick (http://127.0.0.1/static/b8cb6a6d/scripts/sortable.js#80)
```

### Proposed changelog entries

Fix sorting of British currency in tables.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7250"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

