### PR TITLE
Synchronize agent protocol access

### DIFF
--- a/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
+++ b/core/src/main/java/hudson/security/GlobalSecurityConfiguration.java
@@ -92,6 +92,7 @@ public class GlobalSecurityConfiguration extends ManagementLink implements Descr
         return Jenkins.get().isSlaveAgentPortEnforced();
     }
 
+    @NonNull
     public Set<String> getAgentProtocols() {
         return Jenkins.get().getAgentProtocols();
     }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -647,6 +647,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 2.16
      */
     @CheckForNull
+    @GuardedBy("this")
     private List<String> disabledAgentProtocols;
     /**
      * @deprecated Just a temporary buffer for XSTream migration code from JENKINS-39465, do not use
@@ -661,6 +662,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 2.16
      */
     @CheckForNull
+    @GuardedBy("this")
     private List<String> enabledAgentProtocols;
     /**
      * @deprecated Just a temporary buffer for XSTream migration code from JENKINS-39465, do not use
@@ -676,6 +678,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @see #setAgentProtocols(Set)
      * @see #getAgentProtocols()
      */
+    @GuardedBy("this")
     private transient Set<String> agentProtocols;
 
     /**
@@ -1063,16 +1066,18 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         if (SLAVE_AGENT_PORT_ENFORCE) {
             slaveAgentPort = getSlaveAgentPortInitialValue(slaveAgentPort);
         }
-        if (disabledAgentProtocols == null && _disabledAgentProtocols != null) {
-            disabledAgentProtocols = Arrays.asList(_disabledAgentProtocols);
-            _disabledAgentProtocols = null;
+        synchronized (this) {
+            if (disabledAgentProtocols == null && _disabledAgentProtocols != null) {
+                disabledAgentProtocols = Arrays.asList(_disabledAgentProtocols);
+                _disabledAgentProtocols = null;
+            }
+            if (enabledAgentProtocols == null && _enabledAgentProtocols != null) {
+                enabledAgentProtocols = Arrays.asList(_enabledAgentProtocols);
+                _enabledAgentProtocols = null;
+            }
+            // Invalidate the protocols cache after the reload
+            agentProtocols = null;
         }
-        if (enabledAgentProtocols == null && _enabledAgentProtocols != null) {
-            enabledAgentProtocols = Arrays.asList(_enabledAgentProtocols);
-            _enabledAgentProtocols = null;
-        }
-        // Invalidate the protocols cache after the reload
-        agentProtocols = null;
 
         // no longer persisted
         installStateName = null;
@@ -1244,9 +1249,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @return the enabled agent protocols.
      * @since 2.16
      */
-    public Set<String> getAgentProtocols() {
+    @NonNull
+    public synchronized Set<String> getAgentProtocols() {
         if (agentProtocols == null) {
-            // idempotent, so don't care if we do this concurrently, should all get same result
             Set<String> result = new TreeSet<>();
             Set<String> disabled = new TreeSet<>();
             for (String p : Util.fixNull(disabledAgentProtocols)) {
@@ -1275,7 +1280,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @param protocols the enabled agent protocols.
      * @since 2.16
      */
-    public void setAgentProtocols(Set<String> protocols) {
+    public synchronized void setAgentProtocols(@NonNull Set<String> protocols) {
         Set<String> disabled = new TreeSet<>();
         Set<String> enabled = new TreeSet<>();
         for (AgentProtocol p : AgentProtocol.all()) {


### PR DESCRIPTION
### Problem

In [this run](https://ci.jenkins.io/job/Core/job/jenkins/job/master/4355/testReport/junit/jenkins.security/Security218Test/Windows_jdk11___Windows_Build___Test___jnlpSlave/) `jenkins.security.Security218Test#jnlpSlave` flaked with:

```
org.junit.runners.model.TestTimedOutException: test timed out after 180 seconds
	at java.base@11.0.16.1/java.lang.Thread.sleep(Native Method)
	at app//org.jvnet.hudson.test.JenkinsRule.waitOnline(JenkinsRule.java:1201)
	at app//jenkins.security.Security218Test.jnlpSlave(Security218Test.java:51)
	at java.base@11.0.16.1/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@11.0.16.1/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base@11.0.16.1/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@11.0.16.1/java.lang.reflect.Method.invoke(Method.java:566)
	at app//org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at app//org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at app//org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at app//org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at app//org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at app//org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:618)
	at app//org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at app//org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base@11.0.16.1/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base@11.0.16.1/java.lang.Thread.run(Thread.java:829)
```

### Evaluation

Standard error contained:

```
   0.122 [id=101]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:52977/jenkins/
   0.188 [id=100]	WARNING	h.TcpSlaveAgentListener$ConnectionHandler#error: Connection #1 is aborted: Disabled protocol:Protocol:Ping
   0.253 [id=114]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.255 [id=113]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.273 [id=115]	INFO	j.b.api.BouncyCastlePlugin#start: C:\Jenkins\workspace\Core_jenkins_master\test\target\j h17792043900988697694\plugins\bouncycastle-api\WEB-INF\optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   2.238 [id=113]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   2.321 [id=115]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   2.347 [id=118]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   3.732 [id=119]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   3.734 [id=119]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   3.734 [id=119]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   3.736 [id=116]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   3.876 [id=114]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   4.082 [id=101]	FINE	jenkins.security.ClassFilterImpl#lambda$isLocationWhitelisted$2: file:/C:/Jenkins/workspace/Core_jenkins_master/core/target/jenkins-core-2.378-rc33093.6757d0414557.jar seems to be the location of Jenkins core, OK
   4.083 [id=101]	FINE	jenkins.security.ClassFilterImpl#lambda$isBlacklisted$1: permitting hudson.slaves.JNLPLauncher due to its location in file:/C:/Jenkins/workspace/Core_jenkins_master/core/target/jenkins-core-2.378-rc33093.6757d0414557.jar
   4.085 [id=101]	FINE	jenkins.security.ClassFilterImpl#lambda$isBlacklisted$1: permitting jenkins.slaves.RemotingWorkDirSettings due to its location in file:/C:/Jenkins/workspace/Core_jenkins_master/core/target/jenkins-core-2.378-rc33093.6757d0414557.jar
Running: [C:\openjdk-11\bin\java.exe, -Xmx512m, -XX:+PrintCommandLineFlags, -Djava.awt.headless=true, -jar, C:\Jenkins\workspace\Core_jenkins_master\test\target\j h17792043900988697694\agent.jar, -jnlpUrl, http://localhost:52977/jenkins/computer/agent0/slave-agent.jnlp, -secret, 7a54ff99d6128ab6210704b25b84199f092615d5d419c469ae944b54117af984, -workDir, C:\Jenkins\workspace\Core_jenkins_master\test\target\j h17792043900988697694\agent-work-dirs\agent0]
-XX:G1ConcRefinementThreads=4 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=134200512 -XX:MaxHeapSize=536870912 -XX:+PrintCommandLineFlags -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC -XX:-UseLargePagesIndividualAllocation 
Nov 14, 2022 2:23:50 PM org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
INFO: Using C:\Jenkins\workspace\Core_jenkins_master\test\target\j h17792043900988697694\agent-work-dirs\agent0\remoting as a remoting work directory
Nov 14, 2022 2:23:50 PM org.jenkinsci.remoting.engine.WorkDirManager setupLogging
INFO: Both error and output logs will be printed to C:\Jenkins\workspace\Core_jenkins_master\test\target\j h17792043900988697694\agent-work-dirs\agent0\remoting
Nov 14, 2022 2:24:03 PM hudson.remoting.jnlp.Main createEngine
INFO: Setting up agent: agent0
Nov 14, 2022 2:24:03 PM hudson.remoting.Engine startEngine
INFO: Using Remoting version: 3071.v7e9b_0dc08466
Nov 14, 2022 2:24:03 PM org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
INFO: Using C:\Jenkins\workspace\Core_jenkins_master\test\target\j h17792043900988697694\agent-work-dirs\agent0\remoting as a remoting work directory
Nov 14, 2022 2:24:03 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Locating server among [http://localhost:52977/jenkins/]
Nov 14, 2022 2:24:04 PM org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver resolve
WARNING: Received the empty list of supported protocols from the server. All protocols are disabled on the controller side OR the 'X-Jenkins-Agent-Protocols' header is corrupted (JENKINS-41730). In the case of the header corruption as a workaround you can use the 'org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.protocolNamesToTry' system property to define the supported protocols.
  19.057 [id=146]	INFO	h.TcpSlaveAgentListener$ConnectionHandler#run: Connection #2 from /127.0.0.1:52993 failed: null
Nov 14, 2022 2:24:04 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Agent discovery successful
  Agent address: localhost
  Agent port:    52983
  Identity:      53:bd:f4:bb:70:4e:dc:e7:94:3d:71:c1:24:32:a6:f1
Nov 14, 2022 2:24:04 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Handshaking
Nov 14, 2022 2:24:04 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Connecting to localhost:52983
Nov 14, 2022 2:24:04 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Trying protocol: JNLP4-connect
Nov 14, 2022 2:24:04 PM org.jenkinsci.remoting.protocol.impl.BIONetworkLayer$Reader run
INFO: Waiting for ProtocolStack to start.
  19.374 [id=147]	WARNING	h.TcpSlaveAgentListener$ConnectionHandler#error: Connection #3 is aborted: Disabled protocol:Protocol:JNLP4-connect
Nov 14, 2022 2:24:04 PM org.jenkinsci.remoting.protocol.impl.AckFilterLayer abort
WARNING: [JNLP4-connect connection to localhost/127.0.0.1:52983] Incorrect acknowledgement sequence, expected 0x000341434b got 0x4469736162
Nov 14, 2022 2:24:04 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Protocol JNLP4-connect encountered an unexpected exception
java.util.concurrent.ExecutionException: org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException: Connection closed before acknowledgement sent
	at org.jenkinsci.remoting.util.SettableFuture.get(SettableFuture.java:223)
	at hudson.remoting.Engine.innerRun(Engine.java:805)
	at hudson.remoting.Engine.run(Engine.java:543)
Caused by: org.jenkinsci.remoting.protocol.impl.ConnectionRefusalException: Connection closed before acknowledgement sent
	at org.jenkinsci.remoting.protocol.impl.AckFilterLayer.onRecvClosed(AckFilterLayer.java:280)
	at org.jenkinsci.remoting.protocol.FilterLayer.abort(FilterLayer.java:165)
	at org.jenkinsci.remoting.protocol.impl.AckFilterLayer.abort(AckFilterLayer.java:133)
	at org.jenkinsci.remoting.protocol.impl.AckFilterLayer.onRecv(AckFilterLayer.java:258)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecv(ProtocolStack.java:677)
	at org.jenkinsci.remoting.protocol.NetworkLayer.onRead(NetworkLayer.java:137)
	at org.jenkinsci.remoting.protocol.impl.BIONetworkLayer.access$1400(BIONetworkLayer.java:51)
	at org.jenkinsci.remoting.protocol.impl.BIONetworkLayer$Reader.run(BIONetworkLayer.java:293)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:125)
	at java.base/java.lang.Thread.run(Thread.java:829)
[…]
```

After reading the client-side code I determined there were no bugs there (though that code could be simplified as in https://github.com/jenkinsci/remoting/pull/601). However, the logs showed a very suspicious line "Received the empty list of supported protocols from the server" which could only be the case if the server both sent the `X-Jenkins-Agent-Protocols` header and set it to the empty string (i.e., `X-Jenkins-Agent-Protocols: `), something which should never happen. Reading the code that gets the value of this header I theorized that the above condition could be reproduced if `Jenkins#getAgentProtocols` returned the empty set. Sure enough, with

```java
diff --git a/core/src/main/java/jenkins/model/Jenkins.java b/core/src/main/java/jenkins/model/Jenkins.java
index d5c3d42655..5dddb0d224 100644
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1245,28 +1245,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 2.16
      */
     public Set<String> getAgentProtocols() {
-        if (agentProtocols == null) {
-            // idempotent, so don't care if we do this concurrently, should all get same result
-            Set<String> result = new TreeSet<>();
-            Set<String> disabled = new TreeSet<>();
-            for (String p : Util.fixNull(disabledAgentProtocols)) {
-                disabled.add(p.trim());
-            }
-            Set<String> enabled = new TreeSet<>();
-            for (String p : Util.fixNull(enabledAgentProtocols)) {
-                enabled.add(p.trim());
-            }
-            for (AgentProtocol p : AgentProtocol.all()) {
-                String name = p.getName();
-                if (name != null && (p.isRequired()
-                        || (!disabled.contains(name) && (!p.isOptIn() || enabled.contains(name))))) {
-                    result.add(name);
-                }
-            }
-            agentProtocols = result;
-            return result;
-        }
-        return agentProtocols;
+        return new HashSet<>();
     }
 
     /**
```

I was able to reproduce the problem. Examining the workings of `Jenkins#getAgentProtocols` I saw that it was subject to many race conditions. The comment "idempotent, so don't care if we do this concurrently, should all get same result" seemed to show that someone had at least thought about this problem before but had not attempted to solve it. There are three fields that affect this computation, and they may be mutated in several places (saving the Global Security Configuration, reloading config from disk, etc). In any case the solution is simple: to apply proper synchronization around any reads and writes of this trio of fields.

### Testing done

To ensure there were no regressions, I ran `mvn clean verify -Dtest=hudson.model.SlaveTest,hudson.slaves.JNLPLauncherRealTest,jenkins.AgentProtocolTest,jenkins.agents.WebSocketAgentsTest,jenkins.model.JenkinsTest,jenkins.security.Security218Test,jenkins.slaves.OldRemotingAgentTest,jenkins.slaves.RemotingVersionInfoTest,jenkins.slaves.restarter.JnlpSlaveRestarterInstallerTest,jenkins.slaves.UnsupportedRemotingAgentEscapeHatchTest,jenkins.slaves.UnsupportedRemotingAgentTest`.

### Proposed changelog entries

- Fix a race condition affecting the launch of inbound agents.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7378"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

