### PR TITLE
[JENKINS-70394] Move 'set node temporarily offline/online' buttons to app-bar

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/index-top.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index-top.jelly
@@ -1,11 +1,5 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
-  <!-- Node name and status -->
-  <h1>
-    <l:icon src="${it.iconClassName}" class="icon-xlg" />
-    ${it.caption}
-  </h1>
-
   <!-- Node description -->
   <t:editableDescription permission="${it.CONFIGURE}" description="${it.node.nodeDescription}" submissionUrl="submitDescription" />
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
     <l:main-panel>
-      <l:app-bar title="">
+      <l:app-bar title="${it.caption}">
         <!-- temporarily offline switch -->
         <j:choose>
           <j:when test="${it.temporarilyOffline}">

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -29,6 +29,9 @@ THE SOFTWARE.
     <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
     <l:main-panel>
       <l:app-bar title="${it.caption}">
+        <j:if test="${it.manualLaunchAllowed}">
+          <st:include from="${it.launcher}" page="app-bar-controls.jelly" optional="true"/>
+        </j:if>
         <!-- temporarily offline switch -->
         <j:choose>
           <j:when test="${it.temporarilyOffline}">
@@ -37,14 +40,14 @@ THE SOFTWARE.
                 <f:submit value="${%submit.temporarilyOffline}"  />
               </form>
               <form method="post" action="setOfflineCause">
-              <f:submit value="${%submit.updateOfflineCause}"  />
+              <f:submit primary="false" value="${%submit.updateOfflineCause}"  />
               </form>
             </l:hasPermission>
           </j:when>
           <j:otherwise>
             <l:hasPermission permission="${it.DISCONNECT}">
               <form method="post" action="markOffline">
-                <f:submit value="${%submit.not.temporarilyOffline}"  />
+                <f:submit primary="false" value="${%submit.not.temporarilyOffline}"  />
               </form>
             </l:hasPermission>
           </j:otherwise>

--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -28,17 +28,14 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
     <l:main-panel>
-      <st:include page="index-top.jelly" it="${it}" />
-
-      <!-- temporarily offline switch -->
-      <div style="float:right">
+      <l:app-bar title="">
+        <!-- temporarily offline switch -->
         <j:choose>
           <j:when test="${it.temporarilyOffline}">
             <l:hasPermission permission="${it.CONNECT}">
               <form method="post" action="toggleOffline">
                 <f:submit value="${%submit.temporarilyOffline}"  />
               </form>
-              <br/>
               <form method="post" action="setOfflineCause">
               <f:submit value="${%submit.updateOfflineCause}"  />
               </form>
@@ -52,7 +49,10 @@ THE SOFTWARE.
             </l:hasPermission>
           </j:otherwise>
         </j:choose>
-      </div>
+        <t:help href="https://www.jenkins.io/doc/book/using/using-agents/" />
+      </l:app-bar>
+
+      <st:include page="index-top.jelly" it="${it}" />
 
       <j:if test="${it.offlineCause!=null and it.offline and !it.connecting}">
         <st:include it="${it.offlineCause}" page="cause.jelly" />
@@ -67,7 +67,7 @@ THE SOFTWARE.
       </j:if>
 
         <j:if test="${it.node.assignedLabels.size() gt 1}">
-        <div>
+        <div class="jenkins-!-margin-bottom-3">
           <h2>${%Labels}</h2>
           <j:forEach var="entry" items="${it.node.labelCloud}">
             <!-- Skip the label for this node -->

--- a/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task contextMenu="false" href="${rootURL}/${it.url}" icon="symbol-computer" title="${%Status}"/>
+      <l:task contextMenu="false" href="${rootURL}/${it.url}" icon="${it.iconClassName}" title="${%Status}"/>
       <l:task href="${rootURL}/${it.url}delete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%Delete Agent}"/>
       <l:task href="${rootURL}/${it.url}configure" icon="symbol-settings" permission="${it.EXTENDED_READ}"
               title="${it.hasPermission(it.CONFIGURE) ? '%Configure' : '%View Configuration'}"/>

--- a/core/src/main/resources/hudson/slaves/ComputerLauncher/app-bar-controls.jelly
+++ b/core/src/main/resources/hudson/slaves/ComputerLauncher/app-bar-controls.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2023, Sun Microsystems, Inc., Kohsuke Kawaguchi, Jenkins project contributors
+Copyright (c) 2023, Jenkins project contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,13 +23,23 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core">
-  <j:if test="${it.launchSupported and it.offline and !it.temporarilyOffline and it.isConnecting()}">
-    <p>
-      ${%launchingDescription}
-      <j:if test="${it.hasPermission(it.CONFIGURE) or it.hasPermission(it.CONNECT)}">
-        <a href="log">${%See log for more details}</a>
-      </j:if>
-    </p>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+  <j:if test="${it.launchSupported and it.offline and !it.temporarilyOffline}">
+    <j:choose>
+      <j:when test="${it.isConnecting()}">
+        <l:hasPermission permission="${it.CONNECT}">
+          <form method="post" action="launchSlaveAgent">
+            <f:submit value="${%Relaunch agent}"/>
+          </form>
+        </l:hasPermission>
+      </j:when>
+      <j:otherwise>
+        <l:hasPermission permission="${it.CONNECT}">
+          <form method="post" action="launchSlaveAgent">
+            <f:submit value="${%Launch agent}"/>
+          </form>
+        </l:hasPermission>
+      </j:otherwise>
+    </j:choose>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/MasterComputer/index-top.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/MasterComputer/index-top.jelly
@@ -1,11 +1,5 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <!-- Node name and status -->
-  <h1>
-    <l:icon src="${it.iconClassName}" class="icon-xlg" />
-    ${it.caption}
-  </h1>
-
   <!-- Node description -->
   <div class="jenkins-!-margin-bottom-5">
     ${%blurb}


### PR DESCRIPTION
As describe in JENKINS-70394 are the to set the node temp. online/offline not clickable, because the offline-cause warning covers this buttons.

See [JENKINS-70394](https://issues.jenkins.io/browse/JENKINS-70394).

### Testing done

No Java changes, therefore no new automatic tests.
The UI looks now like this:
![image](https://user-images.githubusercontent.com/89339813/211941933-0eea72ba-43ea-417e-8a65-69adb32411a9.png)
![image](https://user-images.githubusercontent.com/89339813/211912609-868bebb9-9df7-4be1-9af5-25302ac7dc67.png)
![image](https://user-images.githubusercontent.com/89339813/211912776-4a00e12d-0423-42e7-ae37-3d7927cc11b0.png)

### Proposed changelog entries

- Move 'set node temporarily offline/online' buttons to app-bar

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- ~~[ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.~~
- ~~[ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.~~
- ~~[ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~~
- ~~[ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.~~
- ~~[ ] For new APIs and extension points, there is a link to at least one consumer.~~

### Desired reviewers

@jenkinsci/core-pr-reviewers 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7577"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

