### PR TITLE
Add debug logs to `NodeProvisionerTest`

### DIFF
--- a/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
+++ b/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
@@ -47,6 +47,7 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.Builder;
+import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,6 +59,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -372,6 +377,15 @@ public class NodeProvisionerTest {
         // no build on the built-in node, to make sure we get everything from the cloud
         r.jenkins.setNumExecutors(0);
         r.jenkins.setNodes(Collections.emptyList());
+
+        // TODO RealJenkinsRule does not yet support LoggerRule
+        Handler handler = new ConsoleHandler();
+        handler.setFormatter(new SupportLogFormatter());
+        handler.setLevel(Level.FINER);
+        Logger logger = Logger.getLogger(NodeProvisioner.class.getName());
+        logger.setLevel(Level.FINER);
+        logger.addHandler(handler);
+
         return cloud;
     }
 


### PR DESCRIPTION
`NodeProvisionerTest#loadSpike` continues to be (anecdotally) one of the flakier tests in this test suite, as seen in [this run](https://ci.jenkins.io/job/Core/job/jenkins/job/master/4213/testReport/junit/hudson.slaves/NodeProvisionerTest/Linux_jdk11___Linux_Build___Test___loadSpike/). The relevant code appears to be in

```
provision:90, DummyCloudImpl (hudson.slaves)
provision:210, Cloud (hudson.slaves)
apply:726, NodeProvisioner$StandardStrategyImpl (hudson.slaves)
update:325, NodeProvisioner (hudson.slaves)
```

but I could not come up with any root cause just reading through it. However, I did notice that there is plenty of fine debug logging that we're missing out on, so comparing the debug logs from a flaky test run to a passing test run could be of great help in figuring out why the test flaked and eventually coming up with a real fix.

### Testing done

Ran the test with these changes and confirmed that the `FINER` level logs from `NodeProvisioner` were now printed.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7251"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

