### PR TITLE
Label destructive 'Dismiss' buttons red

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <div class="alert alert-warning">
   <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
     <f:submit name="yes" value="${%Tell me more}"/>
-    <f:submit name="no" value="${%Dismiss}"/>
+    <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
   </form>
   ${%blurb(app.rootDir)}
 </div>

--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="alert alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
     </form>
     ${%You have data stored in an older format and/or unreadable data.}
   </div>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
       <l:isAdmin>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
       </l:isAdmin>
     </form>
     <div>${%blurb}</div>

--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
         <f:submit name="yes" value="${%Create a view now}"/>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
       </form>
     </l:isAdmin>
     ${%blurb}

--- a/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
+++ b/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="alert alert-warning">
     <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:submit value="${%Dismiss}"/>
+      <f:submit primary="false" clazz="jenkins-!-destructive-color" value="${%Dismiss}"/>
     </form>
     ${%blurb(rootURL)}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="alert alert-warning">
      <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
      </form>
 
     ${%ExecutorsWarning}

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="agent" value="${%Set up agent}"/>
       <f:submit name="cloud" value="${%Set up cloud}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
     </form>
     ${%ExecutorsWarning}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <div class="alert alert-warning">
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/disable">
-        <f:submit value="${%Dismiss}"/>
+        <f:submit primary="false" clazz="jenkins-!-destructive-color" value="${%Dismiss}"/>
       </form>
     </l:isAdmin>
     <j:set var="actionAnchor">

--- a/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="alert alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Setup Security}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
     </form>
     ${%blurb}
   </div>

--- a/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
+++ b/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
@@ -3,7 +3,7 @@
     <div class="alert alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Apply Migration}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/message.groovy
@@ -54,5 +54,5 @@ form(method: "post", action: "${rootURL}/${my.url}/scan", name:"rekey") {
     } else {
         f.submit(name: "schedule", value:_("Schedule a re-key during the next startup"))
     }
-    f.submit(name: "dismiss", value:_("Dismiss"))
+    f.submit(name: "dismiss", value:_("Dismiss"), primary: "false", clazz: "jenkins-!-destructive-color")
 }

--- a/core/src/main/resources/jenkins/security/ResourceDomainRecommendation/message.groovy
+++ b/core/src/main/resources/jenkins/security/ResourceDomainRecommendation/message.groovy
@@ -32,7 +32,7 @@ dl {
         l.isAdmin() {
           form(method: "post", action: "${rootURL}/${my.url}/act") {
               f.submit(name: 'redirect', value: _("Configure resource root URL"))
-              f.submit(name: 'dismiss', value: _("Dismiss"))
+              f.submit(name: 'dismiss', value: _("Dismiss"), primary: "false", clazz: "jenkins-!-destructive-color")
             }
         }
 

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
     <div class="alert alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Disable automatic generation of legacy API tokens}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
         </form>
         ${%warningMessage}
     </div>

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
     <div class="alert alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Prevent users from manually creating legacy API tokens}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
         </form>
         ${%warningMessage}
     </div>

--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <div class="alert alert-warning">
         <form method="post" action="${rootURL}/${it.url}/disable">
-            <f:submit value="${%Dismiss}"/>
+            <f:submit primary="false" clazz="jenkins-!-destructive-color" value="${%Dismiss}"/>
         </form>
         <j:set var="referenceAnchor">
             <a href="https://www.jenkins.io/redirect/csrf-protection" rel="noopener noreferrer" target="_blank">${%referenceUrlContent}</a>


### PR DESCRIPTION
This PR intends to distinguish better between primary buttons' with positive and negative operations. Dismissing warnings silences them forever. Making the button red draws more attention to it, like buttons used in other views themed red for irreversible actions.
Additionally, this gets a rid of multiple primary buttons with different, non-primary, tasks for the same notification window.

### Testing done

**Before**:
![Screenshot 2022-11-11 at 23 17 30](https://user-images.githubusercontent.com/13383509/201438493-a22450fe-7ea0-4ca4-a60e-1d4d7c5704ef.png)

**After**:
![Screenshot 2022-11-12 at 10 44 29](https://user-images.githubusercontent.com/13383509/201468480-17a1136b-15ee-470b-9610-11a40c19f943.png)

### Proposed changelog entries

- Label 'Dismiss' buttons red.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7364"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

