### PR TITLE
[JENKINS-70334] Fix and simplify TcpSlaveAgentListenerRescheduler

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -277,7 +277,7 @@ public final class TcpSlaveAgentListener extends Thread {
                 } catch (IOException ex) {
                     // try to clean up the socket
                 }
-            } catch (IOException e) {
+            } catch (Throwable e) {
                 if (e instanceof EOFException) {
                     LOGGER.log(Level.INFO, () -> "Connection " + connectionInfo + " failed: " + e.getMessage());
                 } else {

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -26,7 +26,6 @@ package hudson;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.model.AperiodicWork;
 import hudson.slaves.OfflineCause;
 import hudson.util.VersionNumber;
 import java.io.ByteArrayInputStream;
@@ -100,9 +99,8 @@ public final class TcpSlaveAgentListener extends Thread {
         }
         this.configuredPort = port;
         setUncaughtExceptionHandler((t, e) -> {
-            LOGGER.log(Level.SEVERE, "Uncaught exception in TcpSlaveAgentListener " + t + ", attempting to reschedule thread", e);
+            LOGGER.log(Level.SEVERE, "Uncaught exception in TcpSlaveAgentListener " + t, e);
             shutdown();
-            TcpSlaveAgentListenerRescheduler.schedule(t, e);
         });
 
         LOGGER.log(Level.FINE, "TCP agent listener started on port {0}", getPort());
@@ -184,14 +182,7 @@ public final class TcpSlaveAgentListener extends Thread {
                 // we take care of buffering on our own
                 s.setTcpNoDelay(true);
 
-                new ConnectionHandler(s, new ConnectionHandlerFailureCallback(this) {
-                    @Override
-                    public void run(Throwable cause) {
-                        LOGGER.log(Level.WARNING, "Connection handler failed, restarting listener", cause);
-                        shutdown();
-                        TcpSlaveAgentListenerRescheduler.schedule(getParentThread(), cause);
-                    }
-                }).start();
+                new ConnectionHandler(s).start();
             }
         } catch (IOException e) {
             if (!shuttingDown) {
@@ -234,21 +225,12 @@ public final class TcpSlaveAgentListener extends Thread {
          */
         private final int id;
 
-        ConnectionHandler(Socket s, ConnectionHandlerFailureCallback parentTerminator) {
+        ConnectionHandler(Socket s) {
             this.s = s;
             synchronized (getClass()) {
                 id = iotaGen++;
             }
             setName("TCP agent connection handler #" + id + " with " + s.getRemoteSocketAddress());
-            setUncaughtExceptionHandler((t, e) -> {
-                LOGGER.log(Level.SEVERE, "Uncaught exception in TcpSlaveAgentListener ConnectionHandler " + t, e);
-                try {
-                    s.close();
-                    parentTerminator.run(e);
-                } catch (IOException e1) {
-                    LOGGER.log(Level.WARNING, "Could not close socket after unexpected thread death", e1);
-                }
-            });
         }
 
         @Override
@@ -351,21 +333,6 @@ public final class TcpSlaveAgentListener extends Thread {
         }
     }
 
-    // This is essentially just to be able to pass the parent thread into the callback, as it can't access it otherwise
-    private abstract static class ConnectionHandlerFailureCallback {
-        private Thread parentThread;
-
-        ConnectionHandlerFailureCallback(Thread parentThread) {
-            this.parentThread = parentThread;
-        }
-
-        public Thread getParentThread() {
-            return parentThread;
-        }
-
-        public abstract void run(Throwable cause);
-    }
-
     /**
      * This extension provides a Ping protocol that allows people to verify that the {@link TcpSlaveAgentListener} is alive.
      * We also use this to wake the acceptor thread on termination.
@@ -433,83 +400,6 @@ public final class TcpSlaveAgentListener extends Thread {
                     }
                 }
             }
-        }
-    }
-
-    /**
-     * Reschedules the {@code TcpSlaveAgentListener} on demand.  Disables itself after running.
-     */
-    @Extension
-    @Restricted(NoExternalUse.class)
-    public static class TcpSlaveAgentListenerRescheduler extends AperiodicWork {
-        private Thread originThread;
-        private Throwable cause;
-        private long recurrencePeriod = 5000;
-        private boolean isActive;
-
-        public TcpSlaveAgentListenerRescheduler() {
-            isActive = false;
-        }
-
-        public TcpSlaveAgentListenerRescheduler(Thread originThread, Throwable cause) {
-            this.originThread = originThread;
-            this.cause = cause;
-            this.isActive = false;
-        }
-
-        public void setOriginThread(Thread originThread) {
-            this.originThread = originThread;
-        }
-
-        public void setCause(Throwable cause) {
-            this.cause = cause;
-        }
-
-        public void setActive(boolean active) {
-            isActive = active;
-        }
-
-        @Override
-        public long getRecurrencePeriod() {
-            return recurrencePeriod;
-        }
-
-        @Override
-        public AperiodicWork getNewInstance() {
-            return new TcpSlaveAgentListenerRescheduler(originThread, cause);
-        }
-
-        @Override
-        protected void doAperiodicRun() {
-            if (isActive) {
-                try {
-                    if (originThread.isAlive()) {
-                        originThread.interrupt();
-                    }
-                    int port = Jenkins.get().getSlaveAgentPort();
-                    if (port != -1) {
-                        new TcpSlaveAgentListener(port).start();
-                        LOGGER.log(Level.INFO, "Restarted TcpSlaveAgentListener");
-                    } else {
-                        LOGGER.log(Level.SEVERE, "Uncaught exception in TcpSlaveAgentListener " + originThread + ". Port is disabled, not rescheduling", cause);
-                    }
-                    isActive = false;
-                } catch (IOException e) {
-                    LOGGER.log(Level.SEVERE, "Could not reschedule TcpSlaveAgentListener - trying again.", cause);
-                }
-            }
-        }
-
-        public static void schedule(Thread originThread, Throwable cause) {
-            schedule(originThread, cause, 5000);
-        }
-
-        public static void schedule(Thread originThread, Throwable cause, long approxDelay) {
-            TcpSlaveAgentListenerRescheduler rescheduler = AperiodicWork.all().get(TcpSlaveAgentListenerRescheduler.class);
-            rescheduler.originThread = originThread;
-            rescheduler.cause = cause;
-            rescheduler.recurrencePeriod = approxDelay;
-            rescheduler.isActive = true;
         }
     }
 

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -191,7 +191,6 @@ public final class TcpSlaveAgentListener extends Thread {
                 if (!shuttingDown) {
                     LOGGER.log(Level.SEVERE, "Failed to accept TCP connections", e);
                     if (!serverSocket.isOpen()) {
-                        // Socket open, no need to restart it, just loop
                         LOGGER.log(Level.INFO, "Restarting server socket");
                         try {
                             serverSocket = createSocket(configuredPort);


### PR DESCRIPTION
See [JENKINS-70334](https://issues.jenkins.io/browse/JENKINS-70334).

### Testing done

**Unit test**

* Unit test throws an uncaught exception an demonstrates that the rescheduler properly restart the listener (shutdown the previous thread and start a new one) within 5 seconds (recurrence period of the aperiodic task).

**Manual Test**

* Start Jenkins
* Enable JNLP with a Fixed port
* Validate that a tcpSlaveAgentListener thread exists in a thread dump `/threadDump`
* Validate that you can connect a permanent agent
* Simulate an interruption with `jenkins.model.Jenkins.get().tcpSlaveAgentListener.getUncaughtExceptionHandler().uncaughtException(jenkins.model.Jenkins.get().tcpSlaveAgentListener, new UnsupportedOperationException("Test"));` from the Script Console
* Validate that within 5 seconds, a new tcpSlaveAgentListener thread is created and the old one is gone
* Validate that you can connect a permanent agent

### Proposed changelog entries

- Fix the TcpSlaveAgentListenerRescheduler functionality. TcpSlaveAgentListener is automatically restarted on failure.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7547"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

