### PR TITLE
Remove WMI Windows Agents plugin from setup wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -75,7 +75,7 @@
     "category": "Distributed Builds",
     "plugins": [
       { "name": "matrix-project" },
-      { "name": "ssh-slaves", "suggested": true },
+      { "name": "ssh-slaves", "suggested": true }
     ]
   },
   {

--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -76,7 +76,6 @@
     "plugins": [
       { "name": "matrix-project" },
       { "name": "ssh-slaves", "suggested": true },
-      { "name": "windows-slaves" }
     ]
   },
   {


### PR DESCRIPTION
## Remove [WMI Windows Agents](https://plugins.jenkins.io/windows-slaves) plugin from setup wizard

The [WMI Windows Agents](https://plugins.jenkins.io/windows-slaves) plugin will be deprecated in May 2023 due to security related changes in Microsoft DCOM and no one available to adapt the plugin to those changes.

Let's remove it from the setup wizard now rather than waiting for deprecation.

The [deprecation notice](https://plugins.jenkins.io/windows-slaves/#plugin-content-notice-of-deprecation-may-2023) says:

> This plugin will be deprecated in May of 2023.

> The method for connecting agents to the controller in this plugin, which is based on DCOM, has several pitfalls and issues and can be brittle. The SSH and other solutions can unify the method for connecting to all agents (Windows, Linux, macOS, etc.) in your infrastructure. It is highly recommended that you migrate to one of these other methods sooner rather than later.

> Microsoft is tightening security on DCOM based on a CVE. Initial OS updates will require a registry change to enable the current security level, then in May of 2023 they will not have a way to override the secure behavior.

### Testing done

Built jenkins.war with the windows-slaves plugin removed from the setup wizard and tested the following configurations:

1. Setup wizard installing the suggested plugins
2. Setup wizard installing my commonly used plugins (removes several suggested, adds several that are available but not suggested)

In both cases, I confirmed that the WMI Windows Agents plugin was not installed and that there were no warning messages or error messages due to the absence of the WMI Windows Agents plugin from the setup wizard plugin list.

### Proposed changelog entries

- Remove WMI Windows Agents plugin from setup wizard.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

