### PR TITLE
[JENKINS-71087] create dedicated 404 error page

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5674,6 +5674,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         "adjuncts", // #getAdjuncts
         "error", // AbstractModelObject/error.jelly
         "oops", // .jelly
+        "404", // .jelly
         "signup", // #doSignup
         "tcpSlaveAgentListener", // #getTcpSlaveAgentListener
         "federatedLoginService", // #getFederatedLoginService

--- a/core/src/main/resources/jenkins/model/Jenkins/404.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/404.jelly
@@ -1,0 +1,38 @@
+<!--
+The MIT License
+
+Copyright (c) 2023 MArkus Winter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout title="Jenkins" type="one-column">
+    <l:header />
+    <l:main-panel>
+        <h1 style="text-align: center">
+          <img src="${imagesURL}/rage.svg" height="179" width="154"/> <span style="font-size:50px"><st:nbsp/>404 ${%Not found}!</span>
+        </h1>
+        <div id="error-description">
+          <h2 style="text-align: center">${%notFound}</h2>
+      </div>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/core/src/main/resources/jenkins/model/Jenkins/404.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/404.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="Jenkins" type="one-column">
+  <l:layout title="404" type="one-column">
     <l:header />
     <l:main-panel>
         <h1 style="text-align: center">

--- a/core/src/main/resources/jenkins/model/Jenkins/404.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/404.properties
@@ -1,0 +1,2 @@
+notFound=The requested page wasn’t found. <br/>\
+  This means the page really doesn’t exist or a lack of permissions to discover the corresponding page.

--- a/core/src/main/resources/jenkins/model/Jenkins/404_de.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/404_de.properties
@@ -1,0 +1,3 @@
+Not\ found=Nicht gefunden!
+notFound=Die angeforderte Seite wurde nicht gefunden.<br/>\
+  Dies bedeutet dass die Seite wirklich nicht existiert oder dass die Berechtigung fehlt, die entsprechende Seite zu entdecken.

--- a/war/src/main/webapp/WEB-INF/web.xml
+++ b/war/src/main/webapp/WEB-INF/web.xml
@@ -257,6 +257,10 @@ THE SOFTWARE.
     <exception-type>java.lang.Throwable</exception-type>
     <location>/oops</location>
   </error-page>
+  <error-page>
+    <error-code>404</error-code>
+    <location>/404</location>
+  </error-page>
 
   <session-config>
     <cookie-config>


### PR DESCRIPTION
Currently Jenkins serves the error page of the underlying servlet container when a page doesn't exist or the permissions deny the discovery of the page.
The user experience will be better if a page is returned that will look like all other pages including navigation back to the root. Add a hint that it might be a permission problem.

Tested following scenarios:
- User is logged in and accesses a non existing pages -> 404 page is served
- User is logged in and accesses a page for which he has no discover rights -> 404 page is served
- User is logged in and acceses a page for which he has discover nut no read rights -> AccessDenied page is shown (this hints that the user should login, though he is logged in, but that is something for another PR)
- User is logged out and accesses a page where anonymous has discover rights but overall read -> login page is shown
- User is logged out and accesses a page where anonymous has no discover rights but overall read -> 404 page is shown
- User is logged out and accesses a non existing page, anonymous has overall read -> 404 page is shown

Development scenario:
run a `mvn hpi:run` for a plugin:
did the same tests as above, instead of the new 404 page a page with stapler trace is shown when 
 
Things that are not optimal currently:
- The 404 page is served in a way that a user appears as not logged even though he was logged in before. This probably also implies that the used theme is the one that is globally defined.


See [JENKINS-71087](https://issues.jenkins.io/browse/JENKINS-71087)

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Show a Jenkins styled error page when a page is not found

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7865"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

