### PR TITLE
Record Launchable commits for successful builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,6 +128,15 @@ for (i = 0; i < buildTypes.size(); i++) {
               if (failFast && currentBuild.result == 'UNSTABLE') {
                 error 'Static analysis quality gates not passed; halting early'
               }
+              /*
+               * If the current build was successful, we send the commits to Launchable so that the
+               * result can be consumed by a Launchable build in the future.
+               */
+              if (currentBuild.currentResult == 'SUCCESS') {
+                launchable.install()
+                launchable('verify')
+                launchable('record commit')
+              }
 
               def changelist = readFile(changelistF)
               dir(m2repo) {


### PR DESCRIPTION
Depends on https://github.com/jenkins-infra/pipeline-library/pull/630 (and the PR build will fail until it is rebased on top of https://github.com/jenkins-infra/pipeline-library/pull/630).

Like https://github.com/jenkins-infra/pipeline-library/pull/632 but for Jenkins core.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7780"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

