### PR TITLE
Remove Ajax.Request from filter-build-history

### DIFF
--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -25,65 +25,70 @@ const updateBuildsRefreshInterval = 5000;
 
 function updateBuilds(params) {
   if (isPageVisible()) {
-    new Ajax.Request(ajaxUrl + toQueryString(params), {
-      requestHeaders: buildHistoryContainer.headers,
-      onSuccess: function (rsp) {
-        var dataTable = getDataTable(buildHistoryContainer);
-        var rows = dataTable.rows;
-
-        // Check there are no existing rows (except the search bar) before showing the no builds banner
-        if (
-          rows.length <= 1 &&
-          rsp.responseText === '<table class="pane"></table>'
-        ) {
-          noBuildsBanner.style.display = "block";
-        } else {
-          noBuildsBanner.style.display = "none";
-        }
-
-        //delete rows with transitive data
-        var firstBuildRow = 0;
-        if (rows[firstBuildRow].classList.contains("build-search-row")) {
-          firstBuildRow++;
-        }
-        while (
-          rows.length > 1 &&
-          rows[firstBuildRow].classList.contains("transitive")
-        ) {
-          Element.remove(rows[firstBuildRow]);
-        }
-
-        // insert new rows
-        var div = document.createElement("div");
-        div.innerHTML = rsp.responseText;
-        Behaviour.applySubtree(div);
-
-        var pivot = rows[firstBuildRow];
-        var newDataTable = getDataTable(div);
-        var newRows = newDataTable.rows;
-        while (newRows.length > 0) {
-          if (pivot !== undefined) {
-            // The data table has rows.  Insert before a "pivot" row (first row).
-            pivot.parentNode.insertBefore(newRows[0], pivot);
-          } else {
-            // The data table has no rows.  In this case, we just add all new rows directly to the
-            // table, one after the other i.e. we don't insert before a "pivot" row (first row).
-            dataTable.getElementsByTagName("tbody")[0].appendChild(newRows[0]);
-          }
-        }
-
-        if (newDataTable.classList.contains("hasPageData")) {
-          buildHistoryPage.setAttribute(
-            "page-entry-newest",
-            newDataTable.getAttribute("page-entry-newest")
-          );
-        }
-
-        // next update
-        buildHistoryContainer.headers = ["n", rsp.getResponseHeader("n")];
-        checkAllRowCellOverflows();
-        createRefreshTimeout(params);
+    fetch(ajaxUrl + toQueryString(params), {
+      headers: {
+        n: buildHistoryContainer.headers[1],
       },
+    }).then((rsp) => {
+      if (rsp.ok) {
+        rsp.text().then((responseText) => {
+          var dataTable = getDataTable(buildHistoryContainer);
+          var rows = dataTable.rows;
+
+          // Check there are no existing rows (except the search bar) before showing the no builds banner
+          if (
+            rows.length <= 1 &&
+            responseText === '<table class="pane"></table>'
+          ) {
+            noBuildsBanner.style.display = "block";
+          } else {
+            noBuildsBanner.style.display = "none";
+          }
+
+          //delete rows with transitive data
+          var firstBuildRow = 0;
+          if (rows[firstBuildRow].classList.contains("build-search-row")) {
+            firstBuildRow++;
+          }
+          while (
+            rows.length > 1 &&
+            rows[firstBuildRow].classList.contains("transitive")
+            ) {
+            Element.remove(rows[firstBuildRow]);
+          }
+
+          // insert new rows
+          var div = document.createElement("div");
+          div.innerHTML = responseText;
+          Behaviour.applySubtree(div);
+
+          var pivot = rows[firstBuildRow];
+          var newDataTable = getDataTable(div);
+          var newRows = newDataTable.rows;
+          while (newRows.length > 0) {
+            if (pivot !== undefined) {
+              // The data table has rows.  Insert before a "pivot" row (first row).
+              pivot.parentNode.insertBefore(newRows[0], pivot);
+            } else {
+              // The data table has no rows.  In this case, we just add all new rows directly to the
+              // table, one after the other i.e. we don't insert before a "pivot" row (first row).
+              dataTable.getElementsByTagName("tbody")[0].appendChild(newRows[0]);
+            }
+          }
+
+          if (newDataTable.classList.contains("hasPageData")) {
+            buildHistoryPage.setAttribute(
+              "page-entry-newest",
+              newDataTable.getAttribute("page-entry-newest")
+            );
+          }
+
+          // next update
+          buildHistoryContainer.headers = ["n", rsp.headers.get("n")];
+          checkAllRowCellOverflows();
+          createRefreshTimeout(params);
+        });
+      }
     });
   } else {
     createRefreshTimeout(params);
@@ -465,48 +470,50 @@ function loadPage(params, focusOnSearch) {
     params.search = searchString;
   }
 
-  new Ajax.Request(ajaxUrl + toQueryString(params), {
-    onSuccess: function (rsp) {
-      pageSearchInputContainer.classList.remove("jenkins-search--loading");
-      buildHistoryContainer.classList.remove("jenkins-pane--loading");
+  fetch(ajaxUrl + toQueryString(params)).then((rsp) => {
+    if (rsp.ok) {
+      rsp.text().then((responseText) => {
+        pageSearchInputContainer.classList.remove("jenkins-search--loading");
+        buildHistoryContainer.classList.remove("jenkins-pane--loading");
 
-      if (rsp.responseText === '<table class="pane"></table>') {
-        noBuildsBanner.style.display = "block";
-      } else {
-        noBuildsBanner.style.display = "none";
-      }
+        if (responseText === '<table class="pane"></table>') {
+          noBuildsBanner.style.display = "block";
+        } else {
+          noBuildsBanner.style.display = "none";
+        }
 
-      var dataTable = getDataTable(buildHistoryContainer);
-      var tbody = dataTable.getElementsByTagName("tbody")[0];
-      var rows = tbody.getElementsByClassName("build-row");
+        var dataTable = getDataTable(buildHistoryContainer);
+        var tbody = dataTable.getElementsByTagName("tbody")[0];
+        var rows = tbody.getElementsByClassName("build-row");
 
-      // Delete all build rows
-      while (rows.length > 0) {
-        Element.remove(rows[0]);
-      }
+        // Delete all build rows
+        while (rows.length > 0) {
+          Element.remove(rows[0]);
+        }
 
-      // insert new rows
-      var div = document.createElement("div");
-      div.innerHTML = rsp.responseText;
-      Behaviour.applySubtree(div);
+        // insert new rows
+        var div = document.createElement("div");
+        div.innerHTML = responseText;
+        Behaviour.applySubtree(div);
 
-      var newDataTable = getDataTable(div);
-      var newRows = newDataTable.rows;
-      while (newRows.length > 0) {
-        tbody.appendChild(newRows[0]);
-      }
+        var newDataTable = getDataTable(div);
+        var newRows = newDataTable.rows;
+        while (newRows.length > 0) {
+          tbody.appendChild(newRows[0]);
+        }
 
-      checkAllRowCellOverflows();
-      updatePageParams(newDataTable);
-      togglePageUpDown();
-      if (!hasPageUp()) {
-        createRefreshTimeout(params);
-      }
+        checkAllRowCellOverflows();
+        updatePageParams(newDataTable);
+        togglePageUpDown();
+        if (!hasPageUp()) {
+          createRefreshTimeout(params);
+        }
 
-      if (focusOnSearch) {
-        pageSearchInput.focus();
-      }
-    },
+        if (focusOnSearch) {
+          pageSearchInput.focus();
+        }
+      });
+    }
   });
 }
 

--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -53,7 +53,7 @@ function updateBuilds(params) {
           while (
             rows.length > 1 &&
             rows[firstBuildRow].classList.contains("transitive")
-            ) {
+          ) {
             Element.remove(rows[firstBuildRow]);
           }
 
@@ -72,7 +72,9 @@ function updateBuilds(params) {
             } else {
               // The data table has no rows.  In this case, we just add all new rows directly to the
               // table, one after the other i.e. we don't insert before a "pivot" row (first row).
-              dataTable.getElementsByTagName("tbody")[0].appendChild(newRows[0]);
+              dataTable
+                .getElementsByTagName("tbody")[0]
+                .appendChild(newRows[0]);
             }
           }
 


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See https://groups.google.com/g/jenkinsci-dev/c/DR9Rr08fd0Y/m/xDWOixaXAwAJ

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Reviewed content side-by-side from one using prototype
Started and stopped builds making sure the content refreshed
Checked 'no builds' displays fine

Searched for builds by number and custom display name
Searched for builds that don't exist
Cleared a search and saw builds table reset

### Proposed changelog entries

- Entry 1: (too minor?)
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7728"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

