### PR TITLE
Add option to display latest artifacts in Jenkins job page

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -767,6 +767,10 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
         return getActions(ProminentProjectAction.class);
     }
 
+    /**
+     * Returns whether the project should display the latest artifacts
+     * @since 2.376
+     */
     public boolean displayLatestArtifacts() {
         return getPublishersList().stream()
                 .filter(publisher -> publisher instanceof ArtifactArchiver)

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -768,14 +768,13 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
     }
 
     /**
-     * Returns whether the project should display the latest artifacts
      * @since 2.376
      */
-    public boolean displayLatestArtifacts() {
+    public boolean displayLastArtifacts() {
         return getPublishersList().stream()
                 .filter(publisher -> publisher instanceof ArtifactArchiver)
                 .map(publisher -> (ArtifactArchiver) publisher)
-                .map(ArtifactArchiver::isDisplayLatestArtifacts)
+                .map(ArtifactArchiver::isDisplayLastArtifacts)
                 .findFirst()
                 .orElse(false);
     }

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -65,6 +65,7 @@ import hudson.search.SearchIndexBuilder;
 import hudson.security.Permission;
 import hudson.slaves.Cloud;
 import hudson.slaves.WorkspaceList;
+import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.BuildStep;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildTrigger;
@@ -764,6 +765,15 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
 
     public List<ProminentProjectAction> getProminentActions() {
         return getActions(ProminentProjectAction.class);
+    }
+
+    public boolean displayLatestArtifacts() {
+        return getPublishersList().stream()
+                .filter(publisher -> publisher instanceof ArtifactArchiver)
+                .map(publisher -> (ArtifactArchiver) publisher)
+                .map(ArtifactArchiver::isDisplayLatestArtifacts)
+                .findFirst()
+                .orElse(false);
     }
 
     @Override

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -122,6 +122,7 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     /**
      * Display the latest artifacts in main project page instead of the latest successful artifacts.
      * Useful for test automation jobs where you are interested in the artifacts of an unsuccessful build.
+     * @since 2.376
      */
     @NonNull
     private Boolean displayLatestArtifacts = false;

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -119,6 +119,13 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     @NonNull
     private Boolean followSymlinks = true;
 
+    /**
+     * Display the latest artifacts in main project page instead of the latest successful artifacts.
+     * Useful for test automation jobs where you are interested in the artifacts of an unsuccessful build.
+     */
+    @NonNull
+    private Boolean displayLatestArtifacts = false;
+
     @DataBoundConstructor public ArtifactArchiver(String artifacts) {
         this.artifacts = artifacts.trim();
         allowEmptyArchive = false;
@@ -164,6 +171,9 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
         }
         if (followSymlinks == null) {
             followSymlinks = true;
+        }
+        if (displayLatestArtifacts == null) {
+            displayLatestArtifacts = false;
         }
         return this;
     }
@@ -232,6 +242,16 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
 
     @DataBoundSetter public final void setFollowSymlinks(boolean followSymlinks) {
         this.followSymlinks = followSymlinks;
+    }
+
+    @NonNull
+    public boolean isDisplayLatestArtifacts() {
+        return displayLatestArtifacts;
+    }
+
+    @DataBoundSetter
+    public void setDisplayLatestArtifacts(boolean displayLatestArtifacts) {
+        this.displayLatestArtifacts = displayLatestArtifacts;
     }
 
     @Override

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -120,12 +120,12 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     private Boolean followSymlinks = true;
 
     /**
-     * Display the latest artifacts in main project page instead of the latest successful artifacts.
+     * Indicate whether the last artifacts in main project page should be shown instead of last successful artifacts.
      * Useful for test automation jobs where you are interested in the artifacts of an unsuccessful build.
      * @since 2.376
      */
     @NonNull
-    private Boolean displayLatestArtifacts = false;
+    private Boolean displayLastArtifacts = false;
 
     @DataBoundConstructor public ArtifactArchiver(String artifacts) {
         this.artifacts = artifacts.trim();
@@ -173,8 +173,8 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
         if (followSymlinks == null) {
             followSymlinks = true;
         }
-        if (displayLatestArtifacts == null) {
-            displayLatestArtifacts = false;
+        if (displayLastArtifacts == null) {
+            displayLastArtifacts = false;
         }
         return this;
     }
@@ -246,13 +246,13 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     }
 
     @NonNull
-    public boolean isDisplayLatestArtifacts() {
-        return displayLatestArtifacts;
+    public boolean isDisplayLastArtifacts() {
+        return displayLastArtifacts;
     }
 
     @DataBoundSetter
-    public void setDisplayLatestArtifacts(boolean displayLatestArtifacts) {
-        this.displayLatestArtifacts = displayLatestArtifacts;
+    public void setDisplayLastArtifacts(boolean displayLastArtifacts) {
+        this.displayLastArtifacts = displayLastArtifacts;
     }
 
     @Override

--- a/core/src/main/resources/hudson/model/AbstractProject/main.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/main.jelly
@@ -38,13 +38,13 @@ THE SOFTWARE.
       </t:summary>
     </j:forEach>
 
-    <j:if test="${!it.displayLatestArtifacts()}">
+    <j:if test="${!it.displayLastArtifacts()}">
       <t:artifactList caption="${%Last Successful Artifacts}"
         build="${it.lastSuccessfulBuild}" baseURL="lastSuccessfulBuild/"
         permission="${it.lastSuccessfulBuild.ARTIFACTS}"/>
     </j:if>
 
-    <j:if test="${it.displayLatestArtifacts()}">
+    <j:if test="${it.displayLastArtifacts()}">
       <t:artifactList caption="${%Last Artifacts}"
         build="${it.lastCompletedBuild}" baseURL="lastCompletedBuild/"
         permission="${it.lastCompletedBuild.ARTIFACTS}"/>

--- a/core/src/main/resources/hudson/model/AbstractProject/main.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/main.jelly
@@ -38,9 +38,17 @@ THE SOFTWARE.
       </t:summary>
     </j:forEach>
 
-    <t:artifactList caption="${%Last Successful Artifacts}"
+    <j:if test="${!it.displayLatestArtifacts()}">
+      <t:artifactList caption="${%Last Successful Artifacts}"
         build="${it.lastSuccessfulBuild}" baseURL="lastSuccessfulBuild/"
         permission="${it.lastSuccessfulBuild.ARTIFACTS}"/>
+    </j:if>
+
+    <j:if test="${it.displayLatestArtifacts()}">
+      <t:artifactList caption="${%Last Artifacts}"
+        build="${it.lastCompletedBuild}" baseURL="lastCompletedBuild/"
+        permission="${it.lastCompletedBuild.ARTIFACTS}"/>
+    </j:if>
   </table>
 
   <!-- merge fragments from the actions -->

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
@@ -49,8 +49,8 @@ THE SOFTWARE.
     <f:entry field="followSymlinks" >
       <f:checkbox title="${%followSymlinks}" default="false"/>
     </f:entry>
-    <f:entry field="displayLatestArtifacts" >
-      <f:checkbox title="${%displayLatestArtifacts}" default="false"/>
+    <f:entry field="displayLastArtifacts" >
+      <f:checkbox title="${%displayLastArtifacts}" default="false"/>
     </f:entry>
   </f:advanced>
 </j:jelly>

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
@@ -49,6 +49,9 @@ THE SOFTWARE.
     <f:entry field="followSymlinks" >
       <f:checkbox title="${%followSymlinks}" default="false"/>
     </f:entry>
+    <f:entry field="displayLatestArtifacts" >
+      <f:checkbox title="${%displayLatestArtifacts}" default="false"/>
+    </f:entry>
   </f:advanced>
 </j:jelly>
 

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.properties
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.properties
@@ -25,4 +25,4 @@ onlyIfSuccessful=Archive artifacts only if build is successful
 defaultExcludes=Use default excludes
 caseSensitive=Treat include and exclude patterns as case sensitive
 followSymlinks=Follow symbolic links
-
+displayLatestArtifacts=Display the latest artifacts instead of the latest successful artifacts

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.properties
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.properties
@@ -25,4 +25,4 @@ onlyIfSuccessful=Archive artifacts only if build is successful
 defaultExcludes=Use default excludes
 caseSensitive=Treat include and exclude patterns as case sensitive
 followSymlinks=Follow symbolic links
-displayLatestArtifacts=Display the latest artifacts instead of the latest successful artifacts
+displayLastArtifacts=Display last artifacts instead of last successful artifacts

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -209,7 +209,7 @@ public class ArtifactArchiverTest {
     }
 
     @Test
-    public void displaysTheLatestArtifacts() throws Exception {
+    public void displaysTheLastArtifacts() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildersList().add(new TestBuilder() {
             @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
@@ -224,14 +224,14 @@ public class ArtifactArchiverTest {
             }
         });
         ArtifactArchiver aa = new ArtifactArchiver("testdir/fizz");
-        aa.setDisplayLatestArtifacts(true);
+        aa.setDisplayLastArtifacts(true);
         p.getPublishersList().add(aa);
         FreeStyleBuild b = j.buildAndAssertStatus(Result.FAILURE, p);
 
         try (JenkinsRule.WebClient webClient = j.createWebClient()) {
             HtmlPage mainProjectPage = webClient.goTo("job/" + p.getName());
             String textContent = mainProjectPage.getVisibleText();
-            assertThat("Main project page displays the latest artifacts", textContent.contains("Last Artifacts"));
+            assertThat("Main project page displays the last artifacts", textContent.contains("Last Artifacts"));
             assertThat("fizz is in the main artifacts list, even though the job failed, because the last artifact should be shown if the build fails", textContent.contains("fizz"));
         }
     }


### PR DESCRIPTION
This pull request add functionality for displaying the last artifacts in a Jenkins project page instead of the last successful artifacts. This is for example useful for test automation jobs with a video recording attached.
For test jobs the last successful artifact is confusing as you expect to see the test output from the last build.

### Testing done
Manually tested it by having the boolean flag on and off and switching between. Also did a job run without an ArtifactArchiver attached. I also created a integration test (only flow with displayLastArtifacts enabled because there are a lot of existing tests that rely on lastSuccesfulArtifacts) 

**Before screenshots:**
![image](https://user-images.githubusercontent.com/15960623/199085624-079cd088-f719-482d-abe8-51bab4db7d83.png)
![image](https://user-images.githubusercontent.com/15960623/199085828-1af2529e-ff45-4c21-8d21-7bb0606e2e3f.png)


**After screenshots:**
![image](https://user-images.githubusercontent.com/15960623/199085251-bba24aa7-1a87-4c12-90e4-ece68cf0f43d.png)
![image](https://user-images.githubusercontent.com/15960623/199085345-c5647dfa-61b7-4f64-8b82-d09ce4ffe9a8.png)

### Proposed changelog entries

- Add option for displaying last job artifacts instead of last succesful job artifacts in main job page

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7323"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

