### PR TITLE
De-flake `TelemetryTest`

### DIFF
--- a/test/src/test/java/jenkins/telemetry/TelemetryTest.java
+++ b/test/src/test/java/jenkins/telemetry/TelemetryTest.java
@@ -66,11 +66,19 @@ public class TelemetryTest {
         ExtensionList.lookupSingleton(Telemetry.TelemetryReporter.class).doRun();
         await().pollInterval(250, TimeUnit.MILLISECONDS)
                 .atMost(10, TimeUnit.SECONDS)
+                .until(logger::getMessages, hasItem("Telemetry submission received response 200 for: test-data"));
+        await().pollInterval(250, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(logger::getMessages, hasItem("Skipping telemetry for 'future' as it is configured to start later"));
+        await().pollInterval(250, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(logger::getMessages, hasItem("Skipping telemetry for 'past' as it is configured to end in the past"));
+        await().pollInterval(250, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(logger::getMessages, hasItem("Skipping telemetry for 'empty' as it has no data"));
+        await().pollInterval(250, TimeUnit.MILLISECONDS)
+                .atMost(10, TimeUnit.SECONDS)
                 .until(() -> types, hasItem("test-data"));
-        assertThat(logger.getMessages(), hasItem("Telemetry submission received response 200 for: test-data"));
-        assertThat(logger.getMessages(), hasItem("Skipping telemetry for 'future' as it is configured to start later"));
-        assertThat(logger.getMessages(), hasItem("Skipping telemetry for 'past' as it is configured to end in the past"));
-        assertThat(logger.getMessages(), hasItem("Skipping telemetry for 'empty' as it has no data"));
         assertThat(types, not(hasItem("future")));
         assertThat(types, not(hasItem("past")));
         assertThat(correlators.size(), is(counter));


### PR DESCRIPTION
Apparently waiting until `types` has `test-data` as was done in #7380 still was not sufficient to ensure that the log messages were available, as evidenced by [this stack trace](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7042/6/testReport/junit/jenkins.telemetry/TelemetryTest/Linux_jdk17___Linux_Build___Test___testSubmission/) from a recent test run:

```
Expected: a collection containing "Telemetry submission received response 200 for: test-data"
     but: mismatches were: [was "Skipping telemetry for 'future' as it is configured to start later", was "Skipping telemetry for 'past' as it is configured to end in the past", was "Skipping telemetry for 'empty' as it has no data", was "Submitting JSON: {\"type\":\"test-data\",\"payload\":{},\"correlator\":\"96e98f4a4cca8146b3bd32284d9c8028e5daf5fb6ce70178fa8085003cb5aa76\"}"]
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at jenkins.telemetry.TelemetryTest.testSubmission(TelemetryTest.java:70)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:618)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

There is still clearly some asynchronous behavior since we got far enough to prepare the JSON object for submission but not far enough to submit the HTTP request and log the HTTP status code by the time we hit the test assertion. This PR solves the problem by busy-waiting on the log messages to avoid being susceptible to this race condition. With that we can move the busy waiting on `types` back to its original place from before #7380, since the only reason for moving it in the first place was to ostensibly avoid this race.

### Testing done

Ran `mvn clean verify -Dtest=jenkins.telemetry.TelemetryTest`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7445"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

