### PR TITLE
Clean up `JnlpSlaveRestarterInstaller`

### DIFF
--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -52,20 +52,20 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
             install(c, listener);
             return null;
         }
-    }
 
-    private static void install(Computer c, TaskListener listener) {
-        try {
-            final List<SlaveRestarter> restarters = new ArrayList<>(SlaveRestarter.all());
+        private static void install(Computer c, TaskListener listener) {
+            try {
+                final List<SlaveRestarter> restarters = new ArrayList<>(SlaveRestarter.all());
 
-            VirtualChannel ch = c.getChannel();
-            if (ch == null) return;  // defensive check
+                VirtualChannel ch = c.getChannel();
+                if (ch == null) return;  // defensive check
 
-            List<SlaveRestarter> effective = ch.call(new FindEffectiveRestarters(restarters));
+                List<SlaveRestarter> effective = ch.call(new FindEffectiveRestarters(restarters));
 
-            LOGGER.log(FINE, "Effective SlaveRestarter on {0}: {1}", new Object[] {c.getName(), effective});
-        } catch (Throwable e) {
-            Functions.printStackTrace(e, listener.error("Failed to install restarter"));
+                LOGGER.log(FINE, "Effective SlaveRestarter on {0}: {1}", new Object[] {c.getName(), effective});
+            } catch (Throwable e) {
+                Functions.printStackTrace(e, listener.error("Failed to install restarter"));
+            }
         }
     }
 
@@ -80,12 +80,6 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
         public List<SlaveRestarter> call() throws IOException {
             Engine e = Engine.current();
             if (e == null) return null;    // not running under Engine
-
-            try {
-                Engine.class.getMethod("addListener", EngineListener.class);
-            } catch (NoSuchMethodException ignored) {
-                return null;    // running with older version of remoting that doesn't support adding listener
-            }
 
             // filter out ones that doesn't apply
             restarters.removeIf(r -> !r.canWork());


### PR DESCRIPTION
Minor cleanup of `JnlpSlaveRestarterInstaller` to fix things that irritated me when reading this code:

- The `install` method was defined in the outer class but only called from the inner class. Methods should be defined in the most narrow scope possible.
- There was some defensive code to support versions of Remoting that didn't have an `Engine#addListener` method. Remoting has included this method for more than 5 years, and the minimum version that we require has it, so this is just dead code that can be deleted.

### Testing done

The following tests cover the modified code:

```
mvn clean verify -Dtest=hudson.slaves.JNLPLauncherRealTest,jenkins.agents.WebSocketAgentsTest,jenkins.slaves.OldRemotingAgentTest,jenkins.slaves.RemotingVersionInfoTest,jenkins.slaves.restarter.JnlpSlaveRestarterInstallerTest,jenkins.slaves.UnsupportedRemotingAgentEscapeHatchTest,jenkins.slaves.UnsupportedRemotingAgentTest
```

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7302"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

