### PR TITLE
[JENKINS-68696] Remove `javax.servlet:servlet-api` dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,11 +37,6 @@ updates:
       # Contains incompatible API changes and needs compatibility work.
       - dependency-name: "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api"
 
-      # This is a banned dependency, and we have a redundant trick in our POM to
-      # prevent it from being pulled in. If and when the reference is removed in
-      # our POM, this exclusion can also be removed.
-      - dependency-name: "javax.servlet:servlet-api"
-
       # Needs significant testing. See:
       # https://github.com/jenkinsci/jenkins/pull/5112#issuecomment-744429487
       # https://github.com/jenkinsci/jenkins/pull/5116#issuecomment-744526638

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -379,24 +379,6 @@ THE SOFTWARE.
         <version>1.2</version>
         <scope>provided</scope>
       </dependency>
-      <dependency>
-        <!--  make sure these old servlet versions are never used by us or by any plugins which end up depending on this version -->
-        <!--  plugin-pom tries to fudge servlet support to be compatible with cores < 2.0 and JTH which needs 3.x for jetty, and ends up causing issues with some IDEs -->
-        <groupId>javax.servlet</groupId>
-        <!-- the old artifactID for the servlet API -->
-        <artifactId>servlet-api</artifactId>
-        <version>[0]</version>
-        <!--
-              "[0]" is a range that must be exactly 0
-              this is different to "0" which is hint to use version 0.
-              therefore unless anyone else uses ranges (they should not) this version will always win
-              We have deployed a version 0 to jenkins repo which has an empty jar
-              This prevents conflicts between the old Servlet API and the new Servlet API as the groupIDs have changed
-              see https://github.com/jenkinsci/jenkins/pull/3033/files#r141325857 for a fuller description
-        -->
-        <scope>provided</scope>
-        <optional>true</optional>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,39 +101,6 @@ THE SOFTWARE.
     <winstone.version>6.6</winstone.version>
   </properties>
 
-  <dependencyManagement>
-    <!-- any dependencies that can be used by plugins must be defined in the bom and not here -->
-    <dependencies>
-      <dependency>
-        <!--  make sure these old servlet versions are never used by us or by any plugins which end up depending on this version -->
-        <!--  plugin-pom tries to fudge servlet support to be compatible with cores < 2.0 and JTH which needs 3.x for jetty, and ends up causing issues with some IDEs -->
-        <groupId>javax.servlet</groupId>
-        <!-- the old artifactID for the servlet API -->
-        <artifactId>servlet-api</artifactId>
-        <version>[0]</version>
-        <!--
-          "[0]" is a range that must be exactly 0
-          this is different to "0" which is hint to use version 0.
-          therefore unless anyone else uses ranges (they should not) this version will always win
-          We have deployed a version 0 to jenkins repo which has an empty jar
-          This prevents conflicts between the old Servet API and the new Servlet API as the groupIDs have changed
-          see https://github.com/jenkinsci/jenkins/pull/3033/files#r141325857 for a fuller description
-        -->
-        <scope>provided</scope>
-        <optional>true</optional>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
-  <dependencies>
-    <dependency>
-      <!-- make sure our dependency tree and all others are clean of the legacy servlet api.  -->
-      <groupId>javax.servlet</groupId>
-      <!-- the old artifactID for the servlet API -->
-      <artifactId>servlet-api</artifactId>
-    </dependency>
-  </dependencies>
-
   <!--
     Note that the 'repositories' and 'pluginRepositories' blocks below are actually copy-pasted
     from the Jenkins org pom. This is on purpose to keep Jenkins core buildable even if one has

--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@ THE SOFTWARE.
             <configuration>
               <rules>
                 <bannedDependencies>
-                  <excludes>
+                  <excludes combine.children="append">
                     <exclude>org.sonatype.sisu:sisu-guice</exclude>
                     <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
                     <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>


### PR DESCRIPTION
See [JENKINS-68696](https://issues.jenkins.io/browse/JENKINS-68696).

https://github.com/jenkinsci/jenkins/blob/a4f9f5b64b441172f6a1d871a7c615c03ac26235/pom.xml#L115-L132= is a trick added in commit [982a8fa](https://github.com/jenkinsci/jenkins/commit/982a8faf5a853129039ba2babe2a8cb35d9aca1f) apparently to prevent plugins (and core?) from bundling Servlet API 2.x. `javax.servlet:servlet-api` has been banned through Enforcer in the plugin parent POM since jenkinsci/plugin-pom@a608967 and in the core parent POM since jenkinsci/pom@82f73fef, so it is longer necessary to keep this trick in core. Keeping it complicates `jenkinsci/jenkins/pom.xml` and our Dependabot configuration, so I think it is best to dispense with it from both the core dependency tree and the Dependendabot exclusions list and rely on the abovementioned Enforcer bans to keep it out of our dependency trees.

### Testing done

- Core test suite passes
- BOM test passed in https://github.com/jenkinsci/bom/pull/1626

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7478"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

