### PR TITLE
De-flake `TelemetryTest`

### DIFF
--- a/test/src/test/java/jenkins/telemetry/TelemetryTest.java
+++ b/test/src/test/java/jenkins/telemetry/TelemetryTest.java
@@ -1,5 +1,6 @@
 package jenkins.telemetry;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -21,6 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 import javax.servlet.FilterChain;
@@ -62,14 +64,13 @@ public class TelemetryTest {
         j.jenkins.setNoUsageStatistics(false); // tests usually don't submit this, but we need this
         assertEquals("no requests received", 0, counter);
         ExtensionList.lookupSingleton(Telemetry.TelemetryReporter.class).doRun();
-        do {
-            Thread.sleep(250);
-        } while (counter == 0); // this might end up being flaky due to 1 to many active telemetry trials
+        await().pollInterval(250, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> types, hasItem("test-data"));
         assertThat(logger.getMessages(), hasItem("Telemetry submission received response '200 OK' for: test-data"));
         assertThat(logger.getMessages(), hasItem("Skipping telemetry for 'future' as it is configured to start later"));
         assertThat(logger.getMessages(), hasItem("Skipping telemetry for 'past' as it is configured to end in the past"));
         assertThat(logger.getMessages(), hasItem("Skipping telemetry for 'empty' as it has no data"));
-        assertThat(types, hasItem("test-data"));
         assertThat(types, not(hasItem("future")));
         assertThat(types, not(hasItem("past")));
         assertThat(correlators.size(), is(counter));
@@ -85,11 +86,9 @@ public class TelemetryTest {
         correlator.setCorrelationId(correlationId);
 
         ExtensionList.lookupSingleton(Telemetry.TelemetryReporter.class).doRun();
-        do {
-            Thread.sleep(250);
-        } while (counter == 0); // this might end up being flaky due to 1 to many active telemetry trials
-
-        assertThat(types, hasItem("test-data"));
+        await().pollInterval(250, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> types, hasItem("test-data"));
         //90ecf3ce1cd5ba1e5ad3cde7ad08a941e884f2e4d9bd463361715abab8efedc5
         assertThat(correlators, hasItem(DigestUtils.sha256Hex(correlationId + "test-data")));
     }


### PR DESCRIPTION
### Problem

`TelemetryTest` has been flaking with e.g.

```
Expected: a collection containing "Telemetry submission received response '200 OK' for: test-data"
     but: mismatches were: [was "Skipping telemetry for 'future' as it is configured to start later", was "Skipping telemetry for 'past' as it is configured to end in the past", was "Skipping telemetry for 'empty' as it has no data", was "Submitting JSON: {\"type\":\"test-data\",\"payload\":{},\"correlator\":\"71b40410c8cb8e40679995e1920f1ee48e2a819dbd021ef05debdb8e288feabe\"}"]
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at jenkins.telemetry.TelemetryTest.testSubmission(TelemetryTest.java:68)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:618)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

### Evaluation

I could reproduce the problem within about 3 iterations by running the test in a loop with

```java
diff --git a/core/src/main/java/jenkins/telemetry/Telemetry.java b/core/src/main/java/jenkins/telemetry/Telemetry.java
index 7780b5642f..1d1c817566 100644
--- a/core/src/main/java/jenkins/telemetry/Telemetry.java
+++ b/core/src/main/java/jenkins/telemetry/Telemetry.java
@@ -193,6 +193,11 @@ public abstract class Telemetry implements ExtensionPoint {
                 return;
             }
             Telemetry.all().forEach(telemetry -> {
+                try {
+                    Thread.sleep(1500);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
                 if (telemetry.getStart().isAfter(LocalDate.now())) {
                     LOGGER.config("Skipping telemetry for '" + telemetry.getId() + "' as it is configured to start later");
                     return;
```

Increasing the sleep in the test from 250 milliseconds to 2.5 seconds chased the problem away but was not a very satisfying solution. Debugging the test further, we observed that the readiness condition was necessary but not sufficient (as the comment itself notes).

### Solution

Add calls to Awaitility to wait a bit longer to get the expected results, failing if the expected results are not achieved within 10 seconds. This readiness condition is both necessary and sufficient because the expected value is only added to `types` after `correlators` has been updated and after all logging statements have fired. With this fix we can no longer reproduce the problem within 10 iterations.

### Testing done

With the abovementioned sleep inserted into the production code, the problem could be reproduced within 3 iterations before this PR and could not be reproduced within 10 iterations after this PR.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7380"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

