### PR TITLE
Let `TokenBasedRememberMeServices2` tolerate `Authentication.principal` not `UserDetails`

### DIFF
--- a/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
+++ b/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
@@ -95,7 +95,7 @@ public class TokenBasedRememberMeServices2 extends AbstractRememberMeServices {
         super(Jenkins.get().getSecretKey(), new ImpersonatingUserDetailsService2(userDetailsService));
     }
 
-    protected String makeTokenSignature(long tokenExpiryTime, String username, String password) {
+    protected String makeTokenSignature(long tokenExpiryTime, String username) {
         String userSeed;
         if (UserSeedProperty.DISABLE_USER_SEED) {
             userSeed = "no-seed";
@@ -137,13 +137,20 @@ public class TokenBasedRememberMeServices2 extends AbstractRememberMeServices {
 
         // TODO is it really still necessary to reimplement all of the below, or could we simply override rememberMeRequested?
 
-        Objects.requireNonNull(successfulAuthentication.getPrincipal());
-        UserDetails.class.cast(successfulAuthentication.getPrincipal());
+        String username;
+        Object principal = successfulAuthentication.getPrincipal();
+        if (principal instanceof UserDetails) {
+            username = ((UserDetails) principal).getUsername();
+        } else if (principal instanceof String) {
+            username = (String) principal;
+        } else {
+            LOGGER.warning(() -> "from " + successfulAuthentication + " found principal " + principal + " of unexpected " + (principal == null ? null : principal.getClass()));
+            return;
+        }
 
         long expiryTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(getTokenValiditySeconds());
-        String username = ((UserDetails) successfulAuthentication.getPrincipal()).getUsername();
 
-        String signatureValue = makeTokenSignature(expiryTime, username, ((UserDetails) successfulAuthentication.getPrincipal()).getPassword());
+        String signatureValue = makeTokenSignature(expiryTime, username);
         int tokenLifetime = calculateLoginLifetime(request, successfulAuthentication);
         setCookie(new String[] { username, Long.toString(expiryTime), signatureValue },
                 tokenLifetime, request, response);
@@ -204,8 +211,7 @@ public class TokenBasedRememberMeServices2 extends AbstractRememberMeServices {
         // only called once per HttpSession - if the token is valid, it will cause
         // SecurityContextHolder population, whilst if invalid, will cause the cookie to
         // be cancelled.
-        String expectedTokenSignature = makeTokenSignature(tokenExpiryTime, userDetails.getUsername(),
-                userDetails.getPassword());
+        String expectedTokenSignature = makeTokenSignature(tokenExpiryTime, userDetails.getUsername());
         if (!equals(expectedTokenSignature, cookieTokens[2])) {
             throw new InvalidCookieException("Cookie token[2] contained signature '" + cookieTokens[2]
                     + "' but expected '" + expectedTokenSignature + "'");

--- a/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
+++ b/core/src/main/java/hudson/security/TokenBasedRememberMeServices2.java
@@ -137,18 +137,8 @@ public class TokenBasedRememberMeServices2 extends AbstractRememberMeServices {
 
         // TODO is it really still necessary to reimplement all of the below, or could we simply override rememberMeRequested?
 
-        String username;
-        Object principal = successfulAuthentication.getPrincipal();
-        if (principal instanceof UserDetails) {
-            username = ((UserDetails) principal).getUsername();
-        } else if (principal instanceof String) {
-            username = (String) principal;
-        } else {
-            LOGGER.warning(() -> "from " + successfulAuthentication + " found principal " + principal + " of unexpected " + (principal == null ? null : principal.getClass()));
-            return;
-        }
-
         long expiryTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(getTokenValiditySeconds());
+        String username = successfulAuthentication.getName();
 
         String signatureValue = makeTokenSignature(expiryTime, username);
         int tokenLifetime = calculateLoginLifetime(request, successfulAuthentication);

--- a/test/src/test/java/hudson/security/TokenBasedRememberMeServices2Test.java
+++ b/test/src/test/java/hudson/security/TokenBasedRememberMeServices2Test.java
@@ -335,7 +335,7 @@ public class TokenBasedRememberMeServices2Test {
         expiryTime += deltaDuration;
 
         HudsonPrivateSecurityRealm.Details details = user.getProperty(HudsonPrivateSecurityRealm.Details.class);
-        String signatureValue = tokenService.makeTokenSignature(expiryTime, details.getUsername(), details.getPassword());
+        String signatureValue = tokenService.makeTokenSignature(expiryTime, details.getUsername());
         String tokenValue = user.getId() + ":" + expiryTime + ":" + signatureValue;
         String tokenValueBase64 = Base64.getEncoder().encodeToString(tokenValue.getBytes(StandardCharsets.UTF_8));
         return new Cookie(j.getURL().getHost(), tokenService.getCookieName(), tokenValueBase64);


### PR DESCRIPTION
While experimenting with tests of SSO logins, I came across a case where clicking **Remember me** caused a CCE because the `Authentication` had a `principal` of type `String` rather than the `UserDetails` this class currently expects. Using a debugger I found that the `String`-based token was created here:

```
at org.springframework.security.authentication.AbstractAuthenticationToken.setDetails(AbstractAuthenticationToken.java:99)
at org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.setDetails(UsernamePasswordAuthenticationFilter.java:126)
at org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.attemptAuthentication(UsernamePasswordAuthenticationFilter.java:84)
at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:231)
at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:221)
at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:99)
at jenkins.security.BasicHeaderProcessor.doFilter(BasicHeaderProcessor.java:97)
at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:99)
at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:117)
at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:87)
at hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:63)
at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:99)
at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:111)
at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:172)
at …
```

I think this arose because the test was actually mistaken at that point, trying to use the `/login` form when the configured security realm was not username/password-based. Probably `UsernamePasswordAuthenticationFilter` would not normally be used in this way. At any rate, the Javadoc for `Object getPrincipal()` says

> In the case of an authentication request with username and password, this would be the username.
> …
> Many of the authentication providers will create a `UserDetails` object as the principal.

implying that `String` and `UserDetails` are the expected types (but that there might be others!); and so it would be best to tolerate anything.

### Testing done

Prevented a CCE in the context of original experiments (closed source). Interactive sanity test logging in to built-in security realm.

### Proposed changelog entries

- Avoiding a `ClassCastException` from `TokenBasedRememberMeServices2` (not known to occur in realistic environments).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7724"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

