### PR TITLE
[JENKINS-70662] Disable browser form validation from submit button

### DIFF
--- a/core/src/main/resources/lib/form/submit.jelly
+++ b/core/src/main/resources/lib/form/submit.jelly
@@ -50,7 +50,7 @@ THE SOFTWARE.
     <s:attribute name="clazz" />
   </s:documentation>
 
-  <button id="${attrs.id}" name="${attrs.name ?: 'Submit'}" formNoValidate="true"
+  <button id="${attrs.id}" name="${attrs.name ?: 'Submit'}" formNoValidate="formNoValidate"
           class="jenkins-button ${attrs.primary != 'false' ? 'jenkins-button--primary' : ''} ${attrs.clazz}">
     ${attrs.value ?: '%Submit'}
   </button>

--- a/core/src/main/resources/lib/form/submit.jelly
+++ b/core/src/main/resources/lib/form/submit.jelly
@@ -50,7 +50,7 @@ THE SOFTWARE.
     <s:attribute name="clazz" />
   </s:documentation>
 
-  <button id="${attrs.id}" name="${attrs.name ?: 'Submit'}"
+  <button id="${attrs.id}" name="${attrs.name ?: 'Submit'}" formNoValidate="true"
           class="jenkins-button ${attrs.primary != 'false' ? 'jenkins-button--primary' : ''} ${attrs.clazz}">
     ${attrs.value ?: '%Submit'}
   </button>


### PR DESCRIPTION
See [JENKINS-70662](https://issues.jenkins.io/browse/JENKINS-70662).

Hello :wave:

As described in [JENKINS-70662](https://issues.jenkins.io/browse/JENKINS-70662), and shared in the [Jenkins 2.387.1 RC testing thread](https://groups.google.com/g/jenkinsci-dev/c/jY6M9oM8tQA/m/PCMcn887BQAJ), a regression was introduced in Jenkins `2.376`: Built-in validations are broken when inside an `optionalBlock`.

Prior to that version, validations were simply ignored when clicking on the `submit` button. The change introduced in https://github.com/jenkinsci/jenkins/pull/7203 though, transforming `input type="button"` in a `button` changed that behavior and led to that regression. The actual bug can be reproduced from https://github.com/jenkinsci/jenkins/pull/7666, leading to an error in the Javascript console when clicking the `save` button from the configuration: `An invalid form control with name='_.someValue' is not focusable`.

While there could be other solutions for this problem, the one proposed in that PR should be simple enough to cover most
cases. It seems that a [similar approach](https://github.com/jenkinsci/jenkins/pull/5479/files#diff-88b45c0cb6a9503b93249b86dbe85af08efe3ccfb327201dbf996ce40db78185R2718) was used in other places as well.

This PR should ideally be part of the `2.387` LTS, in order to avoid introducing a regression from the previous LTS.

Please let me know if anything is missing from this PR or if I could help in some other way :smile:

### Testing done

I did some manual testing for this PR, following the approach described in https://github.com/jenkinsci/jenkins/pull/7666.

I also tested it on some of our internal plugins facing the issue to confirm it was working fine.

### Proposed changelog entries

- Disable unwanted browser form validation.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@daniel-beck @jtnord @basil @jglick @Vlatombe

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
