### PR TITLE
[JENKINS-21052] Warn user that the copy button requires HTTPS

### DIFF
--- a/core/src/main/resources/lib/layout/copyButton/copyButton.js
+++ b/core/src/main/resources/lib/layout/copyButton/copyButton.js
@@ -4,28 +4,35 @@ Behaviour.specify(
   0,
   function (copyButton) {
     copyButton.addEventListener("click", () => {
-      // Make an invisible textarea element containing the text
-      const fakeInput = document.createElement("textarea");
-      fakeInput.value = copyButton.getAttribute("text");
-      fakeInput.style.width = "1px";
-      fakeInput.style.height = "1px";
-      fakeInput.style.border = "none";
-      fakeInput.style.padding = "0px";
-      fakeInput.style.position = "absolute";
-      fakeInput.style.top = "-99999px";
-      fakeInput.style.left = "-99999px";
-      fakeInput.setAttribute("tabindex", "-1");
-      document.body.appendChild(fakeInput);
+      if (isSecureContext) {
+        // Make an invisible textarea element containing the text
+        const fakeInput = document.createElement("textarea");
+        fakeInput.value = copyButton.getAttribute("text");
+        fakeInput.style.width = "1px";
+        fakeInput.style.height = "1px";
+        fakeInput.style.border = "none";
+        fakeInput.style.padding = "0px";
+        fakeInput.style.position = "absolute";
+        fakeInput.style.top = "-99999px";
+        fakeInput.style.left = "-99999px";
+        fakeInput.setAttribute("tabindex", "-1");
+        document.body.appendChild(fakeInput);
 
-      // Select the text and copy it to the clipboard
-      fakeInput.select();
-      navigator.clipboard.writeText(fakeInput.value);
+        // Select the text and copy it to the clipboard
+        fakeInput.select();
+        navigator.clipboard.writeText(fakeInput.value);
 
-      // Remove the textarea element
-      document.body.removeChild(fakeInput);
+        // Remove the textarea element
+        document.body.removeChild(fakeInput);
 
-      // Show the completion message
-      hoverNotification(copyButton.getAttribute("message"), copyButton);
+        // Show the completion message
+        hoverNotification(copyButton.getAttribute("message"), copyButton);
+      } else {
+        hoverNotification(
+          "Copy is only supported with a secure (HTTPS) connection",
+          copyButton
+        );
+      }
     });
   }
 );


### PR DESCRIPTION
## [JENKINS-21052](https://issues.jenkins.io/browse/JENKINS-21052) Warn user that copy button requires HTTPS

Users that run Jenkins over an unencrypted (HTTP) connection will see the copy button, but it does not perform a copy.  Browsers will only allow access to the clipboard if the page is in a secure context.

With this change, the text that is displayed when the user clicks the copy button from an insecure context will alert the user that copy requires a secure connection.

https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript describes the alternatives in more detail.

[JENKINS-21052](https://issues.jenkins.io/browse/JENKINS-21052) reported that the copy button does not work.  I've confirmed that it works when using an HTTPS connection.

### Testing done

* Confirmed that the copy button now displays the "requires a secure context" when attempted with HTTP

#### Insecure context

![HTTP-connection-without-copy](https://user-images.githubusercontent.com/156685/220205753-bf973615-4369-4031-a75b-2c6801330fdb.png)

* Confirmed that the copy button displays the expected text when used in in a secure context (HTTPS)

#### Secure context

![HTTPS-connection-with-copy](https://user-images.githubusercontent.com/156685/220205818-e11450f6-2ccd-442d-853e-25b5a296eacd.png)

No automated test because configuring an automated test in a secure context seems very complicated.

### Proposed changelog entries

- Warn user that copy button requires HTTPS.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

Use a [space suppressing diff](https://github.com/jenkinsci/jenkins/pull/7665/files?w=1) to clearly see the added conditional for contexts that are not secure.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7665"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

