### PR TITLE
Collect Launchable test results for core and ATH workspaces in core builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,15 +117,31 @@ for (i = 0; i < buildTypes.size(); i++) {
                 skipBlames: true,
                 trendChartType: 'TOOLS_ONLY',
                 qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
+              launchable.install()
+              withCredentials([string(credentialsId: 'launchable-jenkins-jenkins', variable: 'LAUNCHABLE_TOKEN')]) {
+                launchable('verify')
+                /*
+                 * TODO Create a Launchable build and session earlier, and replace "--no-build" with
+                 * "--session" to associate these test results with a particular build. The commits
+                 * associated with the Launchable build should be the commits of the transitive
+                 * closure of the Jenkins WAR under test in this build.
+                 */
+                launchable("record tests --no-build --flavor platform=${buildType.toLowerCase()} --flavor jdk=${jdk} maven './**/target/surefire-reports'")
+              }
               if (failFast && currentBuild.result == 'UNSTABLE') {
                 error 'Static analysis quality gates not passed; halting early'
               }
               /*
-               * If the current build was successful, we send the commits to Launchable so that the
-               * result can be consumed by a Launchable build in the future.
+               * If the current build was successful, we send the commits to Launchable so that
+               * these commits can be consumed by a build in the Launchable BOM workspace in the
+               * future.
+               *
+               * TODO Move this up to before the present parallel block starts (or move the ATH run
+               * in this file to after joining on the present parallel block) so that these commits
+               * can be consumed by a build in the Launchable ATH workspace in this file in the
+               * future.
                */
               if (currentBuild.currentResult == 'SUCCESS') {
-                launchable.install()
                 withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
                   launchable('verify')
                   launchable('record commit')
@@ -155,10 +171,23 @@ builds.ath = {
       // Just to be safe
       deleteDir()
       checkout scm
+      def browser = 'firefox'
       infra.withArtifactCachingProxy {
-        sh 'bash ath.sh'
+        sh 'bash ath.sh ' + browser
       }
       junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
+      launchable.install()
+      withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
+        launchable('verify')
+        /*
+         * TODO Create a Launchable build and session earlier, and replace "--no-build" with
+         * "--session" to associate these test results with a particular build. The commits
+         * associated with the Launchable build should be the commits of the transitive closure of
+         * the Jenkins WAR under test in this build as well as the commits of the transitive closure
+         * of the ATH JAR.
+         */
+        launchable("record tests --no-build --flavor platform=linux --flavor jdk=11 --flavor browser=${browser} maven './target/ath-reports'")
+      }
     }
   }
 }

--- a/ath.sh
+++ b/ath.sh
@@ -8,6 +8,12 @@ cd "$(dirname "$0")"
 # https://github.com/jenkinsci/acceptance-test-harness/releases
 export ATH_VERSION=5541.va_c0a_36b_b_f825
 
+if [[ $# -eq 0 ]]; then
+	export BROWSER=firefox
+else
+	export BROWSER=$1
+fi
+
 MVN='mvn -B -ntp -Pquick-build -am -pl war package'
 if [[ -n ${MAVEN_SETTINGS-} ]]; then
 	MVN="${MVN} -s ${MAVEN_SETTINGS}"
@@ -20,6 +26,7 @@ chmod a+rwx target/ath-reports
 
 exec docker run --rm \
 	--env ATH_VERSION \
+	--env BROWSER \
 	--shm-size 2g `# avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed` \
 	--volume "$(pwd)"/war/target/jenkins.war:/jenkins.war:ro \
 	--volume /var/run/docker.sock:/var/run/docker.sock:rw \
@@ -37,7 +44,7 @@ exec docker run --rm \
 		env | sort
 		git clone --branch "$ATH_VERSION" --depth 1 https://github.com/jenkinsci/acceptance-test-harness
 		cd acceptance-test-harness
-		run.sh firefox /jenkins.war \
+		run.sh "$BROWSER" /jenkins.war \
 			-Dmaven.test.failure.ignore \
 			-DforkCount=1 \
 			-Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest


### PR DESCRIPTION
See [the design document](https://docs.google.com/document/d/12LdoAFA566P4LgHhu1L-fuOQuhipxk77tUDXQdNmhss/edit) for a thorough explanation of the design. This PR begins to implement the design described in that document by implementing test result collection for the core and ATH Launchable workspaces in the core build. (Test result collection for the ATH workspace in ATH builds is being done in https://github.com/jenkinsci/acceptance-test-harness/pull/1113.) Test result collection is the easy part of integrating Launchable into our CI system; the difficult part (as explained in the design document) is commit collection, which I plan to work on after this. (As part of commit collection, I have various PRs open to add Git hash information to `MANIFEST.MF` for core, core components, and all plugins, so that change will need a little more time.) The ultimate goal, once the model is trained, is to increase velocity, decrease costs, and shift left. For example, once the model is trained, we could query Launchable for a subset of relevant ATH tests and run them within core PRs labelled with `web-ui` (for example). The purpose of this PR is not to discuss what to do with Launchable subsets in the long term but to begin to train the model so that we can have that discussion a month or so after commit collection and test result collection have been enabled for each Launchable workspace.

### Testing done

Successful PR build.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7857"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

