### PR TITLE
[JENKINS-71089] Fix `hasHeader` attribute for `f:hetero-list`

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -85,11 +85,13 @@ THE SOFTWARE.
         <j:set var="help" value="${descriptor.helpFile}" />
 
         <div class="repeated-chunk__header">
-          <div class="${attrs.disableDragAndDrop or readOnlyMode ? '' : 'dd-handle'}"/>
+          <j:if test="${attrs.hasHeader}">
+            <div class="${attrs.disableDragAndDrop or readOnlyMode ? '' : 'dd-handle'}"/>
 
-          ${descriptor.displayName}
+            ${descriptor.displayName}
 
-          <f:helpLink url="${help}"/>
+            <f:helpLink url="${help}"/>
+          </j:if>
 
           <j:if test="${!readOnlyMode}">
             <f:repeatableDeleteButton value="${attrs.deleteCaption}" />


### PR DESCRIPTION
See [JENKINS-71089](https://issues.jenkins.io/browse/JENKINS-71089).

Restores the `hasHeader = false` functionality.

### Testing done

<img width="509" alt="image" src="https://user-images.githubusercontent.com/43062514/232773077-276becc9-0b83-4c54-9830-6cd90cde07f6.png">

* Changed a hetero-list on `core` (as there isn't an existing one) to set the has header attribute to false, the title/dragdrop handle/help no longer shows now.

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7853"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

