### PR TITLE
Backporting for LTS 2.387.3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -175,6 +175,7 @@ THE SOFTWARE.
         <artifactId>jcip-annotations</artifactId>
         <version>1.0</version>
       </dependency>
+      <!-- TODO remove after determining this will not break plugins -->
       <dependency>
         <groupId>net.sf.kxml</groupId>
         <artifactId>kxml2</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -265,6 +265,7 @@ THE SOFTWARE.
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
     </dependency>
+    <!-- TODO remove after determining this will not break plugins -->
     <dependency>
       <groupId>net.sf.kxml</groupId>
       <artifactId>kxml2</artifactId>

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -31,8 +31,7 @@ THE SOFTWARE.
   <st:include page="sidepanel.jelly" />
   <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
   <l:main-panel>
-    <l:app-bar title="${%Manage nodes and clouds}">
-      <l:hasAdministerOrManage>
+    <l:app-bar title="${%Nodes}">
         <j:getStatic var="createPermission" className="hudson.model.Computer" field="CREATE"/>
         <j:if test="${h.hasPermission(createPermission)}">
           <a class="jenkins-button jenkins-button--primary" href="new">
@@ -40,6 +39,7 @@ THE SOFTWARE.
             ${%New Node}
           </a>
         </j:if>
+      <l:hasAdministerOrManage>
         <form method="post" action="updateNow" class="jenkins-!-display-contents">
           <button tooltip="${%Refresh status}" class="jenkins-button">
             <l:icon src="symbol-refresh" />

--- a/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
@@ -49,18 +49,15 @@ THE SOFTWARE.
             <l:icon class="icon-red icon-md"/>
             <l:icon class="icon-nobuilt icon-md"/>
           </div>
-          <p class="info jenkins-checkbox" style="font-weight: normal">
+          <p class="info">
             <j:if test="${app.lifecycle.canRestart()}">
               <j:if test="${app.isQuietingDown() or it.isRestartScheduled()}">
-                <input id="scheduleRestartCheckbox" type="checkbox" checked="checked" />
+                <f:checkbox checked="true" id="scheduleRestartCheckbox" name="scheduleRestart" title="${%warning}" />
               </j:if>
               <j:if test="${!app.isQuietingDown() and !it.isRestartScheduled()}">
-                <input id="scheduleRestartCheckbox" type="checkbox" />
+                <f:checkbox readonly="true" id="scheduleRestartCheckbox" name="scheduleRestart" title="${%warning}" />
               </j:if>
             </j:if>
-            <label for="scheduleRestartCheckbox">
-              ${%warning}
-            </label>
           </p>
         </l:isAdmin>
       </form>

--- a/core/src/test/java/hudson/XmlFileTest.java
+++ b/core/src/test/java/hudson/XmlFileTest.java
@@ -2,17 +2,19 @@ package hudson;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThrows;
 
+import com.thoughtworks.xstream.converters.ConversionException;
+import com.thoughtworks.xstream.io.StreamException;
 import hudson.model.Node;
+import hudson.util.RobustReflectionConverter;
 import hudson.util.XStream2;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import jenkins.model.Jenkins;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.xml.sax.SAXParseException;
 
 public class XmlFileTest {
 
@@ -30,9 +32,6 @@ public class XmlFileTest {
         }
     }
 
-    // KXml2Driver is able to parse XML 1.0 even if it has control characters which
-    // should be illegal.  Ignoring this test until we switch to a more compliant driver
-    @Ignore
     @Test
     public void xml1_0_withSpecialCharsShouldFail() {
         URL configUrl = getClass().getResource("/hudson/config_1_0_with_special_chars.xml");
@@ -41,7 +40,15 @@ public class XmlFileTest {
 
         XmlFile xmlFile =  new XmlFile(xs, new File(configUrl.getFile()));
         if (xmlFile.exists()) {
-            assertThrows(SAXParseException.class, xmlFile::read);
+            IOException e = assertThrows(IOException.class, xmlFile::read);
+            assertThat(e.getCause(), instanceOf(ConversionException.class));
+            ConversionException ce = (ConversionException) e.getCause();
+            assertThat(ce.get("cause-exception"), is(StreamException.class.getName()));
+            assertThat(ce.get("class"), is(Jenkins.class.getName()));
+            assertThat(ce.get("required-type"), is(Jenkins.class.getName()));
+            assertThat(ce.get("converter-type"), is(RobustReflectionConverter.class.getName()));
+            assertThat(ce.get("path"), is("/hudson/label"));
+            assertThat(ce.get("line number"), is("7"));
         }
     }
 

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -40,6 +40,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.mapper.CannotResolveClassException;
 import hudson.model.Result;
 import hudson.model.Run;
+import java.io.InputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -570,4 +571,23 @@ public class XStream2Test {
     @XStreamAlias("C-5")
     public static final class C5 {}
 
+    @Issue("JENKINS-69129")
+    @Test
+    public void testEmoji() throws Exception {
+        Bar bar;
+        try (InputStream is = getClass().getResource("XStream2Emoji.xml").openStream()) {
+            bar = (Bar) new XStream2().fromXML(is);
+        }
+        assertEquals("Fox 🦊", bar.s);
+    }
+
+    @Issue("JENKINS-69129")
+    @Test
+    public void testEmojiEscaped() throws Exception {
+        Bar bar;
+        try (InputStream is = getClass().getResource("XStream2EmojiEscaped.xml").openStream()) {
+            bar = (Bar) new XStream2().fromXML(is);
+        }
+        assertEquals("Fox 🦊", bar.s);
+    }
 }

--- a/core/src/test/resources/hudson/util/XStream2Emoji.xml
+++ b/core/src/test/resources/hudson/util/XStream2Emoji.xml
@@ -1,0 +1,4 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.util.XStream2Test_-Bar>
+  <s>Fox 🦊</s>
+</hudson.util.XStream2Test_-Bar>

--- a/core/src/test/resources/hudson/util/XStream2EmojiEscaped.xml
+++ b/core/src/test/resources/hudson/util/XStream2EmojiEscaped.xml
@@ -1,0 +1,4 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.util.XStream2Test_-Bar>
+  <s>Fox &#129418;</s>
+</hudson.util.XStream2Test_-Bar>

--- a/war/src/main/less/modules/side-panel-tasks.less
+++ b/war/src/main/less/modules/side-panel-tasks.less
@@ -112,6 +112,7 @@
 
   .task-link-text {
     display: contents;
+    word-break: break-word;
   }
 
   &--active {


### PR DESCRIPTION
```shell
Latest core version: jenkins-2.400

Fixed
-----

JENKINS-70820           Minor                   2.396
        "New Node" button missing in Web UI
        regression
        https://issues.jenkins.io/browse/JENKINS-70820

JENKINS-70809           Minor                   2.397
        "delete build" button overflow the side-panel
        regression
        https://issues.jenkins.io/browse/JENKINS-70809

JENKINS-69489           Minor                   2.396
        plugin manager restart looks interactive but is not
        regression
        https://issues.jenkins.io/browse/JENKINS-69489

JENKINS-69129           Minor                   2.398
        DisplayName and unicode character
        https://issues.jenkins.io/browse/JENKINS-69129
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7852"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

