### PR TITLE
Remove jQuery from `page-init.js`

### DIFF
--- a/war/src/main/js/page-init.js
+++ b/war/src/main/js/page-init.js
@@ -1,37 +1,35 @@
-import $ from "jquery";
 import jsModules from "jenkins-js-modules";
 
 /*
  * Page initialisation tasks.
  */
-
-$(function () {
+document.addEventListener("DOMContentLoaded", () => {
   loadScripts();
   loadCSS();
 });
 
 function loadScripts() {
-  $(".jenkins-js-load").each(function () {
-    var scriptUrl = $(this).attr("data-src");
+  document.querySelectorAll(".jenkins-js-load").forEach((element) => {
+    const scriptUrl = element.dataset.src;
     if (scriptUrl) {
       // jsModules.addScript will ensure that the script is
       // loaded once and once only. So, this can be considered
       // analogous to a client-side adjunct.
       jsModules.addScript(scriptUrl);
-      $(this).remove();
+      element.remove();
     }
   });
 }
 
 function loadCSS() {
-  $(".jenkins-css-load").each(function () {
-    var cssUrl = $(this).attr("data-src");
+  document.querySelectorAll(".jenkins-css-load").forEach((element) => {
+    const cssUrl = element.dataset.src;
     if (cssUrl) {
       // jsModules.addCSSToPage will ensure that the CSS is
       // loaded once and once only. So, this can be considered
       // analogous to a client-side adjunct.
       jsModules.addCSSToPage(cssUrl);
-      $(this).remove();
+      element.remove();
     }
   });
 }


### PR DESCRIPTION
Inspired by the great works by @basil and @timja, this PR removes `page-init.js`' reliance on jQuery.

### Testing done

* Went to a page that uses `<l:js />` (New job), page works as expected and JS loads in 
* Went to a page that uses `<l:css />` (New job), page works as expected and CSS loads in 

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7815"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

