### PR TITLE
Stop using `infra.runATH`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,7 +152,7 @@ builds.ath = {
       // Just to be safe
       deleteDir()
       checkout scm
-      sh './ath.sh'
+      sh 'bash ath.sh'
       junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,27 +151,9 @@ builds.ath = {
     node('docker-highmem') {
       // Just to be safe
       deleteDir()
-      def fileUri
-      def metadataPath
-      dir('sources') {
-        checkout scm
-        def mavenOptions = [
-          '-Pquick-build',
-          '-Dmaven.repo.local=$WORKSPACE_TMP/m2repo',
-          '-am',
-          '-pl',
-          'war',
-          'package',
-        ]
-        infra.runMaven(mavenOptions, 11)
-        dir('war/target') {
-          fileUri = 'file://' + pwd() + '/jenkins.war'
-        }
-        metadataPath = pwd() + '/essentials.yml'
-      }
-      dir('ath') {
-        runATH jenkins: fileUri, metadataFile: metadataPath
-      }
+      checkout scm
+      sh './ath.sh'
+      junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
     }
   }
 }

--- a/ath.sh
+++ b/ath.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+cd $(dirname $0)
+
+# https://github.com/jenkinsci/acceptance-test-harness/releases
+ATH_VERSION=5458.v911b_2f0818ee
+
+# TODO use Artifactory proxy?
+
+[ -f war/target/jenkins.war ] || mvn -B -ntp -Pquick-build -am -pl war package
+
+mkdir -p target/ath-reports
+chmod a+rwx target/ath-reports
+
+docker run --rm \
+  -e ATH_VERSION=$ATH_VERSION \
+  --shm-size 2g `# avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed` \
+  -v $(pwd)/war/target/jenkins.war:/jenkins.war \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v $(pwd)/target/ath-reports:/reports \
+  jenkins/ath:$ATH_VERSION \
+  bash -c 'cd && eval $(vnc.sh) && env | sort && git clone -b $ATH_VERSION --depth 1 https://github.com/jenkinsci/acceptance-test-harness && cd acceptance-test-harness && run.sh firefox /jenkins.war -Dmaven.test.failure.ignore -DforkCount=1 -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest && cp -v target/surefire-reports/TEST-*.xml /reports'

--- a/ath.sh
+++ b/ath.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 cd $(dirname $0)
 
 # https://github.com/jenkinsci/acceptance-test-harness/releases
-ATH_VERSION=5458.v911b_2f0818ee
+export ATH_VERSION=5458.v911b_2f0818ee
 
 # TODO use Artifactory proxy?
 
@@ -13,10 +13,10 @@ mkdir -p target/ath-reports
 chmod a+rwx target/ath-reports
 
 docker run --rm \
-  -e ATH_VERSION=$ATH_VERSION \
+  --env ATH_VERSION \
   --shm-size 2g `# avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed` \
-  -v $(pwd)/war/target/jenkins.war:/jenkins.war \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v $(pwd)/target/ath-reports:/reports \
-  jenkins/ath:$ATH_VERSION \
+  --volume "$(pwd)"/war/target/jenkins.war:/jenkins.war:ro \
+  --volume /var/run/docker.sock:/var/run/docker.sock:rw \
+  --volume "$(pwd)"/target/ath-reports:/reports:rw \
+  jenkins/ath:"$ATH_VERSION" \
   bash -c 'cd && eval $(vnc.sh) && env | sort && git clone -b $ATH_VERSION --depth 1 https://github.com/jenkinsci/acceptance-test-harness && cd acceptance-test-harness && run.sh firefox /jenkins.war -Dmaven.test.failure.ignore -DforkCount=1 -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest && cp -v target/surefire-reports/TEST-*.xml /reports'

--- a/ath.sh
+++ b/ath.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/bash
-set -euxo pipefail
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
 cd $(dirname $0)
 
 # https://github.com/jenkinsci/acceptance-test-harness/releases
@@ -20,8 +23,11 @@ docker run --rm \
   --volume "$(pwd)"/target/ath-reports:/reports:rw \
   --interactive \
   jenkins/ath:"$ATH_VERSION" \
-  bash <<'EOF'
-set -euxo pipefail
+  bash <<'INSIDE'
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
 cd
 # Start the VNC system provided by the image from the default user home directory
 eval $(vnc.sh)
@@ -32,5 +38,5 @@ run.sh firefox /jenkins.war \
   -Dmaven.test.failure.ignore \
   -DforkCount=1 \
   -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest
-cp -v target/surefire-reports/TEST-*.xml /reports
-EOF
+cp --verbose target/surefire-reports/TEST-*.xml /reports
+INSIDE

--- a/ath.sh
+++ b/ath.sh
@@ -18,5 +18,16 @@ docker run --rm \
   --volume "$(pwd)"/war/target/jenkins.war:/jenkins.war:ro \
   --volume /var/run/docker.sock:/var/run/docker.sock:rw \
   --volume "$(pwd)"/target/ath-reports:/reports:rw \
+  --interactive \
   jenkins/ath:"$ATH_VERSION" \
-  bash -c 'cd && eval $(vnc.sh) && env | sort && git clone -b $ATH_VERSION --depth 1 https://github.com/jenkinsci/acceptance-test-harness && cd acceptance-test-harness && run.sh firefox /jenkins.war -Dmaven.test.failure.ignore -DforkCount=1 -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest && cp -v target/surefire-reports/TEST-*.xml /reports'
+  bash <<'EOF'
+set -euxo pipefail
+cd
+# Start the VNC system provided by the image from the default user home directory
+eval $(vnc.sh)
+env | sort
+git clone --branch "$ATH_VERSION" --depth 1 https://github.com/jenkinsci/acceptance-test-harness
+cd acceptance-test-harness
+run.sh firefox /jenkins.war -Dmaven.test.failure.ignore -DforkCount=1 -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest
+cp -v target/surefire-reports/TEST-*.xml /reports
+EOF

--- a/ath.sh
+++ b/ath.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 set -euxo pipefail
 cd $(dirname $0)
 

--- a/ath.sh
+++ b/ath.sh
@@ -28,6 +28,9 @@ eval $(vnc.sh)
 env | sort
 git clone --branch "$ATH_VERSION" --depth 1 https://github.com/jenkinsci/acceptance-test-harness
 cd acceptance-test-harness
-run.sh firefox /jenkins.war -Dmaven.test.failure.ignore -DforkCount=1 -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest
+run.sh firefox /jenkins.war \
+  -Dmaven.test.failure.ignore \
+  -DforkCount=1 \
+  -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest
 cp -v target/surefire-reports/TEST-*.xml /reports
 EOF

--- a/essentials.yml
+++ b/essentials.yml
@@ -1,9 +1,0 @@
----
-ath:
-  useLocalSnapshots: false
-  athRevision: "5458.v911b_2f0818ee"
-  athImage: "jenkins/ath:5458.v911b_2f0818ee"
-  categories:
-    - org.jenkinsci.test.acceptance.junit.SmokeTest
-  jdks:
-    - 11


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/pipeline-library/issues/523 by just ceasing to use the problematic library function, which was extremely opaque. Amends #3350.

If accepted, please also backport this to the LTS branch (replacing the ATH version there as needed).

### Testing done

https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7397/1/execution/node/48/log/ and https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7397/1/testReport/core/ look fine.

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7397"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

