### PR TITLE
Clean up `ath.sh`

### DIFF
--- a/ath.sh
+++ b/ath.sh
@@ -3,40 +3,40 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -o xtrace
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 # https://github.com/jenkinsci/acceptance-test-harness/releases
 export ATH_VERSION=5478.vb_b_cd04943676
 
 # TODO use Artifactory proxy?
 
-[ -f war/target/jenkins.war ] || mvn -B -ntp -Pquick-build -am -pl war package
+[[ -f war/target/jenkins.war ]] || mvn -B -ntp -Pquick-build -am -pl war package
 
 mkdir -p target/ath-reports
 chmod a+rwx target/ath-reports
 
-docker run --rm \
-  --env ATH_VERSION \
-  --shm-size 2g `# avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed` \
-  --volume "$(pwd)"/war/target/jenkins.war:/jenkins.war:ro \
-  --volume /var/run/docker.sock:/var/run/docker.sock:rw \
-  --volume "$(pwd)"/target/ath-reports:/reports:rw \
-  --interactive \
-  jenkins/ath:"$ATH_VERSION" \
-  bash <<'INSIDE'
-set -o errexit
-set -o nounset
-set -o pipefail
-set -o xtrace
-cd
-# Start the VNC system provided by the image from the default user home directory
-eval $(vnc.sh)
-env | sort
-git clone --branch "$ATH_VERSION" --depth 1 https://github.com/jenkinsci/acceptance-test-harness
-cd acceptance-test-harness
-run.sh firefox /jenkins.war \
-  -Dmaven.test.failure.ignore \
-  -DforkCount=1 \
-  -Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest
-cp --verbose target/surefire-reports/TEST-*.xml /reports
-INSIDE
+exec docker run --rm \
+	--env ATH_VERSION \
+	--shm-size 2g `# avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed` \
+	--volume "$(pwd)"/war/target/jenkins.war:/jenkins.war:ro \
+	--volume /var/run/docker.sock:/var/run/docker.sock:rw \
+	--volume "$(pwd)"/target/ath-reports:/reports:rw \
+	--interactive \
+	jenkins/ath:"$ATH_VERSION" \
+	bash <<-'INSIDE'
+		set -o errexit
+		set -o nounset
+		set -o pipefail
+		set -o xtrace
+		cd
+		# Start the VNC system provided by the image from the default user home directory
+		eval "$(vnc.sh)"
+		env | sort
+		git clone --branch "$ATH_VERSION" --depth 1 https://github.com/jenkinsci/acceptance-test-harness
+		cd acceptance-test-harness
+		run.sh firefox /jenkins.war \
+			-Dmaven.test.failure.ignore \
+			-DforkCount=1 \
+			-Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest
+		cp --verbose target/surefire-reports/TEST-*.xml /reports
+	INSIDE


### PR DESCRIPTION
Cleans up this shell script to pass `shellcheck(1)` and `shfmt(1)`.

### Note to reviewers

It is recommended to review this change with **Hide whitespace** enabled.

### Testing done

The CI build exercises this code.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7531"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

