### PR TITLE
Correct tag declaring required arguments in Jelly

### DIFF
--- a/core/src/main/resources/lib/hudson/buildHealth.jelly
+++ b/core/src/main/resources/lib/hudson/buildHealth.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <!--
-  <%@ attribute name="job" required="true" type="hudson.model.Job" %>
+  <%@ attribute name="job" use="required" type="hudson.model.Job" %>
   <%@ attribute name="iconSizeClass" type="java.lang.String" %>
   <%@ attribute name="iconSize" type="java.lang.String" %>
   <%@ attribute name="td" required="false" type="java.lang.String" %>

--- a/core/src/main/resources/lib/hudson/buildRangeLink.jelly
+++ b/core/src/main/resources/lib/hudson/buildRangeLink.jelly
@@ -25,8 +25,8 @@ THE SOFTWARE.
 <!--
   Link to a range of build. Used by fingerprint/index.jsp
 
-	<%@ attribute name="range" type="java.lang.Object" required="true" %>
-	<%@ attribute name="job" type="hudson.model.Job" required="true" %>
+	<%@ attribute name="range" type="java.lang.Object" use="required" %>
+	<%@ attribute name="job" type="hudson.model.Job" use="required" %>
 -->
 <!-- it's hudson.model.Fingerprint.RangeSet but Tomcat can't seem to handler inner classes -->
 <?jelly escape-by-default='true'?>

--- a/core/src/main/resources/lib/hudson/editTypeIcon.jelly
+++ b/core/src/main/resources/lib/hudson/editTypeIcon.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <!--
   Displays the edit type icon.
-	<%@ attribute name="type" type="hudson.scm.EditType" required="true" %>
+	<%@ attribute name="type" type="hudson.scm.EditType" use="required" %>
 -->
 <?jelly escape-by-default='true'?>
 <l:icon alt="${type.description}" class="icon-sm" src="symbol-${type.name}" title="${type.description}" xmlns:l="/lib/layout"/>

--- a/core/src/main/resources/lib/hudson/progressiveText.jelly
+++ b/core/src/main/resources/lib/hudson/progressiveText.jelly
@@ -27,8 +27,8 @@ THE SOFTWARE.
   This is used to achieve the effect of "tail -f"
   without relying on full page reload.
 
-	<%@attribute name="href" required="true" description="URL that returns text data" %>
-	<%@attribute name="idref" required="true" description="ID of the HTML element in which the result is displayed" %>
+	<%@attribute name="href" use="required" description="URL that returns text data" %>
+	<%@attribute name="idref" use="required" description="ID of the HTML element in which the result is displayed" %>
 	<%@attribute name="spinner" required="false" description="ID of the HTML element in which the spinner is displayed" %>
 	<%@attribute name="startOffset" required="false" description="Skip this many bytes rather than showing from start of data" %>
 	<%@attribute name="onFinishEvent" required="false" description="JS custom event to be fired when progress is finished" %>

--- a/core/src/main/resources/lib/layout/css.jelly
+++ b/core/src/main/resources/lib/layout/css.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     Client-side CSS loading tag. Similar to adjunct, but driven from the client. See page-init.js.
 
     @since 2.0
-    <st:attribute name="src" required="true">
+    <st:attribute name="src" use="required">
       CSS source path (relative to Jenkins).
     </st:attribute>
   </st:documentation>

--- a/core/src/main/resources/lib/layout/js.jelly
+++ b/core/src/main/resources/lib/layout/js.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     Client-side JavaScript loading tag. Similar to adjunct, but driven from the client. See page-init.js.
 
     @since 2.0
-    <st:attribute name="src" required="true">
+    <st:attribute name="src" use="required">
       JavaScript source path (relative to Jenkins).
     </st:attribute>
   </st:documentation>

--- a/core/src/main/resources/lib/layout/pageHeader.jelly
+++ b/core/src/main/resources/lib/layout/pageHeader.jelly
@@ -5,23 +5,23 @@
         This tag is used by l:layout and not expected to be used by anyone else,
         but it's written as separate tag for better readability of code.
 
-        <st:attribute name="title" required="true">
+        <st:attribute name="title" use="required">
             Page title and title attribute for the logo
         </st:attribute>
 
-        <st:attribute name="logoAlt" required="true">
+        <st:attribute name="logoAlt" use="required">
             Alt text for the logo
         </st:attribute>
 
-        <st:attribute name="searchPlaceholder" required="true">
+        <st:attribute name="searchPlaceholder" use="required">
             Placeholder text for the search input
         </st:attribute>
 
-        <st:attribute name="searchHelpUrl" required="true">
+        <st:attribute name="searchHelpUrl" use="required">
             Link value for the help icon on the search box
         </st:attribute>
 
-        <st:attribute name="logout" required="true">
+        <st:attribute name="logout" use="required">
             Text for the logout link
         </st:attribute>
     </st:documentation>


### PR DESCRIPTION
If an argument is required for a Jelly tag, it's declared via `use="required"` according to [stapler](https://github.com/jenkinsci/stapler/blob/cddc267f76003cb20a135a5c08d27da38f0164ac/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeTag.java#L54-L61). This practice is already [widely](https://github.com/search?q=repo%3Ajenkinsci%2Fjenkins%20lang%3Axml%20use%3D%22required%22&type=code) used in core, just these 7 files are using the wrong syntax.
This PR fixes them up.

### Testing done

Third parties listening to the correct syntax now function properly:

![Screenshot 2023-02-12 at 11 07 04](https://user-images.githubusercontent.com/13383509/218304776-e88ca4f0-7259-42f5-a4d9-13478a700954.png)

### Proposed changelog entries

- Developer: Ensure required Jelly arguments are correctly labeled as required.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7644"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

