### PR TITLE
Use morph tag library for f:file

### DIFF
--- a/core/src/main/resources/lib/form/file.jelly
+++ b/core/src/main/resources/lib/form/file.jelly
@@ -23,18 +23,22 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form"
+         xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary">
   <st:documentation>
     Generates an input field <code>&lt;input type="file" ... /></code>
+    All unknown attributes are passed through to the field.
 
     <st:attribute name="field">
       Used for databinding.
     </st:attribute>
-    <st:attribute name="jsonAware">
-      Enable structured form submission.
+    <st:attribute name="clazz">
+      Additional CSS class(es) to add.
     </st:attribute>
-    <st:attribute name="accept">
-      Defines the file types the file input should accept. This string is a comma-separated list.
+    <st:attribute name="name"> <![CDATA[
+      This becomes @name of the <input> tag.
+      If @field is specified, this value is inferred from it.
+      ]]>
     </st:attribute>
     @since TODO
   </st:documentation>
@@ -42,10 +46,9 @@ THE SOFTWARE.
 
   <j:set var="name" value="${attrs.name ?: attrs.field}"/>
 
-  <input name="${name}"
-         type="file"
-         jsonAware="${attrs.jsonAware}"
-         class="jenkins-file-upload"
-         accept="${attrs.accept}"
+  <m:input name="${name}"
+           type="file"
+           class="jenkins-file-upload${attrs.clazz == null ? '' : ' ' +  attrs.clazz}"
+           ATTRIBUTES="${attrs}" EXCEPT="field clazz"
   />
 </j:jelly>

--- a/core/src/main/resources/lib/form/file.jelly
+++ b/core/src/main/resources/lib/form/file.jelly
@@ -35,9 +35,10 @@ THE SOFTWARE.
     <st:attribute name="clazz">
       Additional CSS class(es) to add.
     </st:attribute>
-    <st:attribute name="name">
+    <st:attribute name="name"> <![CDATA[
       This becomes @name of the <input> tag.
       If @field is specified, this value is inferred from it.
+      ]]>
     </st:attribute>
     @since TODO
   </st:documentation>

--- a/core/src/main/resources/lib/form/file.jelly
+++ b/core/src/main/resources/lib/form/file.jelly
@@ -40,6 +40,13 @@ THE SOFTWARE.
       If @field is specified, this value is inferred from it.
       ]]>
     </st:attribute>
+    <!-- the below fields are passed through using the morph tag library but defined here for documentation -->
+    <st:attribute name="jsonAware">
+      Enable structured form submission.
+    </st:attribute>
+    <st:attribute name="accept">
+      Defines the file types the file input should accept. This string is a comma-separated list.
+    </st:attribute>
     @since TODO
   </st:documentation>
   <f:prepareDatabinding />

--- a/core/src/main/resources/lib/form/file.jelly
+++ b/core/src/main/resources/lib/form/file.jelly
@@ -35,10 +35,9 @@ THE SOFTWARE.
     <st:attribute name="clazz">
       Additional CSS class(es) to add.
     </st:attribute>
-    <st:attribute name="name"> <![CDATA[
+    <st:attribute name="name">
       This becomes @name of the <input> tag.
       If @field is specified, this value is inferred from it.
-      ]]>
     </st:attribute>
     @since TODO
   </st:documentation>


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/7452#discussion_r1060738108

I've updated the docs in https://github.com/jenkinsci/design-library-plugin/pull/193 for this

### Testing done

Tested with `f:file` in `PluginManager/advanced.jelly` and `FileParameterDefinition/index.jelly`

Added `clazz` attribute and checked class was there as expected

### Proposed changelog entries

- Developer: `f:file` now uses the morph tag library, all unknown attributes will be copied to the element.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7562"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

