### PR TITLE
[JENKINS-70933] Remove Prototype `Event.on` usages from `confirm.js`

### DIFF
--- a/core/src/main/resources/lib/form/confirm.js
+++ b/core/src/main/resources/lib/form/confirm.js
@@ -77,12 +77,12 @@
       var button = buttons[i];
       name = button.getAttribute("name");
       if (name == "Submit" || name == "Apply" || name == "OK") {
-        $(button).on("click", function () {
+        button.addEventListener("click", function () {
           needToConfirm = false;
         });
       } else {
         if (isModifyingButton(button)) {
-          $(button).on("click", confirm);
+          button.addEventListener("click", confirm);
         }
       }
     }
@@ -92,9 +92,9 @@
       var input = inputs[i];
       if (!isIgnoringConfirm(input)) {
         if (input.type == "checkbox" || input.type == "radio") {
-          $(input).on("click", confirm);
+          input.addEventListener("click", confirm);
         } else {
-          $(input).on("input", confirm);
+          input.addEventListener("input", confirm);
         }
       }
     }
@@ -103,7 +103,7 @@
     for (let i = 0; i < inputs.length; i++) {
       let input = inputs[i];
       if (!isIgnoringConfirm(input)) {
-        $(input).on("change", confirm);
+        input.addEventListener("change", confirm);
       }
     }
 
@@ -111,7 +111,7 @@
     for (let i = 0; i < inputs.length; i++) {
       let input = inputs[i];
       if (!isIgnoringConfirm(input)) {
-        $(input).on("input", confirm);
+        input.addEventListener("input", confirm);
       }
     }
   }


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

See [JENKINS-70933](https://issues.jenkins.io/browse/JENKINS-70933). Usages of Prototype's `Event.on` in `confirm.js` remain.

### Solution

Replace these usages with modern JavaScript APIs.

### Testing done

Created a Freestyle job with a Git cloning step. With the old code, triggered the logic by loading the page and stepping through the modified code in the debugger. Also verified that I could exercise the behavior by adding a repository and trying to navigate away from the page before saving. With the changes in this PR, triggered the new logic by loading the page and stepping through the new code in the debugger. Verified that the behavior was the same as before. Also ran `mvn clean verify -Dtest=lib.layout.ConfirmationLinkTest`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7794"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

