### PR TITLE
Stop using `infra.runATH` (backport)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,27 +151,9 @@ builds.ath = {
     node('docker-highmem') {
       // Just to be safe
       deleteDir()
-      def fileUri
-      def metadataPath
-      dir('sources') {
-        checkout scm
-        def mavenOptions = [
-          '-Pquick-build',
-          '-Dmaven.repo.local=$WORKSPACE_TMP/m2repo',
-          '-am',
-          '-pl',
-          'war',
-          'package',
-        ]
-        infra.runMaven(mavenOptions, 11)
-        dir('war/target') {
-          fileUri = 'file://' + pwd() + '/jenkins.war'
-        }
-        metadataPath = pwd() + '/essentials.yml'
-      }
-      dir('ath') {
-        runATH jenkins: fileUri, metadataFile: metadataPath
-      }
+      checkout scm
+      sh 'bash ath.sh'
+      junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
     }
   }
 }

--- a/ath.sh
+++ b/ath.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+cd $(dirname $0)
+
+# https://github.com/jenkinsci/acceptance-test-harness/releases
+export ATH_VERSION=5458.v911b_2f0818ee
+
+# TODO use Artifactory proxy?
+
+[ -f war/target/jenkins.war ] || mvn -B -ntp -Pquick-build -am -pl war package
+
+mkdir -p target/ath-reports
+chmod a+rwx target/ath-reports
+
+docker run --rm \
+  --env ATH_VERSION \
+  --shm-size 2g `# avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed` \
+  --volume "$(pwd)"/war/target/jenkins.war:/jenkins.war:ro \
+  --volume /var/run/docker.sock:/var/run/docker.sock:rw \
+  --volume "$(pwd)"/target/ath-reports:/reports:rw \
+  --interactive \
+  jenkins/ath:"$ATH_VERSION" \
+  bash <<'INSIDE'
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+cd
+# Start the VNC system provided by the image from the default user home directory
+eval $(vnc.sh)
+env | sort
+git clone --branch "$ATH_VERSION" --depth 1 https://github.com/jenkinsci/acceptance-test-harness
+cd acceptance-test-harness
+run.sh firefox /jenkins.war \
+  -Dmaven.test.failure.ignore \
+  -DforkCount=1 \
+  -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest
+cp --verbose target/surefire-reports/TEST-*.xml /reports
+INSIDE

--- a/essentials.yml
+++ b/essentials.yml
@@ -1,9 +1,0 @@
----
-ath:
-  useLocalSnapshots: false
-  athRevision: "5458.v911b_2f0818ee"
-  athImage: "jenkins/ath:5458.v911b_2f0818ee"
-  categories:
-    - org.jenkinsci.test.acceptance.junit.SmokeTest
-  jdks:
-    - 11


### PR DESCRIPTION
Porting #7397 so that the library function can be removed.

It seems `essentials.yml#ath.athRevision` did not change in trunk since the branch point, so there was no merge conflict here after all.


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7438"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

