### PR TITLE
Update bundled script-security and workflow-support plugins

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -322,7 +322,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>script-security</artifactId>
-                  <version>1184.v85d16b_d851b_3</version>
+                  <version>1189.vb_a_b_7c8fd5fde</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -322,7 +322,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>script-security</artifactId>
-                  <version>1172.v35f6a_0b_8207e</version>
+                  <version>1184.v85d16b_d851b_3</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -335,7 +335,7 @@ THE SOFTWARE.
                   <!-- dependency of junit -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-api</artifactId>
-                  <version>1144.v61c3180fa_03f</version>
+                  <version>1164.v760c223ddb_32</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -364,7 +364,7 @@ THE SOFTWARE.
                   <!-- dependency of checks-api -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-support</artifactId>
-                  <version>813.vb_d7c3d2984a_0</version>
+                  <version>839.v35e2736cfd5c</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -434,7 +434,7 @@ THE SOFTWARE.
                   <!-- dependency of workflow-api -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>scm-api</artifactId>
-                  <version>602.v6a_81757a_31d2</version>
+                  <version>608.vfa_f971c5a_a_e9</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
See [Jenkins Security Advisory 2022-10-19](https://www.jenkins.io/security/advisory/2022-10-19/).

### Testing done

Ran `LoadDetachedPluginsTest` including un-ignored `#noUpdateSiteWarnings` locally.

### Proposed changelog entries

- Update bundled Script Security Plugin from 1172.v35f6a_0b_8207e to 1189.vb_a_b_7c8fd5fde (<a href="https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2824%20(1)">SECURITY-2824 (1) in the 2022-10-19 security advisory</a>).
- Update bundled Pipeline: API Plugin from 1144.v61c3180fa_03f to 1164.v760c223ddb_32.
- Update bundled Pipeline: Supporting APIs Plugin from 813.vb_d7c3d2984a_0 to 839.v35e2736cfd5c (<a href="https://www.jenkins.io/security/advisory/2022-10-19/#SECURITY-2881">SECURITY-2881 in the 2022-10-19 security advisory</a>).
- Update bundled SCM API Plugin from 602.v6a_81757a_31d2 to 608.vfa_f971c5a_a_e9.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7275"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

