### PR TITLE
[JENKINS-70083] Update bundled script-security and junit versions

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -330,14 +330,14 @@ THE SOFTWARE.
                   <!-- dependency of command-launcher, junit, matrix-project, and workflow-support -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>script-security</artifactId>
-                  <version>1189.vb_a_b_7c8fd5fde</version>
+                  <version>1190.v65867a_a_47126</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 1.577 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>junit</artifactId>
-                  <version>1156.vcf492e95a_a_b_0</version>
+                  <version>1160.vf1f01a_a_ea_b_7f</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
See [JENKINS-70083](https://issues.jenkins.io/browse/JENKINS-70083) and [Jenkins Security Advisory 2022-11-15](https://www.jenkins.io/security/advisory/2022-11-15/).

### Testing done

Ran `-Dtest=LoadDetachedPluginsTest` with un-`@Ignore`'ed `#noUpdateSiteWarnings`. Tests passed.

Without the change,

```
[ERROR] jenkins.install.LoadDetachedPluginsTest.noUpdateSiteWarnings  Time elapsed: 6.271 s  <<< FAILURE!
java.lang.AssertionError: 
There should be no active plugin security warnings
Expected: an empty collection
     but: <[Plugin:junit, Plugin:script-security]>
```

### Proposed changelog entries

- Updated bundled Script Security plugin from 1189.vb_a_b_7c8fd5fde to 1190.v65867a_a_47126 and JUnit plugin from 1156.vcf492e95a_a_b_0 to 1160.vf1f01a_a_ea_b_7f (<a href="https://www.jenkins.io/security/advisory/2022-11-15/">2022-11-15 security advisory</a>)

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7385"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

