### PR TITLE
Temporarily roll back #7809

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,6 @@
     ":semanticCommitsDisabled"
   ],
   "enabledManagers": ["npm", "regex"],
-  "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [
     {
       "matchDatasources": ["npm"],


### PR DESCRIPTION
While the deduplication introduced in #7809 is generally desirable, and we have employed it in a number of PRs in the past, at the present time there is some issue with the latest version of Babel, and deduplicating means that we're forced to upgrade Babel in any other dependency upgrade PR, effectively blocking us from upgrading any other dependencies. For now, this PR disables deduplication until the Babel issues can be sorted out to unblock other dependency upgrades. Once the Babel issues are sorted out this can be re-enabled.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7822"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

