### PR TITLE
[JENKINS-49138] Build Now to redirect to new build

### DIFF
--- a/core/src/main/resources/lib/hudson/project/configurable.jelly
+++ b/core/src/main/resources/lib/hudson/project/configurable.jelly
@@ -30,7 +30,22 @@ THE SOFTWARE.
         <l:task href="${url}/build?delay=0sec" icon="icon-clock icon-md" onclick="${it.parameterized?null:'return build_' + id + '(this)'}" permission="${it.BUILD}" post="${!it.parameterized}" title="${it.buildNowText}"/>
         <script>
             function build_${id}(a) {
-                new Ajax.Request(a.href);
+                new Ajax.Request(a.href, {
+                    method: 'POST',
+                    onSuccess: function (t) {
+                        if (t.status === 201) {
+                            setTimeout(function () {
+                                new Ajax.Request(t.getHeader('Location') + 'api/json?tree=executable[url]', {
+                                    onSuccess: function (t2) {
+                                        if (t2.status === 200 &amp;&amp; t2.responseJSON.executable != null &amp;&amp; t2.responseJSON.executable.url != null) {
+                                            location = t2.responseJSON.executable.url;
+                                        }
+                                    }
+                                });
+                            }, 1000);
+                        }
+                    }
+                });
                 hoverNotification('${%Build scheduled}',a.parentNode);
                 return false;
             }


### PR DESCRIPTION
Fixes #22534. There are a lot of different UI gestures to trigger a build, and this just covers one of them so far, and perhaps not in the ideal way (needs UX design in some cases). Not sure if I have the appetite to continue, or if it makes sense to open for review even when incomplete.

- [X] **Build Now** from sidebar of project redirects to new build
- [ ] warn user if build is not scheduled immediately (mainly relevant for non-Pipeline projects)
- [ ] **Build Now** in context menu
- [ ] **Build** column button
- [ ] **Build with Parameters** form submission
- [ ] Pipeline **Replay** / **Rebuild**
- [ ] Declarative Pipeline **Restart from Stage** (https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/228#discussion_r183927485)

### Testing done

https://user-images.githubusercontent.com/154109/217349251-013a84cf-481e-406b-830b-da46024fe31d.mp4

### Proposed changelog entries

- TBD

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7633"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

