### PR TITLE
Refactor combinations in `Jenkinsfile` for readability

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,151 +12,150 @@ properties([
   disableConcurrentBuilds(abortPrevious: true)
 ])
 
-def buildTypes = ['Linux', 'Windows']
-def jdks = [11, 17, 19]
-
 def builds = [:]
-for (i = 0; i < buildTypes.size(); i++) {
-  for (j = 0; j < jdks.size(); j++) {
-    def buildType = buildTypes[i]
-    def jdk = jdks[j]
-    if (buildType == 'Windows' && jdk != 17) {
-      continue // unnecessary use of hardware
+
+def axes = [
+  platforms: ['linux', 'windows'],
+  jdks: [11, 17, 19],
+]
+axes.values().combinations {
+  def (platform, jdk) = it
+  if (platform == 'windows' && jdk != 17) {
+    return // unnecessary use of hardware
+  }
+  builds["${platform}-jdk${jdk}"] = {
+    // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#node-labels for information on what node types are available
+    def agentContainerLabel = 'maven-' + jdk
+    if (platform == 'windows') {
+      agentContainerLabel += '-windows'
     }
-    builds["${buildType}-jdk${jdk}"] = {
-      // see https://github.com/jenkins-infra/documentation/blob/master/ci.adoc#node-labels for information on what node types are available
-      def agentContainerLabel = 'maven-' + jdk
-      if (buildType == 'Windows') {
-        agentContainerLabel += '-windows'
-      }
-      retry(conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2) {
-        node(agentContainerLabel) {
-          // First stage is actually checking out the source. Since we're using Multibranch
-          // currently, we can use "checkout scm".
-          stage('Checkout') {
-            infra.checkoutSCM()
-          }
+    retry(conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2) {
+      node(agentContainerLabel) {
+        // First stage is actually checking out the source. Since we're using Multibranch
+        // currently, we can use "checkout scm".
+        stage("${platform.capitalize()} - JDK ${jdk} - Checkout") {
+          infra.checkoutSCM()
+        }
 
-          def changelistF = "${pwd tmp: true}/changelist"
-          def m2repo = "${pwd tmp: true}/m2repo"
+        def changelistF = "${pwd tmp: true}/changelist"
+        def m2repo = "${pwd tmp: true}/m2repo"
 
-          // Now run the actual build.
-          stage("${buildType} Build / Test") {
-            timeout(time: 6, unit: 'HOURS') {
-              realtimeJUnit(healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml') {
-                def mavenOptions = [
-                  '-Pdebug',
-                  '-Penable-jacoco',
-                  '--update-snapshots',
-                  "-Dmaven.repo.local=$m2repo",
-                  '-Dmaven.test.failure.ignore',
-                  '-DforkCount=2',
-                  '-Dspotbugs.failOnError=false',
-                  '-Dcheckstyle.failOnViolation=false',
-                  '-Dset.changelist',
-                  'help:evaluate',
-                  '-Dexpression=changelist',
-                  "-Doutput=$changelistF",
-                  'clean',
-                  'install',
-                ]
-                infra.runMaven(mavenOptions, jdk)
-                if (isUnix()) {
-                  sh 'git add . && git diff --exit-code HEAD'
-                }
+        // Now run the actual build.
+        stage("${platform.capitalize()} - JDK ${jdk} - Build / Test") {
+          timeout(time: 6, unit: 'HOURS') {
+            realtimeJUnit(healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml') {
+              def mavenOptions = [
+                '-Pdebug',
+                '-Penable-jacoco',
+                '--update-snapshots',
+                "-Dmaven.repo.local=$m2repo",
+                '-Dmaven.test.failure.ignore',
+                '-DforkCount=2',
+                '-Dspotbugs.failOnError=false',
+                '-Dcheckstyle.failOnViolation=false',
+                '-Dset.changelist',
+                'help:evaluate',
+                '-Dexpression=changelist',
+                "-Doutput=$changelistF",
+                'clean',
+                'install',
+              ]
+              infra.runMaven(mavenOptions, jdk)
+              if (isUnix()) {
+                sh 'git add . && git diff --exit-code HEAD'
               }
             }
           }
+        }
 
-          // Once we've built, archive the artifacts and the test results.
-          stage("${buildType} Publishing") {
-            archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
-            if (!fileExists('core/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
-              error 'JUnit 4 tests are no longer being run for the core package'
+        // Once we've built, archive the artifacts and the test results.
+        stage("${platform.capitalize()} - JDK ${jdk} - Publish") {
+          archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
+          if (!fileExists('core/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
+            error 'JUnit 4 tests are no longer being run for the core package'
+          }
+          if (!fileExists('test/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
+            error 'JUnit 4 tests are no longer being run for the test package'
+          }
+          // cli and war have been migrated to JUnit 5
+          if (failFast && currentBuild.result == 'UNSTABLE') {
+            error 'There were test failures; halting early'
+          }
+          if (platform == 'linux' && jdk == axes['jdks'][0]) {
+            def folders = env.JOB_NAME.split('/')
+            if (folders.length > 1) {
+              discoverGitReferenceBuild(scm: folders[1])
             }
-            if (!fileExists('test/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
-              error 'JUnit 4 tests are no longer being run for the test package'
-            }
-            // cli and war have been migrated to JUnit 5
-            if (failFast && currentBuild.result == 'UNSTABLE') {
-              error 'There were test failures; halting early'
-            }
-            if (buildType == 'Linux' && jdk == jdks[0]) {
-              def folders = env.JOB_NAME.split('/')
-              if (folders.length > 1) {
-                discoverGitReferenceBuild(scm: folders[1])
-              }
-              recordCoverage(tools: [[parser: 'JACOCO', pattern: 'coverage/target/site/jacoco-aggregate/jacoco.xml']], sourceCodeRetention: 'MODIFIED')
+            recordCoverage(tools: [[parser: 'JACOCO', pattern: 'coverage/target/site/jacoco-aggregate/jacoco.xml']], sourceCodeRetention: 'MODIFIED')
 
-              echo "Recording static analysis results for '${buildType}'"
-              recordIssues(
-                  enabledForFailure: true,
-                  tools: [java(), javaDoc()],
-                  filters: [excludeFile('.*Assert.java')],
-                  sourceCodeEncoding: 'UTF-8',
-                  skipBlames: true,
-                  trendChartType: 'TOOLS_ONLY'
-                  )
-              recordIssues([tool: spotBugs(pattern: '**/target/spotbugsXml.xml'),
+            echo "Recording static analysis results for '${platform.capitalize()}'"
+            recordIssues(
+                enabledForFailure: true,
+                tools: [java(), javaDoc()],
+                filters: [excludeFile('.*Assert.java')],
                 sourceCodeEncoding: 'UTF-8',
                 skipBlames: true,
-                trendChartType: 'TOOLS_ONLY',
-                qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]])
-              recordIssues([tool: checkStyle(pattern: '**/target/checkstyle-result.xml'),
-                sourceCodeEncoding: 'UTF-8',
-                skipBlames: true,
-                trendChartType: 'TOOLS_ONLY',
-                qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
-              recordIssues([tool: esLint(pattern: '**/target/eslint-warnings.xml'),
-                sourceCodeEncoding: 'UTF-8',
-                skipBlames: true,
-                trendChartType: 'TOOLS_ONLY',
-                qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
-              recordIssues([tool: styleLint(pattern: '**/target/stylelint-warnings.xml'),
-                sourceCodeEncoding: 'UTF-8',
-                skipBlames: true,
-                trendChartType: 'TOOLS_ONLY',
-                qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
-              launchable.install()
-              withCredentials([string(credentialsId: 'launchable-jenkins-jenkins', variable: 'LAUNCHABLE_TOKEN')]) {
-                launchable('verify')
-                /*
-                 * TODO Create a Launchable build and session earlier, and replace "--no-build" with
-                 * "--session" to associate these test results with a particular build. The commits
-                 * associated with the Launchable build should be the commits of the transitive
-                 * closure of the Jenkins WAR under test in this build.
-                 */
-                launchable("record tests --no-build --flavor platform=${buildType.toLowerCase()} --flavor jdk=${jdk} maven './**/target/surefire-reports'")
-              }
-              if (failFast && currentBuild.result == 'UNSTABLE') {
-                error 'Static analysis quality gates not passed; halting early'
-              }
+                trendChartType: 'TOOLS_ONLY'
+                )
+            recordIssues([tool: spotBugs(pattern: '**/target/spotbugsXml.xml'),
+              sourceCodeEncoding: 'UTF-8',
+              skipBlames: true,
+              trendChartType: 'TOOLS_ONLY',
+              qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]])
+            recordIssues([tool: checkStyle(pattern: '**/target/checkstyle-result.xml'),
+              sourceCodeEncoding: 'UTF-8',
+              skipBlames: true,
+              trendChartType: 'TOOLS_ONLY',
+              qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
+            recordIssues([tool: esLint(pattern: '**/target/eslint-warnings.xml'),
+              sourceCodeEncoding: 'UTF-8',
+              skipBlames: true,
+              trendChartType: 'TOOLS_ONLY',
+              qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
+            recordIssues([tool: styleLint(pattern: '**/target/stylelint-warnings.xml'),
+              sourceCodeEncoding: 'UTF-8',
+              skipBlames: true,
+              trendChartType: 'TOOLS_ONLY',
+              qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
+            launchable.install()
+            withCredentials([string(credentialsId: 'launchable-jenkins-jenkins', variable: 'LAUNCHABLE_TOKEN')]) {
+              launchable('verify')
               /*
-               * If the current build was successful, we send the commits to Launchable so that
-               * these commits can be consumed by a build in the Launchable BOM workspace in the
-               * future.
-               *
-               * TODO Move this up to before the present parallel block starts (or move the ATH run
-               * in this file to after joining on the present parallel block) so that these commits
-               * can be consumed by a build in the Launchable ATH workspace in this file in the
-               * future.
+               * TODO Create a Launchable build and session earlier, and replace "--no-build" with
+               * "--session" to associate these test results with a particular build. The commits
+               * associated with the Launchable build should be the commits of the transitive
+               * closure of the Jenkins WAR under test in this build.
                */
-              if (currentBuild.currentResult == 'SUCCESS') {
-                withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
-                  launchable('verify')
-                  launchable('record commit')
-                }
+              launchable("record tests --no-build --flavor platform=${platform} --flavor jdk=${jdk} maven './**/target/surefire-reports'")
+            }
+            if (failFast && currentBuild.result == 'UNSTABLE') {
+              error 'Static analysis quality gates not passed; halting early'
+            }
+            /*
+             * If the current build was successful, we send the commits to Launchable so that
+             * these commits can be consumed by a build in the Launchable BOM workspace in the
+             * future.
+             *
+             * TODO Move this up to before the present parallel block starts (or move the ATH run
+             * in this file to after joining on the present parallel block) so that these commits
+             * can be consumed by a build in the Launchable ATH workspace in this file in the
+             * future.
+             */
+            if (currentBuild.currentResult == 'SUCCESS') {
+              withCredentials([string(credentialsId: 'launchable-jenkins-bom', variable: 'LAUNCHABLE_TOKEN')]) {
+                launchable('verify')
+                launchable('record commit')
               }
+            }
 
-              def changelist = readFile(changelistF)
-              dir(m2repo) {
-                archiveArtifacts(
-                    artifacts: "**/*$changelist/*$changelist*",
-                    excludes: '**/*.lastUpdated,**/jenkins-coverage*/,**/jenkins-test*/',
-                    allowEmptyArchive: true, // in case we forgot to reincrementalify
-                    fingerprint: true
-                    )
-              }
+            def changelist = readFile(changelistF)
+            dir(m2repo) {
+              archiveArtifacts(
+                  artifacts: "**/*$changelist/*$changelist*",
+                  excludes: '**/*.lastUpdated,**/jenkins-coverage*/,**/jenkins-test*/',
+                  allowEmptyArchive: true, // in case we forgot to reincrementalify
+                  fingerprint: true
+                  )
             }
           }
         }
@@ -165,28 +164,35 @@ for (i = 0; i < buildTypes.size(); i++) {
   }
 }
 
-builds.ath = {
-  retry(conditions: [agent(), nonresumable()], count: 2) {
-    node('docker-highmem') {
-      // Just to be safe
-      deleteDir()
-      checkout scm
-      def browser = 'firefox'
-      infra.withArtifactCachingProxy {
-        sh 'bash ath.sh ' + browser
-      }
-      junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
-      launchable.install()
-      withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
-        launchable('verify')
-        /*
-         * TODO Create a Launchable build and session earlier, and replace "--no-build" with
-         * "--session" to associate these test results with a particular build. The commits
-         * associated with the Launchable build should be the commits of the transitive closure of
-         * the Jenkins WAR under test in this build as well as the commits of the transitive closure
-         * of the ATH JAR.
-         */
-        launchable("record tests --no-build --flavor platform=linux --flavor jdk=11 --flavor browser=${browser} maven './target/ath-reports'")
+def athAxes = [
+  platforms: ['linux'],
+  jdks: [11],
+  browsers: ['firefox'],
+]
+athAxes.values().combinations {
+  def (platform, jdk, browser) = it
+  builds["ath-${platform}-jdk${jdk}-${browser}"] = {
+    retry(conditions: [agent(), nonresumable()], count: 2) {
+      node('docker-highmem') {
+        // Just to be safe
+        deleteDir()
+        checkout scm
+        infra.withArtifactCachingProxy {
+          sh 'bash ath.sh ' + browser
+        }
+        junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
+        launchable.install()
+        withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
+          launchable('verify')
+          /*
+           * TODO Create a Launchable build and session earlier, and replace "--no-build" with
+           * "--session" to associate these test results with a particular build. The commits
+           * associated with the Launchable build should be the commits of the transitive closure of
+           * the Jenkins WAR under test in this build as well as the commits of the transitive closure
+           * of the ATH JAR.
+           */
+          launchable("record tests --no-build --flavor platform=${platform} --flavor jdk=${jdk} --flavor browser=${browser} maven './target/ath-reports'")
+        }
       }
     }
   }


### PR DESCRIPTION
This `Jenkinsfile` includes a matrix of combinations, which is a common pattern in builds (common enough that declarative Pipeline jobs feature dedicated syntax for it). This PR refactors the `Jenkinsfile` to use the Groovy `combinations` method to produce the combinations, which improves readability a little I think. I plan to make the same change in ATH.

### Testing done

I will check the CI build once it completes.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7869"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

