### PR TITLE
[JENKINS-70044] Add telemetry for activation of optional permissions

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/OptionalPermissions.java
+++ b/core/src/main/java/jenkins/telemetry/impl/OptionalPermissions.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2022, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.telemetry.impl;
+
+import hudson.Extension;
+import hudson.model.Computer;
+import hudson.model.Item;
+import hudson.model.Run;
+import hudson.security.Permission;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import jenkins.model.Jenkins;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Telemetry implementation that gathers information about optional permissions.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class OptionalPermissions extends Telemetry {
+    private static final Set<String> OPTIONAL_PERMISSION_IDS = Set.of(
+            // Defined in core
+            Computer.EXTENDED_READ.getId(),
+            Item.EXTENDED_READ.getId(),
+            Item.WIPEOUT.getId(),
+            Jenkins.MANAGE.getId(),
+            Jenkins.SYSTEM_READ.getId(),
+            Run.ARTIFACTS.getId(),
+            // Defined in credentials
+            "com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn",
+            "com.cloudbees.plugins.credentials.CredentialsProvider.UseItem");
+
+    @Override
+    public String getDisplayName() {
+        return "Activation of permissions that are not enabled by default";
+    }
+
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2022, 11, 1);
+    }
+
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2023, 3, 1);
+    }
+
+    @Override
+    public JSONObject createContent() {
+        Map<String, Boolean> permissions = new TreeMap<>();
+        for (Permission p : Permission.getAll()) {
+            if (OPTIONAL_PERMISSION_IDS.contains(p.getId())) {
+                permissions.put(p.getId(), p.getEnabled());
+            }
+        }
+        JSONObject payload = new JSONObject();
+        payload.put("components", buildComponentInformation());
+        payload.put("permissions", permissions);
+        return payload;
+    }
+
+}

--- a/core/src/main/resources/jenkins/telemetry/impl/OptionalPermissions/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/OptionalPermissions/description.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     Some permissions in Jenkins core and plugins are disabled by default and must be activated by setting a system property or installing a special plugin.
-    This trial collects information about these properties to understand how frequently they are activated.
+    This trial collects which of these permissions are enabled and disabled, as well as the list of installed plugins.
     This data will be used to understand whether these permissions are activated frequently enough to justify their maintenance cost, and to see if any of the permissions are popular enough to consider enabling them by default.
 </j:jelly>

--- a/core/src/main/resources/jenkins/telemetry/impl/OptionalPermissions/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/OptionalPermissions/description.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    Some permissions in Jenkins core and plugins are disabled by default and must be activated by setting a system property or installing a special plugin.
+    This trial collects information about these properties to understand how frequently they are activated.
+    This data will be used to understand whether these permissions are activated frequently enough to justify their maintenance cost, and to see if any of the permissions are popular enough to consider enabling them by default.
+</j:jelly>


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-70044](https://issues.jenkins.io/browse/JENKINS-70044).

Note that we would like to backport this change to the LTS. https://www.jenkins.io/download/lts/#backporting-process does not list telemetry explicitly, but otherwise we will have to set activation dates far into the future and then wait for this to be picked up by the next LTS baseline. I recall @daniel-beck mentioning that new telemetry collectors have been backported in the past, but I could not find any discussion of this from a very quick search on the developer mailing list.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

I tested this PR by replacing [`Telemetry.ENDPOINT`](https://github.com/jenkinsci/jenkins/blob/5bf632f261bacb214b2ba499890c5ba3ffea2189/core/src/main/java/jenkins/telemetry/Telemetry.java#L75) with a link to https://webhook.site, then I called `ExtensionList.lookupSingleton(jenkins.telemetry.impl.OptionalPermissions.class).run()` from the Jenkins script console and verified that the request showed up with the expected content. I then installed `credentials` and `manage-permission` from the Plugin Manager, reran the script, and verified that the credentials-related permissions were included in the payload and that `hudson.model.Hudson.Manage` was now marked as being enabled.

<details>
<summary>Sample payload</summary>

```
{
    "components": {
        "bouncycastle-api": "2.26",
        "credentials": "1189.vf61b_a_5e2f62e",
        "instance-identity": "116.vf8f487400980",
        "javax-activation-api": "1.2.0-5",
        "javax-mail-api": "1.6.2-8",
        "jenkins-core": "2.378-SNAPSHOT",
        "manage-permission": "1.0.1",
        "mina-sshd-api-common": "2.9.1-44.v476733c11f82",
        "mina-sshd-api-core": "2.9.1-44.v476733c11f82",
        "sshd": "3.249.v2dc2ea_416e33",
        "structs": "324.va_f5d6774f3a_d"
    },
    "permissions": {
        "com.cloudbees.plugins.credentials.CredentialsProvider.UseItem": false,
        "com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn": false,
        "hudson.model.Computer.ExtendedRead": false,
        "hudson.model.Hudson.Manage": true,
        "hudson.model.Hudson.SystemRead": false,
        "hudson.model.Item.ExtendedRead": false,
        "hudson.model.Item.WipeOut": false,
        "hudson.model.Run.Artifacts": false
    }
}
```
</details>

I did not add any automated tests. [`TelemetryTest`](https://github.com/jenkinsci/jenkins/blob/5bf632f261bacb214b2ba499890c5ba3ffea2189/test/src/test/java/jenkins/telemetry/TelemetryTest.java) already covers the overall behavior of the `Telemetry` extension point. I can add a test that checks the output of `OptionalPermissions.createContent` if reviewers think that would be useful.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Add telemetry for activation of permissions that are not enabled by default.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

