### PR TITLE
Make `StopBuildsCommand` work even if the last build is not running

### DIFF
--- a/core/src/main/java/jenkins/cli/StopBuildsCommand.java
+++ b/core/src/main/java/jenkins/cli/StopBuildsCommand.java
@@ -83,8 +83,10 @@ public class StopBuildsCommand extends CLICommand {
     private void stopJobBuilds(final Job job) {
         final Run lastBuild = job.getLastBuild();
         final String jobName = job.getFullDisplayName();
-        if (lastBuild != null && lastBuild.isBuilding()) {
-            stopBuild(lastBuild, jobName);
+        if (lastBuild != null) {
+            if (lastBuild.isBuilding()) {
+                stopBuild(lastBuild, jobName);
+            }
             checkAndStopPreviousBuilds(lastBuild, jobName);
         }
     }

--- a/test/src/test/java/jenkins/cli/StopBuildsCommandTest.java
+++ b/test/src/test/java/jenkins/cli/StopBuildsCommandTest.java
@@ -38,13 +38,18 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.SleepBuilder;
 
 public class StopBuildsCommandTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -173,6 +178,28 @@ public class StopBuildsCommandTest {
 
         b1.doStop();
         b2.doStop();
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b1));
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b2));
+    }
+
+    @Test
+    public void shouldStopEarlierBuildsEvenIfLatestComplete() throws Exception {
+        final FreeStyleProject project = createLongRunningProject(TEST_JOB_NAME);
+        project.setConcurrentBuild(true);
+        j.jenkins.setNumExecutors(3);
+
+        FreeStyleBuild b1 = project.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("Sleeping", b1);
+        FreeStyleBuild b2 = project.scheduleBuild2(0).waitForStart();
+        j.waitForMessage("Sleeping", b2);
+
+        project.getBuildersList().clear();
+        FreeStyleBuild b3 = j.buildAndAssertSuccess(project);
+
+        final String stdout = runWith(List.of(TEST_JOB_NAME)).stdout();
+
+        assertThat(stdout, equalTo("Build '#2' stopped for job 'jobName'" + LN +
+                "Build '#1' stopped for job 'jobName'" + LN));
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b1));
         j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b2));
     }


### PR DESCRIPTION
Fixes a corner case in #3686.

### Proposed changelog entries

- The `stop-builds` command did nothing if the last build of the job was already finished, even while earlier builds were running.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7679"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

