### PR TITLE
Ignore `BuildKeepsRunningWhenFaultySubTasksTest`

### DIFF
--- a/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
+++ b/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
@@ -13,6 +13,7 @@ import hudson.model.ResourceList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Level;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -30,6 +31,39 @@ public class BuildKeepsRunningWhenFaultySubTasksTest {
     public static final String ERROR_MESSAGE = "My unexpected exception";
 
     // When using SubTaskContributor (FailingSubTaskContributor) the build never ends
+    @Ignore("Too flaky; sometimes the build fails with java.util.concurrent.ExecutionException: java.lang.InterruptedException\n" +
+            "\tat hudson.remoting.AsyncFutureImpl.get(AsyncFutureImpl.java:80)\n" +
+            "\tat org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1484)\n" +
+            "\tat org.jvnet.hudson.test.JenkinsRule.assertBuildStatusSuccess(JenkinsRule.java:1512)\n" +
+            "\tat org.jvnet.hudson.test.JenkinsRule.buildAndAssertSuccess(JenkinsRule.java:1539)\n" +
+            "\tat hudson.model.queue.BuildKeepsRunningWhenFaultySubTasksTest.buildFinishesWhenSubTaskFails(BuildKeepsRunningWhenFaultySubTasksTest.java:39)\n" +
+            "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+            "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)\n" +
+            "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n" +
+            "\tat java.base/java.lang.reflect.Method.invoke(Method.java:568)\n" +
+            "\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)\n" +
+            "\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n" +
+            "\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)\n" +
+            "\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n" +
+            "\tat org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:618)\n" +
+            "\tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)\n" +
+            "\tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)\n" +
+            "\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\n" +
+            "\tat java.base/java.lang.Thread.run(Thread.java:833)\n" +
+            "Caused by: java.lang.InterruptedException\n" +
+            "\tat hudson.model.queue.Latch.check(Latch.java:104)\n" +
+            "\tat hudson.model.queue.Latch.synchronize(Latch.java:83)\n" +
+            "\tat hudson.model.queue.WorkUnitContext.synchronizeStart(WorkUnitContext.java:132)\n" +
+            "\tat hudson.model.Executor.run(Executor.java:408)\n" +
+            "Caused by: hudson.AbortException\n" +
+            "\tat hudson.model.queue.Latch.abort(Latch.java:58)\n" +
+            "\tat hudson.model.queue.WorkUnitContext.abort(WorkUnitContext.java:204)\n" +
+            "\tat hudson.model.Executor.finish1(Executor.java:492)\n" +
+            "\tat hudson.model.Executor.run(Executor.java:471)\n" +
+            "Caused by: java.lang.ArrayIndexOutOfBoundsException: My unexpected exception\n" +
+            "\tat hudson.model.queue.BuildKeepsRunningWhenFaultySubTasksTest$FailingSubTaskContributor$1$1.run(BuildKeepsRunningWhenFaultySubTasksTest.java:61)\n" +
+            "\tat hudson.model.ResourceController.execute(ResourceController.java:107)\n" +
+            "\tat hudson.model.Executor.run(Executor.java:449)")
     @Test
     @Issue("JENKINS-59793")
     public void buildFinishesWhenSubTaskFails() throws Exception {


### PR DESCRIPTION
This test still occasionally fails as in https://ci.jenkins.io/job/Core/job/jenkins/job/master/4236/testReport/junit/hudson.model.queue/BuildKeepsRunningWhenFaultySubTasksTest/Linux_jdk17___Linux_Build___Test___buildFinishesWhenSubTaskFails/ and I could not reproduce the failure locally even after trying to disturb the timing in various places. I think this is a pretty low-value test, since it tests graceful handling of a situation that should never happen; namely, programmer error, so I think it is fine to ignore the test for the sake of more stable builds.

### Testing done

Ran `mvn clean verify -Dtest=hudson.model.queue.BuildKeepsRunningWhenFaultySubTasksTest` locally and ensured the test was skipped.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7292"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

