### PR TITLE
JENKINS-70730 Don't remove id inside symbol

### DIFF
--- a/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
+++ b/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
@@ -94,7 +94,6 @@ public final class Symbol {
                      .replaceAll("(class=\").*?(\")", "")
                      .replaceAll("(tooltip=\").*?(\")", "")
                      .replaceAll("(data-html-tooltip=\").*?(\")", "")
-                     .replaceAll("(id=\").*?(\")", "")
                      .replace("stroke:#000", "stroke:currentColor");
     }
 

--- a/core/src/test/java/org/jenkins/ui/symbol/SymbolTest.java
+++ b/core/src/test/java/org/jenkins/ui/symbol/SymbolTest.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
 
 public class SymbolTest {
     public static final String SCIENCE_PATH;
@@ -189,5 +190,16 @@ public class SymbolTest {
         symbol = Symbol.get(builder.build());
         assertThat(symbol, containsString(SCIENCE_PATH));
         assertThat(symbol, not(containsString("tooltip")));
+    }
+
+    @Test
+    @DisplayName("IDs in symbol should not be removed")
+    @Issue("JENKINS-70730")
+    void getSymbol_idInSymbolIsPresent() {
+        String symbol = Symbol.get(new SymbolRequest.Builder()
+                .withId("some-random-id")
+                .withName("with-id").build());
+
+        assertThat(symbol, containsString("id=\"a\""));
     }
 }

--- a/core/src/test/resources/images/symbols/with-id.svg
+++ b/core/src/test/resources/images/symbols/with-id.svg
@@ -1,0 +1,14 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="82"
+    height="82"
+    viewBox="0 0 82 82"
+>
+  <defs>
+    <linearGradient id="a" x1="0%" x2="102%" y1="0%" y2="101%">
+      <stop offset="0%" stop-color="#3023AE"/>
+      <stop offset="100%" stop-color="#C86DD7"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#a)" d="M0 0h82v82H0z"/>
+</svg>


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-70730](https://issues.jenkins.io/browse/JENKINS-70730).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

I can't see why we would need to remove existing ids in symbols, they're highly unlikely to be in an svg and this part of the code is before the caching is done.

Far better that we don't remove an id here than we do and break an svg completely....

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Unit test + interactively tested with https://issues.jenkins.io/browse/JENKINS-70729 and the azure vm agents plugin.

### Proposed changelog entries

- JENKINS-70730 Don't remove id inside symbol

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7689"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

