### PR TITLE
Keep gitpods Dockerfile up to date with renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,7 +62,3 @@ updates:
       interval: "daily"
     # Include only security updates and exclude version updates.
     open-pull-requests-limit: 0
-  - package-ecosystem: "docker"
-    directory: "./gitpod"
-    schedule:
-      interval: "daily"

--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,12 @@
       "depNameTemplate": "jenkins/ath",
       "datasourceTemplate": "docker",
       "versioningTemplate": "loose"
+    },
+    {
+      "fileMatch": [".gitpod/Dockerfile"],
+      "matchStrings": ["ARG MAVEN_VERSION=(?<currentValue>.*?)\n"],
+      "depNameTemplate": "org.apache.maven:maven-core",
+      "datasourceTemplate": "maven"
     }
   ],
   "labels": ["dependencies", "skip-changelog"],


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/jenkins/pull/7372#issuecomment-1345275155. Given dependabot does not know where the information should come from, I added it to renovate's config with a custom file template.

A PoC is available at https://github.com/NotMyFault/gitpod-dependabot/pull/2

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7507"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

