### PR TITLE
[JENKINS-70301] Do not report implied dependencies for WMI Windows Agents plugin

### DIFF
--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -2,14 +2,12 @@
 # JENKINS-28942 could make this obsolete.
 
 credentials matrix-auth
-credentials windows-slaves
 
 script-security antisamy-markup-formatter
 script-security bouncycastle-api
 script-security command-launcher
 script-security matrix-auth
 script-security matrix-project
-script-security windows-slaves
 
 # Weird unexpected cycle that showed up during testing of this new plugin
 # so breaking all potential cycles until JENKINS-28942
@@ -25,7 +23,6 @@ ldap jaxb
 pam-auth jaxb
 mailer jaxb
 matrix-auth jaxb
-windows-slaves jaxb
 antisamy-markup-formatter jaxb
 matrix-project jaxb
 junit jaxb

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -16,7 +16,6 @@ ldap 1.467 1.0
 pam-auth 1.467 1.0
 mailer 1.493 1.2
 matrix-auth 1.535 1.0.2
-windows-slaves 1.547 1.0
 antisamy-markup-formatter 1.553 1.0
 matrix-project 1.561 1.0
 junit 1.577 1.0

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -306,13 +306,6 @@ THE SOFTWARE.
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
-                  <!-- detached after 1.547 -->
-                  <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>windows-slaves</artifactId>
-                  <version>1.8.1</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
                   <!-- detached after 1.553 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>antisamy-markup-formatter</artifactId>


### PR DESCRIPTION
## Do not report implied dependencies for WMI Windows Agents plugin

[JENKINS-70301](https://issues.jenkins.io/browse/JENKINS-70301) notes that the [WMI Windows Agents plugin](https://plugins.jenkins.io/windows-slaves/) (id:windows-slaves) was split from core in 1.547 and is now deprecated.  Because it is deprecated, users want to remove it.  They cannot remove it if they have plugins installed that depend on a Jenkins version prior to 1.547.

Only two plugins in the jenkinsci GitHub organization actually depend on any classes from the WMI Windows Agent plugin.

* [cli-extras-plugin](https://github.com/jenkinsci/cli-extras-plugin) - never released, no tags, no install history
* [multi-slave-config](https://github.com/jenkinsci/multi-slave-config-plugin) - already requires windows-slaves plugin explicitly and already requires a Jenkins core version newer than 1.547. 1340 installations, last released 8 years ago

Rather than require updates of all the plugins that require a Jenkins version less than 1.547, this removes the windows-slaves plugin from the split plugins list.  Users will not be warned that their plugin might have a dependency on windows-slaves because the analysis has confirmed that there is only 1 delivered plugin with that dependency, and it is an explicitly declared dependency with a newer Jenkins minimum version than the version from which the WMI Windows Agents plugin was split from Jenkins core.

[A google sheet](https://docs.google.com/spreadsheets/d/1KDIJIu41rIRlj6PjzyhAY9vazKmd3PVwqM3_-32Lt-o/edit?usp=sharing) lists the plugins that have an implied dependency on the WMI Windows Agents plugin.

No new automated tests because this is a one-time operation that has been tested interactively.  Plugin compatibility test evaluation:

* https://github.com/jenkinsci/bom/pull/1674 passed

### Testing done

* Installed suggested plugins from wizard and confirmed WMI Windows Agents plugin is not installed
* Installed slave-setup plugin (has implied WMI Windows Agents plugin dependency) and confirmed that WMI Windows Agents plugin is not installed
* Installed multi-slave-setup plugin (has explicit WMI Windows Agents plugin dependency) and confirmed that WMI Windows Agents plugin was installed as a dependency
* Remove multi-slave-setup plugin and WMI Windows Agents plugin and confirmed that Jenkins reported no errors or issues
* Installed five plugins with old base versions and confirmed that WMI Windows Agents plugin was not installed.  The five plugins included backup-plugin, cloudbees-credentials-plugin, unity3d-plugin, groovy-label-assignment-plugin, and maven-deployment-linker plugin.
* Performed a backup with the backup plugin and confirmed that it was well behaved
* Removed the windows-slaves plugin as a bundled plugin so that it is not included in the war file.  Confirmed the result war file loaded the five plugins tested earlier and was well behaved before and after those five plugins were uninstalled

### Proposed changelog entries

- Do not report implied dependencies for WMI Windows Agents plugin.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
- [x] Run plugin compatibility tester with an incremental build

### Desired reviewers

@jglick or @bcrow

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7568"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

