### PR TITLE
Upgrade Winstone from 6.7 to 6.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
     <antlr.version>4.11.1</antlr.version>
     <bridge-method-injector.version>1.25</bridge-method-injector.version>
     <spotless.version>2.31.0</spotless.version>
-    <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
+    <!-- Make sure to keep the jetty-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
     <winstone.version>6.10</winstone.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,8 @@ THE SOFTWARE.
     <antlr.version>4.11.1</antlr.version>
     <bridge-method-injector.version>1.25</bridge-method-injector.version>
     <spotless.version>2.31.0</spotless.version>
-    <winstone.version>6.7</winstone.version>
+    <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
+    <winstone.version>6.10</winstone.version>
   </properties>
 
   <!--

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -145,7 +145,6 @@ THE SOFTWARE.
       -->
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <!-- Make sure to keep jetty-maven-plugin elsewhere in this file in sync with the Jetty release in Winstone -->
       <version>${winstone.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Easily forgotten due to https://github.com/jenkinsci/jenkins/blob/af5a649a470f7fecff38de754df8ee10c9a17c62/.github/dependabot.yml#L22-L25

* https://github.com/jenkinsci/winstone/pull/310
* https://github.com/jenkinsci/winstone/pull/312
* https://github.com/jenkinsci/winstone/pull/313

### Testing done

`jetty:run` sanity check

### Proposed changelog entries

- Upgraded bundled Winstone. Notably, the `--excludeProtocols` option was added.

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7632"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

