### PR TITLE
[FIX]: delay the initialization of fields keyStore, trustManager, and sslContext 

### DIFF
--- a/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
+++ b/core/src/main/java/jenkins/slaves/JnlpSlaveAgentProtocol4.java
@@ -72,11 +72,11 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
     /**
      * Our keystore.
      */
-    private final KeyStore keyStore;
+    private KeyStore keyStore = null;
     /**
      * Our trust manager.
      */
-    private final TrustManager trustManager;
+    private TrustManager trustManager = null;
 
     /**
      * The provider of our {@link IOHub}
@@ -111,7 +111,9 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
         }
 
         // prepare our keyStore so we can provide our authentication
-        keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        if (keyStore == null && getName() == null) {
+            keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        }
         char[] password = constructPassword();
         try {
             keyStore.load(null, password);
@@ -135,14 +137,18 @@ public class JnlpSlaveAgentProtocol4 extends AgentProtocol {
         }
 
         // prepare our trustManagers
-        trustManager = new PublicKeyMatchingX509ExtendedTrustManager(false, true);
+        if (trustManager == null && getName() == null) {
+            trustManager = new PublicKeyMatchingX509ExtendedTrustManager(false, true);
+        }
         TrustManager[] trustManagers = {trustManager};
 
         // prepare our SSLContext
-        try {
-            sslContext = SSLContext.getInstance("TLS");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Java runtime specification requires support for TLS algorithm", e);
+        if (sslContext == null && getName() == null) {
+            try {
+                sslContext = SSLContext.getInstance("TLS");
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException("Java runtime specification requires support for TLS algorithm", e);
+            }
         }
         sslContext.init(kmf.getKeyManagers(), trustManagers, null);
     }


### PR DESCRIPTION
See [JENKINS-70206](https://issues.jenkins.io/browse/JENKINS-70206).

### Testing done

### Proposed changelog entries
delay the initialization of fields keyStore, trustManager, and sslContext until and unless getName() is initialized

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7512"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

