### PR TITLE
[JENKINS-68692] Upgrade Guice from 5.0.1 to 5.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,9 +31,6 @@ updates:
       # and determined to be temporary. Exclusions should be removed from this
       # section once the remaining action items have been completed.
 
-      # Fails test automation; needs further investigation.
-      - dependency-name: "com.google.inject:guice-bom"
-
       # Contains incompatible API changes and needs compatibility work.
       - dependency-name: "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api"
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice-bom</artifactId>
-        <version>5.0.1</version>
+        <version>5.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -42,6 +42,7 @@ import hudson.model.Hudson;
 import jakarta.annotation.PostConstruct;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -498,10 +499,48 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                          */
                         cc.getGenericSuperclass();
                         cc.getGenericInterfaces();
-                        cc.getDeclaredConstructors();
-                        cc.getDeclaredMethods();
+
+                        /*
+                         * See com.google.inject.spi.InjectionPoint#forConstructorOf(TypeLiteral<?>, boolean)
+                         * and com.google.inject.spi.InjectionPoint(TypeLiteral<?>, Constructor<?>)
+                         */
+                        boolean foundInjectableConstructor = false;
+                        for (Constructor constructor : cc.getDeclaredConstructors()) {
+                            if (constructor.isAnnotationPresent(javax.inject.Inject.class)
+                                    || constructor.isAnnotationPresent(com.google.inject.Inject.class)) {
+                                constructor.getAnnotatedParameterTypes();
+                                constructor.getParameterAnnotations();
+                                foundInjectableConstructor = true;
+                            }
+                        }
+                        if (!foundInjectableConstructor) {
+                            Constructor<?> noArg = null;
+                            try {
+                                noArg = cc.getDeclaredConstructor();
+                            } catch (NoSuchMethodException e) {
+                                // ignore
+                            }
+                            if (noArg != null) {
+                                noArg.getAnnotatedParameterTypes();
+                                noArg.getParameterAnnotations();
+                            }
+                        }
+
+                        // See com.google.inject.spi.InjectionPoint(TypeLiteral<?>, Constructor<?>)
+                        for (Method method : cc.getDeclaredMethods()) {
+                            if (method.isAnnotationPresent(javax.inject.Inject.class)
+                                    || method.isAnnotationPresent(com.google.inject.Inject.class)) {
+                                method.getAnnotatedParameterTypes();
+                                method.getParameterAnnotations();
+                            }
+                        }
+
+                        // See com.google.inject.spi.InjectionPoint(TypeLiteral<?>, Field, boolean)
                         for (Field f : cc.getDeclaredFields()) {
-                            if (f.getAnnotation(javax.inject.Inject.class) != null || f.getAnnotation(com.google.inject.Inject.class) != null) {
+                            if (f.isAnnotationPresent(javax.inject.Inject.class)
+                                    || f.isAnnotationPresent(com.google.inject.Inject.class)) {
+                                f.getAnnotations();
+                                f.getAnnotatedType().getAnnotations();
                                 resolve(f.getType(), encountered);
                             }
                         }

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -501,8 +501,8 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                         cc.getGenericInterfaces();
 
                         /*
-                         * See com.google.inject.spi.InjectionPoint#forConstructorOf(TypeLiteral<?>, boolean)
-                         * and com.google.inject.spi.InjectionPoint(TypeLiteral<?>, Constructor<?>)
+                         * See com.google.inject.spi.InjectionPoint#forConstructorOf(TypeLiteral, boolean)
+                         * and com.google.inject.spi.InjectionPoint(TypeLiteral, Constructor)
                          */
                         boolean foundInjectableConstructor = false;
                         for (Constructor constructor : cc.getDeclaredConstructors()) {
@@ -526,7 +526,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                             }
                         }
 
-                        // See com.google.inject.spi.InjectionPoint(TypeLiteral<?>, Constructor<?>)
+                        // See com.google.inject.spi.InjectionPoint(TypeLiteral, Method, boolean)
                         for (Method method : cc.getDeclaredMethods()) {
                             if (method.isAnnotationPresent(javax.inject.Inject.class)
                                     || method.isAnnotationPresent(com.google.inject.Inject.class)) {
@@ -535,7 +535,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
                             }
                         }
 
-                        // See com.google.inject.spi.InjectionPoint(TypeLiteral<?>, Field, boolean)
+                        // See com.google.inject.spi.InjectionPoint(TypeLiteral, Field, boolean)
                         for (Field f : cc.getDeclaredFields()) {
                             if (f.isAnnotationPresent(javax.inject.Inject.class)
                                     || f.isAnnotationPresent(com.google.inject.Inject.class)) {


### PR DESCRIPTION
See [JENKINS-68692](https://issues.jenkins.io/browse/JENKINS-68692). Upgrades Guice from [5.0.1](https://github.com/google/guice/wiki/Guice501) (released on February 26, 2021) to [5.1.0](https://github.com/google/guice/wiki/Guice510) (released on January 24, 2022).

<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/google/guice/commit/b0ff10c8ec8911137451623a333d6daa65f73d8a"><code>b0ff10c</code></a> specify release version numbers</li>
<li><a href="https://github.com/google/guice/commit/bcc9fe45e39fa2d743616cf822c7f6dcbbff6e88"><code>bcc9fe4</code></a> Fix JDK17+ assistedinject private lookup behavior by catching InaccessibleObj...</li>
<li><a href="https://github.com/google/guice/commit/6d503098ff9704ca6d2865844f269116f523047a"><code>6d50309</code></a> upgrade easy mock versions and enable tests against Java 17.</li>
<li><a href="https://github.com/google/guice/commit/c4854d5cf594e2cc03f3a3413d1576180617b843"><code>c4854d5</code></a> Fix tests that break with Java 17 base on suggestions from <a href="https://github.com/mcculls"><code>@​mcculls</code></a> <a href="https://g">https://g</a>...</li>
<li><a href="https://github.com/google/guice/commit/02c46875940ff75bb393ddb2758fbe8fedc43d64"><code>02c4687</code></a> Mark javadoc_library as manual, so <code>test //...</code> doesn't build it.</li>
<li><a href="https://github.com/google/guice/commit/bc960c5c05e72de98f6417939f93e1354933a49e"><code>bc960c5</code></a> Generate test suite to run tests under a package.</li>
<li><a href="https://github.com/google/guice/commit/1acb91cfff10ec9a58c17c0e1185a07d411e6c3e"><code>1acb91c</code></a> Run bazel test in ci workflow.</li>
<li><a href="https://github.com/google/guice/commit/1c57d16158423fe3e39e021a5acd1f7fac151821"><code>1c57d16</code></a> Add javadoc targets for Guice libraries.</li>
<li><a href="https://github.com/google/guice/commit/f7abab4bb3a6dadeebc1427f2ed44ae0a62040b9"><code>f7abab4</code></a> fix java-version property for publish workflow.</li>
<li><a href="https://github.com/google/guice/commit/dea06c1087bf61738fd9e92d81a4c315b2eb5d02"><code>dea06c1</code></a> Make Guice builds with bazel.</li>
<li>Additional commits viewable in <a href="https://github.com/google/guice/compare/5.0.1...5.1.0">compare view</a></li>
</ul>
</details>

As of google/guice@dc7f4858f, Guice is more strict about classpath correctness with regard to annotations. Guice now examines type use annotations on parameters to scan for annotations named `@Nullable`, which has implications for our implementation of support for optional extensions.

https://github.com/jenkinsci/jenkins/blob/304b4b3197ef71174c6b76d12c7f4d4e6ac11236/core/src/main/java/hudson/ExtensionFinder.java#L474-L485 explains the design of the current implementation of support for optional extensions. When optional extensions are present in the Guice bindings, and when the optional plugins those extensions consume are not installed, then `Guice#createInjector` fails with class loading errors, which has disastrous effects on Jenkins startup, causing Jenkins to start up disastrously without _any_ plugin bindings. Clearly this is a bad outcome, so to avoid this bad outcome the `resolve()` methods preëmptively load any classes that Guice would load when creating the injector _before_ adding the binding to the Guice configuration or calling `Guice#createInjector`. Thus if any class loading errors are encountered (which are logged for non-optional extensions but not logged for optional extensions), then we decline to create the binding. Then when we call `Guice#createInjector` later, the creation of the injector will succeed because the problematic bindings were never added.

This all works well enough, but it relies on the `resolve()` method being able to accurately predict what class loading operations Guice will subsequently perform. And as of google/guice@dc7f4858f Guice is now performing additional class loading operations, which are not predicted by `resolve()`. Therefore `resolve()` allows the optional extension to be placed in the list of bindings, but when `Guice#createInjector` is called, it blows up with a class loading error, which causes Jenkins to start up disastrously without _any_ plugin bindings.

The solution is to enhance `resolve()` to more accurately predict the class loading Guice will do in `Guice#createInjector`. This enables optional extensions that cannot be loaded due to a missing optional dependency to be discovered earlier, to not be added to the list of bindings, and to not cause Jenkins to start up disastrously without _any_ plugin bindings. The code comments provide references to the relevant Guice methods.

### Testing done

#### Automated testing

- [Core test suite](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-7477/8/) passes
- [Plugin BOM test suite](https://ci.jenkins.io/job/Tools/job/bom/job/PR-1631/4/) passes

#### Functional testing

We installed the latest Jenkins weekly without these changes and with the following plugins:

- `bouncycastle-api.jpi`
- `branch-api.jpi`
- `caffeine-api.jpi`
- `cloudbees-folder.jpi`
- `instance-identity.jpi`
- `ionicons-api.jpi`
- `javax-activation-api.jpi`
- `javax-mail-api.jpi`
- `job-dsl.jpi`
- `mina-sshd-api-common.jpi`
- `mina-sshd-api-core.jpi`
- `scm-api.jpi`
- `script-security.jpi`
- `sshd.jpi`
- `structs.jpi`
- `trilead-api.jpi`

Note that this includes `cloudbees-folder` (which has an optional extension depending on `credentials`) and `job-dsl` (which has an optional extension depending on `configuration-as-code`) but _not_ `credentials` or `configuration-as-code`. We confirmed that the weekly started successfully with this set of plugins.

Next we built Jenkins with the change to `bom/pom.xml` in this PR but _not_ the change to `core/src/main/java/hudson/ExtensionFinder.java`. We confirmed that Jenkins now failed to start up because of Guice errors loading the optional extensions in `cloudbees-folder` and `job-dsl`. Then we installed `credentials` and `configuration-as-code` (along with `configuration-as-code` dependencies `commons-text-api`, `commons-lang3-api`, and `snakeyaml-api`) and confirmed that Jenkins could start up again.

Finally we removed `credentials`, `configuration-as-code`, `commons-text-api`, `commons-lang3-api`, and `snakeyaml-api` (going back to the scenario that was passing before this PR but failing with the Guice upgrade without the change to `core/src/main/java/hudson/ExtensionFinder.java`) and started Jenkins with the change to `core/src/main/java/hudson/ExtensionFinder.java` from this PR. We confirmed that Jenkins started up successfully.

We spent some time trying to automate the above scenario with fake plugins but gave up after several hours when we realized that no matter which way we tried to implement it, the result would be too fragile to be maintainable.

### Proposed changelog entries

Upgrade Guice from [5.0.1](https://github.com/google/guice/wiki/Guice501) (released on February 26, 2021) to [5.1.0](https://github.com/google/guice/wiki/Guice510) (released on January 24, 2022). Guice 5.1.0 contains eight fixes and improvements.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7477"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

