### PR TITLE
Backporting for LTS 2.375.1

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/OptionalPermissions.java
+++ b/core/src/main/java/jenkins/telemetry/impl/OptionalPermissions.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2022, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.telemetry.impl;
+
+import hudson.Extension;
+import hudson.model.Computer;
+import hudson.model.Item;
+import hudson.model.Run;
+import hudson.security.Permission;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import jenkins.model.Jenkins;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Telemetry implementation that gathers information about optional permissions.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class OptionalPermissions extends Telemetry {
+    private static final Set<String> OPTIONAL_PERMISSION_IDS = Set.of(
+            // Defined in core
+            Computer.EXTENDED_READ.getId(),
+            Item.EXTENDED_READ.getId(),
+            Item.WIPEOUT.getId(),
+            Jenkins.MANAGE.getId(),
+            Jenkins.SYSTEM_READ.getId(),
+            Run.ARTIFACTS.getId(),
+            // Defined in credentials
+            "com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn",
+            "com.cloudbees.plugins.credentials.CredentialsProvider.UseItem");
+
+    @Override
+    public String getDisplayName() {
+        return "Activation of permissions that are not enabled by default";
+    }
+
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2022, 11, 1);
+    }
+
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2023, 3, 1);
+    }
+
+    @Override
+    public JSONObject createContent() {
+        Map<String, Boolean> permissions = new TreeMap<>();
+        for (Permission p : Permission.getAll()) {
+            if (OPTIONAL_PERMISSION_IDS.contains(p.getId())) {
+                permissions.put(p.getId(), p.getEnabled());
+            }
+        }
+        JSONObject payload = new JSONObject();
+        payload.put("components", buildComponentInformation());
+        payload.put("permissions", permissions);
+        return payload;
+    }
+
+}

--- a/core/src/main/resources/hudson/model/User/index.jelly
+++ b/core/src/main/resources/hudson/model/User/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:main-panel>
       <h1>
         <span class="icon-lg">
-          <l:icon src="${h.getUserAvatar(user,'48x48')}" />
+          <l:icon src="${h.getUserAvatar(it, '48x48')}" />
         </span>
         ${it.fullName}
       </h1>

--- a/core/src/main/resources/jenkins/telemetry/impl/OptionalPermissions/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/OptionalPermissions/description.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    Some permissions in Jenkins core and plugins are disabled by default and must be activated by setting a system property or installing a special plugin.
+    This trial collects which of these permissions are enabled and disabled, as well as the list of installed plugins.
+    This data will be used to understand whether these permissions are activated frequently enough to justify their maintenance cost, and to see if any of the permissions are popular enough to consider enabling them by default.
+</j:jelly>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3068.v09b_895d8da_14</remoting.version>
+    <remoting.version>3071.v7e9b_0dc08466</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.2.1</remoting.minimum.supported.version>
 


### PR DESCRIPTION
```
Latest core version: jenkins-2.377

Fixed
-----

JENKINS-69890           Major                   2.376
        Websocket Agent disconnection: possible deadlock at agent side
        https://issues.jenkins.io/browse/JENKINS-69890

JENKINS-70023           Major                   2.378
        NullPointerException in hudson.Functions.getUserAvatar (regression in 2.335)
        regression
        https://issues.jenkins.io/browse/JENKINS-70023

JENKINS-70044           Minor                   2.378
        Gather telemetry about usage of optional permissions
        https://issues.jenkins.io/browse/JENKINS-70044           
```

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7358"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

