### PR TITLE
[JENKINS-70774] Upgrade to Winstone 6.11 (e.g Jetty 10.0.13 to 10.0.15)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
   <properties>
     <asm.version>9.5</asm.version>
     <slf4jVersion>2.0.7</slf4jVersion>
-    <stapler.version>1777.v7c6fe6d54a_0c</stapler.version>
+    <stapler.version>1781.v62372c33644e</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.26</bridge-method-injector.version>
     <spotless.version>2.36.0</spotless.version>
     <!-- Make sure to keep the jetty-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>6.10</winstone.version>
+    <winstone.version>6.11</winstone.version>
   </properties>
 
   <!--

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -106,7 +106,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>1952.v3a_b_0cd3f5a_03</version>
+      <version>1954.v2e3fd5465b_a_6</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -643,7 +643,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>10.0.13</version>
+        <version>10.0.15</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
See [JENKINS-70774](https://issues.jenkins.io/browse/JENKINS-70774)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

* Started controller and connected an inbound Linux agent with a fixed TCP port configured (50000), confirmed the agent remained connected
* Connected an inbound Linux agent with Websocket and confirmed the agent connected
* Disabled the fixed TCP port and confirmed that the first inbound agent was no longer able to connect and the second inbound agent (using Websocket) was still able to connect

### Proposed changelog entries

- Upgrade Winstone from 6.10 to [6.11](https://github.com/jenkinsci/winstone/releases/tag/winstone-6.11) (Including upgrade of Jetty from 10.0.13 to 10.0.15 ([10.0.14 Changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.14) and [10.0.15 Changelog](https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.15))
<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7858"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

