### PR TITLE
[JENKINS-70988] `TypeError: inputs[i].nextElementSibling is null`

### DIFF
--- a/core/src/main/resources/lib/form/repeatable/repeatable.js
+++ b/core/src/main/resources/lib/form/repeatable/repeatable.js
@@ -258,8 +258,9 @@ Behaviour.specify("DIV.repeated-chunk", "repeatable", -200, function (d) {
 
       // Uniquify the "id" of <input> and "for" of <label>
       inputs[i].id = inputs[i].name + "_" + inputs[i].id;
-      if (inputs[i].nextElementSibling.tagName === "LABEL") {
-        inputs[i].nextElementSibling.setAttribute("for", inputs[i].id);
+      var next = inputs[i].nextElementSibling;
+      if (next != null && next.tagName === "LABEL") {
+        next.setAttribute("for", inputs[i].id);
       }
     }
   }


### PR DESCRIPTION
See [JENKINS-70988](https://issues.jenkins.io/browse/JENKINS-70988). Might also correct some problem with the Gradle plugin reported as [JENKINS-70739](https://issues.jenkins.io/browse/JENKINS-70739), though I did not check that. There is a lot of discussion of the need for unique `id` attributes, but I am not actually sure what that is all about. The apparent reason that radio buttons did not work is just that radio groups did not get unique `name` attributes. This is normally ensured by prepending `removeme123-` to the `name`, tracked as `radioPrefix`. That logic was however broken in the case of `credentials/select.jelly` at least by #7631 because it presumed that `nextElementSibling` was defined when this can be null when custom radio button usages are present. When that happened, the browser console would show

```
TypeError: inputs[i].nextElementSibling is null
    <anonymous> http://localhost:8080/jenkins/adjuncts/f24ce642/lib/form/repeatable/repeatable.js:267
    applySubtree http://localhost:8080/jenkins/scripts/behavior.js:116
    applySubtree http://localhost:8080/jenkins/scripts/behavior.js:111
    applySubtree http://localhost:8080/jenkins/scripts/behavior.js:93
    apply http://localhost:8080/jenkins/scripts/behavior.js:76
    start http://localhost:8080/jenkins/scripts/behavior.js:71
    onload http://localhost:8080/jenkins/scripts/behavior.js:133
    onload http://localhost:8080/jenkins/scripts/behavior.js:133
```

The error aborted the loop, causing only the first radio group to get a uniquified radio prefix.

### Testing done

Install `credentials-binding`. Define secret text credentials. Create a freestyle project. Add a credentials binding wrapper and define three bindings of all secret text type (does not seem to matter which). Save and reconfigure. You will see radio buttons misbehaving: the first group (choice of two radio buttons at the top of a binding entry) is fine but the buttons in the second and third binding are improperly mixed up (since all are named `_.credentialsId` with no prefix).

With this patch, each group gets its own `name` as expected, and as happened prior to #7631.

### Proposed changelog entries

- Fix radio buttons in repeated blocks in configuration forms (regression in 2.391).

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7823"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

