### PR TITLE
Copy multiple class names in `hetero-list.js`

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -63,7 +63,10 @@ Behaviour.specify(
       menuAlign.split("-"),
       250
     );
-    menuButton._button.classList.add(btn.className); // copy class names
+    // copy class names
+    btn.classList.forEach(function (className) {
+      menuButton._button.classList.add(className);
+    });
     menuButton._button.setAttribute("suffix", btn.getAttribute("suffix"));
     menuButton.getMenu().clickEvent.subscribe(function (type, args) {
       var item = args[1];

--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -64,9 +64,9 @@ Behaviour.specify(
       250
     );
     // copy class names
-    btn.classList.forEach(function (className) {
-      menuButton._button.classList.add(className);
-    });
+    for (i = 0; i < btn.classList.length; i++) {
+      menuButton._button.classList.add(btn.classList.item(i));
+    }
     menuButton._button.setAttribute("suffix", btn.getAttribute("suffix"));
     menuButton.getMenu().clickEvent.subscribe(function (type, args) {
       var item = args[1];


### PR DESCRIPTION
Amends #7812. The original Prototype.js version was calling

```
$(menuButton._button).addClassName(btn.className); // copy class names
```

where `btn.className` could have been a single class name or a space-separated list of class names. This was technically an abuse of the Prototype.js API, since `addClassName` is only documented to take in a single class name. But its implementation happened to work fine with a space-separated list. I never noticed this in my interactive testing because I never got any inputs with multiple class names.

After upgrading to these bits a few `branch-api` and `pipeline-groovy-lib` tests started failing because `btn.className` had multiple classes and the native JavaScript `menuButton._button.classList.add()` call does not actually accept multiple class names like the old Prototype version did. So the original bug has to be fixed by iterating over the list.

### Testing done

Ran the failing tests from branch-api and pipeline-groovy-lib after this change and verified that they passed again with this PR.

### Proposed changelog entries

Properly iterate over class names in heterogeneous lists (regression in 2.400).

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7845"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

