### PR TITLE
Backport fix for broken validations inside `optionalBlock`s

### DIFF
--- a/core/src/main/resources/lib/form/submit.jelly
+++ b/core/src/main/resources/lib/form/submit.jelly
@@ -50,7 +50,7 @@ THE SOFTWARE.
     <s:attribute name="clazz" />
   </s:documentation>
 
-  <button id="${attrs.id}" name="${attrs.name ?: 'Submit'}"
+  <button id="${attrs.id}" name="${attrs.name ?: 'Submit'}" formNoValidate="formNoValidate"
           class="jenkins-button ${attrs.primary != 'false' ? 'jenkins-button--primary' : ''} ${attrs.clazz}">
     ${attrs.value ?: '%Submit'}
   </button>


### PR DESCRIPTION
```
Latest core version: jenkins-2.392

Fixed
-----

JENKINS-70662           Major                   2.393
        Built-in validations are broken when inside an `optionalBlock`
        regression
        https://issues.jenkins.io/browse/JENKINS-70662
```

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7674"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

