### PR TITLE
Remove deprecated Multijob plugin from setup wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -51,7 +51,6 @@
       { "name": "pipeline-github-lib", "suggested": true, "added": "2.0" },
       { "name": "pipeline-stage-view", "suggested": true, "added": "2.0" },
       { "name": "conditional-buildstep" },
-      { "name": "jenkins-multijob-plugin" },
       { "name": "parameterized-trigger" },
       { "name": "copyartifact" }
     ]


### PR DESCRIPTION
See https://plugins.jenkins.io/jenkins-multijob-plugin/

### Testing done

None, it's a data file. If there's a test asserting its content, we'll notice in the PR build.

### Proposed changelog entries

- Remove the deprecated Multijob plugin from the setup wizard.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7413"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

