### PR TITLE
Removed browser specific border-radius in `layout-mixins.less`

### DIFF
--- a/war/src/main/js/widgets/layout-mixins.less
+++ b/war/src/main/js/widgets/layout-mixins.less
@@ -13,29 +13,19 @@
  * Border radius
  */
 .border-radius(@border-radius) {
-  -webkit-border-radius: @border-radius;
-  -moz-border-radius: @border-radius;
   border-radius: @border-radius;
 }
 .border-radius-top-left(@border-radius) {
-  -webkit-border-top-left-radius: @border-radius;
-  -moz-border-top-left-radius: @border-radius;
   border-top-left-radius: @border-radius;
 }
 .border-radius-top-right(@border-radius) {
-  -webkit-border-top-right-radius: @border-radius;
-  -moz-border-top-right-radius: @border-radius;
   border-top-right-radius: @border-radius;
 }
 .border-radius-bottom-left(@border-radius) {
-  -webkit-border-bottom-left-radius: @border-radius;
-  -moz-border-bottom-left-radius: @border-radius;
-  border-top-bottom-radius: @border-radius;
+  border-bottom-left-radius: @border-radius;
 }
 .border-radius-bottom-right(@border-radius) {
-  -webkit-border-bottom-right-radius: @border-radius;
-  -moz-border-bottom-right-radius: @border-radius;
-  border-top-bottom-radius: @border-radius;
+  border-bottom-right-radius: @border-radius;
 }
 .border-radius-top(@border-radius) {
   .border-radius-top-left(@border-radius);


### PR DESCRIPTION
Removed browser specific border-radius in `layout-mixins.less` and also changed a possible typeo, since `border-top-bottom-radius` does not make sense to me, I changed it to `border-bottom-left-radius` and `border-bottom-right-radius`

In general the feature does not need the browser workarounds, at least accoring to:

- [caniuse border-top-left-radius](https://caniuse.com/?search=border-top-left-radius)
- [caniuse border-top-right-radius](https://caniuse.com/?search=border-top-right-radius)
- [caniuse border-bottom-left-radius](https://caniuse.com/?search=border-bottom-left-radius)
- [caniuse border-bottom-right-radius](https://caniuse.com/?search=border-bottom-right-radius)

Feedback to this would be appreciated, also if it is worth a changelog entry


### Testing done

I clicked through many UI items, but did not notice any issues around border radius.

### Proposed changelog entries

- Minor bugfix in border-bottom radius
**OR**
- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7416"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

