### PR TITLE
[JENKINS-70240] fix for non http based UpdateCenter URLs cause exception in plugin manager

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1966,6 +1966,13 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             return FormValidation.error(Messages.PluginManager_emptyUpdateSiteUrl());
         }
 
+        //Check to see if the value is a file as some update centers are local json files
+        value = value.replace("file:/", "");
+        File file = new File(value);
+        if (file.isFile()) {
+            return FormValidation.ok();
+        }
+
         value += ((value.contains("?")) ? "&" : "?") + "version=" + Jenkins.VERSION + "&uctest";
 
         URI uri;

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -100,7 +100,8 @@ PluginManager.deprecationWarning=<strong>This plugin is deprecated.</strong> In 
 PluginManager.insecureUrl=\
   You are using an insecure URL to download the plugin, use at your own risk!
 PluginManager.invalidUrl=\
-  You are using an invalid URL to download the plugin, only https and http (not recommended) are supported.
+  You are using an invalid URL to download the plugin, only https and http (not recommended) are supported. \
+  Alternatively if you are using a local json file, make sure the file path to your local update center json file is correct.
 
 PluginManager.emptyUpdateSiteUrl=\
   The update site cannot be empty. Please enter a valid url.

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -100,8 +100,8 @@ PluginManager.deprecationWarning=<strong>This plugin is deprecated.</strong> In 
 PluginManager.insecureUrl=\
   You are using an insecure URL to download the plugin, use at your own risk!
 PluginManager.invalidUrl=\
-  You are using an invalid URL to download the plugin, only https and http (not recommended) are supported. \
-  Alternatively if you are using a local json file, make sure the file path to your local update center json file is correct.
+  You are using an invalid URL to download the plugin. File paths, https and http (not recommended) URLs are supported. \
+  If you are using a local update center json file, make sure the file path to your file is correct.
 
 PluginManager.emptyUpdateSiteUrl=\
   The update site cannot be empty. Please enter a valid url.


### PR DESCRIPTION

- Local update centers use local json files which are valid
- I have added the value.replace("file:/", ""); as when using a war, it adds 'file:/' to the path
- This checks if the file is a valid file and if true returns FormValidation.ok

See [JENKINS-70240](https://issues.jenkins.io/browse/JENKINS-70240).

### Testing done

Steps:
- Forked Repo and opened local version in intelliJ
- Made code changes as seen in this PR
- did  **mvn install -Dmaven.test.skip=true** skipping the tests at first as they took hours to run through all tests
- manually tested to see if demon jenkins appeared. Manual tests involved inputting a valid URL, putting invalid URL, putting valid file location, putting invalid file location
- finally did **mvn install** without skipping the tests to check all tests passed
 
Before:
![image](https://user-images.githubusercontent.com/55280278/207581321-747c7e40-4399-45fe-a6c9-dcf295a5b317.png)

After:
![image](https://user-images.githubusercontent.com/55280278/207582399-76a10760-dac7-497c-af10-f995922d45d5.png)
![image](https://user-images.githubusercontent.com/55280278/207582544-e6918274-b5a0-40a7-9de2-e6bb8ea967e1.png)
![image](https://user-images.githubusercontent.com/55280278/207582679-fd1195f1-5a89-4291-85fa-d567323eb3d8.png)

This issue was caused by https://github.com/jenkinsci/jenkins/pull/6886 which did not have any tests written for the method. I have not written any tests for the method as a whole yet.

### Proposed changelog entries

- Entry 1: Non-HTTP based UpdateCenter URLs do not cause exception in plugin manager

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7520"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

