### PR TITLE
De-flake `QueueTest#testGetCauseOfBlockageForNonConcurrentFreestyle`

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -1093,7 +1093,7 @@ public class QueueTest {
         t1.getBuildersList().add(new SleepBuilder(TimeUnit.SECONDS.toMillis(30)));
         t1.setConcurrentBuild(false);
 
-        t1.scheduleBuild2(0).waitForStart();
+        FreeStyleBuild build = t1.scheduleBuild2(0).waitForStart();
         t1.scheduleBuild2(0);
 
         queue.maintain();
@@ -1103,6 +1103,8 @@ public class QueueTest {
         CauseOfBlockage expected = new BlockedBecauseOfBuildInProgress(t1.getFirstBuild());
 
         assertEquals(expected.getShortDescription(), actual.getShortDescription());
+        Queue.getInstance().doCancelItem(r.jenkins.getQueue().getBlockedItems().get(0).getId());
+        r.assertBuildStatusSuccess(r.waitForCompletion(build));
     }
 
     @Test @LocalData


### PR DESCRIPTION
### Problem

Observed in [this test run](https://ci.jenkins.io/job/Core/job/jenkins/job/master/4330/testReport/junit/hudson.model/QueueTest/Windows_jdk11___Windows_Build___Test___testGetCauseOfBlockageForNonConcurrentFreestyle/), `QueueTest.testGetCauseOfBlockageForNonConcurrentFreestyle` flaked with

```
jenkins.util.io.CompositeIOException: Unable to delete 'C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts.
	at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:96)
	at hudson.Util.deleteRecursive(Util.java:320)
	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1436)
	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1431)
	at hudson.FilePath.act(FilePath.java:1192)
	at hudson.FilePath.act(FilePath.java:1175)
	at hudson.FilePath.deleteRecursive(FilePath.java:1428)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.dispose(TemporaryDirectoryAllocator.java:92)
	at org.jvnet.hudson.test.TestEnvironment.dispose(TestEnvironment.java:84)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:535)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:636)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:829)
	Suppressed: jenkins.util.io.CompositeIOException: Unable to remove directory C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds\1 with directory contents: [C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds\1\atomic394068390572034658tmp]
		at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:249)
		at jenkins.util.io.PathRemover.tryRemoveFile(PathRemover.java:202)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:213)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:93)
		... 14 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds\1
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:236)
			... 25 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds\1
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:240)
			... 25 more
	Suppressed: jenkins.util.io.CompositeIOException: Unable to remove directory C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds with directory contents: [C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds\1]
		at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:249)
		at jenkins.util.io.PathRemover.tryRemoveFile(PathRemover.java:202)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:213)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:93)
		... 14 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:236)
			... 23 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:240)
			... 23 more
	Suppressed: jenkins.util.io.CompositeIOException: Unable to remove directory C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project with directory contents: [C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project\builds]
		at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:249)
		at jenkins.util.io.PathRemover.tryRemoveFile(PathRemover.java:202)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:213)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:93)
		... 14 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:236)
			... 21 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:240)
			... 21 more
	Suppressed: jenkins.util.io.CompositeIOException: Unable to remove directory C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs with directory contents: [C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs\project]
		at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:249)
		at jenkins.util.io.PathRemover.tryRemoveFile(PathRemover.java:202)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:213)
		at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:224)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
		at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:93)
		... 14 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:236)
			... 19 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:240)
			... 19 more
	Suppressed: jenkins.util.io.CompositeIOException: Unable to remove directory C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274 with directory contents: [C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274\jobs]
		at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:249)
		at jenkins.util.io.PathRemover.tryRemoveFile(PathRemover.java:202)
		at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:213)
		at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:93)
		... 14 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:236)
			... 17 more
		Suppressed: java.nio.file.DirectoryNotEmptyException: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h13551618964819980274
			at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:271)
			at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
			at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
			at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:240)
			... 17 more
```

### Evaluation

We start a build but do not wait for it to complete, which means that on Windows the file descriptors are still open when we start to tear down the test, so the test teardown cannot clear the Jenkins home directory.

### Solution

Wait for the build to complete.

### Testing done

Ran `mvn clean verify -Dtest=hudson.model.QueueTest#testGetCauseOfBlockageForNonConcurrentFreestyle` locally.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7354"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

