### PR TITLE
Better null safety for `createProject`

### DIFF
--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.listeners.ItemListener;
@@ -307,7 +308,8 @@ public abstract class ItemGroupMixIn {
         }
     }
 
-    public synchronized TopLevelItem createProject(TopLevelItemDescriptor type, String name, boolean notify)
+    @NonNull
+    public synchronized TopLevelItem createProject(@NonNull TopLevelItemDescriptor type, @NonNull String name, boolean notify)
             throws IOException {
         acl.checkPermission(Item.CREATE);
         type.checkApplicableIn(parent);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3137,12 +3137,14 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return User.get(name, User.ALLOW_USER_CREATION_VIA_URL && hasPermission(ADMINISTER));
     }
 
-    public synchronized TopLevelItem createProject(TopLevelItemDescriptor type, String name) throws IOException {
+    @NonNull
+    public synchronized TopLevelItem createProject(@NonNull TopLevelItemDescriptor type, @NonNull String name) throws IOException {
         return createProject(type, name, true);
     }
 
+    @NonNull
     @Override
-    public synchronized TopLevelItem createProject(TopLevelItemDescriptor type, String name, boolean notify) throws IOException {
+    public synchronized TopLevelItem createProject(@NonNull TopLevelItemDescriptor type, @NonNull String name, boolean notify) throws IOException {
         return itemGroupMixIn.createProject(type, name, notify);
     }
 
@@ -3173,8 +3175,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @throws IllegalArgumentException
      *      if the project of the given name already exists.
      */
-    public synchronized <T extends TopLevelItem> T createProject(Class<T> type, String name) throws IOException {
-        return type.cast(createProject((TopLevelItemDescriptor) getDescriptor(type), name));
+    @NonNull
+    public synchronized <T extends TopLevelItem> T createProject(@NonNull Class<T> type, @NonNull String name) throws IOException {
+        return type.cast(createProject((TopLevelItemDescriptor) getDescriptorOrDie(type), name));
     }
 
     /**


### PR DESCRIPTION
I observed a functional test flake of the form

```
java.lang.NullPointerException
	at hudson.model.ItemGroupMixIn.createProject(ItemGroupMixIn.java:313)
	at jenkins.model.Jenkins.createProject(Jenkins.java:3155)
	at jenkins.model.Jenkins.createProject(Jenkins.java:3150)
	at jenkins.model.Jenkins.createProject(Jenkins.java:3186)
	at …
```

from a call to

```java
r.jenkins.createProject(ProjectType.class, "name");
```

From the stack trace, it appears that a `Descriptor` was missing, for unknown reasons (no related warning messages). At any rate, the initial `createProject` overload was using the wrong method to get a non-null `Descriptor`; correcting that, and adding missing SpotBugs annotations along the call chain. This should at least improve the diagnosis from the current NPE to the usual `… is missing its descriptor` message.

### Testing done

None, just by code inspection.

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
