### PR TITLE
Provide native Java 11 HTTP client versions of `FormValidation#URLCheck` methods

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -357,7 +357,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
     /**
      * Return a new {@link HttpClient} with Jenkins-specific default settings.
      *
-     * <p>Equivalent to {@code newHttpClientBuilder().build()}.
+     * <p>Equivalent to {@code newHttpClientBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()}.
      *
      * <p>The Jenkins-specific default settings include a proxy server and proxy authentication (as
      * configured by {@link ProxyConfiguration}) and a connection timeout (as configured by {@link
@@ -367,7 +367,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
      * @since TODO
      */
     public static HttpClient newHttpClient() {
-        return newHttpClientBuilder().build();
+        return newHttpClientBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
     }
 
     /**

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -472,6 +472,7 @@ public abstract class FormValidation extends IOException implements HttpResponse
          *
          * @throws IOException if the URI scheme is not supported, the connection was interrupted,
          *     or the response was an error
+         * @since TODO
          */
         protected Stream<String> open(URI uri) throws IOException {
             HttpClient httpClient = ProxyConfiguration.newHttpClient();
@@ -519,6 +520,7 @@ public abstract class FormValidation extends IOException implements HttpResponse
          * Find the string literal from the given stream of lines.
          *
          * @return true if found, false otherwise
+         * @since TODO
          */
         protected boolean findText(Stream<String> in, String literal) {
             try (in) {

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -44,14 +44,19 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Stream;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
@@ -462,9 +467,44 @@ public abstract class FormValidation extends IOException implements HttpResponse
      */
     public abstract static class URLCheck {
         /**
+         * Open the given URI and read text content from it. This method honors the Content-type
+         * header.
+         *
+         * @throws IOException if the URI scheme is not supported, the connection was interrupted,
+         *     or the response was an error
+         */
+        protected Stream<String> open(URI uri) throws IOException {
+            HttpClient httpClient = ProxyConfiguration.newHttpClient();
+            HttpRequest httpRequest;
+            try {
+                httpRequest = ProxyConfiguration.newHttpRequestBuilder(uri).GET().build();
+            } catch (IllegalArgumentException e) {
+                throw new IOException(e);
+            }
+            java.net.http.HttpResponse<Stream<String>> httpResponse;
+            try {
+                httpResponse =
+                        httpClient.send(httpRequest, java.net.http.HttpResponse.BodyHandlers.ofLines());
+            } catch (InterruptedException e) {
+                throw new IOException(e);
+            }
+            if (httpResponse.statusCode() != HttpURLConnection.HTTP_OK) {
+                throw new IOException(
+                        "Server returned HTTP response code "
+                                + httpResponse.statusCode()
+                                + " for URI "
+                                + uri);
+            }
+            return httpResponse.body();
+        }
+
+        /**
          * Opens the given URL and reads text content from it.
          * This method honors Content-type header.
+         *
+         * @deprecated use {@link #open(URI)}
          */
+        @Deprecated
         protected BufferedReader open(URL url) throws IOException {
             // use HTTP content type to find out the charset.
             URLConnection con = ProxyConfiguration.open(url);
@@ -476,10 +516,23 @@ public abstract class FormValidation extends IOException implements HttpResponse
         }
 
         /**
+         * Find the string literal from the given stream of lines.
+         *
+         * @return true if found, false otherwise
+         */
+        protected boolean findText(Stream<String> in, String literal) {
+            try (in) {
+                return in.anyMatch(line -> line.contains(literal));
+            }
+        }
+
+        /**
          * Finds the string literal from the given reader.
          * @return
          *      true if found, false otherwise.
+         * @deprecated use {@link #findText(Stream, String)}
          */
+        @Deprecated
         protected boolean findText(BufferedReader in, String literal) throws IOException {
             String line;
             while ((line = in.readLine()) != null)
@@ -499,9 +552,9 @@ public abstract class FormValidation extends IOException implements HttpResponse
             // any invalid URL comes here
             if (e.getMessage().equals(url))
                 // Sun JRE (and probably others too) often return just the URL in the error.
-                return error("Unable to connect " + url);
+                return error("Unable to connect " + url, e);
             else
-                return error(e.getMessage());
+                return error(e.getMessage(), e);
         }
 
         /**

--- a/core/src/test/java/hudson/util/FormValidationTest.java
+++ b/core/src/test/java/hudson/util/FormValidationTest.java
@@ -27,11 +27,15 @@ package hudson.util;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
+import javax.servlet.ServletException;
 import org.junit.Test;
 
 /**
@@ -115,5 +119,25 @@ public class FormValidationTest {
     public void formValidationException() {
         FormValidation fv = FormValidation.error(new Exception("<html"), "Message<html");
         assertThat(fv.renderHtml(), not(containsString("<html")));
+    }
+
+    @Test
+    public void testUrlCheck() throws IOException, ServletException {
+        FormValidation.URLCheck urlCheck = new FormValidation.URLCheck() {
+            @Override
+            protected FormValidation check() throws ServletException, IOException {
+                String uri = "https://www.jenkins.io/";
+                try {
+                    if (findText(open(URI.create(uri)), "Jenkins")) {
+                        return FormValidation.ok();
+                    } else {
+                        return FormValidation.error("This is a valid URI but it does not look like Jenkins");
+                    }
+                } catch (IOException e) {
+                    return handleIOException(uri, e);
+                }
+            }
+        };
+        assertThat(urlCheck.check(), is(FormValidation.ok()));
     }
 }

--- a/test/src/test/java/hudson/util/FormValidationTest.java
+++ b/test/src/test/java/hudson/util/FormValidationTest.java
@@ -4,6 +4,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
+import java.io.IOException;
+import java.net.URI;
+import javax.servlet.ServletException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -30,5 +33,25 @@ public class FormValidationTest {
         FormValidation actual = FormValidation.validateExecutable("git");
         String failMessage = "There's no such executable git in PATH:";
         assertThat(actual, not(is(FormValidation.error(failMessage))));
+    }
+
+    @Test
+    public void testUrlCheck() throws IOException, ServletException {
+        FormValidation.URLCheck urlCheck = new FormValidation.URLCheck() {
+            @Override
+            protected FormValidation check() throws ServletException, IOException {
+                String uri = "https://www.jenkins.io/";
+                try {
+                    if (findText(open(URI.create(uri)), "Jenkins")) {
+                        return FormValidation.ok();
+                    } else {
+                        return FormValidation.error("This is a valid URI but it does not look like Jenkins");
+                    }
+                } catch (IOException e) {
+                    return handleIOException(uri, e);
+                }
+            }
+        };
+        assertThat(urlCheck.check(), is(FormValidation.ok()));
     }
 }

--- a/test/src/test/java/hudson/util/FormValidationTest.java
+++ b/test/src/test/java/hudson/util/FormValidationTest.java
@@ -4,9 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
-import java.io.IOException;
-import java.net.URI;
-import javax.servlet.ServletException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -33,25 +30,5 @@ public class FormValidationTest {
         FormValidation actual = FormValidation.validateExecutable("git");
         String failMessage = "There's no such executable git in PATH:";
         assertThat(actual, not(is(FormValidation.error(failMessage))));
-    }
-
-    @Test
-    public void testUrlCheck() throws IOException, ServletException {
-        FormValidation.URLCheck urlCheck = new FormValidation.URLCheck() {
-            @Override
-            protected FormValidation check() throws ServletException, IOException {
-                String uri = "https://www.jenkins.io/";
-                try {
-                    if (findText(open(URI.create(uri)), "Jenkins")) {
-                        return FormValidation.ok();
-                    } else {
-                        return FormValidation.error("This is a valid URI but it does not look like Jenkins");
-                    }
-                } catch (IOException e) {
-                    return handleIOException(uri, e);
-                }
-            }
-        };
-        assertThat(urlCheck.check(), is(FormValidation.ok()));
     }
 }


### PR DESCRIPTION
Building on #7398, provide native Java 11 HTTP client versions of `FormValidation#URLCheck` methods, deprecating the old `HttpURLConnection` methods in favor of these and adding test coverage for the new functionality (the old functionality had no test coverage).

### Testing done

Ran `mvn clean verify -Dtest=hudson.util.FormValidationTest` locally. As a bonus, I converted `hudson.plugins.git.browser.AssemblaWebDoCheckURLTest#testInitialChecksOnRepoUrl` to this new API and verified that doing so chased away the weird Java 19 problem I was seeing in https://github.com/jenkinsci/bom/pull/1637#issuecomment-1345301126.

### Proposed changelog entries

Provide native Java 11 HTTP client versions of `FormValidation#URLCheck` methods

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7508"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

