### PR TITLE
Loosen assertion in `NodeProvisionerTest` to account for conservative estimation in production code

### DIFF
--- a/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
+++ b/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
@@ -24,6 +24,9 @@
 
 package hudson.slaves;
 
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeFalse;
@@ -161,7 +164,8 @@ public class NodeProvisionerTest {
 
             // the time it takes to complete a job is eternally long compared to the time it takes to launch
             // a new slave, so in this scenario we end up allocating 5 slaves for 5 jobs.
-            assertEquals(5, cloud.numProvisioned);
+            // sometimes we can end up allocating 6 due to the conservative estimation in StandardStrategyImpl#apply
+            assertThat(cloud.numProvisioned, anyOf(equalTo(5), equalTo(6)));
         }
     }
 
@@ -219,7 +223,8 @@ public class NodeProvisionerTest {
             verifySuccessfulCompletion(buildAll(redJobs), r);
 
             // cloud should only give us 5 nodes for 5 red jobs
-            assertEquals(5, cloud.numProvisioned);
+            // sometimes we can end up allocating 6 due to the conservative estimation in StandardStrategyImpl#apply
+            assertThat(cloud.numProvisioned, anyOf(equalTo(5), equalTo(6)));
 
             // and all blue jobs should be still stuck in the queue
             for (Future<FreeStyleBuild> bb : blueBuilds)


### PR DESCRIPTION
The two tests in `NodeProvisionerTest` that assert that 5 nodes were provisioned in response to a load spike of 5 jobs sometimes fail because 6 nodes were provisioned. The logs when 5 are provisioned (most of the time):

```
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=0, onlineExecutors=0, connectingExecutors=0, busyExecutors=0, idleExecutors=0, availableExecutors=0, queueLength=5}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINE h.s.NodeProvisioner$StandardStrategyImpl#apply: Excess workload 3.063 detected. (planned capacity=0,connecting capacity=0,Qlen=3.063,available=0&0,online=0,m=0.5)
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #1 from test with 1 executors. Remaining excess workload: 2.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #1 from test with 1 executors. Remaining excess workload: 2.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #2 from test with 1 executors. Remaining excess workload: 1.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #2 from test with 1 executors. Remaining excess workload: 1.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #3 from test with 1 executors. Remaining excess workload: 0.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #3 from test with 1 executors. Remaining excess workload: 0.063
[id=] FINER hudson.slaves.NodeProvisioner#update: Provisioning strategy hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee declared provisioning complete
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=3, onlineExecutors=1, connectingExecutors=2, busyExecutors=0, idleExecutors=1, availableExecutors=1, queueLength=5}, plannedCapacitySnapshot=3, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=3, onlineExecutors=3, connectingExecutors=0, busyExecutors=3, idleExecutors=0, availableExecutors=0, queueLength=2}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINE h.s.NodeProvisioner$StandardStrategyImpl#apply: Excess workload 1.73 detected. (planned capacity=0.27,connecting capacity=0,Qlen=2,available=0&0,online=3,m=0.15)
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #4 from test with 1 executors. Remaining excess workload: 0.73
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #4 from test with 1 executors. Remaining excess workload: 0.73
[id=] FINER hudson.slaves.NodeProvisioner#update: Provisioning strategy hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee declared provisioning complete
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=4, onlineExecutors=4, connectingExecutors=0, busyExecutors=4, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=4, onlineExecutors=4, connectingExecutors=0, busyExecutors=4, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=4, onlineExecutors=4, connectingExecutors=0, busyExecutors=4, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=4, onlineExecutors=4, connectingExecutors=0, busyExecutors=4, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=4, onlineExecutors=4, connectingExecutors=0, busyExecutors=4, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=4, onlineExecutors=4, connectingExecutors=0, busyExecutors=4, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=4, onlineExecutors=4, connectingExecutors=0, busyExecutors=4, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=4, onlineExecutors=4, connectingExecutors=0, busyExecutors=4, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINE h.s.NodeProvisioner$StandardStrategyImpl#apply: Excess workload 0.884 detected. (planned capacity=0.116,connecting capacity=0,Qlen=1,available=0&0,online=4,m=0.125)
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #5 from test with 1 executors. Remaining excess workload: -0.116
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #5 from test with 1 executors. Remaining excess workload: -0.116
[id=] FINER hudson.slaves.NodeProvisioner#update: Provisioning strategy hudson.slaves.NodeProvisioner$StandardStrategyImpl@7886eeee declared provisioning complete
```

The logs when 6 nodes are provisioned (some of the time):

```
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@1897d909 provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=0, onlineExecutors=0, connectingExecutors=0, busyExecutors=0, idleExecutors=0, availableExecutors=0, queueLength=5}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINE h.s.NodeProvisioner$StandardStrategyImpl#apply: Excess workload 3.063 detected. (planned capacity=0,connecting capacity=0,Qlen=3.063,available=0&0,online=0,m=0.5)
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #1 from test with 1 executors. Remaining excess workload: 2.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #1 from test with 1 executors. Remaining excess workload: 2.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #2 from test with 1 executors. Remaining excess workload: 1.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #2 from test with 1 executors. Remaining excess workload: 1.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #3 from test with 1 executors. Remaining excess workload: 0.063
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #3 from test with 1 executors. Remaining excess workload: 0.063
[id=] FINER hudson.slaves.NodeProvisioner#update: Provisioning strategy hudson.slaves.NodeProvisioner$StandardStrategyImpl@1897d909 declared provisioning complete
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@1897d909 provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=3, onlineExecutors=0, connectingExecutors=3, busyExecutors=0, idleExecutors=0, availableExecutors=0, queueLength=5}, plannedCapacitySnapshot=3, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@1897d909 provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=3, onlineExecutors=3, connectingExecutors=0, busyExecutors=3, idleExecutors=0, availableExecutors=0, queueLength=5}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}
[id=] FINE h.s.NodeProvisioner$StandardStrategyImpl#apply: Excess workload 3.161 detected. (planned capacity=0.27,connecting capacity=0,Qlen=3.431,available=0&0,online=3,m=0.15)
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #4 from test with 1 executors. Remaining excess workload: 2.161
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #4 from test with 1 executors. Remaining excess workload: 2.161
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #5 from test with 1 executors. Remaining excess workload: 1.161
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #5 from test with 1 executors. Remaining excess workload: 1.161
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #6 from test with 1 executors. Remaining excess workload: 0.161
[id=] INFO h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning test #6 from test with 1 executors. Remaining excess workload: 0.161
[id=] FINER hudson.slaves.NodeProvisioner#update: Provisioning strategy hudson.slaves.NodeProvisioner$StandardStrategyImpl@1897d909 declared provisioning complete
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@1897d909 provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=6, onlineExecutors=3, connectingExecutors=3, busyExecutors=3, idleExecutors=0, availableExecutors=0, queueLength=2}, plannedCapacitySnapshot=3, additionalPlannedCapacity=0}
[id=] FINER hudson.slaves.NodeProvisioner#update: Consulting hudson.slaves.NodeProvisioner$StandardStrategyImpl@1897d909 provisioning strategy with state StrategyState{label=red, snapshot=LoadStatisticsSnapshot{definedExecutors=6, onlineExecutors=3, connectingExecutors=3, busyExecutors=3, idleExecutors=0, availableExecutors=0, queueLength=2}, plannedCapacitySnapshot=3, additionalPlannedCapacity=0}
```

As you can see, a sixth node is sometimes provisioned because the remaining excess workload remains above 3 even after provisioning 3 nodes, while in the "normal" case provisioning 3 nodes is enough to drop the excess workload to 1.73. The main difference here is the Qlen which drops from 3.063 to to 2 to 1 in the normal case but actually increases from 3.063 to 3.431 (causing the sixth agent to be provisioned) in the degenerate case.

The block comment indicates that

> there's a time lag between when an agent launches (thus bringing the planned capacity down) and the time when its executors pick up builds (thus bringing the queue length down.)

and that the production code tries to take conservative estimates and compute an exponential moving average (EMA) to smooth things out. That makes sense, and I don't think there is a bug in production, but the tests are assuming that the timing always works out in one way, when in fact it could work out in one of two ways depending on how fast the test system is running and therefore how quickly the moving averages change. Therefore I have loosened up the test to accommodate both 5 and 6 as valid values, accommodating the conservative estimation in the production code. Maybe someone could design a better algorithm in the future that doesn't rely on exponential moving averages, but that seems far outside the scope of my test stabilization effort.

### Testing done

I ran the test locally and confirmed 5 nodes were getting provisioned. The number should never be less than 5, and I have never seen a test system slow enough to result in more than 6 being provisioned, so allowing both 5 and 6 seems like a good compromise.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7291"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

