### PR TITLE
De-flake `ProjectTest#testUnrestrictedJobNoLabelByCloudNoQueue`

### DIFF
--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -27,6 +27,7 @@ package hudson.model;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -102,6 +103,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.reactor.ReactorException;
 import org.jvnet.hudson.test.FakeChangeLogSCM;
+import org.jvnet.hudson.test.InboundAgentRule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
@@ -114,6 +116,9 @@ import org.jvnet.hudson.test.TestExtension;
 public class ProjectTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Rule public InboundAgentRule inboundAgents = new InboundAgentRule();
+
     public static boolean createAction = false;
     public static boolean getFilePath = false;
     public static boolean createSubTask = false;
@@ -731,7 +736,7 @@ public class ProjectTest {
 
         //Now create another slave. And restrict the job to that slave. The slave is offline, leaving the job with no assignable nodes.
         //We tell our mock SCM to return that it has got changes. But since there are no agents, we get the desired result.
-        Slave s2 = j.createSlave();
+        Slave s2 = inboundAgents.createAgent(j, InboundAgentRule.Options.newBuilder().skipStart().build());
         proj.setAssignedLabel(s2.getSelfLabel());
         requiresWorkspaceScm.hasChange = true;
 
@@ -750,7 +755,7 @@ public class ProjectTest {
          */
         HtmlPage log = j.createWebClient().getPage(proj, "scmPollLog");
         String logastext = log.asNormalizedText();
-        assertTrue(logastext.contains("(" + AbstractProject.WorkspaceOfflineReason.all_suitable_nodes_are_offline.name() + ")"));
+        assertThat(logastext, containsString("(" + AbstractProject.WorkspaceOfflineReason.all_suitable_nodes_are_offline.name() + ")"));
 
     }
 


### PR DESCRIPTION
In [this run](https://ci.jenkins.io/job/Core/job/jenkins/job/master/4473/testReport/junit/hudson.model/ProjectTest/Windows_jdk17___Windows_Build___Test___testUnrestrictedJobNoLabelByCloudNoQueue/) `ProjectTest.testUnrestrictedJobNoLabelByCloudNoQueue` flaked with:

```
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at hudson.model.ProjectTest.testUnrestrictedJobNoLabelByCloudNoQueue(ProjectTest.java:753)
```

Debugging the failure I found that the test relies on a node being offline in order to execute the test scenario, but didn't guarantee this: it started a node without waiting for it to come online. On fast systems (e.g. our Linux CI runs) the test finished before the node came online, so the condition for the test was correct. But on slower systems (e.g. our Windows CI runs) the node came online before the test started running, thus invalidating the conditions required for the test to pass. So we were effectively racing with the launch of the second agent, hoping to finish the test in time before the second agent launched. The solution is to use `InboundAgentRule`, which allows us to start a node that is never brought online, which guarantees that the conditions needed for the test to pass are always true.

As a bonus I converted the assertion to Hamcrest Matchers to make future failures more legible.

### Testing done

I could reproduce the flake consistently by adding:

```
diff --git a/test/src/test/java/hudson/model/ProjectTest.java b/test/src/test/java/hudson/model/ProjectTest.java
index 3a19eb27e0..8c88b45dd6 100644
--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -732,6 +732,7 @@ public class ProjectTest {
         //Now create another slave. And restrict the job to that slave. The slave is offline, leaving the job with no assignable nodes.
         //We tell our mock SCM to return that it has got changes. But since there are no agents, we get the desired result.
         Slave s2 = j.createSlave();
+        Thread.sleep(15000);
         proj.setAssignedLabel(s2.getSelfLabel());
         requiresWorkspaceScm.hasChange = true;
```

After this PR, I could no longer reproduce the failure with this sleep.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7519"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

