### PR TITLE
`t:progressiveText` should tolerate 5xx HTTP errors

### DIFF
--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -28,10 +28,15 @@ Behaviour.specify(
         parameters: { start: e.fetchedBytes },
         requestHeaders: headers,
         onComplete: function (rsp) {
-          if (rsp.status >= 500) {
+          if (rsp.status >= 500 || rsp.status === 0) {
             setTimeout(function () {
               fetchNext(e, href, onFinishEvent);
             }, 1000);
+            return;
+          }
+          if (rsp.status === 403) {
+            // likely an expired crumb
+            location.reload();
             return;
           }
           /* append text and do autoscroll if applicable */

--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -28,6 +28,12 @@ Behaviour.specify(
         parameters: { start: e.fetchedBytes },
         requestHeaders: headers,
         onComplete: function (rsp) {
+          if (rsp.status >= 500) {
+            setTimeout(function () {
+              fetchNext(e, href, onFinishEvent);
+            }, 1000);
+            return;
+          }
           /* append text and do autoscroll if applicable */
           var stickToBottom = scroller.isSticking();
           var text = rsp.responseText;

--- a/war/src/main/webapp/scripts/loading.js
+++ b/war/src/main/webapp/scripts/loading.js
@@ -42,15 +42,20 @@ const Fetch = {
   },
 };
 
-function safeRedirector(url) {
+function safeRedirector(preferredUrl, fallbackUrl) {
   const timeout = 5000;
   window.setTimeout(function () {
     const statusChecker = arguments.callee;
-    Fetch.get(url, function (error, status) {
+    Fetch.get(preferredUrl, function (error, status) {
       if ((status >= 502 && status <= 504) || status === 0) {
         window.setTimeout(statusChecker, timeout);
       } else {
-        window.location.replace(url);
+        if (status === 404) {
+          // Perhaps anonymous has Overall/Read but lacks other permissions (e.g. Item/Read+Discover), so go to root URL
+          window.location.replace(fallbackUrl);
+        } else {
+          window.location.replace(preferredUrl);
+        }
       }
       if (error) {
         console.error(error);
@@ -59,4 +64,5 @@ function safeRedirector(url) {
   }, timeout);
 }
 
-safeRedirector(window.location.href);
+const rootUrl = document.head.getAttribute("data-rooturl");
+safeRedirector(window.location.href, rootUrl);

--- a/war/src/main/webapp/scripts/loading.js
+++ b/war/src/main/webapp/scripts/loading.js
@@ -65,4 +65,4 @@ function safeRedirector(preferredUrl, fallbackUrl) {
 }
 
 const rootUrl = document.head.getAttribute("data-rooturl");
-safeRedirector(window.location.href, rootUrl);
+safeRedirector(window.location.href, rootUrl + "/");

--- a/war/src/main/webapp/scripts/loading.js
+++ b/war/src/main/webapp/scripts/loading.js
@@ -59,5 +59,4 @@ function safeRedirector(url) {
   }, timeout);
 }
 
-const rootUrl = document.head.getAttribute("data-rooturl");
-safeRedirector(rootUrl + "/");
+safeRedirector(window.location.href);


### PR DESCRIPTION
If you are displaying e.g. `WorkflowRun/console.jelly` for a running build, your browser will repeatedly contact `job/…/…/logText/progressiveHtml` looking for fresh log text. Normally it will keep receiving `X-More-Data: true` and so trigger another another request after 1s. However if you restart the controller, the request will of course fail while it is down and so the log will stop refreshing. If you are running in front of a reverse proxy, such as `ingress-nginx` in Kubernetes, you will get a 504 (or 502?) response during this time. This change just treats that response as nonfatal so the browser will automatically recheck until the controller is available again and can serve a meaningful response. See #4366 etc.

### Proposed changelog entries

- Running pipeline build logs can now be displayed across controller restarts without reloading in some environments.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7614"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

