### PR TITLE
Decline to cache a likely incorrect computation

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1267,7 +1267,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                     result.add(name);
                 }
             }
-            agentProtocols = result;
+            /*
+             * An empty result is almost never valid, but it can happen due to JENKINS-70206. Since we know the result
+             * is likely incorrect, at least decline to cache it so that a correct result can be computed later on
+             * rather than continuing to deliver the incorrect result indefinitely.
+             */
+            if (!result.isEmpty()) {
+                agentProtocols = result;
+            }
             return result;
         }
         return agentProtocols;


### PR DESCRIPTION
Based on my analysis in [JENKINS-70206](https://issues.jenkins.io/browse/JENKINS-70206), `Jenkins#getAgentProtocols` is caching a bad value early in the initialization process due to a new race condition introduced by the split of `instance-identity` to a plugin, even though a correct value could be computed when it is needed later during the test. If this theory is correct, a simple workaround would be to decline to cache the likely incorrect computation, forcing recomputation later when a correct value is computable. Of course a long-term solution would look more like [this](https://issues.jenkins.io/browse/JENKINS-70206?focusedCommentId=432924&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-432924) or explicitly defining the order of initialization within Guice (for example with a constructor parameter), but this should at least stabilize the test suite on Windows in the meantime.

### Testing done

I've gotten 4 consecutive succesful runs of `jenkins.security.Security218Test` with this PR, which is more than I could get yesterday without this PR. Checking in this change can't hurt, but I'll keep running the build another 2-3 or times and close this PR if a failure of `jenkins.security.Security218Test` demonstrates this PR to be ineffective.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7485"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

