### PR TITLE
[JENKINS-70909] Remove Prototype usages from `behavior.js`

### DIFF
--- a/war/src/main/webapp/scripts/behavior.js
+++ b/war/src/main/webapp/scripts/behavior.js
@@ -59,7 +59,7 @@ var Behaviour = (function() {
     },
 
         /** @deprecated For backward compatibility only; use {@link specify} instead. */
-	list : new Array,
+	list : [],
 
         /** @deprecated For backward compatibility only; use {@link specify} instead. */
 	register : function(sheet){
@@ -87,19 +87,19 @@ var Behaviour = (function() {
      *      this semantics is preserved.
      */
     applySubtree : function(startNode,includeSelf) {
-        if (!(startNode instanceof Array)) {
+        if (!(Array.isArray(startNode))) {
             startNode = [startNode];
         }
-        storage._each(function (registration) {
+        storage.forEach(function (registration) {
             if (registration.id == '_deprecated') {
-                Behaviour.list._each(function(sheet) {
+                Behaviour.list.forEach(function(sheet) {
                     for (var selector in sheet){
-                        startNode._each(function (n) {
+                        startNode.forEach(function (n) {
                           try {
                             var list = findElementsBySelector(n, selector, includeSelf);
                             if (list.length > 0) { // just to simplify setting of a breakpoint.
                                 //console.log('deprecated:' + selector + ' on ' + list.length + ' elements');
-                                list._each(sheet[selector]);
+                                list.forEach(sheet[selector]);
                             }
                           } catch (e) {
                               console.error(e)
@@ -108,12 +108,12 @@ var Behaviour = (function() {
                     }
                 });
             } else {
-                startNode._each(function (node) {
+                startNode.forEach(function (node) {
                   try {
                     var list = findElementsBySelector(node, registration.selector, includeSelf);
                     if (list.length > 0) {
                         //console.log(registration.id + ':' + registration.selector + ' @' + registration.priority + ' on ' + list.length + ' elements');
-                        list._each(registration.behavior);
+                        list.forEach(registration.behavior);
                     }
                   } catch (e) {
                       console.error(e)
@@ -170,9 +170,9 @@ function findElementsBySelector(startNode,selector,includeSelf) {
               c = c.parentNode;
           }
         }
-        return Prototype.Selector.select(selector, startNode.parentNode).filter(isSelfOrChild);
+        return Array.from(startNode.parentNode.querySelectorAll(selector)).filter(isSelfOrChild);
     } else {
-        return Prototype.Selector.select(selector, startNode);
+        return Array.from(startNode.querySelectorAll(selector));
     }
 }
 


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

See [JENKINS-70909](https://issues.jenkins.io/browse/JENKINS-70909). Usages of Prototype remain in `behavior.js`. While I was here I also cleaned up some `Array` usages to be more idiomatic JavaScript.

### Solution

Replace these usages with modern JavaScript APIs.

### Testing done

Stepped through the changed lines in my debugger before and after this change successfully. Also ran `mvn clean verify -Dtest=scripts.BehaviorTest`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7798"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

