### PR TITLE
Document the API for renaming an Item.

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractItem/_api.jelly
+++ b/core/src/main/resources/hudson/model/AbstractItem/_api.jelly
@@ -30,8 +30,12 @@ THE SOFTWARE.
         To programmatically obtain the current configuration of this item (<code>config.xml</code>), access <a href="../config.xml" target="_blank">this URL</a> using <code>GET</code>.
         To programmatically update the configuration based on a modified <code>config.xml</code> file, you can send a <code>POST</code> request with <code>Content-Type: text/xml</code> header and the XML attached as request body to the <a href="../config.xml">same URL</a>.
     </p>
-    <h2>Delete a job</h2>
+    <h2>Rename an item</h2>
     <p>
-        To programmatically delete this job, send an HTTP <code>DELETE</code> request to <a href="../" target="_blank">this URL</a>.
+        To programmatically rename this item, send an HTTP <code>POST</code> request to <a href="../confirmRename" target="_blank">this URL</a> with a new name provided as a <code>newName</code> query parameter. A successful rename will respond with a 302 code with new URL of an item in the <code>location</code> header.
+    </p>
+    <h2>Delete an item</h2>
+    <p>
+        To programmatically delete this item, send an HTTP <code>DELETE</code> request to <a href="../" target="_blank">this URL</a>.
     </p>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Job/_api.jelly
+++ b/core/src/main/resources/hudson/model/Job/_api.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
     To programmatically schedule SCM polling, post to <a href="../polling">this URL</a>.
   </p>
   <p>
-    If security is enabled, the recommended method is to provide the username/password of an
+    If security is enabled, the recommended method is to provide the username/API Token of an
     account with build permission in the request.  Tools such as <code>curl</code> and <code>wget</code>
     have parameters to specify these credentials.  Another alternative (but deprecated) is to
     configure the 'Trigger builds remotely' section in the job configuration.  Then building

--- a/core/src/main/resources/hudson/model/ModifiableItemGroup/_api.jelly
+++ b/core/src/main/resources/hudson/model/ModifiableItemGroup/_api.jelly
@@ -25,19 +25,19 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <h2>Create Job</h2>
+    <h2>Create an Item</h2>
     <p>
-        To create a new job, post <code>config.xml</code> to <a href="../createItem">this URL</a> with
-        query parameter <code>name=<i>JOBNAME</i></code>. You need to send a <code>Content-Type: application/xml</code>
+        To create a new item, post <code>config.xml</code> to <a href="../createItem">this URL</a> with
+        query parameter <code>name=<i>ITEMNAME</i></code>. You need to send a <code>Content-Type: application/xml</code>
         header. You will get a 200 status code if the creation is successful,
-        or 4xx/5xx code if it fails. <code>config.xml</code> is the format Jenkins uses to store the project
+        or 4xx/5xx code if it fails. <code>config.xml</code> is the format Jenkins uses to store an item
         in the file system, so you can see examples of them in the Jenkins home directory, or by retrieving
-        the XML configuration of existing jobs from <code>/job/<i>JOBNAME</i>/config.xml</code>.
+        the XML configuration of existing items from <code>/job/<i>ITEMNAME</i>/config.xml</code>.
     </p>
 
-    <h2>Copy Job</h2>
+    <h2>Copy an Item</h2>
     <p>
-        To copy a job, send a POST request to <a href="../createItem">this URL</a> with
-        three query parameters <code>name=<i>NEWJOBNAME</i>&amp;mode=copy&amp;from=<i>FROMJOBNAME</i></code>
+        To copy an item, send a POST request to <a href="../createItem">this URL</a> with
+        three query parameters <code>name=<i>NEWITEMNAME</i>&amp;mode=copy&amp;from=<i>FROMITEMNAME</i></code>
     </p>
 </j:jelly>


### PR DESCRIPTION
For consistency and clarity, replace Job with Item where API applies to other item types like Folders.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->



<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Freestyle job and other item types that extend from `AbstractItem` and include its `_api.jelly` should show the following snippet:

![2023-03-08-item-rename](https://user-images.githubusercontent.com/348580/223601945-3231a871-24dc-4415-9f1a-a284938e37fb.png)

Documentation change, so no automated tests added.

### Proposed changelog entries

- Add API documentation about renaming an item

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] ~The Jira issue, if it exists, is well-described.~
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] ~New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.~
- [ ] ~New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.~
- [ ] ~New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~
- [ ] ~For dependency updates, there are links to external changelogs and, if possible, full differentials.~
- [ ] ~For new APIs and extension points, there is a link to at least one consumer.~

### Desired reviewers


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7696"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

