### PR TITLE
De-flake `CancelQuietDownCommandTest`

### DIFF
--- a/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
@@ -109,7 +109,7 @@ public class CancelQuietDownCommandTest {
     @Test
     public void cancelQuietDownShouldSuccessOnNoQuietDownedJenkinsAndRunningExecutor() throws Exception {
         final FreeStyleProject project = j.createFreeStyleProject("aProject");
-        final OneShotEvent finish = new OneShotEvent();
+        OneShotEvent finish = new OneShotEvent();
         Future<FreeStyleBuild> build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
@@ -124,6 +124,7 @@ public class CancelQuietDownCommandTest {
         assertThat(project.isBuilding(), equalTo(false));
         j.assertBuildStatusSuccess(build);
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
+        finish = new OneShotEvent();
         build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
         assertThat(project.isBuilding(), equalTo(true));
@@ -142,7 +143,7 @@ public class CancelQuietDownCommandTest {
     @Test
     public void cancelQuietDownShouldSuccessOnQuietDownedJenkinsAndRunningExecutor() throws Exception {
         final FreeStyleProject project = j.createFreeStyleProject("aProject");
-        final OneShotEvent finish = new OneShotEvent();
+        OneShotEvent finish = new OneShotEvent();
         Future<FreeStyleBuild> build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
         assertThat(project.isBuilding(), equalTo(true));
@@ -160,6 +161,7 @@ public class CancelQuietDownCommandTest {
         assertThat(project.isBuilding(), equalTo(false));
         j.assertBuildStatusSuccess(build);
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
+        finish = new OneShotEvent();
         build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
         assertThat(project.isBuilding(), equalTo(true));

--- a/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import hudson.Launcher;
@@ -309,6 +310,8 @@ public class OnlineNodeCommandTest {
      * @throws Exception if somethink wrong happened
      */
     public static Future<FreeStyleBuild> startBlockingAndFinishingBuild(FreeStyleProject project, OneShotEvent finish) throws Exception {
+        assertFalse(finish.isSignaled());
+
         final OneShotEvent block = new OneShotEvent();
 
         project.getBuildersList().add(new BlockingAndFinishingBuilder(block, finish));


### PR DESCRIPTION
### Problem

In [this run](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7375/3/testReport/junit/hudson.cli/CancelQuietDownCommandTest/Linux_jdk17___Linux_Build___Test___cancelQuietDownShouldSuccessOnNoQuietDownedJenkinsAndRunningExecutor/) and [this run](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7377/1/testReport/junit/hudson.cli/CancelQuietDownCommandTest/Linux_jdk17___Linux_Build___Test___cancelQuietDownShouldSuccessOnNoQuietDownedJenkinsAndRunningExecutor/) I observed the following flake:

```
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at hudson.cli.OnlineNodeCommandTest.startBlockingAndFinishingBuild(OnlineNodeCommandTest.java:318)
	at hudson.cli.CancelQuietDownCommandTest.cancelQuietDownShouldSuccessOnNoQuietDownedJenkinsAndRunningExecutor(CancelQuietDownCommandTest.java:127)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:618)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

### Evaluation

`hudson.cli.OnlineNodeCommandTest.BlockingAndFinishingBuilder#perform` relies on finish not having been signalled in order for the `assertTrue(project.getLastBuild().isBuilding())` line in `hudson.cli.OnlineNodeCommandTest#startBlockingAndFinishingBuild` to make any sense. That invariant is almost always true, but not true for two tests in `hudson.cli.OnlineNodeCommandTest`: they accidentally pass an already signalled `finish` object (which happens to be in scope), violating the invariant and creating a race condition in the test.

### Solution

Create a fresh `finish` object each time `hudson.cli.OnlineNodeCommandTest#startBlockingAndFinishingBuild` is invoked, and assert within that method that a fresh object has always been provided in order to prevent this mistake from occurring again in the future.

### Testing done

Ran `mvn clean verify -Dtest=hudson.cli.AddJobToViewCommandTest,hudson.cli.BuildCommandTest,hudson.cli.CancelQuietDownCommandTest,hudson.cli.ClearQueueCommandTest,hudson.cli.CLIActionTest,hudson.cli.CLIEnvVarTest,hudson.cli.CLITest,hudson.cli.ComputerStateTest,hudson.cli.ConnectNodeCommandTest,hudson.cli.ConsoleCommandTest,hudson.cli.CopyJobCommandTest,hudson.cli.CreateJobCommandTest,hudson.cli.CreateNodeCommandTest,hudson.cli.CreateViewCommandTest,hudson.cli.DeleteBuildsCommandTest,hudson.cli.DeleteJobCommandTest,hudson.cli.DeleteNodeCommandTest,hudson.cli.DeleteViewCommandTest,hudson.cli.DisablePluginCommandTest,hudson.cli.DisconnectNodeCommandTest,hudson.cli.EnableJobCommandTest,hudson.cli.EnablePluginCommandTest,hudson.cli.GetJobCommandTest,hudson.cli.GetNodeCommandTest,hudson.cli.GetViewCommandTest,hudson.cli.GroovyshCommandTest,hudson.cli.HelpCommandTest,hudson.cli.InstallPluginCommandTest,hudson.cli.ListJobsCommandTest,hudson.cli.ListPluginsCommandTest,hudson.cli.OfflineNodeCommandTest,hudson.cli.OnlineNodeCommandTest,hudson.cli.QuietDownCommandTest,hudson.cli.ReloadConfigurationCommandTest,hudson.cli.ReloadJobCommandTest,hudson.cli.RemoveJobFromViewCommandTest,hudson.cli.RunRangeCommand2Test,hudson.cli.RunRangeCommandTest,hudson.cli.SetBuildDescriptionCommandTest,hudson.cli.SetBuildDisplayNameCommandTest,hudson.cli.UpdateNodeCommandTest,hudson.cli.UpdateViewCommandTest,hudson.cli.ViewManipulationTestBase,hudson.cli.WaitNodeOfflineCommandTest,hudson.cli.WaitNodeOnlineCommandTest`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7379"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

