### PR TITLE
Use `withCredentials` for Launchable in `Jenkinsfile`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,8 +134,10 @@ for (i = 0; i < buildTypes.size(); i++) {
                */
               if (currentBuild.currentResult == 'SUCCESS') {
                 launchable.install()
-                launchable('verify')
-                launchable('record commit')
+                withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
+                  launchable('verify')
+                  launchable('record commit')
+                }
               }
 
               def changelist = readFile(changelistF)


### PR DESCRIPTION
Having created my second workspace in Launchable, I now realize that it was a mistake to include a `withCredentials` step as an implementation detail of the `launchable` step, since it precludes using multiple workspaces. To fix that, I would like to remove `withCredentials` from the implementation of `launchable`, pushing the responsibility to consumers. But before I can do that, I have to modify existing consumers to fulfill this new obligation. Once existing consumers are modified I will delete the `withCredentials` call from inside the `launchable` step, and then I can start using multiple workspaces.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7789"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

