### PR TITLE
Revert "Improve breadcrumb bar accessibility"

### DIFF
--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -34,8 +34,6 @@ THE SOFTWARE.
       <script src="${resURL}/jsbundles/section-to-sidebar-items.js" type="text/javascript" defer="true" />
     </l:header>
 
-    <l:breadcrumb title="${%Configuration}" />
-
     <l:side-panel>
       <l:app-bar title="${%Configure}" />
       <div id="tasks" />

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -43,10 +43,9 @@ THE SOFTWARE.
   </st:documentation>
 
   <j:if test="${mode=='breadcrumbs'}">
-    <j:set var="hasLink" value="${!(attrs.href == null or h.hyperlinkMatchesCurrentPage(attrs.href))}" />
-    <li id="${attrs.id}" class="jenkins-breadcrumbs__list-item" aria-current="${hasLink ? null : 'page'}">
+    <li id="${attrs.id}" class="item">
       <j:choose>
-        <j:when test="${!hasLink}">
+        <j:when test="${attrs.href == null}">
           ${attrs.title}
         </j:when>
         <j:otherwise>

--- a/core/src/main/resources/lib/layout/breadcrumbBar.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumbBar.jelly
@@ -37,36 +37,36 @@ THE SOFTWARE.
 
   <st:adjunct includes="lib.layout.breadcrumbs" />
 
-  <j:set var="contents" trim="true">
-    <d:invokeBody />
-  </j:set>
+  <div class="top-sticker noedge">
+    <div class="top-sticker-inner">
+      <div class="jenkins-breadcrumbs">
+        <ul id="breadcrumbs">
+          <j:forEach var="anc" items="${request.ancestors}">
+            <j:if test="${h.isModel(anc.object) and anc.prev.url!=anc.url}">
+              <j:set var="mode" value="breadcrumbs" />
+              <l:breadcrumb title="${anc.object == app ? '%Dashboard' : anc.object.displayName}"
+                            href="${anc.url}/"
+                            hasMenu="${h.isModelWithContextMenu(anc.object)}" />
+              <j:choose>
+                <j:when test="${h.isModelWithChildren(anc.object)}">
+                  <li class="children" href="${anc.url}/">
+                    <!-- shows '>' for rendering children -->
+                  </li>
+                </j:when>
+                <j:otherwise>
+                  <li class="separator">
+                  </li>
+                </j:otherwise>
+              </j:choose>
+            </j:if>
+          </j:forEach>
 
-  <div id="breadcrumbBar" class="jenkins-breadcrumbs" aria-label="breadcrumb">
-    <ol class="jenkins-breadcrumbs__list" id="breadcrumbs">
-      <j:forEach var="anc" items="${request.ancestors}" indexVar="index">
-        <j:if test="${h.isModel(anc.object) and anc.prev.url!=anc.url}">
-          <j:set var="mode" value="breadcrumbs" />
-          <l:breadcrumb title="${anc.object == app ? '%Dashboard' : anc.object.displayName}"
-                        href="${contents.length() == 0 and (index == request.ancestors.size() - 1) ? null : anc.url + '/'}"
-                        hasMenu="${h.isModelWithContextMenu(anc.object)}" />
-          <j:choose>
-            <j:when test="${h.isModelWithChildren(anc.object)}">
-              <li class="children" href="${anc.url}/">
-                <!-- shows '>' for rendering children -->
-              </li>
-            </j:when>
-            <j:otherwise>
-              <li class="separator">
-              </li>
-            </j:otherwise>
-          </j:choose>
-        </j:if>
-      </j:forEach>
+          <!-- render additional breadcrumb items -->
+          <d:invokeBody />
+        </ul>
 
-      <!-- render additional breadcrumb items -->
-      <j:out value="${contents}" />
-    </ol>
+        <div id="breadcrumb-menu-target"/><!-- this is where the menu gets rendered -->
+      </div>
+    </div>
   </div>
-
-  <div id="breadcrumb-menu-target"/><!-- this is where the menu gets rendered -->
 </j:jelly>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -187,10 +187,12 @@ THE SOFTWARE.
                     searchHelpUrl="${%searchBox.url}"
                     logout="${%logout}"/>
 
-      <l:breadcrumbBar>
-        <j:set var="mode" value="breadcrumbs" />
-        <d:invokeBody/>
-      </l:breadcrumbBar>
+      <div id="breadcrumbBar">
+        <l:breadcrumbBar>
+          <j:set var="mode" value="breadcrumbs" />
+          <d:invokeBody/>
+        </l:breadcrumbBar>
+      </div>
     </j:if>
 
     <div id="page-body" class="app-page-body app-page-body--${layoutType} clear">

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -34,6 +34,7 @@ import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.DomNodeUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -150,7 +151,7 @@ public class HudsonTest {
     public void breadcrumb() throws Exception {
         HtmlPage root = j.createWebClient().goTo("");
         DomElement navbar = root.getElementById("breadcrumbs");
-        assertEquals(1, navbar.querySelectorAll(".jenkins-breadcrumbs__list-item").size());
+        assertEquals(1, DomNodeUtil.selectNodes(navbar, "LI/A").size());
     }
 
     /**

--- a/war/src/main/js/util/page.js
+++ b/war/src/main/js/util/page.js
@@ -41,13 +41,11 @@ function onWinScroll(callback) {
 }
 
 function pageHeaderHeight() {
-  return (
-    document.querySelector("#page-header").offsetHeight + breadcrumbBarHeight()
-  );
+  return elementHeight("#page-header") + breadcrumbBarHeight();
 }
 
 function breadcrumbBarHeight() {
-  return document.querySelector("#breadcrumbBar").offsetHeight;
+  return elementHeight("#breadcrumbBar");
 }
 
 function removeTextHighlighting(selector) {
@@ -56,6 +54,10 @@ function removeTextHighlighting(selector) {
     highlightSplit.before(highlightSplit.text());
     highlightSplit.remove();
   });
+}
+
+function elementHeight(selector) {
+  return $(selector).height();
 }
 
 export default {

--- a/war/src/main/less/abstracts/theme.less
+++ b/war/src/main/less/abstracts/theme.less
@@ -70,11 +70,11 @@
   // Header dimensions
   --header-item-border-radius: 4px;
 
-  // Breadcrumbs bar
-  --breadcrumbs-bar-background: hsla(240, 0.2, 0.965, 0.8);
-
-  // Footer
-  --footer-background: hsla(240, 0.2, 0.965, 0.8);
+  // Breadcrumbs and footer
+  --breadcrumbs-bg: #f8f8f8;
+  --breadcrumbs-border: var(--light-grey);
+  --breadcrumbs-text-color: #4d545d;
+  --breadcrumbs-item-bg-color--hover: var(--light-grey);
 
   // Alert call outs
   --alert-success-text-color: #155724;

--- a/war/src/main/less/base/layout-commons.less
+++ b/war/src/main/less/base/layout-commons.less
@@ -42,6 +42,10 @@ body {
   margin-left: 0.25rem;
 }
 
+#footer-container {
+  background-color: var(--breadcrumbs-bg);
+}
+
 /* -------------------------------------- */
 
 .app-page-body {

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -518,6 +518,20 @@ pre.console {
   }
 }
 
+.top-sticker,
+#top-sticker {
+  width: 100%; /* it needs to occupy the entire width or else the underlying content will see through */
+  z-index: 999;
+}
+
+.top-sticker.noedge > .top-sticker-edge {
+  display: none;
+}
+
+.top-sticker.noedge > .top-sticker-inner {
+  padding: 0;
+}
+
 .icon16x16 {
   width: 16px;
   height: 16px;

--- a/war/src/main/less/modules/breadcrumbs.less
+++ b/war/src/main/less/modules/breadcrumbs.less
@@ -1,27 +1,35 @@
-.jenkins-breadcrumbs {
+#breadcrumbBar {
   position: sticky;
   top: 0;
   z-index: 999;
+}
+
+.jenkins-breadcrumbs {
   display: flex;
   align-items: center;
-  padding: 0.55rem 0.7rem 0.55rem 0.75rem;
+  padding: 0.5rem 0.7rem 0.5rem 0.75rem;
   backdrop-filter: blur(15px);
-  overflow-x: auto;
-  background: var(--breadcrumbs-bar-background);
 
-  &__list {
-    display: contents;
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--table-background);
+    opacity: 0.95;
+  }
+
+  & > ul {
+    display: flex;
+    align-items: center;
     list-style-type: none;
+    margin: 0;
+    padding: 0;
+    flex: 1;
+    flex-wrap: wrap;
+    z-index: 0;
 
-    & > * {
-      flex-shrink: 0;
-    }
-
-    &-item {
+    & > li {
       position: relative;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
       color: var(--text-color);
       font-weight: 500;
       font-size: 0.85rem;
@@ -37,21 +45,13 @@
         font-size: inherit;
         margin: 0;
         padding: 0;
-        color: var(--text-color);
+        color: inherit;
         text-decoration: none;
         margin-right: 0 !important;
-        transition: var(--standard-transition);
 
         &::before,
         &::after {
           inset: -0.25rem -0.6rem;
-        }
-
-        &:hover,
-        &:active,
-        &:focus,
-        &:focus-visible {
-          color: var(--text-color);
         }
       }
 
@@ -70,9 +70,9 @@
     .children,
     .separator {
       position: relative;
-      width: 1rem;
-      height: 1rem;
-      margin: 0.375rem 0.2rem;
+      width: 14px;
+      height: 14px;
+      margin: 6px;
 
       &::after {
         content: "";
@@ -81,16 +81,10 @@
         left: 0;
         bottom: 0;
         right: 0;
+        opacity: 0.5;
         transition: var(--standard-transition);
-        background: var(--text-color-secondary);
+        background: var(--text-color);
         mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'%3E%3Ctitle%3EChevron Forward%3C/title%3E%3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='48' d='M184 112l144 144-144 144'/%3E%3C/svg%3E");
-        opacity: 0.6;
-      }
-    }
-
-    .separator {
-      &:last-of-type {
-        display: none;
       }
     }
 
@@ -111,15 +105,6 @@
         }
       }
 
-      &:hover,
-      &:active,
-      &:focus,
-      &:focus-visible {
-        &::after {
-          background: var(--text-color);
-        }
-      }
-
       // Increase the hit target
       &::before {
         content: "";
@@ -129,6 +114,12 @@
         bottom: -14px;
         right: -5px;
         background: transparent;
+      }
+    }
+
+    .separator {
+      &:last-of-type {
+        display: none;
       }
     }
   }

--- a/war/src/main/less/modules/page-footer.less
+++ b/war/src/main/less/modules/page-footer.less
@@ -1,7 +1,8 @@
 @import url("../abstracts/theme.less");
 
 .page-footer {
-  background-color: var(--footer-background);
+  background-color: var(--breadcrumbs-bg);
+  border-top: 1px solid var(--breadcrumbs-border);
   width: 100%;
   clear: both;
   font-size: var(--font-size-sm);

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2190,7 +2190,7 @@ function ensureVisible(e) {
   }
 
   // if there are any stickers around, subtract them from the viewport
-  handleStickers("jenkins-breadcrumbs", function (t) {
+  handleStickers("top-sticker", function (t) {
     t = t.clientHeight;
     Y += t;
     H -= t;


### PR DESCRIPTION
See [this thread](https://groups.google.com/g/jenkinsci-dev/c/2Z1OuI6XC90/m/Se_zVkfwGwAJ). The Jenkins core maintainers aspire to deliver [First Customer Ship (FCS)](https://illumos.org/docs/contributing/quality/) quality [all the time on the main branch](https://github.com/jenkinsci/jenkins/pull/7218). The integration of https://github.com/jenkinsci/jenkins/pull/6912 has destabilized the main branch, resulting in approximately a dozen pull requests to correct issues with the initial integration. When the main branch is not in a stable state, new problems are far more likely to be introduced, a timeless phenomenon described by Jeff Bonwick as the [Quality Death Spiral](https://illumos.org/docs/contributing/qds/). The overall quality of the delivered software, not any one project, is what matters; therefore, this PR reverts https://github.com/jenkinsci/jenkins/pull/6912.

There is past precedent for this: when the Jetty 10 upgrade was integrated, it destabilized the main branch. It was quickly reverted, then reintegrated later when all known issues had been addressed. The revert of https://github.com/jenkinsci/jenkins/pull/6912 is also intended to be temporary: once the issues caused by the original change are addressed (including [JENKINS-70169](https://issues.jenkins.io/browse/JENKINS-70169), [JENKINS-70255](https://issues.jenkins.io/browse/JENKINS-70255), and https://github.com/jenkinsci/design-library-plugin/issues/182), we fully hope and expect for it to be reintegrated and delivered in its final form.

The original author of https://github.com/jenkinsci/jenkins/pull/6912 has offered a partial revert instead of a full one in https://github.com/jenkinsci/jenkins/pull/6912#issuecomment-1331319966. It is unclear to me whether the partial revert would address [JENKINS-70169](https://issues.jenkins.io/browse/JENKINS-70169), [JENKINS-70255](https://issues.jenkins.io/browse/JENKINS-70255), and https://github.com/jenkinsci/design-library-plugin/issues/182. If it addresses all three issues and is completed prior to the release of 2.383, this would address my concerns and this PR could be closed. If a partial revert does not address all three issues or if it is not completed prior to the release of 2.383, I would like to proceed with a full revert for 2.383 as in this PR.

### Testing done

Built core with these changes and verified that the console output page looked the same as it did prior to #6912.

### Proposed changelog entries

Restore breadcrumb navigation behavior from 2.374 and earlier.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7525"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

