### PR TITLE
[JENKINS-70169] Add missing breadcrumb items in `resources/hudson/model/Abstract*`

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractBuild/changes.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/changes.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName} ${%Changes}">
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Changes}" />
     <l:main-panel>
       <t:buildCaption>${%Changes}</t:buildCaption>
       <j:choose>

--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName}">
     <st:include page="sidepanel.jelly" />
-    <!-- no need for breadcrumb here -->
+    <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
     <l:main-panel>
       <div style="float:right; z-index: 1; position:relative; margin-left: 1em">
         <l:hasPermission permission="${it.UPDATE}">

--- a/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName}">
     <st:include page="sidepanel.jelly" />
+    <!-- no need for breadcrumb here -->
     <l:main-panel>
       <div style="float:right; z-index: 1; position:relative; margin-left: 1em">
         <l:hasPermission permission="${it.UPDATE}">

--- a/core/src/main/resources/hudson/model/AbstractItem/confirm-rename.jelly
+++ b/core/src/main/resources/hudson/model/AbstractItem/confirm-rename.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%Rename}">
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Rename}" />
     <l:main-panel>
       <h1>${%DescribeRename(it.pronoun, it.name)}</h1>
       <f:form method="post" action="confirmRename" name="config" tableClass="config-table scrollspy">

--- a/core/src/main/resources/hudson/model/AbstractItem/delete.jelly
+++ b/core/src/main/resources/hudson/model/AbstractItem/delete.jelly
@@ -30,6 +30,7 @@ THE SOFTWARE.
 	</st:documentation>
   <l:layout>
 		<st:include page="sidepanel.jelly" />
+		<l:breadcrumb title="${%Delete}" />
 		<l:main-panel>
 		  <form method="post" action="doDelete">
 		    ${%blurb(it.pronoun, it.displayName)}

--- a/core/src/main/resources/hudson/model/AbstractItem/noWorkspace.jelly
+++ b/core/src/main/resources/hudson/model/AbstractItem/noWorkspace.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
   <st:statusCode value="404"/>
   <l:layout>
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Error}" />
     <l:main-panel>
       <h1><l:icon class="icon-error icon-xlg"/>${%Error: no workspace}</h1>
       <j:choose>

--- a/core/src/main/resources/hudson/model/AbstractModelObject/editDescription.jelly
+++ b/core/src/main/resources/hudson/model/AbstractModelObject/editDescription.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Edit description}" />
     <l:main-panel>
       <form action="submitDescription" method="post">
         <table>

--- a/core/src/main/resources/hudson/model/AbstractProject/changes.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/changes.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%changes.title(it.name)}">
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Changes}" />
     <l:main-panel>
       <j:set var="from" value="${request.getParameter('from')}"/>
       <j:set var="to" value="${request.getParameter('to')}"/>

--- a/core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />
+    <l:breadcrumb title="${%Error}" />
     <l:main-panel>
       <h1><l:icon class="icon-error icon-xlg"/>${%Error: Wipe Out Workspace blocked by SCM}</h1>
       <p>


### PR DESCRIPTION
Extract from #7457 

Follow-up of https://github.com/jenkinsci/jenkins/pull/6912

Initially fixing [JENKINS-70169](https://issues.jenkins.io/browse/JENKINS-70169), I've included every missing breadcrumb items I've found by searching for "sidepanel.jelly" in jelly files.

Notes: 
- I've added `<!-- no need for breadcrumb here -->` as comment in views where adding a breadcrumb item wasn't necessary, let me know if it's preferable to omit them.

- This doesn't fix missing breadcrumb depending on plugin (ex: https://github.com/jenkinsci/cloudbees-folder-plugin/pull/278)

### Testing done

Built and ran Jenkins locally, going on modified pages to check the change.

There is no additional automatic test added for these breadcrumb items.

With a job "test",

`http://localhost:8080/jenkins/job/test/changes`:
<img width="618" alt="image" src="https://user-images.githubusercontent.com/91831478/206299720-5953b743-af31-438c-8a4b-885b64689f2a.png">

`http://localhost:8080/jenkins/job/test/confirm-rename`:
<img width="755" alt="image" src="https://user-images.githubusercontent.com/91831478/206299829-e2438c48-04e9-4907-9c3e-5b57522c2269.png">

`http://localhost:8080/jenkins/job/test/delete`:
<img width="697" alt="image" src="https://user-images.githubusercontent.com/91831478/206299907-4adebe45-e40d-43be-9083-3908c50a6137.png">

`http://localhost:8080/jenkins/job/test/noWorkspace`:
<img width="656" alt="image" src="https://user-images.githubusercontent.com/91831478/206299998-971be7ed-7604-4556-9da8-17703faf7b3e.png">

`http://localhost:8080/jenkins/job/test/editDescription`:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/91831478/206300076-9c08ef20-dbcd-4831-9ef7-660e59757731.png">

(Not sure where to find the corresponding change to core/src/main/resources/hudson/model/AbstractProject/changes.jelly)

`http://localhost:8080/jenkins/job/test/wipeOutWorkspaceBlocked`:
<img width="957" alt="image" src="https://user-images.githubusercontent.com/91831478/206300449-fbf36af8-883a-440a-965e-6eea4b2ff0b7.png">

### Proposed changelog entries

- Entry 1: Add missing breadcrumb items in resources/hudson/model/Abstract*
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7494"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

