### PR TITLE
De-flake `UserRestartTest`

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -1066,6 +1066,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
         }
 
         private Object readResolve() {
+            // Will generally only work if called after UserIdMapper.init:
             return getById(id, false);
         }
     }

--- a/test/src/test/java/hudson/model/UserRestartTest.java
+++ b/test/src/test/java/hudson/model/UserRestartTest.java
@@ -80,6 +80,14 @@ public class UserRestartTest {
         });
         sessions.then(r -> {
             FreeStyleProject p = r.jenkins.getItemByFullName("p", FreeStyleProject.class);
+            /*
+             * User.Replacer.readResolve() is racy, as its comments acknowledge. The loading of jobs
+             * and the initialization of UserIdMapper run concurrently, and UserIdMapper may not
+             * have been initialized yet when we are loading the job. The only way for this test to
+             * work reliably is to reload the job after UserIdMapper has been initialized, thus
+             * assuring that the job's reference to the user can be properly deserialized.
+             */
+            p.doReload();
             User u = p.getProperty(BadProperty.class).user; // do not inline: call User.get second
             assertEquals(User.get("pqhacker"), u);
         });


### PR DESCRIPTION
### Problem

`hudson.model.UserRestartTest#badSerialization` flaked with:

```
java.lang.AssertionError: expected:<pqhacker> but was:<null>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at hudson.model.UserRestartTest.lambda$badSerialization$3(UserRestartTest.java:84)
	at org.jvnet.hudson.test.JenkinsSessionRule$2.evaluate(JenkinsSessionRule.java:104)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:618)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

### Evaluation

The cause is similar to #7199, but in this case rather than a race between two jobs being loaded it is a race between a job being loaded and the user ID mapper being initialized. I could reliably reproduce this race by adding:

```java
diff --git a/core/src/main/java/hudson/model/UserIdMapper.java b/core/src/main/java/hudson/model/UserIdMapper.java
index 93e6a03fd0..cb12b50dff 100644
--- a/core/src/main/java/hudson/model/UserIdMapper.java
+++ b/core/src/main/java/hudson/model/UserIdMapper.java
@@ -71,6 +71,11 @@ public class UserIdMapper {
 
     @Initializer(after = InitMilestone.PLUGINS_STARTED, before = InitMilestone.JOB_LOADED)
     public File init() throws IOException {
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         usersDirectory = createUsersDirectoryAsNeeded();
         load();
         return usersDirectory;
```

This delays the initialization of the user ID mapper, allowing job loading to proceed without a fully initialized user ID mapper and exposing us to the race. Job loading calls `hudson.model.User.Replacer#readResolve`, which implicitly depends on the user ID having been mapped, which is not guaranteed because it is happening concurrently, and when the sleep is added we lose the race and get null, then the test fails.

### Solution

I solved this the same way as in #7199, not by changing the production code but by making the test more robust. Making the production code more robust is risky, and the production code path only exists as a best-effort workaround for a problem that was actually created much earlier when the object was serialized, anyway.

### Testing done

With the sleep in place, I could reliably reproduce the failure before this PR and could no longer reproduce it after this PR.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7449"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

