### PR TITLE
[JENKINS-70908] [JENKINS-70944] [JENKINS-70966] Remove Prototype usages from `hetero-list.js`

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -7,49 +7,49 @@ Behaviour.specify(
   "hetero-list",
   -100,
   function (e) {
-    e = $(e);
     if (isInsideRemovable(e)) {
       return;
     }
 
     // components for the add button
     var menu = document.createElement("SELECT");
-    var btns = findElementsBySelector(e, "INPUT.hetero-list-add"),
-      btn = btns[btns.length - 1]; // In case nested content also uses hetero-list
+    // In case nested content also uses hetero-list
+    var btn = Array.from(e.querySelectorAll("INPUT.hetero-list-add")).pop();
     if (!btn) {
       return;
     }
     YAHOO.util.Dom.insertAfter(menu, btn);
 
-    var prototypes = $(e.lastElementChild);
-    while (!prototypes.hasClassName("prototypes")) {
-      prototypes = prototypes.previous();
+    var prototypes = e.lastElementChild;
+    while (!prototypes.classList.contains("prototypes")) {
+      prototypes = prototypes.previousElementSibling;
     }
-    var insertionPoint = prototypes.previous(); // this is where the new item is inserted.
+    var insertionPoint = prototypes.previousElementSibling; // this is where the new item is inserted.
 
     // extract templates
     var templates = [];
-    var i = 0;
-    $(prototypes)
-      .childElements()
-      .each(function (n) {
-        var name = n.getAttribute("name");
-        var tooltip = n.getAttribute("tooltip");
-        var descriptorId = n.getAttribute("descriptorId");
-        // YUI Menu interprets this <option> text node as HTML, so let's escape it again!
-        var title = n.getAttribute("title");
-        if (title) {
-          title = title.escapeHTML();
-        }
-        menu.options[i] = new Option(title, "" + i);
-        templates.push({
-          html: n.innerHTML,
-          name: name,
-          tooltip: tooltip,
-          descriptorId: descriptorId,
-        });
-        i++;
+    var children = prototypes.children;
+    for (var i = 0; i < children.length; i++) {
+      var n = children[i];
+      var name = n.getAttribute("name");
+      var tooltip = n.getAttribute("tooltip");
+      var descriptorId = n.getAttribute("descriptorId");
+      // YUI Menu interprets this <option> text node as HTML, so let's escape it again!
+      var title = n.getAttribute("title");
+      if (title) {
+        title = title
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+      }
+      menu.options[i] = new Option(title, "" + i);
+      templates.push({
+        html: n.innerHTML,
+        name: name,
+        tooltip: tooltip,
+        descriptorId: descriptorId,
       });
+    }
     prototypes.remove();
 
     // Initialize drag & drop for this component
@@ -63,8 +63,8 @@ Behaviour.specify(
       menuAlign.split("-"),
       250
     );
-    $(menuButton._button).addClassName(btn.className); // copy class names
-    $(menuButton._button).setAttribute("suffix", btn.getAttribute("suffix"));
+    menuButton._button.classList.add(btn.className); // copy class names
+    menuButton._button.setAttribute("suffix", btn.getAttribute("suffix"));
     menuButton.getMenu().clickEvent.subscribe(function (type, args) {
       var item = args[1];
       if (item.cfg.getProperty("disabled")) {
@@ -77,10 +77,10 @@ Behaviour.specify(
       nc.setAttribute("name", t.name);
       nc.setAttribute("descriptorId", t.descriptorId);
       nc.innerHTML = t.html;
-      $(nc).setOpacity(0);
+      nc.style.opacity = "0";
 
       renderOnDemand(
-        findElementsBySelector(nc, "div.config-page")[0],
+        nc.querySelector("div.config-page"),
         function () {
           function findInsertionPoint() {
             // given the element to be inserted 'prospect',
@@ -112,8 +112,8 @@ Behaviour.specify(
               return bestPos;
             }
 
-            var current = e.childElements().findAll(function (e) {
-              return e.match("DIV.repeated-chunk");
+            var current = Array.from(e.children).filter(function (e) {
+              return e.matches("DIV.repeated-chunk");
             });
 
             function o(did) {
@@ -135,10 +135,10 @@ Behaviour.specify(
               return insertionPoint;
             }
           }
-          (e.hasClassName("honor-order")
+          var referenceNode = e.classList.contains("honor-order")
             ? findInsertionPoint()
-            : insertionPoint
-          ).insert({ before: nc });
+            : insertionPoint;
+          referenceNode.parentNode.insertBefore(nc, referenceNode);
 
           // Initialize drag & drop for this component
           if (withDragDrop) {
@@ -176,14 +176,11 @@ Behaviour.specify(
     // does this container already has a configured instance of the specified descriptor ID?
     function has(id) {
       return (
-        Prototype.Selector.find(
-          e.childElements(),
-          'DIV.repeated-chunk[descriptorId="' + id + '"]'
-        ) != null
+        e.querySelector('DIV.repeated-chunk[descriptorId="' + id + '"]') != null
       );
     }
 
-    if (e.hasClassName("one-each")) {
+    if (e.classList.contains("one-each")) {
       menuButton.getMenu().showEvent.subscribe(function () {
         var items = menuButton.getMenu().getItems();
         for (i = 0; i < items.length; i++) {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -377,17 +377,11 @@ function qs(owner) {
 
 // find the nearest ancestor node that has the given tag name
 function findAncestor(e, tagName) {
-  do {
-    e = e.parentNode;
-  } while (e != null && e.tagName != tagName);
-  return e;
+  return e.closest(tagName);
 }
 
 function findAncestorClass(e, cssClass) {
-  do {
-    e = e.parentNode;
-  } while (e != null && !Element.hasClassName(e, cssClass));
-  return e;
+  return e.closest("." + cssClass);
 }
 
 function isTR(tr, nodeClass) {
@@ -884,9 +878,7 @@ function makeButton(e, onclick) {
     the behavior re-executes when the removed master copy gets reinserted later.
  */
 function isInsideRemovable(e) {
-  return Element.ancestors(e).find(function (f) {
-    return f.hasClassName("to-be-removed");
-  });
+  return !!e.closest(".to-be-removed");
 }
 
 /**
@@ -1874,14 +1866,14 @@ function applyNameRefHelper(s, e, id) {
 //   @param c     checkbox element
 function updateOptionalBlock(c) {
   // find the start TR
-  var s = $(c);
-  while (!s.hasClassName("optional-block-start")) s = s.up();
+  var s = c;
+  while (!s.classList.contains("optional-block-start")) s = s.parentNode;
 
   // find the beginning of the rowvg
   var vg = s;
-  while (!vg.hasClassName("rowvg-start")) vg = vg.next();
+  while (!vg.classList.contains("rowvg-start")) vg = vg.nextElementSibling;
 
-  var checked = xor(c.checked, Element.hasClassName(c, "negative"));
+  var checked = xor(c.checked, c.classList.contains("negative"));
 
   vg.rowVisibilityGroup.makeInnerVisible(checked);
 


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

See [JENKINS-70908](https://issues.jenkins.io/browse/JENKINS-70908), [JENKINS-70944](https://issues.jenkins.io/browse/JENKINS-70944), and [JENKINS-70966](https://issues.jenkins.io/browse/JENKINS-70966). Usage of Prototype remains in `hetero-list.js`.

### Solution

Replace these usages with modern JavaScript APIs.

### Bonus

Started chipping away at `hudson-behavior.js` as well.

### Testing done

Ran `mvn clean verify -Dtest=lib.form.HeteroListTest`; stepped through every changed line in the debugger in Firefox to ensure the code still worked. Spent a lot of time on the Configure Project page adding and removing many things to hetero lists in a Freestyle project. Saw no errors and hit every line of code I changed in the debugger.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7812"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

