### PR TITLE
[JENKINS-69850]: Queue.maintain() does no longer trigger an infinite recursive loop after loading a queue from xml

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1111,8 +1111,9 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
         // Blocked downstream tasks must block this project.
         // Projects blocked by upstream or downstream builds
         // are ignored to break deadlocks.
-        for (Queue.Item item : Jenkins.get().getQueue().getBlockedItems()) {
-            if (item.getCauseOfBlockage() instanceof AbstractProject.BecauseOfUpstreamBuildInProgress ||
+        for (Queue.BlockedItem item : Jenkins.get().getQueue().getBlockedItems()) {
+            if (item.isCauseOfBlockageNull() ||
+                    item.getCauseOfBlockage() instanceof AbstractProject.BecauseOfUpstreamBuildInProgress ||
                     item.getCauseOfBlockage() instanceof AbstractProject.BecauseOfDownstreamBuildInProgress) {
                 continue;
             }
@@ -1139,8 +1140,9 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
         // Blocked upstream tasks must block this project.
         // Projects blocked by upstream or downstream builds
         // are ignored to break deadlocks.
-        for (Queue.Item item : Jenkins.get().getQueue().getBlockedItems()) {
-            if (item.getCauseOfBlockage() instanceof AbstractProject.BecauseOfUpstreamBuildInProgress ||
+        for (Queue.BlockedItem item : Jenkins.get().getQueue().getBlockedItems()) {
+            if (item.isCauseOfBlockageNull() ||
+                    item.getCauseOfBlockage() instanceof AbstractProject.BecauseOfUpstreamBuildInProgress ||
                     item.getCauseOfBlockage() instanceof AbstractProject.BecauseOfDownstreamBuildInProgress) {
                 continue;
             }

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2620,6 +2620,14 @@ public class Queue extends ResourceController implements Saveable {
             this.causeOfBlockage = causeOfBlockage;
         }
 
+        public boolean isCauseOfBlockageNull() {
+            if (causeOfBlockage == null) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
         @Override
         public CauseOfBlockage getCauseOfBlockage() {
             if (causeOfBlockage != null) {

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2620,6 +2620,7 @@ public class Queue extends ResourceController implements Saveable {
             this.causeOfBlockage = causeOfBlockage;
         }
 
+        @Restricted(NoExternalUse.class)
         public boolean isCauseOfBlockageNull() {
             if (causeOfBlockage == null) {
                 return true;

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -539,10 +539,12 @@ public class QueueTest {
     }
 
 
-    @TestExtension({"upstreamProjectsInQueueBlock", "downstreamProjectsInQueueBlock"})
+    @TestExtension({"upstreamProjectsInQueueBlock", "downstreamProjectsInQueueBlock", "handleCauseOfBlockageThatIsNull"})
     public static class BlockingQueueTaskDispatcher extends QueueTaskDispatcher {
 
         public static final String NAME_OF_BLOCKED_PROJECT = "blocked project";
+
+        public static final String NAME_OF_ANOTHER_BLOCKED_PROJECT = "another blocked project";
 
         @Override
         public CauseOfBlockage canRun(hudson.model.Queue.Item item) {
@@ -641,6 +643,36 @@ public class QueueTest {
        //Ensure orderly shutdown
        q.clear();
        r.waitUntilNoActivity();
+    }
+
+    @Issue("JENKINS-69850")
+    @Test
+    public void handleCauseOfBlockageThatIsNull() throws Exception {
+
+        FreeStyleProject a = r.createFreeStyleProject(BlockingQueueTaskDispatcher.NAME_OF_BLOCKED_PROJECT);
+        FreeStyleProject b = r.createFreeStyleProject(BlockingQueueTaskDispatcher.NAME_OF_ANOTHER_BLOCKED_PROJECT);
+        a.getPublishersList().add(new BuildTrigger(b.getName(), true));
+        a.setBlockBuildWhenDownstreamBuilding(true);
+        b.setBlockBuildWhenUpstreamBuilding(true);
+        r.jenkins.rebuildDependencyGraph();
+
+        Queue q = r.jenkins.getQueue();
+        Queue.withLock(() -> {
+            a.scheduleBuild(0, new UserIdCause());
+            b.scheduleBuild(0, new UserIdCause());
+            // Move both projects from pending to blocked
+            q.maintain();
+
+            q.save();
+            // Loading blocked items sets the CauseOfBlockage to null
+            q.load();
+            // Before JENKINS-69850 was fixed the null CauseOfBlockage caused a stack overflow
+            q.maintain();
+        });
+
+        //Ensure orderly shutdown
+        q.clear();
+        r.waitUntilNoActivity();
     }
 
     public static class TestFlyweightTask extends TestTask implements Queue.FlyweightTask {


### PR DESCRIPTION
See [JENKINS-69850](https://issues.jenkins.io/browse/JENKINS-69850).

### Testing done

QueueTest.handleCauseOfBlockageThatIsNull()

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@res0nance
@jtnord 
@basil 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7273"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

