### PR TITLE
Restore #7809

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
     ":semanticCommitsDisabled"
   ],
   "enabledManagers": ["npm", "regex"],
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [
     {
       "matchDatasources": ["npm"],


### PR DESCRIPTION
Now that we have figured out what is going on with Babel in https://github.com/jenkinsci/jenkins/pull/7801#issuecomment-1500924006, we can restore deduplication. Once this is merged I'll Renovate to recreate #7801, then apply the fix described in that comment, then we will have moved past this event.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7824"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

