### PR TITLE
Do not print at `INFO` every time `AsyncPeriodicWork` starts/stops

### DIFF
--- a/core/src/main/java/hudson/model/AsyncAperiodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncAperiodicWork.java
@@ -110,7 +110,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
                 return;
             }
             thread = new Thread(() -> {
-                logger.log(getNormalLoggingLevel(), "Started {0}", name);
+                logger.log(Level.FINE, "Started {0}", name);
                 long startTime = System.currentTimeMillis();
                 long stopTime;
 
@@ -126,7 +126,7 @@ public abstract class AsyncAperiodicWork extends AperiodicWork {
                     l.close(String.format("Finished at %tc. %dms", new Date(stopTime), stopTime - startTime));
                 }
 
-                logger.log(getNormalLoggingLevel(), "Finished {0}. {1,number} ms",
+                logger.log(Level.FINE, "Finished {0}. {1,number} ms",
                         new Object[]{name, stopTime - startTime});
             }, name + " thread");
             thread.start();

--- a/core/src/main/java/hudson/model/AsyncPeriodicWork.java
+++ b/core/src/main/java/hudson/model/AsyncPeriodicWork.java
@@ -92,7 +92,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
                 return;
             }
             thread = new Thread(() -> {
-                logger.log(getNormalLoggingLevel(), "Started {0}", name);
+                logger.log(Level.FINE, "Started {0}", name);
                 long startTime = System.currentTimeMillis();
                 long stopTime;
 
@@ -110,7 +110,7 @@ public abstract class AsyncPeriodicWork extends PeriodicWork {
                     l.close(String.format("Finished at %tc. %dms", new Date(stopTime), stopTime - startTime));
                 }
 
-                logger.log(getNormalLoggingLevel(), "Finished {0}. {1,number} ms",
+                logger.log(Level.FINE, "Finished {0}. {1,number} ms",
                         new Object[]{name, stopTime - startTime});
             }, name + " thread");
             thread.start();


### PR DESCRIPTION
Depending on the plugins you have installed and the frequency of their background tasks, your system log can consist mostly of these messages which are typically of little interest. See for example https://github.com/jenkinsci/prometheus-plugin/pull/157 or https://github.com/jenkinsci/jclouds-plugin/pull/105 or https://github.com/jenkinsci/datadog-plugin/pull/63. (In the latter case https://github.com/jenkinsci/datadog-plugin/issues/55 suggests that there were other independent log messages from `DatadogHttpClient.getInstance`.) For comparison, `PeriodicWork` by default logs nothing.

I chose to just suppress these specific messages rather than changing the default value of `getNormalLoggingLevel` (which continues to be used for rarer purposes such as log file rotation) since https://github.com/search?q=org%3Ajenkinsci+getNormalLoggingLevel&type=Code indicates that at least some of the Azure-related plugins deliberately log at this level.

Complements #5802 which is about the log file on disk rather than the system log.

### Testing done

`jetty:run`, created a freestyle project, script console

```groovy
ExtensionList.lookupSingleton(BackgroundGlobalBuildDiscarder).run()
```

to avoid waiting for an hour, verified that `war/work/logs/tasks/Periodic background build discarder.log` was created, but that no related log messages were printed.

### Proposed changelog entries

- Suppress log messages from periodically running background tasks, like "Periodic background build discarder"

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
