### PR TITLE
Backporting bundled script-security and junit plugin versions for 2.375.1 (#7385)

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -322,13 +322,13 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>script-security</artifactId>
-                  <version>1189.vb_a_b_7c8fd5fde</version>
+                  <version>1190.v65867a_a_47126</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>junit</artifactId>
-                  <version>1119.1121.vc43d0fc45561</version>
+                  <version>1160.vf1f01a_a_ea_b_7f</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
```
Latest core version: jenkins-2.378

Fixed
-----

JENKINS-70083          Minor                   2.379
        Update bundled script-security and junit plugins
        https://issues.jenkins.io/browse/JENKINS-70083
```

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7386"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

