### PR TITLE
chore(windows/jdk17): provide an aci agent for windows with jdk17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,6 @@ for (i = 0; i < buildTypes.size(); i++) {
   for (j = 0; j < jdks.size(); j++) {
     def buildType = buildTypes[i]
     def jdk = jdks[j]
-    if (buildType == 'Windows' && jdk == 17) {
-      continue // TODO pending jenkins-infra/helpdesk#2822
-    }
     builds["${buildType}-jdk${jdk}"] = {
       // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#node-labels for information on what node types are available
       def agentContainerLabel = 'maven-' + jdk


### PR DESCRIPTION
Replays https://github.com/jenkinsci/jenkins/pull/7429 with write permissions.

cc @smerle33

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7430"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

