### PR TITLE
Use `setText` rather than `type` in `ViewDescriptorTest`

### DIFF
--- a/test/src/test/java/hudson/model/ViewDescriptorTest.java
+++ b/test/src/test/java/hudson/model/ViewDescriptorTest.java
@@ -24,8 +24,8 @@
 
 package hudson.model;
 
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -34,7 +34,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import java.util.Arrays;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import net.sf.json.JSONObject;
 import org.junit.Rule;
@@ -112,7 +111,8 @@ public class ViewDescriptorTest {
                         .getSomeProperty());
 
         //WHEN the users goes with "Edit View" on the configure page
-        HtmlPage editViewPage = r.createWebClient().getPage(myListView, "configure");
+        JenkinsRule.WebClient client = r.createWebClient();
+        HtmlPage editViewPage = client.getPage(myListView, "configure");
 
         //THEN the invisible property is not displayed on page
         assertFalse("CustomInvisibleProperty should not be displayed on the View edition page UI.",
@@ -120,13 +120,11 @@ public class ViewDescriptorTest {
 
 
         HtmlForm editViewForm = editViewPage.getFormByName("viewConfig");
-        editViewForm.getTextAreaByName("description").type("This list view is awesome !");
+        editViewForm.getTextAreaByName("description").setText("This list view is awesome !");
         r.submit(editViewForm);
 
         //Check that the description is updated on view
-        await().pollInterval(1, TimeUnit.SECONDS)
-                .atMost(10, TimeUnit.SECONDS)
-                .until(() -> r.createWebClient().getPage(myListView).asNormalizedText(), containsString("This list view is awesome !"));
+        assertThat(client.getPage(myListView).asNormalizedText(), containsString("This list view is awesome !"));
 
         //AND THEN after View save, the invisible property is still persisted with the View.
         assertNotNull("The CustomInvisibleProperty should be persisted on the View.",


### PR DESCRIPTION
Yet another attempt to de-flake `ViewDescriptorTest` which seems to still fail with an error like:

```
10:16:41  org.awaitility.core.ConditionTimeoutException: Lambda expression in hudson.model.ViewDescriptorTest: expected a string containing "Thlist view awesome !" but was null within 10 seconds.
```

This error makes no sense to me not only because a readthrough of HtmlUnit shows the actual value should never be null but also because the expected value is "Thlist view awesome !" which is a string I cannot find anywhere in the code.

Since almost everywhere else in this test suite we use `setText` rather than `type`, I am switching us to that here, guessing that maybe the typing itself is competing with other keyboard events (perhaps from another test)? If not at least it can't hurt to be more consistent with other tests. I am also getting rid of the use of Awaitility since maybe that is mangling the error message somehow? Cutting it out in favor of pure Hamcrest should eliminate that possibility.

### Testing done

I ran this test in a loop for 12 hours without seeing the failure in #7209, so I know this change at least doesn't make anything worse. Whether it improves things in practice remains to be seen in regular PR builds.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7289"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

