### PR TITLE
Backport script security and junit (#7385)

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -316,47 +316,47 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>matrix-project</artifactId>
-                  <version>1.20</version>
+                  <version>785.v06b_7f47b_c631</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>script-security</artifactId>
-                  <version>1189.vb_a_b_7c8fd5fde</version>
+                  <version>1190.v65867a_a_47126</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>junit</artifactId>
-                  <version>1119.1121.vc43d0fc45561</version>
+                  <version>1160.vf1f01a_a_ea_b_7f</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-api</artifactId>
-                  <version>1164.v760c223ddb_32</version>
+                  <version>1200.v8005c684b_a_c6</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>plugin-util-api</artifactId>
-                  <version>2.16.0</version>
+                  <version>2.18.0</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>bootstrap5-api</artifactId>
-                  <version>5.1.3-6</version>
+                  <version>5.2.1-3</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>checks-api</artifactId>
-                  <version>1.7.4</version>
+                  <version>1.8.0</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -372,14 +372,14 @@ THE SOFTWARE.
                   <!-- dependency of junit and echarts-api -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>jackson2-api</artifactId>
-                  <version>2.13.2.20220328-273.v11d70a_b_a_1a_52</version>
+                  <version>2.13.4.20221013-295.v8e29ea_354141</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>echarts-api</artifactId>
-                  <version>5.3.2-1</version>
+                  <version>5.4.0-1</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -403,7 +403,7 @@ THE SOFTWARE.
                   <!-- dependency of echarts-api and bootstrap4-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>jquery3-api</artifactId>
-                  <version>3.6.0-2</version>
+                  <version>3.6.1-2</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -411,7 +411,7 @@ THE SOFTWARE.
                   <!-- dependency of bootstrap5-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>popper2-api</artifactId>
-                  <version>2.11.2-1</version>
+                  <version>2.11.6-2</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -419,7 +419,7 @@ THE SOFTWARE.
                   <!-- dependency of bootstrap5-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>font-awesome-api</artifactId>
-                  <version>6.0.0-1</version>
+                  <version>6.2.0-3</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -427,7 +427,7 @@ THE SOFTWARE.
                   <!-- dependency of junit and workflow-api -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-step-api</artifactId>
-                  <version>625.vd896b_f445a_f8</version>
+                  <version>639.v6eca_cd8c04a_a_</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -465,7 +465,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>jaxb</artifactId>
-                  <version>2.3.0</version>
+                  <version>2.3.7-1</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -483,7 +483,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>javax-activation-api</artifactId>
-                  <version>1.2.0-2</version>
+                  <version>1.2.0-5</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -496,6 +496,27 @@ THE SOFTWARE.
                   <groupId>org.jenkins-ci.modules</groupId>
                   <artifactId>instance-identity</artifactId>
                   <version>116.vf8f487400980</version>
+                  <type>hpi</type>
+                </artifactItem>
+                <artifactItem>
+                  <!-- dependency of commons-text-api and plugin-util-api -->
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>commons-lang3-api</artifactId>
+                  <version>3.12.0-36.vd97de6465d5b_</version>
+                  <type>hpi</type>
+                </artifactItem>
+                <artifactItem>
+                  <!-- dependency of plugin-util-api -->
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>commons-text-api</artifactId>
+                  <version>1.10.0-27.vb_fa_3896786a_7</version>
+                  <type>hpi</type>
+                </artifactItem>
+                <artifactItem>
+                  <!-- dependency of junit -->
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>ionicons-api</artifactId>
+                  <version>31.v4757b_6987003</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
Given https://github.com/jenkinsci/jenkins/pull/7386 can't be integrated cleanly, due to a variety of bundled plugin dependency updates depending on each other, this PR provides an alternative with resolved dependency conflicts.