### PR TITLE
FIX:[JENKINS-35499]Review and document all remaining uses of the term 'slave' in core

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -89,7 +89,7 @@ import org.kohsuke.stapler.verb.POST;
 /**
  * Records a selected set of logs so that the system administrator
  * can diagnose a specific aspect of the system.
- *
+ * <p>
  * TODO: still a work in progress.
  *
  * <p><strong>Access Control</strong>:
@@ -193,7 +193,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
      * Validate the name.
      *
      * @return {@link FormValidation#ok} if the log target is not empty, otherwise {@link
-     *     FormValidation#warning} with a message explaining the problem.
+     * FormValidation#warning} with a message explaining the problem.
      */
     @NonNull
     @Restricted(NoExternalUse.class)
@@ -373,8 +373,11 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
     }
 
     private static final class SetLevel extends MasterToSlaveCallable<Void, Error> {
-        /** known loggers (kept per agent), to avoid GC */
-        @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") private static final Set<Logger> loggers = new HashSet<>();
+        /**
+         * known loggers (kept per agent), to avoid GC
+         */
+        @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+        private static final Set<Logger> loggers = new HashSet<>();
         private final String name;
         private final Level level;
 
@@ -383,7 +386,8 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
             this.level = level;
         }
 
-        @Override public Void call() throws Error {
+        @Override
+        public Void call() throws Error {
             Logger logger = Logger.getLogger(name);
             loggers.add(logger);
             logger.setLevel(level);
@@ -406,8 +410,11 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
         }
     }
 
-    @Extension @Restricted(NoExternalUse.class) public static final class ComputerLogInitializer extends ComputerListener {
-        @Override public void preOnline(Computer c, Channel channel, FilePath root, TaskListener listener) throws IOException, InterruptedException {
+    @Extension
+    @Restricted(NoExternalUse.class)
+    public static final class ComputerLogInitializer extends ComputerListener {
+        @Override
+        public void preOnline(Computer c, Channel channel, FilePath root, TaskListener listener) throws IOException, InterruptedException {
             for (LogRecorder recorder : Jenkins.get().getLog().getRecorders()) {
                 for (Target t : recorder.getLoggers()) {
                     channel.call(new SetLevel(t.name, t.getLevel()));
@@ -486,7 +493,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
      */
     @Override
     public synchronized void save() throws IOException {
-        if (BulkChange.contains(this))   return;
+        if (BulkChange.contains(this)) return;
 
         handlePluginUpdatingLegacyLogManagerMap();
         getConfigFile().write(this);
@@ -569,11 +576,21 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
     }
 
     /**
+     * @deprecated use of term 'slave' is
+     * replaced by term 'agent' use {@link #getAgentLogRecords()}
+     */
+    @Deprecated
+    public Map<Computer, List<LogRecord>> getSlaveLogRecords() {
+        return getAgentLogRecords();
+    }
+
+    /**
      * Gets a view of log records per agent matching this recorder.
+     *
      * @return a map (sorted by display name) from computer to (nonempty) list of log records
      * @since 1.519
      */
-    public Map<Computer, List<LogRecord>> getSlaveLogRecords() {
+    public Map<Computer, List<LogRecord>> getAgentLogRecords() {
         Map<Computer, List<LogRecord>> result = new TreeMap<>(new Comparator<>() {
             final Collator COLL = Collator.getInstance();
 

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -98,7 +98,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
     /**
      * @deprecated as of 1.301
-     *      Use {@link #getMonitors()}.
+     * Use {@link #getMonitors()}.
      */
     @Deprecated
     public static List<NodeMonitor> get_monitors() {
@@ -143,9 +143,18 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     }
 
     /**
+     * @deprecated use of term 'slave' is
+     * replaced by term 'agent' use {@link #get_agentNames()} ()}
+     */
+    @Deprecated
+    public List<String> get_slaveNames() {
+        return get_agentNames();
+    }
+
+    /**
      * Gets all the agent names.
      */
-    public List<String> get_slaveNames() {
+    public List<String> get_agentNames() {
         return new AbstractList<>() {
             final List<Node> nodes = Jenkins.get().getNodes();
 
@@ -222,7 +231,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
     /**
      * Triggers the schedule update now.
-     *
+     * <p>
      * TODO: ajax on the client side to wait until the update completion might be nice.
      */
     @RequirePOST
@@ -244,8 +253,8 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      */
     @RequirePOST
     public synchronized void doCreateItem(StaplerRequest req, StaplerResponse rsp,
-                                           @QueryParameter String name, @QueryParameter String mode,
-                                           @QueryParameter String from) throws IOException, ServletException {
+                                          @QueryParameter String name, @QueryParameter String mode,
+                                          @QueryParameter String from) throws IOException, ServletException {
         final Jenkins app = Jenkins.get();
         app.checkPermission(Computer.CREATE);
 
@@ -290,8 +299,8 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
      */
     @POST
     public synchronized void doDoCreateItem(StaplerRequest req, StaplerResponse rsp,
-                                           @QueryParameter String name,
-                                           @QueryParameter String type) throws IOException, ServletException, FormException {
+                                            @QueryParameter String name,
+                                            @QueryParameter String type) throws IOException, ServletException, FormException {
         final Jenkins app = Jenkins.get();
         app.checkPermission(Computer.CREATE);
         String fixedName = Util.fixEmptyAndTrim(name);
@@ -310,6 +319,7 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
 
     /**
      * Makes sure that the given name is good as an agent name.
+     *
      * @return trimmed name if valid; throws ParseException if not
      */
     public String checkName(String name) throws Failure {
@@ -408,7 +418,8 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     /**
      * Just to force the execution of the static initializer.
      */
-    public static void initialize() {}
+    public static void initialize() {
+    }
 
     @Initializer(after = JOB_CONFIG_ADAPTED)
     public static void init() {
@@ -478,7 +489,8 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
             NodeMonitor nm = d.clazz.getDeclaredConstructor().newInstance();
             nm.setIgnored(ignored);
             return nm;
-        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+                 InvocationTargetException e) {
             LOGGER.log(Level.SEVERE, "Failed to instantiate " + d.clazz, e);
         }
         return null;

--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -152,10 +152,10 @@ public class LogRecorderManagerTest {
         assertEquals(show(recs), 6, recs.size());
         // Would of course prefer to get "msg #5 1.0 2.0 'OK?'" but all attempts to fix this have ended in disaster (JENKINS-63458):
         assertEquals("msg #5 {0,number,0.0} {1,number,0.0} ''OK?''", new SimpleFormatter().formatMessage(recs.get(1)));
-        recs = r1.getSlaveLogRecords().get(c);
+        recs = r1.getAgentLogRecords().get(c);
         assertNotNull(recs);
         assertEquals(show(recs), 3, recs.size());
-        recs = r2.getSlaveLogRecords().get(c);
+        recs = r2.getAgentLogRecords().get(c);
         assertNotNull(recs);
         assertEquals(show(recs), 1, recs.size());
         String text = j.createWebClient().goTo("log/r1/").asNormalizedText();


### PR DESCRIPTION
See [JENKINS-35499](https://issues.jenkins.io/browse/JENKINS-35499).
as suggested by @daniel-beck in discussions of #7410  I've created a smaller PR

Some of the occurences of slave cant be changed as they are used in Messages.java and it is regenerated everytime we build the project 
All The Classes containing the term 'slave 'That Inherit Slave.java can't be changed as Slave.java is used in Jenkins.java and it is not editable
### Testing done

i ran these tests `mvn -Dtests=LogRecorderManagerTest test`      

### Proposed changelog entries

Rename getSlaveLogRecords to getAgentLogRecords in package hudson.logging in files LogRecorder and LogRecorderManagerTest


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@daniel-beck

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7418"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

