### PR TITLE
[JENKINS-70169] Add missing breadcrumb items in `resources/hudson/model/User`

### DIFF
--- a/core/src/main/resources/hudson/model/User/builds.jelly
+++ b/core/src/main/resources/hudson/model/User/builds.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Builds}" />
     <l:main-panel>
       <h1>
         ${%title(it)}

--- a/core/src/main/resources/hudson/model/User/configure.jelly
+++ b/core/src/main/resources/hudson/model/User/configure.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout permission="${app.ADMINISTER}" title="${%title(it.fullName)}">
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Configure}" />
     <l:main-panel>
       <f:form method="post" action="configSubmit" name="config">
         <j:set var="instance" value="${it}"/>

--- a/core/src/main/resources/hudson/model/User/delete.jelly
+++ b/core/src/main/resources/hudson/model/User/delete.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Delete}" />
     <l:main-panel>
       <form method="post" action="doDelete" name="delete">
         ${%delete.user(it.displayName)}

--- a/core/src/main/resources/hudson/model/User/index.jelly
+++ b/core/src/main/resources/hudson/model/User/index.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />
-    <!-- no need for breadcrumb here -->
+    <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
     <l:main-panel>
       <h1>
         <span class="icon-lg">

--- a/core/src/main/resources/hudson/model/User/index.jelly
+++ b/core/src/main/resources/hudson/model/User/index.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />
+    <!-- no need for breadcrumb here -->
     <l:main-panel>
       <h1>
         <span class="icon-lg">


### PR DESCRIPTION
Extract from #7457 

Follow-up of https://github.com/jenkinsci/jenkins/pull/6912

Initially fixing [JENKINS-70169](https://issues.jenkins.io/browse/JENKINS-70169), I've included every missing breadcrumb items I've found by searching for "sidepanel.jelly" in jelly files.

Notes: 
- I've added `<!-- no need for breadcrumb here -->` as comment in views where adding a breadcrumb item wasn't necessary, let me know if it's preferable to omit them.

- This doesn't fix missing breadcrumb depending on plugin (ex: https://github.com/jenkinsci/cloudbees-folder-plugin/pull/278)

### Testing done

Built and ran Jenkins locally, going on modified pages to check the change.

There is no additional automatic test added for these breadcrumb items.

With a user "test",

`http://localhost:8080/jenkins/user/test/builds`:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/91831478/206295492-292c2132-f797-4b60-9a29-27d51b0759f1.png">

`http://localhost:8080/jenkins/user/test/delete`:
<img width="645" alt="image" src="https://user-images.githubusercontent.com/91831478/206295673-899f210c-6222-4209-8f94-612f8caafc68.png">

`http://localhost:8080/jenkins/user/test/configure`:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/91831478/206295724-c8ffa708-7e4a-4f8a-a1dc-9dd074c066b7.png">

### Proposed changelog entries

- Entry 1: Add missing breadcrumb items in resources/hudson/model/User
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7492"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

