### PR TITLE
Capturing runtime exceptions from `Computer.threadPoolForRemoting.submit(Runnable)`

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -106,6 +106,7 @@ import jenkins.security.ImpersonatingExecutorService;
 import jenkins.security.MasterToSlaveCallable;
 import jenkins.security.stapler.StaplerDispatchable;
 import jenkins.util.ContextResettingExecutorService;
+import jenkins.util.ErrorLoggingExecutorService;
 import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
 import net.jcip.annotations.GuardedBy;
@@ -1362,10 +1363,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
     public static final ExecutorService threadPoolForRemoting = new ContextResettingExecutorService(
         new ImpersonatingExecutorService(
-            Executors.newCachedThreadPool(
-                new ExceptionCatchingThreadFactory(
-                    new NamingThreadFactory(
-                        new DaemonThreadFactory(), "Computer.threadPoolForRemoting"))), ACL.SYSTEM2));
+            new ErrorLoggingExecutorService(
+                Executors.newCachedThreadPool(
+                    new ExceptionCatchingThreadFactory(
+                        new NamingThreadFactory(
+                            new DaemonThreadFactory(), "Computer.threadPoolForRemoting")))), ACL.SYSTEM2));
 
 //
 //

--- a/core/src/main/java/hudson/util/ExceptionCatchingThreadFactory.java
+++ b/core/src/main/java/hudson/util/ExceptionCatchingThreadFactory.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
  *
  * @author Kohsuke Kawaguchi
  * @since 1.226
- * @see ErrorLoggingExecutorService
+ * @see jenkins.util.ErrorLoggingExecutorService
  */
 public class ExceptionCatchingThreadFactory implements ThreadFactory, Thread.UncaughtExceptionHandler {
     private final ThreadFactory core;

--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -131,9 +131,12 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
                 LOGGER.fine(() -> "setting up channel for " + agent);
                 state.fireBeforeChannel(new ChannelBuilder(agent, Computer.threadPoolForRemoting));
                 transport = new Transport();
-                state.fireAfterChannel(state.getChannelBuilder().build(transport));
-                LOGGER.fine(() -> "set up channel for " + agent);
-                return null;
+                try {
+                    state.fireAfterChannel(state.getChannelBuilder().build(transport));
+                    LOGGER.fine(() -> "set up channel for " + agent);
+                } catch (IOException x) {
+                    LOGGER.log(Level.WARNING, "failed to set up channel for " + agent, x);
+                }
             });
         }
 

--- a/core/src/main/java/jenkins/util/ErrorLoggingExecutorService.java
+++ b/core/src/main/java/jenkins/util/ErrorLoggingExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ * Copyright 2022 CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,43 +22,42 @@
  * THE SOFTWARE.
  */
 
-package hudson.util;
+package jenkins.util;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * {@link ThreadFactory} that creates a thread, which in turn displays a stack trace
- * when it terminates unexpectedly.
- *
- * @author Kohsuke Kawaguchi
- * @since 1.226
- * @see ErrorLoggingExecutorService
+ * Executor service that logs unchecked exceptions / errors in {@link Runnable}.
+ * Exceptions thrown from {@link Callable} are <em>not</em> not logged,
+ * under the assumption that something is checking {@link Future#get()}.
  */
-public class ExceptionCatchingThreadFactory implements ThreadFactory, Thread.UncaughtExceptionHandler {
-    private final ThreadFactory core;
+public class ErrorLoggingExecutorService extends InterceptingExecutorService {
 
-    public ExceptionCatchingThreadFactory() {
-        this(Executors.defaultThreadFactory());
-    }
+    private static final Logger LOGGER = Logger.getLogger(ErrorLoggingExecutorService.class.getName());
 
-    public ExceptionCatchingThreadFactory(ThreadFactory core) {
-        this.core = core;
+    public ErrorLoggingExecutorService(ExecutorService base) {
+        super(base);
     }
 
     @Override
-    public Thread newThread(Runnable r) {
-        Thread t = core.newThread(r);
-        t.setUncaughtExceptionHandler(this);
-        return t;
+    protected Runnable wrap(Runnable r) {
+        return () -> {
+            try {
+                r.run();
+            } catch (Throwable x) {
+                LOGGER.log(Level.WARNING, null, x);
+                throw x;
+            }
+        };
     }
 
     @Override
-    public void uncaughtException(Thread t, Throwable e) {
-        LOGGER.log(Level.WARNING, "Thread " + t.getName() + " terminated unexpectedly", e);
+    protected <V> Callable<V> wrap(Callable<V> r) {
+        return r;
     }
 
-    private static final Logger LOGGER = Logger.getLogger(ExceptionCatchingThreadFactory.class.getName());
 }


### PR DESCRIPTION
Spent a while trying to track down an issue which turned out to be an unchecked exception thrown out of `JnlpConnectionStateListener.afterChannel` and swallowed by `FutureTask`, which `ExceptionCatchingThreadFactory` does _not_ address.

### Proposed changelog entries

- Developer: better error logging for unexpected problems in `Computer.threadPoolForRemoting`.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7284"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

