### PR TITLE
Restrict JnlpSlaveRestarterInstaller to DumbSlave

### DIFF
--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -36,7 +36,7 @@ public class JnlpSlaveRestarterInstaller extends ComputerListener implements Ser
     /**
      * To force installer to run on all agents, set this system property to true.
      */
-    private static final boolean FORCE_INSTALL = Boolean.getBoolean(JnlpSlaveRestarterInstaller.class.getName()+".forceInstall");
+    private static final boolean FORCE_INSTALL = Boolean.getBoolean(JnlpSlaveRestarterInstaller.class.getName() + ".forceInstall");
 
     @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification = "method signature does not permit plumbing through the return value")
     @Override

--- a/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
+++ b/core/src/main/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstaller.java
@@ -13,6 +13,7 @@ import hudson.remoting.EngineListener;
 import hudson.remoting.EngineListenerAdapter;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.ComputerListener;
+import hudson.slaves.DumbSlave;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -25,17 +26,24 @@ import jenkins.security.MasterToSlaveCallable;
  * Actual agent restart logic.
  *
  * <p>
- * Use {@link ComputerListener} to install {@link EngineListener}, which in turn gets executed when
- * the agent gets disconnected.
+ *     Use {@link ComputerListener} to install {@link EngineListener} on {@link hudson.model.Computer} instances tied to {@link DumbSlave},
+ *     which in turn gets executed when the agent gets disconnected.
  *
  * @author Kohsuke Kawaguchi
  */
 @Extension
 public class JnlpSlaveRestarterInstaller extends ComputerListener implements Serializable {
+    /**
+     * To force installer to run on all agents, set this system property to true.
+     */
+    private static final boolean FORCE_INSTALL = Boolean.getBoolean(JnlpSlaveRestarterInstaller.class.getName()+".forceInstall");
+
     @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification = "method signature does not permit plumbing through the return value")
     @Override
     public void onOnline(final Computer c, final TaskListener listener) throws IOException, InterruptedException {
-        Computer.threadPoolForRemoting.submit(new Install(c, listener));
+        if (FORCE_INSTALL || c.getNode() instanceof DumbSlave) {
+            Computer.threadPoolForRemoting.submit(new Install(c, listener));
+        }
     }
 
     private static class Install implements Callable<Void> {


### PR DESCRIPTION
The exec was initially introduced to workaround memory leaks on long-running agents, it doesn't make sense to apply it to ephemeral nodes such as the ones managed by clouds.

Existing tests in `JnlpSlaveRestarterInstallerTest` still pass since they operate on static agents, unsure how I could introduce a cloud agent in `test` module.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- `SlaveRestarter` implementations are now only installed on static agents. Use `-Djenkins.slaves.restarter.JnlpSlaveRestarterInstaller.forceInstall=true` to fall back to the previous behaviour in case of any issue.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7693"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

