### PR TITLE
Introduce `SubTask.getOwnerExecutable`

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2077,10 +2077,14 @@ public class Queue extends ResourceController implements Saveable {
 
         /**
          * An umbrella executable (such as a {@link Run}) of which this is one part.
-         * If {@link #getParent} has a distinct {@link SubTask#getOwnerTask},
-         * then it should be the case that {@code getParentExecutable().getParent() == getParent().getOwnerTask()}.
+         * Some invariants:
+         * <ul>
+         * <li>{@code getParent().getOwnerTask() == getParent() || getParentExecutable().getParent() == getParent().getOwnerTask()}
+         * <li>{@code getParent().getOwnerExecutable() == null || getParentExecutable() == getParent().getOwnerExecutable()}
+         * </ul>
          * @return a <em>distinct</em> executable (never {@code this}, unlike the default of {@link SubTask#getOwnerTask}!); or null if this executable was already at top level
          * @since 2.313, but implementations can already implement this with a lower core dependency.
+         * @see SubTask#getOwnerExecutable
          */
         default @CheckForNull Executable getParentExecutable() {
             return null;

--- a/core/src/main/java/hudson/model/queue/SubTask.java
+++ b/core/src/main/java/hudson/model/queue/SubTask.java
@@ -35,9 +35,9 @@ import hudson.model.ResourceActivity;
 import java.io.IOException;
 
 /**
- * A component of {@link Task} that represents a computation carried out by a single {@link Executor}.
+ * A component of {@link Queue.Task} that represents a computation carried out by a single {@link Executor}.
  *
- * A {@link Task} consists of a number of {@link SubTask}.
+ * A {@link Queue.Task} consists of a number of {@link SubTask}.
  *
  * <p>
  * Plugins are encouraged to extend from {@link AbstractSubTask}
@@ -105,7 +105,7 @@ public interface SubTask extends ResourceActivity {
     }
 
     /**
-     * If a subset of {@link SubTask}s of a {@link Task} needs to be collocated with other {@link SubTask}s,
+     * If a subset of {@link SubTask}s of a {@link Queue.Task} needs to be collocated with other {@link SubTask}s,
      * those {@link SubTask}s should return the equal object here. If null, the execution unit isn't under a
      * colocation constraint.
      * @return by default, null

--- a/core/src/main/java/hudson/model/queue/SubTask.java
+++ b/core/src/main/java/hudson/model/queue/SubTask.java
@@ -30,8 +30,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Executor;
 import hudson.model.Label;
 import hudson.model.Node;
-import hudson.model.Queue.Executable;
-import hudson.model.Queue.Task;
+import hudson.model.Queue;
 import hudson.model.ResourceActivity;
 import java.io.IOException;
 
@@ -79,19 +78,30 @@ public interface SubTask extends ResourceActivity {
     }
 
     /**
-     * Creates {@link Executable}, which performs the actual execution of the task.
-     * @return {@link Executable} to be launched or null if the executable cannot be
+     * Creates an object which performs the actual execution of the task.
+     * @return executable to be launched or null if the executable cannot be
      * created (e.g. {@link AbstractProject} is disabled)
-     * @exception IOException {@link Executable} cannot be created
+     * @exception IOException executable cannot be created
      */
-    @CheckForNull Executable createExecutable() throws IOException;
+    @CheckForNull Queue.Executable createExecutable() throws IOException;
 
     /**
-     * Gets the {@link Task} that this subtask belongs to.
+     * Gets the task that this subtask belongs to.
      * @return by default, {@code this}
+     * @see #getOwnerExecutable
      */
-    default @NonNull Task getOwnerTask() {
-        return (Task) this;
+    default @NonNull Queue.Task getOwnerTask() {
+        return (Queue.Task) this;
+    }
+
+    /**
+     * If this task is associated with an executable of {@link #getOwnerTask}, finds that.
+     * @return by default, {@code null}
+     * @see hudson.model.Queue.Executable#getParentExecutable
+     * @since TODO
+     */
+    default @CheckForNull Queue.Executable getOwnerExecutable() {
+        return null;
     }
 
     /**


### PR DESCRIPTION
#5733 introduced a way to go from `PlaceholderExecutable` to `WorkflowRun` using supported APIs. For example: a Pipeline job

```groovy
node('some-label') {
  sh 'something'
}
```

is running the `sh` step, and given the `node` block executor slot you want to look up the build which encompasses that (and perhaps other `node` blocks). However, if `some-label` were currently unavailable and this item was sitting in the queue waiting to be scheduled, there would be no `PlaceholderExecutable` yet, only a `PlaceholderTask`, and there was no supported way to find the corresponding `WorkflowRun`. Various plugins therefore added a dependency on `workflow-durable-task-step` and directly cast to `PlaceholderTask` to call its `run` or `runForDisplay` methods; for example I could find https://github.com/jenkinsci/blueocean-plugin/pull/2388 as well as https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/197 (though for now this still needs a `workflow-durable-task-step` dep due to another call) as well as a number more in less common plugins. This new API allows the navigation to the owning build to be done in a proper way, assuming https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/287.

### Testing done

N/A

### Proposed changelog entries

- Developer: Introduced an API `SubTask.getOwnerExecutable` to be implemented in Pipeline.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7599"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

