### PR TITLE
[JENKINS-70895] skip `isSecureContext` check in automated tests

### DIFF
--- a/core/src/main/resources/lib/layout/copyButton/copyButton.js
+++ b/core/src/main/resources/lib/layout/copyButton/copyButton.js
@@ -4,7 +4,9 @@ Behaviour.specify(
   0,
   function (copyButton) {
     copyButton.addEventListener("click", () => {
-      if (isSecureContext) {
+      // HTMLUnit 2.70.0 does not recognize isSecureContext
+      // https://issues.jenkins.io/browse/JENKINS-70895
+      if (!window.isRunAsTest && isSecureContext) {
         // Make an invisible textarea element containing the text
         const fakeInput = document.createElement("textarea");
         fakeInput.value = copyButton.getAttribute("text");


### PR DESCRIPTION
## [JENKINS-70895](https://issues.jenkins.io/browse/JENKINS-70895) skip `isSecureContext` check in automated tests

[JENKINS-70895](https://issues.jenkins.io/browse/JENKINS-70895) reports that `isSecureContext` is not recognized by HTMLUnit in its JavaScript handling.  That breaks tests for some plugins that use HTMLUnit to test configuration round trips.

https://github.com/jenkinsci/jenkins/pull/7665 introduced this change to notify users running over HTTP connections (insecure) that the copy button does not work over insecure connections.

[JENKINS-21052](https://issues.jenkins.io/browse/JENKINS-21052) was the original motivation for that informational message to the user.

### Testing done

* James Nord tested this change in the automated test that was failing with Jenkins 2.397 and confirmed that the test passes with this change.
* I tested interactively over HTTP and confirmed that the copy button on the inbound agent page still reports that copy is not supported over an insecure session.
* I tested interactively over HTTPS and confirmed that the copy button on the inbound agent page still correctly copies the expected content.  

I spent several unsuccessful hours trying to create an automated test to show the failure.  I think we should include this fix without an automated test because the automated tests in the plugin that James maintains will detect the issue.

### Proposed changelog entries

- N/A - test fix that is not visible to users.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jtnord

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7784"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

