### PR TITLE
Use Prototype.js in one line of `hetero-list.js` to satisfy HtmlUnit

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -63,7 +63,8 @@ Behaviour.specify(
       menuAlign.split("-"),
       250
     );
-    menuButton._button.classList.add(btn.className); // copy class names
+    // Don't even think about changing the next line without testing the change in HtmlUnit/Rhino…
+    $(menuButton._button).addClassName(btn.className); // copy class names
     menuButton._button.setAttribute("suffix", btn.getAttribute("suffix"));
     menuButton.getMenu().clickEvent.subscribe(function (type, args) {
       var item = args[1];


### PR DESCRIPTION
This single line of #7812 seems to cause JTH/HtmlUnit/Rhino to trip up and start failing in `branch-api` and `pipeline-groovy-lib` round trip tests, even though it works fine in a real browser. I even verified in a real browser that the behavior of this line was the same before and after #7812 by stepping through the Prototype.js execution in a debugger and comparing its effects to the native execution. I have no idea why HtmlUnit trips up on this, since it does not even seem to be an exotic JavaScript feature. The only thing printed by HtmlUnit is the rather unhelpful

```
   2.303 [id=238]       SEVERE  c.g.h.WebConsole$DefaultLogger#error: {"fileName":"http://localhost:41925/jenkins/adjuncts/e163fd7e/lib/form/hetero-list/hetero-list.js","lineNumber":66}
```

If you care enough about debugging HtmlUnit internals, consider this your puzzler of the day. (I do not care enough.) Going back to the older Prototype.js syntax for this one line will restore stability to our test suite. I am not labeling this with `regression` because I do not think any end users would be impacted by this; rather, this seems to be a problem with our test framework running an outdated JavaScript interpreter.

### Testing done

Ran the failing tests from `branch-api` and `pipeline-groovy-lib` after this change and verified that they passed again with this PR.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7840"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

