### PR TITLE
[JENKINS-70169] Add comments explaining the absence of breadcrumb items in `resources/hudson/PluginManager`

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -32,6 +32,7 @@ THE SOFTWARE.
         <j:set var="readOnlyMode" value="${!app.hasPermission(app.ADMINISTER)}"/>
 
         <st:include page="sidepanel.jelly"/>
+        <l:breadcrumb title="${%Advanced settings}" />
 
         <l:main-panel>
           <l:app-bar title="${%Advanced settings}"/>

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
         <j:set var="readOnlyMode" value="${!app.hasPermission(app.ADMINISTER)}"/>
 
         <st:include page="sidepanel.jelly"/>
-        <l:breadcrumb title="${%Advanced settings}" />
+        <!-- no need for additional breadcrumb here as the side panel offers enough functionality to browse between different pages -->
 
         <l:main-panel>
           <l:app-bar title="${%Advanced settings}"/>

--- a/core/src/main/resources/hudson/PluginManager/available.jelly
+++ b/core/src/main/resources/hudson/PluginManager/available.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout title="${%Available plugins} - ${%Plugin Manager}" permission="${app.SYSTEM_READ}">
     <st:include page="sidepanel.jelly"/>
-    <l:breadcrumb title="${%Available plugins}" />
+    <!-- no need for additional breadcrumb here as the side panel offers enough functionality to browse between different pages -->
 
     <l:main-panel>
       <l:app-bar title="${%Plugins}" />

--- a/core/src/main/resources/hudson/PluginManager/available.jelly
+++ b/core/src/main/resources/hudson/PluginManager/available.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout title="${%Available plugins} - ${%Plugin Manager}" permission="${app.SYSTEM_READ}">
     <st:include page="sidepanel.jelly"/>
+    <l:breadcrumb title="${%Available plugins}" />
 
     <l:main-panel>
       <l:app-bar title="${%Plugins}" />

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
     <j:set var="readOnlyMode" value="${!app.hasPermission(app.ADMINISTER)}"/>
 
     <st:include page="sidepanel.jelly"/>
-    <l:breadcrumb title="${%Installed plugins}" />
+    <!-- no need for additional breadcrumb here as the side panel offers enough functionality to browse between different pages -->
 
     <l:main-panel>
       <l:app-bar title="${%Plugins}" />

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -31,6 +31,7 @@ THE SOFTWARE.
     <j:set var="readOnlyMode" value="${!app.hasPermission(app.ADMINISTER)}"/>
 
     <st:include page="sidepanel.jelly"/>
+    <l:breadcrumb title="${%Installed plugins}" />
 
     <l:main-panel>
       <l:app-bar title="${%Plugins}" />

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
   </st:documentation>
   <l:layout title="${%Updates} - ${%Plugin Manager}" permission="${app.SYSTEM_READ}">
     <st:include page="sidepanel.jelly"/>
-    <!-- no need for breadcrumb here -->
+    <!-- no need for additional breadcrumb here as we're on an "index" page already including breadcrumb -->
 
     <l:main-panel>
       <l:app-bar title="${%Plugins}" />

--- a/core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/core/src/main/resources/hudson/PluginManager/table.jelly
@@ -38,6 +38,7 @@ THE SOFTWARE.
   </st:documentation>
   <l:layout title="${%Updates} - ${%Plugin Manager}" permission="${app.SYSTEM_READ}">
     <st:include page="sidepanel.jelly"/>
+    <!-- no need for breadcrumb here -->
 
     <l:main-panel>
       <l:app-bar title="${%Plugins}" />


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

Extract from #7457 

Follow-up of https://github.com/jenkinsci/jenkins/pull/6912

Initially fixing [JENKINS-70169](https://issues.jenkins.io/browse/JENKINS-70169), I've included every missing breadcrumb items I've found by searching for "sidepanel.jelly" in jelly files.

Notes: 
- I've added `<!-- no need for breadcrumb here -->` as comment in views where adding a breadcrumb item wasn't necessary, let me know if it's preferable to omit them.

- This doesn't fix missing breadcrumb depending on plugin (ex: https://github.com/jenkinsci/cloudbees-folder-plugin/pull/278)

### Testing done

Built and ran Jenkins locally, going on modified pages to check the change.

There is no additional automatic test added for these breadcrumb items.

`http://localhost:8080/jenkins/manage/pluginManager/advanced`:
<img width="778" alt="image" src="https://user-images.githubusercontent.com/91831478/206265344-a2a3858a-94cf-4218-a0a2-f16e17f538ab.png">

`http://localhost:8080/jenkins/manage/pluginManager/available`:
<img width="1014" alt="image" src="https://user-images.githubusercontent.com/91831478/206265515-f9ea97c4-03f7-4f6d-805c-0fd4e8ed1c5d.png">

`http://localhost:8080/jenkins/manage/pluginManager/installed`:
<img width="795" alt="image" src="https://user-images.githubusercontent.com/91831478/206265584-d21e8bb4-624e-47d8-a678-5967c93258f2.png">

### Proposed changelog entries

- Entry 1: Add missing breadcrumb items in resources/hudson/PluginManager
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@Wadeck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7489"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

