### PR TITLE
Clean up usages of `Callable#getChannelOrFail` and `Callable#getOpenChannelOrFail`

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -48,7 +48,6 @@ import hudson.model.TaskListener;
 import hudson.model.User;
 import hudson.remoting.Channel;
 import hudson.remoting.ChannelBuilder;
-import hudson.remoting.ChannelClosedException;
 import hudson.remoting.CommandTransport;
 import hudson.remoting.Engine;
 import hudson.remoting.Launcher;
@@ -90,6 +89,7 @@ import jenkins.slaves.RemotingVersionInfo;
 import jenkins.slaves.systemInfo.SlaveSystemInfo;
 import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
+import org.jenkinsci.remoting.ChannelStateException;
 import org.jenkinsci.remoting.util.LoggingChannelListener;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -1113,7 +1113,7 @@ public class SlaveComputer extends Computer {
 
             try {
                 getChannelOrFail().setProperty("agent", Boolean.TRUE); // indicate that this side of the channel is the agent side.
-            } catch (ChannelClosedException e) {
+            } catch (ChannelStateException e) {
                 throw new IllegalStateException(e);
             }
 

--- a/core/src/main/java/jenkins/security/MasterToSlaveCallable.java
+++ b/core/src/main/java/jenkins/security/MasterToSlaveCallable.java
@@ -1,8 +1,6 @@
 package jenkins.security;
 
 import hudson.remoting.Callable;
-import hudson.remoting.Channel;
-import hudson.remoting.ChannelClosedException;
 import jenkins.slaves.RemotingVersionInfo;
 import org.jenkinsci.remoting.RoleChecker;
 
@@ -23,25 +21,5 @@ public abstract class MasterToSlaveCallable<V, T extends Throwable> implements C
     @Override
     public void checkRoles(RoleChecker checker) throws SecurityException {
         checker.check(this, Roles.SLAVE);
-    }
-
-    //TODO: remove once Minimum supported Remoting version is 3.15 or above
-    @Override
-    public Channel getChannelOrFail() throws ChannelClosedException {
-        final Channel ch = Channel.current();
-        if (ch == null) {
-            throw new ChannelClosedException((Channel) null, new IllegalStateException("No channel associated with the thread"));
-        }
-        return ch;
-    }
-
-    //TODO: remove Callable#getOpenChannelOrFail() once minimum supported Remoting version is 3.15 or above
-    @Override
-    public Channel getOpenChannelOrFail() throws ChannelClosedException {
-        final Channel ch = getChannelOrFail();
-        if (ch.isClosingOrClosed()) { // TODO: Since Remoting 2.33, we still need to explicitly declare minimum Remoting version
-            throw new ChannelClosedException(ch, new IllegalStateException("The associated channel " + ch + " is closing down or has closed down", ch.getCloseRequestCause()));
-        }
-        return ch;
     }
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -252,7 +252,7 @@ THE SOFTWARE.
                   <version>${remoting.minimum.supported.version}</version>
                   <type>jar</type>
                   <outputDirectory>${project.build.outputDirectory}/old-remoting</outputDirectory>
-                  <destFileName>remoting-minimal-supported.jar</destFileName>
+                  <destFileName>remoting-minimum-supported.jar</destFileName>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci.main</groupId>

--- a/test/src/test/java/jenkins/slaves/OldRemotingAgentTest.java
+++ b/test/src/test/java/jenkins/slaves/OldRemotingAgentTest.java
@@ -83,16 +83,16 @@ public class OldRemotingAgentTest {
     @Before
     public void extractAgent() throws Exception {
         agentJar = new File(tmpDir.getRoot(), "old-agent.jar");
-        FileUtils.copyURLToFile(OldRemotingAgentTest.class.getResource("/old-remoting/remoting-minimal-supported.jar"), agentJar);
+        FileUtils.copyURLToFile(OldRemotingAgentTest.class.getResource("/old-remoting/remoting-minimum-supported.jar"), agentJar);
     }
 
     @Test
     @Issue("JENKINS-48761")
-    public void shouldBeAbleToConnectAgentWithMinimalSupportedVersion() throws Exception {
+    public void shouldBeAbleToConnectAgentWithMinimumSupportedVersion() throws Exception {
         Label agentLabel = new LabelAtom("old-agent");
         Slave agent = j.createOnlineSlave(agentLabel);
         boolean isUnix = agent.getComputer().isUnix();
-        assertThat("Received wrong agent version. A minimal supported version is expected",
+        assertThat("Received wrong agent version. A minimum supported version is expected",
                 agent.getComputer().getSlaveVersion(),
                 equalTo(RemotingVersionInfo.getMinimumSupportedVersion().toString()));
 


### PR DESCRIPTION
The overrides of `Callable#getChannelOrFail` and `Callable#getOpenChannelOrFail` in `MasterToSlaveCallable` added in #3212 seem to have been added as a temporary workaround pending the minimum Remoting version being increased to 3.15 or later. That took place in #6671, so this long-standing TODO can now be completed.

### Testing done

Ran `mvn clean verify -Dtest=hudson.model.SlaveTest,hudson.slaves.JNLPLauncherRealTest,jenkins.security.Security218Test,jenkins.slaves.OldRemotingAgentTest,jenkins.slaves.RemotingVersionInfoTest,jenkins.slaves.restarter.JnlpSlaveRestarterInstallerTest,jenkins.slaves.UnsupportedRemotingAgentEscapeHatchTest,jenkins.slaves.UnsupportedRemotingAgentTest` locally.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7328"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

