### PR TITLE
[JENKINS-71115] Builds filter field doesn't use full width on sub 970px windows

### DIFF
--- a/war/src/main/scss/form/search-bar.scss
+++ b/war/src/main/scss/form/search-bar.scss
@@ -6,7 +6,6 @@
   --search-bar-height: 2.375rem;
 
   position: relative;
-  max-width: 420px;
 
   &__input {
     appearance: none;


### PR DESCRIPTION
## Removed `max-width:420` from `search-bar.scss` which resolved the issue
* After changes the Build filter field is flexible with relative to browser window size. 
* This pull request does not have any test because the changes was in `scss` file. 
* Kindly do let me know if I have missed anything by chance. 

See [JENKINS-71115](https://issues.jenkins.io/browse/JENKINS-71115).


### Testing done
* I have build and tested on my PC and it works as needed. 
* The Build filter filed cover size with respect to browser window. 

### Proposed changelog entries

- Show full width filter field for builds on pages less than 970 pixels wide.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.

### Desired reviewers

New to this community. Happy to connect with anyone to build long term friendship/mentorship.

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7870"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

