### PR TITLE
Messaging tweaks for `InstallUncaughtExceptionHandler`

### DIFF
--- a/core/src/main/java/hudson/init/impl/InstallUncaughtExceptionHandler.java
+++ b/core/src/main/java/hudson/init/impl/InstallUncaughtExceptionHandler.java
@@ -37,10 +37,10 @@ public class InstallUncaughtExceptionHandler {
         }
         catch (SecurityException ex) {
             LOGGER.log(Level.SEVERE,
-                                                       "Failed to set the default UncaughtExceptionHandler.  " +
-                                                       "If any threads die due to unhandled coding errors then there will be no logging of this information.  " +
-                                                       "The lack of this diagnostic information will make it harder to track down issues which will reduce the supportability of Jenkins.  " +
-                                                       "It is highly recommended that you consult the documentation that comes with you servlet container on how to allow the " +
+                                                       "Failed to set the default UncaughtExceptionHandler. " +
+                                                       "If any threads die due to unhandled coding errors then there will be no logging of this information. " +
+                                                       "The lack of this diagnostic information will make it harder to track down issues which will reduce the supportability of Jenkins. " +
+                                                       "It is highly recommended that you consult the documentation that comes with your servlet container on how to allow the " +
                                                        "`setDefaultUncaughtExceptionHandler` permission and enable it.", ex);
         }
     }
@@ -100,7 +100,7 @@ public class InstallUncaughtExceptionHandler {
             // if this was an OutOfMemoryError then all bets about logging are off - but in the absence of anything else...
             LOGGER.log(Level.SEVERE,
                        "A thread (" + t.getName() + '/' + t.getId()
-                                     + ") died unexpectedly due to an uncaught exception, this may leave your Jenkins in a bad way and is usually indicative of a bug in the code.",
+                                     + ") died unexpectedly due to an uncaught exception. This may leave your server corrupted and usually indicates a software bug.",
                        ex);
         }
 


### PR DESCRIPTION
Amending wording from @jtnord in #2095 etc. In particular, _in a bad way_ does not sound right to me.

### Testing done

N/A

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7622"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

