### PR TITLE
Set `SameSite=Lax` on screenResultion cookie

### DIFF
--- a/core/src/main/resources/hudson/model/View/screen-resolution.js
+++ b/core/src/main/resources/hudson/model/View/screen-resolution.js
@@ -1,12 +1,15 @@
 (function () {
-  var selfScript = document.querySelector("#screenResolution-script");
-  var secureCookie = selfScript.getAttribute("data-use-secure-cookie");
-  YAHOO.util.Cookie.set(
-    "screenResolution",
-    screen.width + "x" + screen.height,
-    {
-      path: "/",
-      secure: secureCookie === "true",
-    }
-  );
+  const selfScript = document.querySelector("#screenResolution-script");
+  const secureCookie = selfScript.getAttribute("data-use-secure-cookie");
+  let cookie =
+    "screenResolution=" +
+    screen.width +
+    "x" +
+    screen.height +
+    "; path=/" +
+    "; SameSite=Strict";
+  if (secureCookie) {
+    cookie += `; secure`;
+  }
+  document.cookie = cookie;
 })();

--- a/core/src/main/resources/hudson/model/View/screen-resolution.js
+++ b/core/src/main/resources/hudson/model/View/screen-resolution.js
@@ -7,7 +7,7 @@
     "x" +
     screen.height +
     "; path=/" +
-    "; SameSite=Strict";
+    "; SameSite=Lax";
   if (secureCookie) {
     cookie += `; secure`;
   }

--- a/core/src/main/resources/hudson/model/View/screen-resolution.js
+++ b/core/src/main/resources/hudson/model/View/screen-resolution.js
@@ -9,7 +9,7 @@
     "; path=/" +
     "; SameSite=Lax";
   if (secureCookie) {
-    cookie += `; secure`;
+    cookie += "; secure";
   }
   document.cookie = cookie;
 })();


### PR DESCRIPTION
Set `SameSite=Lax` on screenResultion cookie. I also replaced the YUI function with native javascript, since the YUI component was not aware of this newer attribute. The reason for adding this was a Firefox warning in the console. 

I found this nice explanation what the attribute does: [samesite-cookies-explained](https://web.dev/i18n/en/samesite-cookies-explained/) Although the cookie functionality will not break with the upcoming changes, I thought we can also mark this as stric, because we do not need it somewhere else or even in a third party website.



### Testing done

I started with the new javascript and checked that the cookie and compared the new and the old cookie that the only difference is the new attribute:

old:
![grafik](https://user-images.githubusercontent.com/22742658/202850353-ec1e80ae-fe34-4274-8b6e-75bc87c5e2b1.png)

new:
![grafik](https://user-images.githubusercontent.com/22742658/202871079-ad5c4ca2-c403-4784-9aee-fac8c828ef27.png)

### Proposed changelog entries

- Set `SameSite=Lax` on screenResultion cookie

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

