### PR TITLE
[JENKINS-70103] `WeakHashMap` broken for looking up Jetty `Session` in WebSocket response

### DIFF
--- a/core/src/main/java/jenkins/websocket/WebSockets.java
+++ b/core/src/main/java/jenkins/websocket/WebSockets.java
@@ -68,7 +68,7 @@ public class WebSockets {
         return (req, rsp, node) -> {
             try {
                 session.handler = provider.handle(req, rsp, new Provider.Listener() {
-                    Object providerSession;
+                    private Object providerSession;
 
                     @Override
                     public void onWebSocketConnect(Object providerSession) {

--- a/core/src/main/java/jenkins/websocket/WebSockets.java
+++ b/core/src/main/java/jenkins/websocket/WebSockets.java
@@ -68,10 +68,18 @@ public class WebSockets {
         return (req, rsp, node) -> {
             try {
                 session.handler = provider.handle(req, rsp, new Provider.Listener() {
+                    Object providerSession;
+
                     @Override
-                    public void onWebSocketConnect() {
+                    public void onWebSocketConnect(Object providerSession) {
+                        this.providerSession = providerSession;
                         session.startPings();
                         session.opened();
+                    }
+
+                    @Override
+                    public Object getProviderSession() {
+                        return providerSession;
                     }
 
                     @Override

--- a/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
+++ b/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
@@ -26,9 +26,6 @@ package jenkins.websocket;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import javax.servlet.http.HttpServletRequest;
@@ -48,9 +45,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public class Jetty10Provider implements Provider {
 
     private static final String ATTR_LISTENER = Jetty10Provider.class.getName() + ".listener";
-
-    // TODO does not seem possible to use HttpServletRequest.get/setAttribute for this
-    private static final Map<Listener, Session> sessions = Collections.synchronizedMap(new WeakHashMap<>());
 
     public Jetty10Provider() {
         JettyWebSocketServerContainer.class.hashCode();
@@ -101,7 +95,7 @@ public class Jetty10Provider implements Provider {
             }
 
             private Session session() {
-                Session session = sessions.get(listener);
+                Session session = (Session) listener.getProviderSession();
                 if (session == null) {
                     throw new IllegalStateException("missing session");
                 }
@@ -151,8 +145,7 @@ public class Jetty10Provider implements Provider {
 
             @Override
             public void onWebSocketConnect(Session session) {
-                sessions.put(listener, session);
-                listener.onWebSocketConnect();
+                listener.onWebSocketConnect(session);
             }
 
             @Override

--- a/websocket/jetty9/src/main/java/jenkins/websocket/Jetty9Provider.java
+++ b/websocket/jetty9/src/main/java/jenkins/websocket/Jetty9Provider.java
@@ -26,9 +26,6 @@ package jenkins.websocket;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.concurrent.Future;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -47,9 +44,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public class Jetty9Provider implements Provider {
 
     private static final String ATTR_LISTENER = Jetty9Provider.class.getName() + ".listener";
-
-    // TODO does not seem possible to use HttpServletRequest.get/setAttribute for this
-    private static final Map<Listener, Session> sessions = Collections.synchronizedMap(new WeakHashMap<>());
 
     private WebSocketServletFactory factory;
 
@@ -104,7 +98,7 @@ public class Jetty9Provider implements Provider {
             }
 
             private Session session() {
-                Session session = sessions.get(listener);
+                Session session = (Session) listener.getProviderSession();
                 if (session == null) {
                     throw new IllegalStateException("missing session");
                 }
@@ -136,8 +130,7 @@ public class Jetty9Provider implements Provider {
 
             @Override
             public void onWebSocketConnect(Session session) {
-                sessions.put(listener, session);
-                listener.onWebSocketConnect();
+                listener.onWebSocketConnect(session);
             }
 
             @Override

--- a/websocket/spi/src/main/java/jenkins/websocket/Provider.java
+++ b/websocket/spi/src/main/java/jenkins/websocket/Provider.java
@@ -47,7 +47,7 @@ interface Provider {
 
     interface Listener {
 
-        void onWebSocketConnect(Object poviderSession);
+        void onWebSocketConnect(Object providerSession);
 
         Object getProviderSession();
 

--- a/websocket/spi/src/main/java/jenkins/websocket/Provider.java
+++ b/websocket/spi/src/main/java/jenkins/websocket/Provider.java
@@ -47,7 +47,9 @@ interface Provider {
 
     interface Listener {
 
-        void onWebSocketConnect();
+        void onWebSocketConnect(Object poviderSession);
+
+        Object getProviderSession();
 
         void onWebSocketClose(int statusCode, String reason);
 


### PR DESCRIPTION
See [JENKINS-70103](https://issues.jenkins.io/browse/JENKINS-70103). Amends #6780. Supersedes #7406.

### Testing done

Used `JNLPLauncherRealTest`.

### Proposed changelog entries

- Memory leak when repeatedly connecting WebSocket agents.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7412"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

