### PR TITLE
Increase minimum required Remoting version from 4.2.1 to 4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@ THE SOFTWARE.
     <!-- Bundled Remoting version -->
     <remoting.version>3071.v7e9b_0dc08466</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
-    <remoting.minimum.supported.version>4.2.1</remoting.minimum.supported.version>
+    <remoting.minimum.supported.version>4.7</remoting.minimum.supported.version>
 
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -256,7 +256,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.main</groupId>
                   <artifactId>remoting</artifactId>
-                  <version>4.2</version>
+                  <version>4.6</version>
                   <type>jar</type>
                   <outputDirectory>${project.build.outputDirectory}/old-remoting</outputDirectory>
                   <destFileName>remoting-unsupported.jar</destFileName>


### PR DESCRIPTION
The current minimum Remoting version (4.2.1) is now 2 years and 7 months old. This PR bumps the minimum Remoting version to 4.7, which is 1 year and 8 months old, effectively raising the minimum Remoting version by 1 year. I still think that 1 year and 8 months is a generous amount of time for people to upgrade agents, and it benefits the ecosystem to have agents running on a recent version of Remoting with bug fixes and dependency updates. We have had no issues previously raising the minimum Remoting version to 4.2.1 a few months ago in #6671. By the time this change makes it out to LTS it will likely be 2023, giving people more than enough time to upgrade.

### Testing done

This use case is covered by test automation; specifically, `jenkins.slaves.OldRemotingAgentTest`, `jenkins.slaves.UnsupportedRemotingAgentEscapeHatchTest` and `jenkins.slaves.UnsupportedRemotingAgentTest`. I ran all of these tests (and more) locally with:

> `mvn clean verify -Dtest=hudson.slaves.ChannelPingerTest,hudson.slaves.JNLPLauncherTest,hudson.slaves.PingThreadTest,hudson.slaves.SlaveComputerTest,jenkins.agents.WebSocketAgentsTest,jenkins.security.AgentToControllerSecurityTest,jenkins.security.CustomClassFilterTest,jenkins.slaves.OldRemotingAgentTest,jenkins.slaves.RemotingVersionInfoTest,jenkins.slaves.UnsupportedRemotingAgentEscapeHatchTest,jenkins.slaves.UnsupportedRemotingAgentTest`

### Proposed changelog entries

The minimum required Remoting version has been increased to 4.7 (released on February 16, 2021).

### Proposed upgrade guidelines

The minimum required Remoting version has been increased to 4.7 (released on February 16, 2021). When an agent with a Remoting version older than 4.7 connects to the Jenkins controller, the agent connection is rejected. Ensure that all agents are running a recent version of Remoting prior to upgrading. Agents with unsupported Remoting versions can be allowed to connect to the controller by setting the `hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions` system property to true.

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7340"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

