### PR TITLE
Backporting for 2.375.3

### DIFF
--- a/core/src/main/resources/jenkins/split-plugin-cycles.txt
+++ b/core/src/main/resources/jenkins/split-plugin-cycles.txt
@@ -2,14 +2,12 @@
 # JENKINS-28942 could make this obsolete.
 
 credentials matrix-auth
-credentials windows-slaves
 
 script-security antisamy-markup-formatter
 script-security bouncycastle-api
 script-security command-launcher
 script-security matrix-auth
 script-security matrix-project
-script-security windows-slaves
 
 # Weird unexpected cycle that showed up during testing of this new plugin
 # so breaking all potential cycles until JENKINS-28942
@@ -25,7 +23,6 @@ ldap jaxb
 pam-auth jaxb
 mailer jaxb
 matrix-auth jaxb
-windows-slaves jaxb
 antisamy-markup-formatter jaxb
 matrix-project jaxb
 junit jaxb

--- a/core/src/main/resources/jenkins/split-plugins.txt
+++ b/core/src/main/resources/jenkins/split-plugins.txt
@@ -16,7 +16,6 @@ ldap 1.467 1.0
 pam-auth 1.467 1.0
 mailer 1.493 1.2
 matrix-auth 1.535 1.0.2
-windows-slaves 1.547 1.0
 antisamy-markup-formatter 1.553 1.0
 matrix-project 1.561 1.0
 junit 1.577 1.0

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -43,7 +43,7 @@ THE SOFTWARE.
   </st:documentation>
 
   <j:if test="${mode=='breadcrumbs'}">
-    <j:set var="hasLink" value="${!(attrs.href == null or h.hyperlinkMatchesCurrentPage(attrs.href))}" />
+    <j:set var="hasLink" value="${attrs.href != null}" />
     <li id="${attrs.id}" class="jenkins-breadcrumbs__list-item" aria-current="${hasLink ? null : 'page'}">
       <j:choose>
         <j:when test="${!hasLink}">

--- a/core/src/main/resources/lib/layout/breadcrumbBar.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumbBar.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
         <j:if test="${h.isModel(anc.object) and anc.prev.url!=anc.url}">
           <j:set var="mode" value="breadcrumbs" />
           <l:breadcrumb title="${anc.object == app ? '%Dashboard' : anc.object.displayName}"
-                        href="${contents.length() == 0 and (index == request.ancestors.size() - 1) ? null : anc.url + '/'}"
+                        href="${anc.url}/"
                         hasMenu="${h.isModelWithContextMenu(anc.object)}" />
           <j:choose>
             <j:when test="${h.isModelWithChildren(anc.object)}">

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -303,12 +303,6 @@ THE SOFTWARE.
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.jenkins-ci.plugins</groupId>
-                  <artifactId>windows-slaves</artifactId>
-                  <version>1.8.1</version>
-                  <type>hpi</type>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>antisamy-markup-formatter</artifactId>
                   <version>1.1</version>
                   <type>hpi</type>

--- a/war/src/main/less/styles.less
+++ b/war/src/main/less/styles.less
@@ -54,7 +54,6 @@ html {
   // The downside is that the page does not resize with the browser's font size,
   // only with the zoom level.
   font-size: 16px !important;
-  letter-spacing: -0.016em;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
```
Latest core version: jenkins-2.387

Fixed
-----

JENKINS-70209           Minor                   2.385
        Letter spacing should not be negative (regression in 2.340 + 2.350)
        regression
        https://issues.jenkins.io/browse/JENKINS-70209

JENKINS-70301           Minor                   2.386
        Resolve implied dependencies on WMI Windows Agent plugin
        https://issues.jenkins.io/browse/JENKINS-70301

JENKINS-70169           Minor                   2.385
        Missing breadcrumb in Console log view
        regression
        https://issues.jenkins.io/browse/JENKINS-70169

JENKINS-70240           Minor                   2.383
        Non-HTTP based UpdateCenter URLs cause exception in plugin manager
        regression
        https://issues.jenkins.io/browse/JENKINS-70240
```

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7590"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

