### PR TITLE
Use artifact caching proxy for Jenkins Core builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,6 @@
  * This Jenkinsfile is intended to run on https://ci.jenkins.io and may fail anywhere else.
  * It makes assumptions about plugins being installed, labels mapping to nodes that can build what is needed, etc.
  */
-@Library('pipeline-library@pull/592/head') _
-
 def failFast = false
 
 properties([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@
  * This Jenkinsfile is intended to run on https://ci.jenkins.io and may fail anywhere else.
  * It makes assumptions about plugins being installed, labels mapping to nodes that can build what is needed, etc.
  */
+@Library('pipeline-library@pull/592/head') _
 
 def failFast = false
 
@@ -152,7 +153,9 @@ builds.ath = {
       // Just to be safe
       deleteDir()
       checkout scm
-      sh 'bash ath.sh'
+      infra.withArtifactCachingProxy {
+        sh 'bash ath.sh'
+      }
       junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@
  * This Jenkinsfile is intended to run on https://ci.jenkins.io and may fail anywhere else.
  * It makes assumptions about plugins being installed, labels mapping to nodes that can build what is needed, etc.
  */
+
 def failFast = false
 
 properties([

--- a/ath.sh
+++ b/ath.sh
@@ -8,9 +8,12 @@ cd "$(dirname "$0")"
 # https://github.com/jenkinsci/acceptance-test-harness/releases
 export ATH_VERSION=5497.vca_4a_876045ce
 
-# TODO use Artifactory proxy?
+MVN='mvn -B -ntp -Pquick-build -am -pl war package'
+if [[ -n ${MAVEN_SETTINGS-} ]]; then
+	MVN="${MVN} -s ${MAVEN_SETTINGS}"
+fi
 
-[[ -f war/target/jenkins.war ]] || mvn -B -ntp -Pquick-build -am -pl war package
+[[ -f war/target/jenkins.war ]] || $MVN
 
 mkdir -p target/ath-reports
 chmod a+rwx target/ath-reports


### PR DESCRIPTION
This pull request is introducing the use of the artifact caching proxy for Jenkins Core builds.

It uses the shared pipeline library modifications of `infra.runMaven` introduced in https://github.com/jenkins-infra/pipeline-library/pull/592, and a similar mechanism as in the BOM (https://github.com/jenkinsci/bom/blob/fe602c266c057636a42a8cbd3a2b77043d717849/Jenkinsfile#L11-L13 & https://github.com/jenkinsci/bom/blob/fe602c266c057636a42a8cbd3a2b77043d717849/prep.sh#L5-L10) for the ATH script.

See [helpdesk-2752](https://github.com/jenkins-infra/helpdesk/issues/2752).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

A replay with only the pipeline library change has been done in https://ci.jenkins.io/job/Core/job/jenkins/job/stable-2.387/5/

This PR is also serving as a test *in situ* for the ATH part.

EDIT: ✅ 

<img width="1312" alt="image" src="https://user-images.githubusercontent.com/91831478/218794011-52bcd994-2b98-4d27-8f09-cdc0857477d4.png">

<img width="2487" alt="image" src="https://user-images.githubusercontent.com/91831478/218794318-3e46bfa5-a37b-4eba-8671-5ed9e7d0940b.png">


### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [N/A] The Jira issue, if it exists, is well-described.
- [N/A] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [N/A] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [N/A] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [N/A] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [N/A] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jglick @MarkEWaite

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7649"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

