### PR TITLE
Align HTTP keep-alive timeout with Jetty default

### DIFF
--- a/essentials.yml
+++ b/essentials.yml
@@ -1,8 +1,8 @@
 ---
 ath:
   useLocalSnapshots: false
-  athRevision: "5450.v1cfec809d04b"
-  athImage: "jenkins/ath:5450.v1cfec809d04b"
+  athRevision: "5458.v911b_2f0818ee"
+  athImage: "jenkins/ath:5458.v911b_2f0818ee"
   categories:
     - org.jenkinsci.test.acceptance.junit.SmokeTest
   jdks:

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,8 @@ THE SOFTWARE.
     <access-modifier.version>1.27</access-modifier.version>
     <bridge-method-injector.version>1.23</bridge-method-injector.version>
     <spotless.version>2.27.2</spotless.version>
-    <winstone.version>6.5</winstone.version>
+    <!-- TODO https://github.com/jenkinsci/winstone/pull/296 -->
+    <winstone.version>6.6-rc793.132f13f6a_33a</winstone.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,7 @@ THE SOFTWARE.
     <access-modifier.version>1.27</access-modifier.version>
     <bridge-method-injector.version>1.23</bridge-method-injector.version>
     <spotless.version>2.27.2</spotless.version>
-    <!-- TODO https://github.com/jenkinsci/winstone/pull/296 -->
-    <winstone.version>6.6-rc793.132f13f6a_33a</winstone.version>
+    <winstone.version>6.6</winstone.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
See [JENKINS-69509](https://issues.jenkins.io/browse/JENKINS-69509) for context and https://github.com/jenkinsci/winstone/pull/296 for a detailed description of this PR.

### Testing done

In [JENKINS-69509](https://issues.jenkins.io/browse/JENKINS-69509) I have been helping a user who was frequently hitting this timeout with a WebSocket agent in almost every build. The same user confirmed that when setting `--httpKeepAliveTimeout=30000` they were able to run 6 builds without hitting the timeout. I think it makes sense to set this as the default for all users, matching Jetty's own default.

I ran `mvn clean verify -Dtest=jenkins.agents.WebSocketAgentsTest,hudson.slaves.JNLPLauncherRealTest` successfully.

### Proposed changelog entries

- Align the default value of the HTTP keep-alive timeout in Winstone with that of the upstream Jetty project by changing it from 5 seconds to 30 seconds.
- Remove unused `--ajp13Port`, `--ajp13ListenAddress`, `--handlerCountMax`, and `--handlerCountMaxIdle` options.

### Proposed upgrade guidelines

The `--ajp13Port`, `--ajp13ListenAddress`, `--handlerCountMax`, and `--handlerCountMaxIdle` options have been removed without replacement. Users are advised to stop using these options.

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7277"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

