### PR TITLE
Tune down warnings from `ProcessTree`

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -453,7 +453,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                 Thread.interrupted(); // Clear the interrupt flag and just accept that no known vetoers exist.
             }
             catch (Exception e) {
-                LOGGER.log(Level.WARNING, "Error while determining if vetoers exist", e);
+                LOGGER.log(Level.FINE, "Error while determining if vetoers exist", e);
             }
         }
 
@@ -476,7 +476,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
             if (os.equals("FreeBSD"))
                 return new FreeBSD(vetoes);
         } catch (LinkageError e) {
-            LOGGER.log(Level.WARNING, "Failed to load winp. Reverting to the default", e);
+            LOGGER.log(Level.FINE, "Failed to load OS-specific implementation; reverting to the default", e);
             enabled = false;
         }
 


### PR DESCRIPTION
`ProcessTree` is often consulted just as a build is ending, to kill off the shell step that was running on an agent. For a one-shot “cloudy” agent, at this point the channel is closing and so new class loading is not going to work. Therefore when using the `kubernetes` plugin the controller and agent logs were constantly spammed by warnings like these:

```
hudson.util.ProcessTree get
WARNING: Error while determining if vetoers exist
hudson.remoting.RequestAbortedException: hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@...:...": channel is already closed
	at hudson.remoting.Request.abort(Request.java:346)
	at hudson.remoting.Channel.terminate(Channel.java:1080)
	at hudson.remoting.Channel$1.terminate(Channel.java:620)
	at hudson.remoting.AbstractByteBufferCommandTransport.terminate(AbstractByteBufferCommandTransport.java:314)
	at hudson.remoting.Engine$1AgentEndpoint.lambda$onClose$1(Engine.java:637)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:125)
	at java.base/java.lang.Thread.run(Thread.java:829)
	Suppressed: hudson.remoting.Channel$CallSiteStackTrace: Remote call to ...
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1784)
		at hudson.remoting.Request.call(Request.java:199)
		at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:288)
		at com.sun.proxy.$Proxy7.fetch3(Unknown Source)
		at hudson.remoting.RemoteClassLoader.prefetchClassReference(RemoteClassLoader.java:354)
		at hudson.remoting.RemoteClassLoader.loadWithMultiClassLoader(RemoteClassLoader.java:259)
		at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:229)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
		at jenkins.agents.AgentComputerUtil.getChannelToController(AgentComputerUtil.java:48)
		at hudson.util.ProcessTree.get(ProcessTree.java:443)
		at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1168)
		at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1158)
		at hudson.remoting.UserRequest.perform(UserRequest.java:211)
		at hudson.remoting.UserRequest.perform(UserRequest.java:54)
		at hudson.remoting.Request$2.run(Request.java:377)
		... 6 more
Caused by: hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@...:...": channel is already closed
	... 7 more
```

```
hudson.util.ProcessTree get
WARNING: Failed to load winp. Reverting to the default
java.lang.NoClassDefFoundError: org/apache/commons/io/output/NullOutputStream
	at hudson.util.ProcessTree.get(ProcessTree.java:467)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1168)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1158)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:377)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:125)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.io.output.NullOutputStream
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:221)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 12 more
```

```
java.lang.NoClassDefFoundError: hudson/util/ProcessTree$Linux$LinuxProcess
	at hudson.util.ProcessTree.get(ProcessTree.java:471)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1168)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1158)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:377)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:125)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: hudson.util.ProcessTree$Linux$LinuxProcess
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:221)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 12 more
```

```
… hudson.util.ProcessTree get
WARNING: Error while determining if vetoers exist
hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@…:JNLP4-connect connection to …": Remote call on JNLP4-connect connection to … failed. The channel is closing down or has closed down
	at hudson.remoting.Channel.call(Channel.java:993)
	at hudson.util.ProcessTree.get(ProcessTree.java:446)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1168)
	at hudson.Launcher$RemoteLauncher$KillTask.call(Launcher.java:1158)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:377)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:125)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.nio.channels.ClosedChannelException
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer.onReadClosed(ChannelApplicationLayer.java:241)
	at org.jenkinsci.remoting.protocol.ApplicationLayer.onRecvClosed(ApplicationLayer.java:221)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecvClosed(ProtocolStack.java:825)
	at org.jenkinsci.remoting.protocol.FilterLayer.onRecvClosed(FilterLayer.java:289)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.onRecvClosed(SSLEngineFilterLayer.java:177)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.switchToNoSecure(SSLEngineFilterLayer.java:279)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.processWrite(SSLEngineFilterLayer.java:501)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.processQueuedWrites(SSLEngineFilterLayer.java:244)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.doSend(SSLEngineFilterLayer.java:196)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.doCloseSend(SSLEngineFilterLayer.java:209)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.doCloseSend(ProtocolStack.java:793)
	at org.jenkinsci.remoting.protocol.ApplicationLayer.doCloseWrite(ApplicationLayer.java:172)
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer$ByteBufferCommandTransport.closeWrite(ChannelApplicationLayer.java:343)
	at hudson.remoting.Channel.close(Channel.java:1494)
	at hudson.remoting.Channel.close(Channel.java:1447)
	at hudson.remoting.Channel$CloseCommand.execute(Channel.java:1312)
	at hudson.remoting.Channel$1.handle(Channel.java:606)
	at hudson.remoting.AbstractByteBufferCommandTransport.processCommand(AbstractByteBufferCommandTransport.java:234)
	at hudson.remoting.AbstractByteBufferCommandTransport.receive(AbstractByteBufferCommandTransport.java:220)
	at org.jenkinsci.remoting.protocol.impl.ChannelApplicationLayer.onRead(ChannelApplicationLayer.java:217)
	at org.jenkinsci.remoting.protocol.ApplicationLayer.onRecv(ApplicationLayer.java:206)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecv(ProtocolStack.java:677)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.processRead(SSLEngineFilterLayer.java:367)
	at org.jenkinsci.remoting.protocol.impl.SSLEngineFilterLayer.onRecv(SSLEngineFilterLayer.java:119)
	at org.jenkinsci.remoting.protocol.ProtocolStack$Ptr.onRecv(ProtocolStack.java:677)
	at org.jenkinsci.remoting.protocol.NetworkLayer.onRead(NetworkLayer.java:137)
	at org.jenkinsci.remoting.protocol.impl.BIONetworkLayer.access$1400(BIONetworkLayer.java:51)
	at org.jenkinsci.remoting.protocol.impl.BIONetworkLayer$Reader.run(BIONetworkLayer.java:293)
	... 4 more
```

### Testing done

Ran `kubernetes` builds with this patched and confirmed that there were no more warnings coming from `ProcessTree`.

### Proposed changelog entries

- Suppress some noisy stack traces from `ProcessTree`.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7681"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

