### PR TITLE
Backporting for 2.361.3

### DIFF
--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -27,7 +27,7 @@ public class ModelHyperlinkNote extends HyperlinkNote {
 
     @Override
     protected String extraAttributes() {
-        return " class='model-link model-link--float'";
+        return " class='jenkins-table__link model-link model-link--float'";
     }
 
     public static String encodeTo(@NonNull User u) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -240,6 +240,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -529,7 +530,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * {@link Computer}s in this Jenkins system. Read-only.
      */
-    protected final transient Map<Node, Computer> computers = new CopyOnWriteMap.Hash<>();
+    protected final transient ConcurrentMap<Node, Computer> computers = new ConcurrentHashMap<>();
 
     /**
      * Active {@link Cloud}s.
@@ -2178,7 +2179,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     }
 
     @Override
-    protected Map<Node, Computer> getComputerMap() {
+    protected ConcurrentMap<Node, Computer> getComputerMap() {
         return computers;
     }
 

--- a/war/src/main/less/modules/table.less
+++ b/war/src/main/less/modules/table.less
@@ -44,6 +44,10 @@
         a {
           color: var(--table-header-foreground);
           font-weight: 700;
+
+          span.sortarrow {
+            width: 24px;
+          }
         }
       }
     }
@@ -113,7 +117,7 @@
 
   &__cell--tight {
     padding-left: 0 !important;
-    text-align: center !important;
+    text-align: right !important;
     white-space: nowrap;
     width: 3.5rem;
   }


### PR DESCRIPTION
```
Latest core version: jenkins-2.373

Fixed
-----

JENKINS-69534           Major                   2.369
        File descriptor leak on slave.log when using cloud agents (regression in 2.294)
        regression
        https://issues.jenkins.io/browse/JENKINS-69534

JENKINS-69257           Minor                   2.369
        Model link chevron is not in center in user build cause on console log
        regression
        https://issues.jenkins.io/browse/JENKINS-69257           

JENKINS-67864           Minor                   2.369
        Table columns get wider and smaller if you click on buttons
        https://issues.jenkins.io/browse/JENKINS-67864
```

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7257"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

