### PR TITLE
Fix URICheckEncodingMonitor NPE

### DIFF
--- a/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
@@ -43,7 +43,7 @@ public class URICheckEncodingMonitor extends AdministrativeMonitor {
 
         if (!expected.equals(value)) {
             String expectedHex = Util.toHexString(expected.getBytes(StandardCharsets.UTF_8));
-            String valueHex = value != null ? Util.toHexString(value.getBytes(StandardCharsets.UTF_8)) : "<empty string>";
+            String valueHex = value != null ? Util.toHexString(value.getBytes(StandardCharsets.UTF_8)) : null;
             LOGGER.log(Level.CONFIG, "Expected to receive: " + expected + " (" + expectedHex + ") but got: " + value + " (" + valueHex + ")");
             return FormValidation.warningWithMarkup(hudson.model.Messages.Hudson_NotUsesUTF8ToDecodeURL());
         }

--- a/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
@@ -43,7 +43,7 @@ public class URICheckEncodingMonitor extends AdministrativeMonitor {
 
         if (!expected.equals(value)) {
             String expectedHex = Util.toHexString(expected.getBytes(StandardCharsets.UTF_8));
-            String valueHex = Util.toHexString(value.getBytes(StandardCharsets.UTF_8));
+            String valueHex = value != null ? Util.toHexString(value.getBytes(StandardCharsets.UTF_8)) : "<empty string>";
             LOGGER.log(Level.CONFIG, "Expected to receive: " + expected + " (" + expectedHex + ") but got: " + value + " (" + valueHex + ")");
             return FormValidation.warningWithMarkup(hudson.model.Messages.Hudson_NotUsesUTF8ToDecodeURL());
         }

--- a/test/src/test/java/jenkins/diagnostics/URICheckEncodingMonitorTest.java
+++ b/test/src/test/java/jenkins/diagnostics/URICheckEncodingMonitorTest.java
@@ -1,0 +1,31 @@
+package jenkins.diagnostics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import hudson.util.FormValidation;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.Stapler;
+
+public class URICheckEncodingMonitorTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    /* Test that an empty value returned to URICheckEncodingMonitor
+     * does not cause a null pointer exception
+     */
+    @Test
+    public void emptyValueInResponse() throws Exception {
+        j.executeOnServer(() -> {
+                URICheckEncodingMonitor monitor = new URICheckEncodingMonitor();
+                FormValidation validation = monitor.doCheckURIEncoding(Stapler.getCurrentRequest());
+                assertThat(validation.kind, is(FormValidation.Kind.WARNING));
+                assertThat(validation.getMessage(), containsString("Your container doesn’t use UTF-8 to decode URLs."));
+                return null;
+            });
+    }
+}


### PR DESCRIPTION
## Fix URICheckEncodingMonitor null pointer exception

A [null pointer exception report](https://community.jenkins.io/t/reverse-proxy-test-does-not-handle-url-correctly/1294/9) on https://community.jenkins.io/ notes that if the `value` returned by `URICheckEncodingMonitor` is the empty string or does not exist, then a null pointer exception is throws.  Since the `URICheckEncodingMonitor` is checking for configuration errors and one of the (rather obscure) configuration errors might be to return an empty string, this pull request provides a test that checks the failure case and prevents the failure with a null check.

No Jira ticket was opened for the issue.  I can open a Jira ticket if that is required.

Test fails without the change and passes with the change.

- Test null pointer exception in URICheckEncodingMonitor
- Avoid URICheckEncodingMonitor empty value NPE

### Testing done

Automated test written to confirm the failure is visible.  Automated test run after the fix to confirm it passes.  Interactive test run to start Jenkins and confirm that the monitor causes no unexpected side effects.

### Proposed changelog entries

- No changelog - too minor

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7543"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

