### PR TITLE
[JENKINS-60866] Un-inline setup wizard root URL js

### DIFF
--- a/core/src/main/resources/jenkins/install/SetupWizard/setInitialRootUrlFieldValue.js
+++ b/core/src/main/resources/jenkins/install/SetupWizard/setInitialRootUrlFieldValue.js
@@ -1,17 +1,20 @@
-var rootUrlField = $('root-url');
+var rootUrlField = $("root-url");
 
 rootUrlField.focus();
-rootUrlField.onkeydown = function(event) {
-  if (event.keyCode == 13){
+rootUrlField.onkeydown = function (event) {
+  if (event.keyCode == 13) {
     event.preventDefault();
   }
 };
 
-(function setInitialRootUrlFieldValue(){
+(function setInitialRootUrlFieldValue() {
   var iframeUrl = window.location.href;
   // will let the trailing slash in the rootUrl
-  var iframeRelativeUrl = 'setupWizard/setupWizardConfigureInstance';
-  var rootUrl = iframeUrl.substr(0, iframeUrl.length - iframeRelativeUrl.length);
+  var iframeRelativeUrl = "setupWizard/setupWizardConfigureInstance";
+  var rootUrl = iframeUrl.substr(
+    0,
+    iframeUrl.length - iframeRelativeUrl.length
+  );
   // to keep only the root url
   rootUrlField.value = rootUrl;
   // to adjust the width of the input,

--- a/core/src/main/resources/jenkins/install/SetupWizard/setInitialRootUrlFieldValue.js
+++ b/core/src/main/resources/jenkins/install/SetupWizard/setInitialRootUrlFieldValue.js
@@ -1,0 +1,19 @@
+var rootUrlField = $('root-url');
+
+rootUrlField.focus();
+rootUrlField.onkeydown = function(event) {
+  if (event.keyCode == 13){
+    event.preventDefault();
+  }
+};
+
+(function setInitialRootUrlFieldValue(){
+  var iframeUrl = window.location.href;
+  // will let the trailing slash in the rootUrl
+  var iframeRelativeUrl = 'setupWizard/setupWizardConfigureInstance';
+  var rootUrl = iframeUrl.substr(0, iframeUrl.length - iframeRelativeUrl.length);
+  // to keep only the root url
+  rootUrlField.value = rootUrl;
+  // to adjust the width of the input,
+  rootUrlField.size = Math.min(50, rootUrl.length);
+})();

--- a/core/src/main/resources/jenkins/install/SetupWizard/setupWizardConfigureInstance.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/setupWizardConfigureInstance.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
 
   <l:layout norefresh="true" type="full-screen" title="${it.displayName}">
     <l:main-panel>
@@ -45,27 +45,7 @@ THE SOFTWARE.
             </tr>
             </table>
           </div>
-         <script>
-            var rootUrlField = $('root-url');
-
-            rootUrlField.focus();
-            rootUrlField.onkeydown = function(event) {
-                if (event.keyCode == 13){
-                    event.preventDefault();
-                }
-            };
-
-            (function setInitialRootUrlFieldValue(){
-              var iframeUrl = window.location.href;
-              // will let the trailing slash in the rootUrl
-              var iframeRelativeUrl = 'setupWizard/setupWizardConfigureInstance';
-              var rootUrl = iframeUrl.substr(0, iframeUrl.length - iframeRelativeUrl.length);
-              // to keep only the root url
-              rootUrlField.value = rootUrl
-              // to adjust the width of the input,
-              rootUrlField.size = Math.min(50, rootUrl.length);
-            })();
-          </script>
+         <st:adjunct includes="jenkins.install.SetupWizard.setInitialRootUrlFieldValue"/>
         </form>
      </div>
     </l:main-panel>


### PR DESCRIPTION
See [JENKINS-60866](https://issues.jenkins.io/browse/JENKINS-60866) for the issue that covers the process.  This pull request does not resolve that issue, but it is progress on the goal of that issue.

### Testing done

Testing interactively, I didn't encounter any regressions while walking through the setup wizard until the root URL page.

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
