### PR TITLE
[JENKINS-70240] Backport to 2.375.x

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1992,7 +1992,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     return FormValidation.ok();
                 } else {
                     LOGGER.log(Level.FINE, "Obtained a non OK ({0}) response from the update center",
-                            new Object[]{conn.getResponseCode(), uriWithQuery});
+                            new Object[]{conn.getResponseCode(), baseUri});
                     return FormValidation.error(Messages.PluginManager_connectionFailed());
                 }
             } catch (IOException e) {

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -100,7 +100,7 @@ PluginManager.deprecationWarning=<strong>This plugin is deprecated.</strong> In 
 PluginManager.insecureUrl=\
   You are using an insecure URL to download the plugin, use at your own risk!
 PluginManager.invalidUrl=\
-  You are using an invalid URL to download the plugin, only https and http (not recommended) are supported.
+  You are using an invalid URL to download the plugin, only file, https and http (not recommended) are supported.
 
 PluginManager.emptyUpdateSiteUrl=\
   The update site cannot be empty. Please enter a valid url.

--- a/core/src/main/resources/hudson/Messages_pt_BR.properties
+++ b/core/src/main/resources/hudson/Messages_pt_BR.properties
@@ -71,7 +71,7 @@ FilePath.validateAntFileMask.doesntMatchAnythingAndSuggest="{0}" não retornou n
 PluginWrapper.NoSuchPlugin=Nenhuma extensão encontrada com o nome ''{0}''
 PluginWrapper.failed_to_load_plugin_2=Falhou para carregar: {0} ({1} {2})
 PluginManager.invalidUrl= \
-  Você está usando uma URL inválida para baixar a extensão, somente https e http (não recomendado) são suportados.
+  Você está usando uma URL inválida para baixar a extensão, somente file, https e http (não recomendado) são suportados.
 PluginWrapper.Already.Disabled=A extensão ''{0}'' já foi desabilitada
 PluginWrapper.disabled_2=A extensão requerida está desabilitada: {0} {1}
 PluginManager.parentDepCompatWarning=As seguintes extensões são incompatíveis:

--- a/core/src/main/resources/hudson/Messages_zh_TW.properties
+++ b/core/src/main/resources/hudson/Messages_zh_TW.properties
@@ -74,7 +74,7 @@ PluginManager.newerVersionEntry=已有此版本的外掛但不作為更新提供
 PluginManager.unavailable=無法使用
 PluginManager.deprecationWarning=<strong>此外掛已棄用。</strong>這通常表示它可能已過時、不再繼續開發、不再正常運作等。<a href\="{0}" rel\="noopener noreferrer" target\="_blank">了解更多。</a>
 PluginManager.insecureUrl=您正在使用不安全的 URL 下載該外掛，風險請自負！
-PluginManager.invalidUrl=您正在使用無效的 URL 下載該外掛，只支援 https 和 http (不建議)。
+PluginManager.invalidUrl=您正在使用無效的 URL 下載該外掛，只支援 https、 http (不建議) 和 file。
 
 
 AboutJenkins.DisplayName=關於 Jenkins

--- a/core/src/test/java/hudson/PluginManagerTest.java
+++ b/core/src/test/java/hudson/PluginManagerTest.java
@@ -27,11 +27,14 @@ package hudson;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import hudson.util.FormValidation;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +47,8 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
@@ -114,6 +119,39 @@ public class PluginManagerTest {
                 equalTo(jar.lastModified()));
     }
 
+    @Test
+    @Issue("JENKINS-70420")
+    public void updateSiteURLCheckValidation() throws Exception {
+        LocalPluginManager pm = new LocalPluginManager(tmp.toFile());
+
+        assertThat("ftp urls are not acceptable", pm.checkUpdateSiteURL("ftp://foo/bar"),
+                allOf(FormValidationMatcher.validationWithMessage(FormValidation.Kind.ERROR), hasProperty("message", containsString("invalid URL"))));
+        assertThat("file urls to non files are not acceptable", pm.checkUpdateSiteURL(tmp.toUri().toURL().toString()),
+                allOf(FormValidationMatcher.validationWithMessage(FormValidation.Kind.ERROR), hasProperty("message", containsString("Unable to connect to the URL"))));
+
+        assertThat("invalid URLs do not cause a stack tracek", pm.checkUpdateSiteURL("sufslef3,r3;r99 3 l4i34"),
+                allOf(FormValidationMatcher.validationWithMessage(FormValidation.Kind.ERROR), hasProperty("message", containsString("invalid URL"))));
+
+        assertThat("empty url message", pm.checkUpdateSiteURL(""),
+                allOf(FormValidationMatcher.validationWithMessage(FormValidation.Kind.ERROR), hasProperty("message", containsString("cannot be empty"))));
+        assertThat("null url message", pm.checkUpdateSiteURL(""),
+                allOf(FormValidationMatcher.validationWithMessage(FormValidation.Kind.ERROR), hasProperty("message", containsString("cannot be empty"))));
+
+        // create a tempoary local file
+        Path p = tmp.resolve("some.json");
+        Files.writeString(tmp.resolve("some.json"), "{}");
+        assertThat("file urls pointing to existing files work", pm.checkUpdateSiteURL(p.toUri().toURL().toString()),
+                FormValidationMatcher.validationWithMessage(FormValidation.Kind.OK));
+
+        assertThat("http urls with non existing servers", pm.checkUpdateSiteURL("https://bogus.example.com"),
+                allOf(FormValidationMatcher.validationWithMessage(FormValidation.Kind.ERROR), hasProperty("message", containsString("Unable to connect to the URL"))));
+
+        // starting a http server here is likely to be overkill and given this is the predominant use case is not so likely to regress.
+        assertThat("main UC validates correctly", pm.checkUpdateSiteURL("https://updates.jenkins.io/update-center.json"),
+                FormValidationMatcher.validationWithMessage(FormValidation.Kind.OK));
+
+    }
+
     private static void assertAttribute(Manifest manifest, String attributeName, String value) {
         Attributes attributes = manifest.getMainAttributes();
         assertThat("Main attributes must not be empty", attributes, notNullValue());
@@ -167,5 +205,30 @@ public class PluginManagerTest {
     private URL toManifestUrl(File jarFile) throws MalformedURLException {
         final String manifestPath = "META-INF/MANIFEST.MF";
         return new URL("jar:" + jarFile.toURI().toURL() + "!/" + manifestPath);
+    }
+
+    private static class FormValidationMatcher extends TypeSafeDiagnosingMatcher<FormValidation> {
+
+        private final FormValidation.Kind kind;
+
+        private FormValidationMatcher(FormValidation.Kind kind) {
+            this.kind = kind;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("FormValidation of type ").appendValue(kind);
+        }
+
+        @Override
+        protected boolean matchesSafely(FormValidation item, Description mismatchDescription) {
+            mismatchDescription.appendText("FormValidation of type ").appendValue(item.kind);
+            return item.kind == kind;
+        }
+
+        static FormValidationMatcher validationWithMessage(FormValidation.Kind kind) {
+            return new FormValidationMatcher(kind);
+        }
+
     }
 }


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-70240](https://issues.jenkins.io/browse/JENKINS-70240).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Prevent Angry Jenkins when checking a non http(s) based update center URL.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [X] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [X] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [X] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [X] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [X] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jtnord @julieheard @basil @NotMyFault 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7597"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

