### PR TITLE
[JENKINS-69904] _safeRestart.jelly must not use parentheses in localizable messages

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 			<j:choose>
 				<j:when test="${app.lifecycle.canRestart()}">
 					<form method="post" action="safeRestart">
-						${%Are you sure you want to restart Jenkins? Jenkins will restart once all running jobs are finished. (Pipeline builds may prevent Jenkins from restarting for a short period of time in some cases, but if so, they will be paused at the next available opportunity and then resumed after Jenkins restarts.) }
+						${%confirmRestart}
 						<f:submit value="${%Yes}" />
 					</form>
 				</j:when>

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart.properties
@@ -1,0 +1,26 @@
+# The MIT License
+#
+# Copyright 2022 CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+confirmRestart=\
+  Are you sure you want to restart Jenkins? \
+  Jenkins will restart once all running jobs are finished. \
+  (Pipeline builds may prevent Jenkins from restarting for a short period of time in some cases, but if so, they will be paused at the next available opportunity and then resumed after Jenkins restarts.)

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_bg.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_bg.properties
@@ -24,6 +24,3 @@ Jenkins\ cannot\ restart\ itself\ as\ currently\ configured.=\
  С текущите си настройки Jenkins не може да се рестартира.
 Yes=\
  Да
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=\
- Сигурни ли сте, че искате да рестартирате Jenkins? Той ще се рестартира с\
- приключването на всички текущи задачи.

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_da.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_da.properties
@@ -21,5 +21,3 @@
 # THE SOFTWARE.
 
 Yes=Ja
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=\
-Er du sikker på at du vil genstarte Jenkins? Jenkins vil genstarte når alle kørende jobs er færdige.

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_de.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_de.properties
@@ -20,8 +20,5 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=\
-  Möchten Sie Jenkins wirklich neu starten? Jenkins wird neu starten, \
-  sobald alle laufenden Jobs abgeschlossen wurden.
 Yes=Ja
 Jenkins\ cannot\ restart\ itself\ as\ currently\ configured.=Jenkins kann sich wie konfiguriert nicht selbst neu starten.

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_es.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_es.properties
@@ -20,5 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=¿Estás seguro de querer reiniciar Jenkins después de que acaben todos los procesos en ejecución?
 Yes=Sí

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_fr.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_fr.properties
@@ -20,5 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=Êtes-vous sûr de vouloir redémarrer Jenkins? Jenkins redémarrera une fois tous les jobs terminés.
 Yes=Oui

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_it.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_it.properties
@@ -21,9 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Are\ you\ sure\ you\ want\ to\ restart\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=\
-  Riavviare Jenkins? Jenkins si riavvierà una volta terminati tutti i \
-  processi in esecuzione.
 Jenkins\ cannot\ restart\ itself\ as\ currently\ configured.=Jenkins non può \
   riavviarsi autononomamente così come configurato attualmente.
 Yes=Sì

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_ja.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_ja.properties
@@ -20,6 +20,4 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=\
- Jenkinsを再起動してもよろしいですか? 実行中のジョブが終了したら再起動します。
 Yes=はい

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_lt.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_lt.properties
@@ -1,3 +1,2 @@
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=Ar tikrai norite iš naujo paleisti Jenkinsą? Jenkinsas bus paleistas iš naujo, kai visi vykdomi darbai bus baigti.
 Yes=Taip
 Jenkins\ cannot\ restart\ itself\ as\ currently\ configured.=Toks, kaip dabar sukonfigūruotas, Jenkinas negali pats savęs paleisti iš naujo.

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_lv.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_lv.properties
@@ -20,5 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=Vai Jūs esat drošs par Jenkins pārstartēšanos? Jenkins pārstartēsies tiklīdz visi darbojošies darbi būs pabeiguši darbu.
 Yes=Jā

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_pt_BR.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_pt_BR.properties
@@ -23,5 +23,3 @@
 Yes=Sim
 Jenkins\ cannot\ restart\ itself\ as\ currently\ configured.=O Jenkins não pode se reiniciar da forma como está \
   atualmente configurado.
-Are\ you\ sure\ you\ want\ to\ restart\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=Você \
-  tem certeza de que quer reiniciar o Jenkins? Ele reiniciará uma vez que todas tarefas estejam concluídas.

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_ru.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_ru.properties
@@ -1,3 +1,2 @@
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=Вы уверены, что хотите перезапустить Jenkins? Jenkins будет перезагружен, когда все запущенные задачи завершатся.
 Yes=Да
 Jenkins\ cannot\ restart\ itself\ as\ currently\ configured.=В текущей конфигурации Jenkins не может перезапуститься сам.

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_sr.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_sr.properties
@@ -1,5 +1,4 @@
 # This file is under the MIT License by authors
 
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=Да ли желите да поново покренете Jenkins кад све текуће послове буду биле готове?
 Yes=Да
 Jenkins\ cannot\ restart\ itself\ as\ currently\ configured.=Неможе се поново покренути Jenkins за овим подешавањима.

--- a/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_zh_TW.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_safeRestart_zh_TW.properties
@@ -21,7 +21,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Are\ you\ sure\ about\ restarting\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=您確定要重新啟動 Jenkins 嗎? Jenkins 會在所有作業都完成後重新啟動。
 Yes=是
 Jenkins\ cannot\ restart\ itself\ as\ currently\ configured.=Jenkins 無法在目前的設定值下自行重新啟動。
-Are\ you\ sure\ you\ want\ to\ restart\ Jenkins?\ Jenkins\ will\ restart\ once\ all\ running\ jobs\ are\ finished.=您確定要重新啟動 Jenkins 嗎？Jenkins 會在所有作業都完成後重新啟動。


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-69904](https://issues.jenkins.io/browse/JENKINS-69904) and https://github.com/jenkinsci/jenkins/pull/7091.

This PR also deletes all existing translations since #7091 made them obsolete.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

<details>
<summary>Here's a screenshot of the <code>/safeRestart</code> page with these changes</summary>

<img width="1728" alt="Screen Shot 2022-10-20 at 4 33 32 PM" src="https://user-images.githubusercontent.com/1068968/197057493-d398072c-7966-47d4-8244-e524f3668669.png">
</details>

I could add a `WebClient` test that just navigates to this page if desired, but I'm not sure how valuable that would be. Let me know if you want to me to add this.

### Proposed changelog entries

- Prevent exception from being thrown when attempting to initiate a safe restart (regression in 2.374)

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7286"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

