### PR TITLE
Fix nested link Javadoc warning

### DIFF
--- a/core/src/main/java/hudson/model/Actionable.java
+++ b/core/src/main/java/hudson/model/Actionable.java
@@ -164,11 +164,13 @@ public abstract class Actionable extends AbstractModelObject implements ModelObj
      * though technically consistent from the concurrency contract of {@link CopyOnWriteArrayList} (we would need
      * some form of transactions or a different backing type).
      *
+     * <p>See also {@link #addOrReplaceAction(Action)} if you want to know whether the backing
+     * {@link #actions} was modified, for example in cases where the caller would need to persist
+     * the {@link Actionable} in order to persist the change and there is a desire to elide
+     * unnecessary persistence of unmodified objects.
+     *
      * @param a an action to add/replace
      * @since 1.548
-     * @see #addOrReplaceAction(Action) if you want to know whether the backing {@link #actions} was modified, for
-     * example in cases where the caller would need to persist the {@link Actionable} in order to persist the change
-     * and there is a desire to elide unnecessary persistence of unmodified objects.
      */
     public void replaceAction(@NonNull Action a) {
         addOrReplaceAction(a);


### PR DESCRIPTION
Fixes the following Javadoc warning I noticed when running Javadoc on Java 19:

```
[WARNING] Javadoc Warnings
[WARNING] /home/basil/src/jenkinsci/jenkins/core/src/main/java/hudson/model/Actionable.java:169: warning: Tag {@link}: nested link
[WARNING] * @see #addOrReplaceAction(Action) if you want to know whether the backing {@link #actions} was modified, for
[WARNING] ^
[WARNING] /home/basil/src/jenkinsci/jenkins/core/src/main/java/hudson/model/Actionable.java:170: warning: Tag {@link}: nested link
[WARNING] * example in cases where the caller would need to persist the {@link Actionable} in order to persist the change
[WARNING] ^
[WARNING] 2 warnings
```

### Testing done

I re-ran the same command with these changes and the warning no longer appears.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7329"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

