### PR TITLE
[JENKINS-70438] Newer build displayed when filtering the builds in Build History Widget even if the build name didn't match

### DIFF
--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -23,9 +23,9 @@ const pageDown = buildHistoryPageNav.querySelectorAll(".pageDown")[0];
 const leftRightPadding = 4;
 const updateBuildsRefreshInterval = 5000;
 
-function updateBuilds() {
+function updateBuilds(params) {
   if (isPageVisible()) {
-    new Ajax.Request(ajaxUrl, {
+    new Ajax.Request(ajaxUrl + toQueryString(params), {
       requestHeaders: buildHistoryContainer.headers,
       onSuccess: function (rsp) {
         var dataTable = getDataTable(buildHistoryContainer);
@@ -82,19 +82,19 @@ function updateBuilds() {
         // next update
         buildHistoryContainer.headers = ["n", rsp.getResponseHeader("n")];
         checkAllRowCellOverflows();
-        createRefreshTimeout();
+        createRefreshTimeout(params);
       },
     });
   } else {
-    createRefreshTimeout();
+    createRefreshTimeout(params);
   }
 }
 
 var buildRefreshTimeout;
-function createRefreshTimeout() {
+function createRefreshTimeout(params) {
   cancelRefreshTimeout();
   buildRefreshTimeout = window.setTimeout(
-    updateBuilds,
+    () => updateBuilds(params),
     updateBuildsRefreshInterval
   );
 }
@@ -500,7 +500,7 @@ function loadPage(params, focusOnSearch) {
       updatePageParams(newDataTable);
       togglePageUpDown();
       if (!hasPageUp()) {
-        createRefreshTimeout();
+        createRefreshTimeout(params);
       }
 
       if (focusOnSearch) {


### PR DESCRIPTION
See [JENKINS-70438](https://issues.jenkins.io/browse/JENKINS-70438).

In the original method, the `ajax` will be sent periodically even if you were filtering the build. After changes, the (filtering) parameter will also send with the `ajax` (e.g. `ajax?search=foo`) periodically. Therefore, the newer build whose name doesn't match the keyword won't show.

See demo. (The interval between each request was cut in the below gif)

![sol](https://user-images.githubusercontent.com/20413055/212850184-b67e4f16-7a6a-437e-9e61-3aa01594b07c.gif)


<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Fix the behaviour of filtering in Build History Widget

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7589"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

