### PR TITLE
[JENKINS-70820] - Restore 'New Node' button for users with node creation permission

### DIFF
--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -32,7 +32,6 @@ THE SOFTWARE.
   <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
   <l:main-panel>
     <l:app-bar title="${%Nodes}">
-      <l:hasAdministerOrManage>
         <j:getStatic var="createPermission" className="hudson.model.Computer" field="CREATE"/>
         <j:if test="${h.hasPermission(createPermission)}">
           <a class="jenkins-button jenkins-button--primary" href="new">
@@ -40,6 +39,7 @@ THE SOFTWARE.
             ${%New Node}
           </a>
         </j:if>
+      <l:hasAdministerOrManage>
         <form method="post" action="updateNow" class="jenkins-!-display-contents">
           <button tooltip="${%Refresh status}" class="jenkins-button">
             <l:icon src="symbol-refresh" />


### PR DESCRIPTION
See [JENKINS-70820](https://issues.jenkins.io/browse/JENKINS-70820).

In https://github.com/jenkinsci/jenkins/pull/7352/files#diff-adb297c23217f8909fe9f14b38677a0c2d2aaf89a5566871abd65dcd72c2b58cR35-R45 the button to create a node was moved in `</lib/layout:hasAdministerOrManage>`, yet the button is guarded by a lower-tier permission than Administer or Manage.

The change proposed moves the button outside `</lib/layout:hasAdministerOrManage>` to ensure the dedicated permission check is warranted independently.

### Testing done

I could verify the button appears again with the permissions the submitter included in their bug report.

### Proposed changelog entries

- Restore 'New Node' button in computer overview for users with node creation permission.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
