### PR TITLE
Wait for inbound agent to go offline in tests

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -93,7 +93,8 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>1859.v6c8f5a_eb_9ef7</version>
+      <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/501 -->
+      <version>1864.va_a_215a_b_26513</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -93,8 +93,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/501 -->
-      <version>1864.va_a_215a_b_26513</version>
+      <version>1865.vc314fb_c2fa_a_4</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
+++ b/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
@@ -102,12 +102,16 @@ public class JnlpAccessWithSecuredHudsonTest {
     public void serviceUsingDirectSecret() throws Exception {
         Slave slave = inboundAgents.createAgent(r, InboundAgentRule.Options.newBuilder().name("test").secret().build());
         r.waitOnline(slave);
-        r.createWebClient().goTo("computer/test/jenkins-agent.jnlp?encrypt=true", "application/octet-stream");
+        try {
+            r.createWebClient().goTo("computer/test/jenkins-agent.jnlp?encrypt=true", "application/octet-stream");
             Channel channel = slave.getComputer().getChannel();
             assertFalse("SECURITY-206", channel.isRemoteClassLoadingAllowed());
             r.jenkins.getExtensionList(AdminWhitelistRule.class).get(AdminWhitelistRule.class).setMasterKillSwitch(false);
             final File f = new File(r.jenkins.getRootDir(), "config.xml");
             assertTrue(f.exists());
+        } finally {
+            inboundAgents.stop(r, slave.getNodeName());
+        }
     }
 
 

--- a/test/src/test/java/hudson/slaves/JNLPLauncherRealTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherRealTest.java
@@ -82,13 +82,17 @@ public class JNLPLauncherRealTest {
                 }
                 Slave agent = inboundAgents.createAgent(r, builder.build());
                 r.waitOnline(agent);
-                FreeStyleProject p = r.createFreeStyleProject();
-                p.setAssignedNode(agent);
-                FreeStyleBuild b = r.buildAndAssertSuccess(p);
-                if (webSocket) {
-                    assertThat(agent.toComputer().getSystemProperties().get("java.class.path"), is(new File(r.jenkins.root, "agent.jar").getAbsolutePath()));
+                try {
+                    FreeStyleProject p = r.createFreeStyleProject();
+                    p.setAssignedNode(agent);
+                    FreeStyleBuild b = r.buildAndAssertSuccess(p);
+                    if (webSocket) {
+                        assertThat(agent.toComputer().getSystemProperties().get("java.class.path"), is(new File(r.jenkins.root, "agent.jar").getAbsolutePath()));
+                    }
+                    System.err.println(JenkinsRule.getLog(b));
+                } finally {
+                    inboundAgents.stop(r, agent.getNodeName());
                 }
-                System.err.println(JenkinsRule.getLog(b));
             }
         }, Description.EMPTY).evaluate();
 

--- a/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
+++ b/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
@@ -78,8 +78,9 @@ public class WebSocketAgentsTest {
      */
     @Test
     public void smokes() throws Exception {
-            Slave s = inboundAgents.createAgent(r, InboundAgentRule.Options.newBuilder().secret().webSocket().build());
-            r.waitOnline(s);
+        Slave s = inboundAgents.createAgent(r, InboundAgentRule.Options.newBuilder().secret().webSocket().build());
+        r.waitOnline(s);
+        try {
             assertEquals("response", s.getChannel().call(new DummyTask()));
             assertNotNull(s.getChannel().call(new FatTask()));
             FreeStyleProject p = r.createFreeStyleProject();
@@ -87,6 +88,9 @@ public class WebSocketAgentsTest {
             p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo hello") : new Shell("echo hello"));
             r.buildAndAssertSuccess(p);
             s.toComputer().getLogText().writeLogTo(0, System.out);
+        } finally {
+            inboundAgents.stop(r, s.getNodeName());
+        }
     }
 
     private static class DummyTask extends SlaveToMasterCallable<String, RuntimeException> {

--- a/test/src/test/java/jenkins/security/Security218Test.java
+++ b/test/src/test/java/jenkins/security/Security218Test.java
@@ -49,8 +49,12 @@ public class Security218Test implements Serializable {
     public void jnlpSlave() throws Exception {
         DumbSlave a = (DumbSlave) inboundAgents.createAgent(j, InboundAgentRule.Options.newBuilder().secret().build());
         j.waitOnline(a);
-        j.createWebClient().goTo("computer/" + a.getNodeName() + "/jenkins-agent.jnlp?encrypt=true", "application/octet-stream");
-        check(a);
+        try {
+            j.createWebClient().goTo("computer/" + a.getNodeName() + "/jenkins-agent.jnlp?encrypt=true", "application/octet-stream");
+            check(a);
+        } finally {
+            inboundAgents.stop(j, a.getNodeName());
+        }
     }
 
     /**

--- a/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
+++ b/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
@@ -80,7 +80,11 @@ public class JnlpSlaveRestarterInstallerTest {
             rr.then(r -> {
                 DumbSlave s = (DumbSlave) r.jenkins.getNode("remote");
                 r.waitOnline(s);
-                assertEquals(canWork.get() ? 1 : 2, s.getChannel().call(new JVMCount()).intValue());
+                try {
+                    assertEquals(canWork.get() ? 1 : 2, s.getChannel().call(new JVMCount()).intValue());
+                } finally {
+                    inboundAgents.stop(r, s.getNodeName());
+                }
             });
     }
 


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins-test-harness/pull/501. I have been seeing a lot of flakiness in `InboundAgentRule`-based tests in #after methods and I think the cause could be that we aren't waiting for the inbound agent to go offline before starting to tear down the test. This should solve the problem by generalizing https://github.com/jenkinsci/jenkins/blob/5b5040298f5fbf9d5ff7ea7fbfd34f7169e94d75/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java#L109-L113 to `InboundAgentRule`. The new stop method is analogous to the existing `#start(JenkinsRule, String)` method.

### Testing done

Ran `mvn clean verify -Dtest=hudson.bugs.JnlpAccessWithSecuredHudsonTest,hudson.slaves.JNLPLauncherRealTest,jenkins.agents.WebSocketAgentsTest,jenkins.security.Security218Test,jenkins.slaves.restarter.JnlpSlaveRestarterInstallerTest` in the debugger and stepped through the teardown sequence to ensure that it was working as expected: `InboundAgentRule#stop` correctly waited for the process to terminate and for the ndoe to go offline.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7261"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

