### PR TITLE
Javadoc correction for `AsynchronousExecution`

### DIFF
--- a/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
+++ b/core/src/main/java/jenkins/model/queue/AsynchronousExecution.java
@@ -45,7 +45,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Special means of indicating that an executable will proceed in the background without consuming a native thread ({@link Executor}).
  * May be thrown from {@link Executable#run} after doing any preparatory work synchronously.
  * <p>{@link Executor#isActive} will remain true (even though {@link Executor#isAlive} is not) until {@link #completed} is called.
- * The thrower will need to hold on to a reference to this instance as a handle to call {@link #completed}.
+ * The thrower could hold on to a reference to this instance as a handle to call {@link #completed},
+ * or look it up later via {@link Executor#getAsynchronousExecution}.
  * <p>The execution may not extend into another Jenkins session; if you wish to model a long-running execution, you must schedule a new task after restart.
  * This class is not serializable anyway.
  * <p>Mainly intended for use with {@link OneOffExecutor} (from a {@link FlyweightTask}), of which there could be many,


### PR DESCRIPTION
I noticed that the sole implementation, `WorkflowRun`, did not actually do what the Javadoc claimed it needed to.

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7787"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

