### PR TITLE
Use hashes for third party action

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -65,14 +65,14 @@ jobs:
           wget -q https://get.jenkins.io/${REPO}/${PROJECT_VERSION}/${FILE_NAME}
       - name: Upload Release Asset
         id: upload-war
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ${{ steps.fetch-war.outputs.file-name }}
   debian:
     permissions:
-      contents: write # to upload release asset (softprops/action-gh-release@v1)
+      contents: write # to upload release asset (softprops/action-gh-release)
 
     runs-on: ubuntu-latest
     needs: determine-version
@@ -99,14 +99,14 @@ jobs:
       - name: Upload Release Asset
         id: upload-deb
         if: always()
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ${{ steps.fetch-deb.outputs.file-name }}
   redhat:
     permissions:
-      contents: write # to upload release asset (softprops/action-gh-release@v1)
+      contents: write # to upload release asset (softprops/action-gh-release)
 
     runs-on: ubuntu-latest
     needs: determine-version
@@ -134,14 +134,14 @@ jobs:
       - name: Upload Release Asset
         id: upload-rpm
         if: always()
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ${{ steps.fetch-rpm.outputs.file-name }}
   windows:
     permissions:
-      contents: write # to upload release asset (softprops/action-gh-release@v1)
+      contents: write # to upload release asset (softprops/action-gh-release)
 
     runs-on: ubuntu-latest
     needs: determine-version
@@ -169,14 +169,14 @@ jobs:
       - name: Upload Release Asset
         id: upload-msi
         if: always()
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ${{ steps.fetch-msi.outputs.file-name }}
   suse:
     permissions:
-      contents: write # to upload release asset (softprops/action-gh-release@v1)
+      contents: write # to upload release asset (softprops/action-gh-release)
 
     runs-on: ubuntu-latest
     needs: determine-version
@@ -204,7 +204,7 @@ jobs:
       - name: Upload Release Asset
         id: upload-suse-rpm
         if: always()
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Amends #7285 and partially implements recommendation surfaced in https://github.com/jenkinsci/jenkins/pull/7113 to not use mutable refs. https://github.com/softprops/action-gh-release/releases/tag/v1 currently points to `de2c0eb89ae2a093876385947365aca7b0e5f844` so I used that.

Untested. Lazy branch, please delete on merge.