### PR TITLE
Missing `since` tag on `ErrorLoggingExecutorService`

### DIFF
--- a/core/src/main/java/jenkins/util/ErrorLoggingExecutorService.java
+++ b/core/src/main/java/jenkins/util/ErrorLoggingExecutorService.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
  * Executor service that logs unchecked exceptions / errors in {@link Runnable}.
  * Exceptions thrown from {@link Callable} are <em>not</em> not logged,
  * under the assumption that something is checking {@link Future#get()}.
+ * @since TODO
  */
 public class ErrorLoggingExecutorService extends InterceptingExecutorService {
 


### PR DESCRIPTION
Forgotten in #7284, sorry!

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7456"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

