### PR TITLE
[JENKINS-70935] [JENKINS-70952] Remove Prototype usages from `progressiveRendering.js`

### DIFF
--- a/core/src/main/resources/lib/layout/progressiveRendering/progressiveRendering.js
+++ b/core/src/main/resources/lib/layout/progressiveRendering/progressiveRendering.js
@@ -27,20 +27,27 @@ function progressivelyRender(handler, callback, statusId) {
     var r = response.responseObject();
     if (r.status == "done") {
       callback(r.data);
-      $(statusId).style.display = "none";
+      document.getElementById(statusId).style.display = "none";
     } else if (r.status == "canceled") {
       // TODO ugly; replace with single tr of class=unknown?
-      $$("#" + statusId + " .progress-bar-done")[0].innerHTML = "Aborted.";
+      document.querySelector("#" + statusId + " .progress-bar-done").innerHTML =
+        "Aborted.";
     } else if (r.status == "error") {
-      $$("#" + statusId + " .progress-bar-done")[0].style.width = "100%";
-      $$("#" + statusId + " .progress-bar-left")[0].style.width = "0%";
-      $(statusId).className = "progress-bar red";
+      document.querySelector(
+        "#" + statusId + " .progress-bar-done"
+      ).style.width = "100%";
+      document.querySelector(
+        "#" + statusId + " .progress-bar-left"
+      ).style.width = "0%";
+      document.getElementById(statusId).className = "progress-bar red";
     } else {
       callback(r.data);
-      $$("#" + statusId + " .progress-bar-done")[0].style.width =
-        100 * r.status + "%";
-      $$("#" + statusId + " .progress-bar-left")[0].style.width =
-        100 - 100 * r.status + "%";
+      document.querySelector(
+        "#" + statusId + " .progress-bar-done"
+      ).style.width = 100 * r.status + "%";
+      document.querySelector(
+        "#" + statusId + " .progress-bar-left"
+      ).style.width = 100 - 100 * r.status + "%";
       checkNewsLater(500);
     }
   }


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

See [JENKINS-70935](https://issues.jenkins.io/browse/JENKINS-70935) and [JENKINS-70952](https://issues.jenkins.io/browse/JENKINS-70952). Usage of Prototype $ and $$ remain in `progressiveRendering.js`.

### Solution

Replace these usages with modern JavaScript APIs.

### Testing done

Exercised the "done" and "error" code paths by going to the build history page and stepping through the code in the debugger. Ran `mvn clean verify -Dtest=jenkins.widgets.BuildTimeTrendTest`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7810"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

