### PR TITLE
Update bundled Apache Mina-sshd plugins

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -556,14 +556,14 @@ THE SOFTWARE.
                   <!-- dependency of mina-sshd-api-core -->
                   <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
                   <artifactId>mina-sshd-api-common</artifactId>
-                  <version>2.9.1-44.v476733c11f82</version>
+                  <version>2.9.2-50.va_0e1f42659a_a</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of sshd -->
                   <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
                   <artifactId>mina-sshd-api-core</artifactId>
-                  <version>2.9.1-44.v476733c11f82</version>
+                  <version>2.9.2-50.va_0e1f42659a_a</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
## Update `sshd-common` and `sshd-core` plugins from 2.9.1 to 2.9.2

**Changelog**: The [Apache MINA sshd 2.9.2 changelog](https://github.com/apache/mina-sshd/blob/master/docs/changes/2.9.2.md) links to [CVE-2022-45047](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45047)  - Unsafe deserialization in SimpleGeneratorHostKeyProvider

Jenkins core does not reference the SimpleGeneratorHostKeyProvider class.

SimpleGeneratorHostKeyProvider is referenced from [sshd plugin](https://github.com/jenkinsci/sshd-plugin/blob/251d59011530b4d3a4db4a3e6ee8f076c61c3bfe/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java#L162)

Users can upgrade the plugin themselves during installation but it is easier if we bundle the updated plugin version with new releases rather than requiring that the user perform the update.

See [JENKINS-70554](https://issues.jenkins.io/browse/JENKINS-70554).

### Testing done

* Confirmed that the Jenkins 2.389 war file includes mina-sshd-api-common.hpi and mina-sshd-api-core.hpi 2.9.1-44.v476733c11f82
* Generated the war file and confirmed that mina-sshd-api-common.hpi and mina-sshd-api-core.hpi 2.9.2-50.va_0e1f42659a_a are included
* Ran the war file with `mvn -pl war -Dhost=0.0.0.0 jetty:run` and confirmed the Apache Mina SSHD plugins were not installed but were offered for install as 2.9.2-50.va_0e1f42659a_a

### Proposed changelog entries

- Update bundled Apache Mina SSHD API plugins from 2.9.1-44.v476733c11f82 to 2.9.2-50.va_0e1f42659a_a.
  Include fix for [CVE-2022-45047](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45047) - Unsafe deserialization in SimpleGeneratorHostKeyProvider.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7623"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

