### PR TITLE
[JENKINS-70103] Clear websocket sessions on connection close or error

### DIFF
--- a/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
+++ b/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
@@ -147,6 +147,7 @@ public class Jetty10Provider implements Provider {
             @Override
             public void onWebSocketClose(int statusCode, String reason) {
                 listener.onWebSocketClose(statusCode, reason);
+                sessions.remove(listener);
             }
 
             @Override
@@ -158,6 +159,7 @@ public class Jetty10Provider implements Provider {
             @Override
             public void onWebSocketError(Throwable cause) {
                 listener.onWebSocketError(cause);
+                sessions.remove(listener);
             }
         };
     }

--- a/websocket/jetty9/src/main/java/jenkins/websocket/Jetty9Provider.java
+++ b/websocket/jetty9/src/main/java/jenkins/websocket/Jetty9Provider.java
@@ -132,6 +132,7 @@ public class Jetty9Provider implements Provider {
             @Override
             public void onWebSocketClose(int statusCode, String reason) {
                 listener.onWebSocketClose(statusCode, reason);
+                sessions.remove(listener);
             }
 
             @Override
@@ -143,6 +144,7 @@ public class Jetty9Provider implements Provider {
             @Override
             public void onWebSocketError(Throwable cause) {
                 listener.onWebSocketError(cause);
+                sessions.remove(listener);
             }
         };
     }


### PR DESCRIPTION
This is causing a memory leak, as sessions pile up there and the GC does not collect them.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-70103](https://issues.jenkins.io/browse/JENKINS-70103) for more information.

I'll file a follow up PR in remoting to slow down connection re-try at agent side. There is no point on trying hundreds of times per second.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

AFAICT the current test setup is not ready to test an agent running on Java 8 trying to connect to Jenkins on Java 11, so I did some manual tests:

1. Run Jenkins on Java 11.
2. Create an agent using websocket connection.
3. Run the agent (an older version that supports Java 8) on Java 8.
4. The agent connects and immediately disconnects (because of the Java version mismatch). There are hundreds of connection re-tries per second.
5. Kill the agent process.
6. Using the Jenkins script console verify that `jenkins.websocket.Jetty10Provider.sessions` is clear.

### Proposed changelog entries

- [JENKINS-70103] Clear websocket sessions on agent connection close or error, otherwise sessions are accumulated causing a memory leak.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7406"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

