### PR TITLE
Simplify `JNLPLauncherRealTest` using the new methods in `InboundAgentRule`

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -93,7 +93,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>1878.v3a_b_a_0a_8728b_0</version>
+      <version>1881.v5d4b_a_f650249</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -93,7 +93,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>1873.va_ed9d52f2b_42</version>
+      <version>1878.v3a_b_a_0a_8728b_0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/src/test/java/hudson/slaves/JNLPLauncherRealTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherRealTest.java
@@ -27,9 +27,12 @@ package hudson.slaves;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import hudson.ExtensionList;
+import hudson.PluginWrapper;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Slave;
+import hudson.util.FormValidation;
 import java.io.File;
 import jenkins.agents.WebSocketAgentsTest;
 import jenkins.slaves.JnlpSlaveAgentProtocol4;
@@ -91,6 +94,10 @@ public class JNLPLauncherRealTest {
 
         @Override
         public void run(JenkinsRule r) throws Throwable {
+            for (PluginWrapper plugin : r.jenkins.pluginManager.getPlugins()) {
+                System.err.println(plugin + " active=" + plugin.isActive() + " enabled=" + plugin.isEnabled());
+            }
+            assertThat(ExtensionList.lookupSingleton(JNLPLauncher.DescriptorImpl.class).doCheckWebSocket(webSocket, null).kind, is(FormValidation.Kind.OK));
             Slave agent = (Slave) r.jenkins.getNode(agentName);
             r.waitOnline(agent);
             FreeStyleProject p = r.createFreeStyleProject();

--- a/test/src/test/java/hudson/slaves/JNLPLauncherRealTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherRealTest.java
@@ -27,19 +27,14 @@ package hudson.slaves;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import hudson.ExtensionList;
-import hudson.PluginWrapper;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Slave;
-import hudson.util.FormValidation;
 import java.io.File;
 import jenkins.agents.WebSocketAgentsTest;
 import jenkins.slaves.JnlpSlaveAgentProtocol4;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.For;
 import org.jvnet.hudson.test.InboundAgentRule;
 import org.jvnet.hudson.test.Issue;
@@ -49,54 +44,18 @@ import org.jvnet.hudson.test.RealJenkinsRule;
 @For({JNLPLauncher.class, JnlpSlaveAgentProtocol4.class})
 public class JNLPLauncherRealTest {
 
+    private static final String STATIC_AGENT_NAME = "static";
+
     @Rule public RealJenkinsRule rr = new RealJenkinsRule().includeTestClasspathPlugins(false);
+
+    @Rule public InboundAgentRule iar = new InboundAgentRule();
 
     @Issue("JEP-230")
     @Test public void smokes() throws Throwable {
         /* Since RealJenkinsRuleInit.jpi will load detached plugins, to reproduce a failure use:
         FileUtils.touch(new File(rr.getHome(), "plugins/instance-identity.jpi.disabled"));
         */
-        rr.then(new ConnectStep(false));
-    }
-
-    private static class ConnectStep implements RealJenkinsRule.Step {
-
-      private final boolean webSocket;
-
-      private ConnectStep(boolean webSocket) {
-        this.webSocket = webSocket;
-      }
-
-      @Override
-      public void run(JenkinsRule r) throws Throwable {
-        InboundAgentRule inboundAgents = new InboundAgentRule(); // cannot use @Rule since it would not be accessible from the controller JVM
-        inboundAgents.apply(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                for (PluginWrapper plugin : r.jenkins.pluginManager.getPlugins()) {
-                    System.err.println(plugin + " active=" + plugin.isActive() + " enabled=" + plugin.isEnabled());
-                }
-                assertThat(ExtensionList.lookupSingleton(JNLPLauncher.DescriptorImpl.class).doCheckWebSocket(webSocket, null).kind, is(FormValidation.Kind.OK));
-                InboundAgentRule.Options.Builder builder = InboundAgentRule.Options.newBuilder().name("static").secret();
-                if (webSocket) {
-                    builder.webSocket();
-                }
-                Slave agent = inboundAgents.createAgent(r, builder.build());
-                r.waitOnline(agent);
-                try {
-                    FreeStyleProject p = r.createFreeStyleProject();
-                    p.setAssignedNode(agent);
-                    FreeStyleBuild b = r.buildAndAssertSuccess(p);
-                    if (webSocket) {
-                        assertThat(agent.toComputer().getSystemProperties().get("java.class.path"), is(new File(r.jenkins.root, "agent.jar").getAbsolutePath()));
-                    }
-                    System.err.println(JenkinsRule.getLog(b));
-                } finally {
-                    inboundAgents.stop(r, agent.getNodeName());
-                }
-            }
-        }, Description.EMPTY).evaluate();
-
-      }
+        then(false);
     }
 
     /**
@@ -104,7 +63,43 @@ public class JNLPLauncherRealTest {
      */
     @Issue("JENKINS-68933")
     @Test public void webSocket() throws Throwable {
-        rr.then(new ConnectStep(true));
+        then(true);
     }
 
+    private void then(boolean websocket) throws Throwable {
+        try {
+            rr.startJenkins();
+            InboundAgentRule.Options.Builder options = InboundAgentRule.Options.newBuilder().name(STATIC_AGENT_NAME);
+            if (websocket) {
+                options = options.webSocket();
+            }
+            iar.createAgent(rr, options.build());
+            rr.runRemotely(new RunJobStep(STATIC_AGENT_NAME, websocket));
+        } finally {
+            iar.stop(rr, STATIC_AGENT_NAME);
+        }
+    }
+
+    private static class RunJobStep implements RealJenkinsRule.Step {
+        private final String agentName;
+        private final boolean webSocket;
+
+        RunJobStep(String agentName, boolean webSocket) {
+            this.agentName = agentName;
+            this.webSocket = webSocket;
+        }
+
+        @Override
+        public void run(JenkinsRule r) throws Throwable {
+            Slave agent = (Slave) r.jenkins.getNode(agentName);
+            r.waitOnline(agent);
+            FreeStyleProject p = r.createFreeStyleProject();
+            p.setAssignedNode(agent);
+            FreeStyleBuild b = r.buildAndAssertSuccess(p);
+            if (webSocket) {
+                assertThat(agent.toComputer().getSystemProperties().get("java.class.path"), is(new File(r.jenkins.root, "agent.jar").getAbsolutePath()));
+            }
+            System.err.println(JenkinsRule.getLog(b));
+        }
+    }
 }


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

This is a test update, downstream of https://github.com/jenkinsci/jenkins-test-harness/pull/517

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7381"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

