### PR TITLE
Default CLI mode to `-webSocket`

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -124,7 +124,6 @@ public class CLI {
 
         boolean noKeyAuth = false;
 
-        // TODO perhaps allow mode to be defined by environment variable too (assuming $JENKINS_USER_ID can be used for -user)
         Mode mode = null;
 
         String user = null;
@@ -273,7 +272,7 @@ public class CLI {
             args = List.of("help"); // default to help
 
         if (mode == null) {
-            mode = Mode.HTTP;
+            mode = Mode.WEB_SOCKET;
         }
 
         LOGGER.log(FINE, "using connection mode {0}", mode);

--- a/cli/src/main/resources/hudson/cli/client/Messages.properties
+++ b/cli/src/main/resources/hudson/cli/client/Messages.properties
@@ -2,13 +2,13 @@ CLI.Usage=Jenkins CLI\n\
   Usage: java -jar jenkins-cli.jar [-s URL] command [opts...] args...\n\
   Options:\n\
   \ -s URL              : the server URL (defaults to the JENKINS_URL env var)\n\
-  \ -http               : use a plain CLI protocol over HTTP(S) (the default; mutually exclusive with -ssh)\n\
-  \ -webSocket          : like -http but using WebSocket (works better with most reverse proxies)\n\
-  \ -ssh                : use SSH protocol (requires -user; SSH port must be open on server, and user must have registered a public key)\n\
+  \ -webSocket          : connect using WebSocket (the default; works well with most reverse proxies; requires Jetty)\n\
+  \ -http               : use a pair of HTTP(S) connections rather than WebSocket\n\
+  \ -ssh                : use SSH protocol rather than WebSocket (requires -user; SSH port must be open on server)\n\
   \ -i KEY              : SSH private key file used for authentication (for use with -ssh)\n\
   \ -noCertificateCheck : bypass HTTPS certificate check entirely. Use with caution\n\
-  \ -noKeyAuth          : don''t try to load the SSH authentication private key. Conflicts with -i\n\
-  \ -user               : specify user (for use with -ssh)\n\
+  \ -noKeyAuth          : do not try to load the SSH authentication private key. Conflicts with -i\n\
+  \ -user               : specify user (for use with -ssh; must have registered a public key)\n\
   \ -strictHostKey      : request strict host key checking (for use with -ssh)\n\
   \ -logger FINE        : enable detailed logging from the client\n\
   \ -auth [ USER:SECRET | @FILE ] : specify username and either password or API token (or load from them both from a file);\n\

--- a/core/src/main/resources/hudson/cli/CLIAction/example.jelly
+++ b/core/src/main/resources/hudson/cli/CLIAction/example.jelly
@@ -24,6 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <pre id="example">java -jar <a href="${rootURL}/jnlpJars/jenkins-cli.jar">jenkins-cli.jar</a> -s ${h.inferHudsonURL(request)} <j:if test="${!it.webSocketSupported}">-http</j:if> ${commandArgs}</pre>
+  <pre id="example">java -jar <a href="${rootURL}/jnlpJars/jenkins-cli.jar">jenkins-cli.jar</a> -s ${h.inferHudsonURL(request)} <j:if test="${!it.webSocketSupported}">-http </j:if>${commandArgs}</pre>
 </j:jelly>
 

--- a/core/src/main/resources/hudson/cli/CLIAction/example.jelly
+++ b/core/src/main/resources/hudson/cli/CLIAction/example.jelly
@@ -24,6 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <pre id="example">java -jar <a href="${rootURL}/jnlpJars/jenkins-cli.jar">jenkins-cli.jar</a> -s ${h.inferHudsonURL(request)} <j:if test="${it.webSocketSupported}">-webSocket</j:if> ${commandArgs}</pre>
+  <pre id="example">java -jar <a href="${rootURL}/jnlpJars/jenkins-cli.jar">jenkins-cli.jar</a> -s ${h.inferHudsonURL(request)} <j:if test="${!it.webSocketSupported}">-http</j:if> ${commandArgs}</pre>
 </j:jelly>
 

--- a/test/src/test/java/hudson/cli/CLIActionTest.java
+++ b/test/src/test/java/hudson/cli/CLIActionTest.java
@@ -104,7 +104,7 @@ public class CLIActionTest {
     private static final String ADMIN = "admin@mycorp.com";
 
     private void assertExitCode(int code, boolean useApiToken, File jar, String... args) throws IOException, InterruptedException {
-        List<String> commands = new ArrayList<>(Arrays.asList("java", "-jar", jar.getAbsolutePath(), "-s", j.getURL().toString(), /* TODO until it is the default */ "-webSocket"));
+        List<String> commands = new ArrayList<>(Arrays.asList("java", "-jar", jar.getAbsolutePath(), "-s", j.getURL().toString()));
         if (useApiToken) {
             commands.add("-auth");
             commands.add(ADMIN + ":" + User.getOrCreateByIdOrFullName(ADMIN).getProperty(ApiTokenProperty.class).getApiToken());
@@ -140,7 +140,6 @@ public class CLIActionTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         assertEquals(0, new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
             "java", "-Dfile.encoding=ISO-8859-2", "-Duser.language=cs", "-Duser.country=CZ", "-jar", jar.getAbsolutePath(),
-                "-webSocket", // TODO as above
                 "-s", j.getURL().toString()./* just checking */replaceFirst("/$", ""), "test-diagnostic").
             stdout(baos).stderr(System.err).join());
         assertEquals("encoding=ISO-8859-2 locale=cs_CZ", baos.toString(Charset.forName("ISO-8859-2")).trim());
@@ -160,7 +159,6 @@ public class CLIActionTest {
         PrintWriter pw = new PrintWriter(new OutputStreamWriter(new TeeOutputStream(pos, System.err), Charset.defaultCharset()), true);
         Proc proc = new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
             "java", "-jar", jar.getAbsolutePath(), "-s", j.getURL().toString(),
-                "-webSocket", // TODO as above
                 "groovysh").
             stdout(new TeeOutputStream(baos, System.out)).stderr(System.err).stdin(pis).start();
         while (!baos.toString(Charset.defaultCharset()).contains("000")) { // cannot just search for, say, "groovy:000> " since there are ANSI escapes there (cf. StringEscapeUtils.escapeJava)


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/4369 introduced `-webSocket` transport, which was at the time considered experimental and so the default remained `-http`. Since then, as far as I know it has been stable (at least after #5455), so it seems appropriate to make it the default now rather than `-http` which relies on a hack (`FullDuplexHttpService`) to keep two HTTP connections open. Since both modes accept the same authentication option—namely, an API token—the change ought to be transparent for most users.

### Testing done

Ran with various transport options, or none, plus `-logger FINE` to confirm the mode being used.

### Proposed changelog entries

- The default connection mode for the Java CLI client is now `-webSocket`. You can specify `-http` to continue to use the former default (for example because you are running Jenkins in a servlet container other than the recommended built-in Jetty, or because you are running an unusual reverse proxy which does not support WebSocket). You can also continue to specify `-ssh` to use SSH transport (for example because you prefer to authenticate with a private key rather than an API token), or use a native SSH client.

### Proposed upgrade guidelines

If you use the Jenkins CLI but cannot make WebSocket connections to the Jenkins controller, you will now need to pass the `-http` or `-ssh` option if you were not already doing so.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7605"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

