### PR TITLE
[JENKINS-70599] restore installNecessaryPlugins redirect destination

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2225,7 +2225,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @RequirePOST
     public HttpResponse doInstallNecessaryPlugins(StaplerRequest req) throws IOException {
         prevalidateConfig(req.getInputStream());
-        return HttpResponses.redirectViaContextPath("updates/");
+        return HttpResponses.redirectViaContextPath("updateCenter");
     }
 
     /**

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2225,7 +2225,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @RequirePOST
     public HttpResponse doInstallNecessaryPlugins(StaplerRequest req) throws IOException {
         prevalidateConfig(req.getInputStream());
-        return HttpResponses.redirectViaContextPath("updateCenter");
+        return HttpResponses.redirectViaContextPath("pluginManager/updates/");
     }
 
     /**

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -678,7 +678,6 @@ public class PluginManagerTest {
                         .build();
         HttpClient clientGet =
                 HttpClient.newBuilder()
-                        .version(HttpClient.Version.HTTP_1_1)
                         .cookieHandler(CookieHandler.getDefault())
                         .connectTimeout(Duration.ofSeconds(3))
                         .build();
@@ -703,7 +702,6 @@ public class PluginManagerTest {
                         .build();
         HttpClient client =
                 HttpClient.newBuilder()
-                        .version(HttpClient.Version.HTTP_1_1)
                         .cookieHandler(CookieHandler.getDefault())
                         .followRedirects(HttpClient.Redirect.ALWAYS)
                         .connectTimeout(Duration.ofSeconds(3))

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -49,9 +49,17 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.CookieHandler;
+import java.net.CookieManager;
+import java.net.HttpCookie;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -643,5 +651,66 @@ public class PluginManagerTest {
         assertTrue(json.has("data"));
         data = json.getJSONArray("data");
         assertEquals("Should be two search hits for hello", 2, data.size());
+    }
+
+    @Issue("JENKINS-70599")
+    @Test
+    public void installNecessaryPluginsTest() throws Exception {
+        String jenkinsUrl = r.getURL().toString();
+
+        // Define a cookie handler
+        CookieHandler.setDefault(new CookieManager());
+        HttpCookie sessionCookie = new HttpCookie("session", "test-session-cookie");
+        sessionCookie.setPath("/");
+        sessionCookie.setVersion(0);
+        ((CookieManager) CookieHandler.getDefault())
+                .getCookieStore()
+                .add(new URI(jenkinsUrl), sessionCookie);
+
+        // Initialize the cookie handler and get the crumb
+        URI crumbIssuer = new URI(jenkinsUrl + "crumbIssuer/api/json");
+        HttpRequest httpGet =
+                HttpRequest.newBuilder()
+                        .uri(crumbIssuer)
+                        .header("Accept", "application/json")
+                        .timeout(Duration.ofSeconds(5))
+                        .GET()
+                        .build();
+        HttpClient clientGet =
+                HttpClient.newBuilder()
+                        .version(HttpClient.Version.HTTP_1_1)
+                        .cookieHandler(CookieHandler.getDefault())
+                        .connectTimeout(Duration.ofSeconds(3))
+                        .build();
+        HttpResponse<String> responseGet = clientGet.send(httpGet, HttpResponse.BodyHandlers.ofString());
+        assertEquals("Bad response for crumb issuer", 200, responseGet.statusCode());
+        String body = responseGet.body();
+        assertTrue("crumbRequestField not in response", body.contains("crumbRequestField"));
+        org.json.JSONObject jsonObject = new org.json.JSONObject(body);
+        String crumb = (String) jsonObject.get("crumb");
+        String crumbRequestField = (String) jsonObject.get("crumbRequestField");
+
+        // Call installNecessaryPlugins XML API for git client plugin 4.0.0 with crumb
+        URI installNecessaryPlugins = new URI(jenkinsUrl + "pluginManager/installNecessaryPlugins");
+        String xmlRequest = "<jenkins><install plugin=\"git-client@4.0.0\"></install></jenkins>";
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(installNecessaryPlugins)
+                        .timeout(Duration.ofSeconds(29))
+                        .header("Content-Type", "application/xml")
+                        .header(crumbRequestField, crumb)
+                        .POST(HttpRequest.BodyPublishers.ofString(xmlRequest))
+                        .build();
+        HttpClient client =
+                HttpClient.newBuilder()
+                        .version(HttpClient.Version.HTTP_1_1)
+                        .cookieHandler(CookieHandler.getDefault())
+                        .followRedirects(HttpClient.Redirect.ALWAYS)
+                        .connectTimeout(Duration.ofSeconds(3))
+                        .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        // Redirect reported 404 before bug was fixed
+        assertEquals("Bad response for installNecessaryPlugins", 200, response.statusCode());
     }
 }

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -673,13 +673,13 @@ public class PluginManagerTest {
                 HttpRequest.newBuilder()
                         .uri(crumbIssuer)
                         .header("Accept", "application/json")
-                        .timeout(Duration.ofSeconds(5))
+                        .timeout(Duration.ofSeconds(7))
                         .GET()
                         .build();
         HttpClient clientGet =
                 HttpClient.newBuilder()
                         .cookieHandler(CookieHandler.getDefault())
-                        .connectTimeout(Duration.ofSeconds(3))
+                        .connectTimeout(Duration.ofSeconds(2))
                         .build();
         HttpResponse<String> responseGet = clientGet.send(httpGet, HttpResponse.BodyHandlers.ofString());
         assertEquals("Bad response for crumb issuer", 200, responseGet.statusCode());
@@ -695,7 +695,7 @@ public class PluginManagerTest {
         HttpRequest request =
                 HttpRequest.newBuilder()
                         .uri(installNecessaryPlugins)
-                        .timeout(Duration.ofSeconds(29))
+                        .timeout(Duration.ofSeconds(20))
                         .header("Content-Type", "application/xml")
                         .header(crumbRequestField, crumb)
                         .POST(HttpRequest.BodyPublishers.ofString(xmlRequest))
@@ -704,7 +704,7 @@ public class PluginManagerTest {
                 HttpClient.newBuilder()
                         .cookieHandler(CookieHandler.getDefault())
                         .followRedirects(HttpClient.Redirect.ALWAYS)
-                        .connectTimeout(Duration.ofSeconds(3))
+                        .connectTimeout(Duration.ofSeconds(2))
                         .build();
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 


### PR DESCRIPTION
## [JENKINS-70599](https://issues.jenkins.io/browse/JENKINS-70599) restore installNecessaryPlugins redirect destination

The installNecessaryPlugins API end point previously redirected to the "/updateCenter" URL.  When the side bar was added to the plugin manager, the redirect was changed to "/updates".  Unfortunately, there is no page at "/updates", while there is a page at "/updateCenter".

This restores the redirect for the installNecessaryPlugins API call.

If the redirect is not restored, calls to the API that follow the redirect fail with a page not found (HTTP 404).

I did not find any callers to that API from inside Jenkins core.

Change introduced in 6db88c3f5ba82ecc68af2bced3a568058cf80e2b

See [JENKINS-70599](https://issues.jenkins.io/browse/JENKINS-70599).

### Testing done

* Interactively tested with `curl --location` to confirm that without this change, the call to `installNecessaryPlugins` redirects to a non-existent page.  Testing details are in the [Jira issue](https://issues.jenkins.io/browse/JENKINS-70599)
* Interactively tested with `curl --location` to confirm that with this change, the call to `installNecessaryPlugins` redirects to a valid page.  Testing details are in the [Jira issue](https://issues.jenkins.io/browse/JENKINS-70599)
* Automated test added to check the redirect URL is found after the fix and is not found before the fix.  Automated test uses the same technique as was used in the interactive test (request a crumb and a cookie, submit POST request with crumb and cookie)

### Proposed changelog entries

- Restore `installNecessaryPlugins` redirect destination.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@janfaracik or @NotMyFault 

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7653"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

