### PR TITLE
Updating the descriptions for the escape/encode functions

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -758,6 +758,11 @@ public class Functions {
         return s.indexOf('\r') >= 0 || s.indexOf('\n') >= 0;
     }
 
+    /**
+     * Encodes a string into UTF-8 encoding
+     * Input example  1: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Output example 1: %20!"%C2%A3$%^&*()_+}{:@~?><|%C2%AC`,./;'#[]-=%20%20
+     */
     public static String encode(String s) {
         return Util.encode(s);
     }
@@ -766,6 +771,13 @@ public class Functions {
      * Shortcut function for calling {@link URLEncoder#encode(String,String)} (with UTF-8 encoding).<br>
      * Useful for encoding URL query parameters in jelly code (as in {@code "...?param=${h.urlEncode(something)}"}).<br>
      * For convenience in jelly code, it also accepts null parameter, and then returns an empty string.
+     *
+     * Input example  1: & " ' < >
+     * Output example 1: %26+%22+%27+%3C+%3E
+     * Input example  2: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Output example 2: %21%22%C2%A3%24%25%5E%26*%28%29_%2B%7D%7B%3A%40%7E%3F%3E%3C%7C%C2%AC%60%2C.%2F%3B%27%23%5B%5D-%3D++
+     * Note:
+     * - a blank space will render as + (You can see this in above examples)
      *
      * @since 2.200
      */
@@ -776,10 +788,27 @@ public class Functions {
         return URLEncoder.encode(s, StandardCharsets.UTF_8);
     }
 
+    /**
+     * Escapes HTML unsafe characters
+     * Input example  1: & " ' < >
+     * Output example 1: &amp; &quot; &#039; &lt; &gt;
+     * Input example  2: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Output example 2: !&quot;£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;&#039;#[]-=&nbsp;
+     * Notes:
+     * - 2 consecutive blank spaces will render as &nbsp; (which is a non-breaking space char)
+     * - This method will render an apostrophe as &#039;
+     */
     public static String escape(String s) {
         return Util.escape(s);
     }
 
+    /**
+     * Escapes XML unsafe characters
+     * Input example  1: < > &
+     * Output example 1: &lt; &gt; &amp;
+     * Input example  2: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Output example 2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
+     */
     public static String xmlEscape(String s) {
         return Util.xmlEscape(s);
     }
@@ -788,6 +817,15 @@ public class Functions {
         return s.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&");
     }
 
+    /**
+     * Escapes HTML unsafe characters
+     * Input example  1: & " ' < >
+     * Output example 1: &amp; &quot; &#39; &lt; &gt;
+     * Input example  2: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Output example 2: !&quot;£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;&#39;#[]-=
+     * Note:
+     * - 2 consecutive blank spaces will not render any special chars
+     */
     public static String htmlAttributeEscape(String text) {
         StringBuilder buf = new StringBuilder(text.length() + 64);
         for (int i = 0; i < text.length(); i++) {
@@ -1569,6 +1607,11 @@ public class Functions {
         return Collections.emptyList();
     }
 
+    /**
+     * Escapes Javascript unsafe characters
+     * Input example : \ \\ ' "
+     * Output example: \\ \\\\ \' \"
+     */
     public static String jsStringEscape(String s) {
         if (s == null) return null;
         StringBuilder buf = new StringBuilder();

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -759,13 +759,17 @@ public class Functions {
     }
 
     /**
-     * Partially encodes a string into UTF-8 encoding. It uses the hudson.Util encode method to escape non-ASCII characters in URL.
-     * Input example  1: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
-     * Output example 1: !"%C2%A3$%^&*()_+}{:@~?><|%C2%AC`,./;'#[]-=%20
+     * Partially encodes a string into UTF-8 encoding. It uses the {@link hudson.Util} encode method to escape non-ASCII characters in URL.
+     * <pre>
+     * Input example  1: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
+     * Output example 1: !"%C2%A3$%^&amp;*()_+}{:@~?&gt;&lt;|%C2%AC`,./;'#[]-=%20
+     * </pre>
      * Notes:
-     * - a blank space will render as %20
-     * - this methods only escapes non-ASCII but leaves other URL-unsafe characters, such as '#'
-     * - rawEncode(String) in the hudson.Util library should generally be used instead (do check the documentation for that method)
+     * <ul>
+     * <li>a blank space will render as %20</li>
+     * <li>this methods only escapes non-ASCII but leaves other URL-unsafe characters, such as '#'</li>
+     * <li>{@link hudson.Util#rawEncode(String)} in the {@link hudson.Util} library should generally be used instead (do check the documentation for that method)</li>
+     * </ul>
      */
     public static String encode(String s) {
         return Util.encode(s);
@@ -775,13 +779,13 @@ public class Functions {
      * Shortcut function for calling {@link URLEncoder#encode(String,String)} (with UTF-8 encoding).<br>
      * Useful for encoding URL query parameters in jelly code (as in {@code "...?param=${h.urlEncode(something)}"}).<br>
      * For convenience in jelly code, it also accepts null parameter, and then returns an empty string.
-     *
-     * Input example  1: & " ' < >
+     * <pre>
+     * Input example  1: &amp; " ' &lt; &gt;
      * Output example 1: %26+%22+%27+%3C+%3E
-     * Input example  2: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
      * Output example 2: %21%22%C2%A3%24%25%5E%26*%28%29_%2B%7D%7B%3A%40%7E%3F%3E%3C%7C%C2%AC%60%2C.%2F%3B%27%23%5B%5D-%3D++
-     * Note:
-     * - a blank space will render as + (You can see this in above examples)
+     * </pre>
+     * Note: A blank space will render as + (You can see this in above examples)
      *
      * @since 2.200
      */
@@ -794,13 +798,17 @@ public class Functions {
 
     /**
      * Escapes HTML unsafe characters
-     * Input example  1: & " ' < >
+     * <pre>
+     * Input example  1: &amp; " ' &lt; &gt;
      * Output example 1: &amp; &quot; &#039; &lt; &gt;
-     * Input example  2: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
      * Output example 2: !&quot;£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;&#039;#[]-=&nbsp;
+     * </pre>
      * Notes:
-     * - 2 consecutive blank spaces will render as &nbsp; (which is a non-breaking space char)
-     * - This method will render an apostrophe as &#039;
+     * <ul>
+     * <li>2 consecutive blank spaces will render as &nbsp; (which is a non-breaking space char)</li>
+     * <li>This method will render an apostrophe as &#039;</li>
+     * </ul>
      */
     public static String escape(String s) {
         return Util.escape(s);
@@ -808,10 +816,12 @@ public class Functions {
 
     /**
      * Escapes XML unsafe characters
-     * Input example  1: < > &
+     * <pre>
+     * Input example  1: &lt; &gt; &amp;
      * Output example 1: &lt; &gt; &amp;
-     * Input example  2: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
      * Output example 2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
+     * </pre>
      */
     public static String xmlEscape(String s) {
         return Util.xmlEscape(s);
@@ -823,12 +833,13 @@ public class Functions {
 
     /**
      * Escapes HTML unsafe characters
-     * Input example  1: & " ' < >
+     * <pre>
+     * Input example  1: &amp; " ' &lt; &gt;
      * Output example 1: &amp; &quot; &#39; &lt; &gt;
-     * Input example  2: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
+     * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
      * Output example 2: !&quot;£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;&#39;#[]-=
-     * Note:
-     * - 2 consecutive blank spaces will not render any special chars
+     * </pre>
+     * Note: 2 consecutive blank spaces will not render any special chars.
      */
     public static String htmlAttributeEscape(String text) {
         StringBuilder buf = new StringBuilder(text.length() + 64);
@@ -1613,8 +1624,10 @@ public class Functions {
 
     /**
      * Escapes Javascript unsafe characters
+     * <pre>
      * Input example : \ \\ ' "
      * Output example: \\ \\\\ \' \"
+     * </pre>
      */
     public static String jsStringEscape(String s) {
         if (s == null) return null;

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -760,7 +760,7 @@ public class Functions {
 
     /**
      * Partially encodes a string into UTF-8 encoding. It uses the hudson.Util encode method to escape non-ASCII characters in URL.
-     * Input example  1: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-= 
+     * Input example  1: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
      * Output example 1: !"%C2%A3$%^&*()_+}{:@~?><|%C2%AC`,./;'#[]-=%20
      * Notes:
      * - a blank space will render as %20

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -830,7 +830,7 @@ public class Functions {
     }
 
     /**
-     * Escapes HTML unsafe characters
+     * Escapes a string so it can be used in an HTML attribute value.
      * <pre>
      * Input example  1: &amp; " ' &lt; &gt;
      * Output example 1: &amp;amp; &amp;quot; &amp;#39; &amp;lt; &amp;gt;

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -759,8 +759,7 @@ public class Functions {
     }
 
     /**
-     * Partially encodes a string into UTF-8 encoding. It uses {@link hudson.Util#encode} to escape
-     * non-ASCII characters in URL.
+     * Percent-encodes space and non-ASCII UTF-8 characters for use in URLs.
      * <pre>
      * Input example  1: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]- =
      * Output example 1: !"%C2%A3$%^&amp;*()_+}{:@~?&gt;&lt;|%C2%AC`,./;'#[]-%20=

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1626,6 +1626,7 @@ public class Functions {
      * Input example : \ \\ ' "
      * Output example: \\ \\\\ \' \"
      * </pre>
+     * @see <a href="https://www.jenkins.io/doc/developer/security/xss-prevention/#passing-values-to-javascript">Passing values to JavaScript</a>
      */
     public static String jsStringEscape(String s) {
         if (s == null) return null;

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -760,9 +760,10 @@ public class Functions {
 
     /**
      * Partially encodes a string into UTF-8 encoding. It uses the hudson.Util encode method to escape non-ASCII characters in URL.
-     * Input example  1: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
-     * Output example 1: %20!"%C2%A3$%^&*()_+}{:@~?><|%C2%AC`,./;'#[]-=%20%20
+     * Input example  1: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-= 
+     * Output example 1: !"%C2%A3$%^&*()_+}{:@~?><|%C2%AC`,./;'#[]-=%20
      * Notes:
+     * - a blank space will render as %20
      * - this methods only escapes non-ASCII but leaves other URL-unsafe characters, such as '#'
      * - rawEncode(String) in the hudson.Util library should generally be used instead (do check the documentation for that method)
      */

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1621,7 +1621,8 @@ public class Functions {
     }
 
     /**
-     * Escapes Javascript unsafe characters
+     * Escape a string so variable values can be used in inline JavaScript in views.
+     * Note that inline JavaScript and especially passing variables is discouraged, see the documentation for alternatives.
      * <pre>
      * Input example : \ \\ ' "
      * Output example: \\ \\\\ \' \"

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -797,10 +797,7 @@ public class Functions {
     }
 
     /**
-     * Escapes HTML unsafe characters.
-     *<br/>
-     * The purpose of this method (originally) was to faithfully render a human-entered description.
-     * So newlines translate to line break tags, consecutive spaces are retained as nbsp, and we escape HTML special chars to not get markup.
+     * Transforms the input string so it renders as written in HTML output: newlines are converted to HTML line breaks, consecutive spaces are retained as {@code &amp;nbsp;}, and HTML metacharacters are escaped.
      * <pre>
      * Input example  1: &amp; " ' &lt; &gt;
      * Output example 1: &amp;amp; &amp;quot; &amp;#039; &amp;lt; &amp;gt;

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -759,9 +759,12 @@ public class Functions {
     }
 
     /**
-     * Encodes a string into UTF-8 encoding
+     * Partially encodes a string into UTF-8 encoding. It uses the hudson.Util encode method to escape non-ASCII characters in URL.
      * Input example  1: !"£$%^&*()_+}{:@~?><|¬`,./;'#[]-=
      * Output example 1: %20!"%C2%A3$%^&*()_+}{:@~?><|%C2%AC`,./;'#[]-=%20%20
+     * Notes:
+     * - this methods only escapes non-ASCII but leaves other URL-unsafe characters, such as '#'
+     * - rawEncode(String) in the hudson.Util library should generally be used instead (do check the documentation for that method)
      */
     public static String encode(String s) {
         return Util.encode(s);

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -804,12 +804,6 @@ public class Functions {
      * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
      * Output example 2: !&amp;quot;£$%^&amp;amp;*()_+}{:@~?&amp;gt;&amp;lt;|¬`,./;&amp;#039;#[]-=
      * </pre>
-     * Notes:
-     * <ul>
-     * <li>2 consecutive blank spaces will render as &amp;nbsp; (which is a non-breaking space char)</li>
-     * <li>This method will render an apostrophe as &amp;#039;</li>
-     * <li>A newline character \n will render as &lt;br&gt; HTML tag</li>
-     * </ul>
      * @see #xmlEscape
      * @see hudson.Util#escape
      */

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -759,7 +759,8 @@ public class Functions {
     }
 
     /**
-     * Partially encodes a string into UTF-8 encoding. It uses the {@link hudson.Util} encode method to escape non-ASCII characters in URL.
+     * Partially encodes a string into UTF-8 encoding. It uses {@link hudson.Util#encode} to escape
+     * non-ASCII characters in URL.
      * <pre>
      * Input example  1: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]- =
      * Output example 1: !"%C2%A3$%^&amp;*()_+}{:@~?&gt;&lt;|%C2%AC`,./;'#[]-%20=
@@ -783,7 +784,7 @@ public class Functions {
      * Input example  1: &amp; " ' &lt; &gt;
      * Output example 1: %26+%22+%27+%3C+%3E
      * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
-     * Output example 2: %21%22%C2%A3%24%25%5E%26*%28%29_%2B%7D%7B%3A%40%7E%3F%3E%3C%7C%C2%AC%60%2C.%2F%3B%27%23%5B%5D-%3D++
+     * Output example 2: %21%22%C2%A3%24%25%5E%26*%28%29_%2B%7D%7B%3A%40%7E%3F%3E%3C%7C%C2%AC%60%2C.%2F%3B%27%23%5B%5D-%3D
      * </pre>
      * Note: A blank space will render as + (You can see this in above examples)
      *
@@ -797,18 +798,24 @@ public class Functions {
     }
 
     /**
-     * Escapes HTML unsafe characters
+     * Escapes HTML unsafe characters.
+     *<br/>
+     * The purpose of this method (originally) was to faithfully render a human-entered description.
+     * So newlines translate to line break tags, consecutive spaces are retained as nbsp, and we escape HTML special chars to not get markup.
      * <pre>
      * Input example  1: &amp; " ' &lt; &gt;
-     * Output example 1: &amp; &quot; &#039; &lt; &gt;
+     * Output example 1: &amp;amp; &amp;quot; &amp;#039; &amp;lt; &amp;gt;
      * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
-     * Output example 2: !&quot;£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;&#039;#[]-=&nbsp;
+     * Output example 2: !&amp;quot;£$%^&amp;amp;*()_+}{:@~?&amp;gt;&amp;lt;|¬`,./;&amp;#039;#[]-=
      * </pre>
      * Notes:
      * <ul>
-     * <li>2 consecutive blank spaces will render as &nbsp; (which is a non-breaking space char)</li>
-     * <li>This method will render an apostrophe as &#039;</li>
+     * <li>2 consecutive blank spaces will render as &amp;nbsp; (which is a non-breaking space char)</li>
+     * <li>This method will render an apostrophe as &amp;#039;</li>
+     * <li>A newline character \n will render as &lt;br&gt; HTML tag</li>
      * </ul>
+     * @see #xmlEscape
+     * @see hudson.Util#escape
      */
     public static String escape(String s) {
         return Util.escape(s);
@@ -818,10 +825,11 @@ public class Functions {
      * Escapes XML unsafe characters
      * <pre>
      * Input example  1: &lt; &gt; &amp;
-     * Output example 1: &lt; &gt; &amp;
+     * Output example 1: &amp;lt; &amp;gt; &amp;amp;
      * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
-     * Output example 2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
+     * Output example 2: !"£$%^&amp;amp;*()_+}{:@~?&amp;gt;&amp;lt;|¬`,./;'#[]-=
      * </pre>
+     *  @see hudson.Util#xmlEscape
      */
     public static String xmlEscape(String s) {
         return Util.xmlEscape(s);
@@ -835,9 +843,9 @@ public class Functions {
      * Escapes HTML unsafe characters
      * <pre>
      * Input example  1: &amp; " ' &lt; &gt;
-     * Output example 1: &amp; &quot; &#39; &lt; &gt;
+     * Output example 1: &amp;amp; &amp;quot; &amp;#39; &amp;lt; &amp;gt;
      * Input example  2: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
-     * Output example 2: !&quot;£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;&#39;#[]-=
+     * Output example 2: !&amp;quot;£$%^&amp;amp;*()_+}{:@~?&amp;gt;&amp;lt;|¬`,./;&amp;#39;#[]-=
      * </pre>
      * Note: 2 consecutive blank spaces will not render any special chars.
      */

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -761,8 +761,8 @@ public class Functions {
     /**
      * Partially encodes a string into UTF-8 encoding. It uses the {@link hudson.Util} encode method to escape non-ASCII characters in URL.
      * <pre>
-     * Input example  1: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]-=
-     * Output example 1: !"%C2%A3$%^&amp;*()_+}{:@~?&gt;&lt;|%C2%AC`,./;'#[]-=%20
+     * Input example  1: !"£$%^&amp;*()_+}{:@~?&gt;&lt;|¬`,./;'#[]- =
+     * Output example 1: !"%C2%A3$%^&amp;*()_+}{:@~?&gt;&lt;|%C2%AC`,./;'#[]-%20=
      * </pre>
      * Notes:
      * <ul>


### PR DESCRIPTION
Adding explanations and examples to the encode and escape functions.
This is a documentation only change.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
I have manually tested the output of these functions multiple times in Jelly and in java and put the output in the documentation. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries
- Added descriptions to the escape and encode functions in the hudson.Functions library


### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7606"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

