### PR TITLE
[JENKINS-71139] Fail fast when serializing invalid XML 1.1 data

### DIFF
--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -138,7 +138,7 @@ public class XStream2 extends XStream {
 
         @Override
         public HierarchicalStreamWriter createWriter(Writer out) {
-            return new PrettyPrintWriter(out, getNameCoder());
+            return new PrettyPrintWriter(out, PrettyPrintWriter.XML_1_1, getNameCoder());
         }
 
         @Override

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableMap;
 import com.thoughtworks.xstream.XStreamException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.mapper.CannotResolveClassException;
+import hudson.Functions;
 import hudson.model.Result;
 import hudson.model.Run;
 import java.io.ByteArrayInputStream;
@@ -56,7 +57,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -599,7 +599,6 @@ public class XStream2Test {
     }
 
     @Issue("JENKINS-71139")
-    @Ignore("TODO ParseError: The reference to entity \"y\" must end with the ';' delimiter.")
     @Test
     public void nullsWithoutEncodingDeclaration() throws Exception {
         Bar b = new Bar();
@@ -607,7 +606,12 @@ public class XStream2Test {
         b.s = text;
         StringWriter w = new StringWriter();
         XStream2 xs = new XStream2();
-        xs.toXML(b, w);
+        try {
+            xs.toXML(b, w);
+        } catch (RuntimeException x) {
+            assertThat("cause is com.thoughtworks.xstream.io.StreamException: Invalid character 0x0 in XML stream", Functions.printThrowable(x), containsString("0x0"));
+            return; // not supported to read either
+        }
         String xml = w.toString();
         assertThat(xml, not(containsString("version=\"1.1\"")));
         System.out.println(xml);
@@ -616,7 +620,6 @@ public class XStream2Test {
     }
 
     @Issue("JENKINS-71139")
-    @Ignore("TODO ParseError: The reference to entity \"y\" must end with the ';' delimiter.")
     @Test
     public void nullsWithEncodingDeclaration() throws Exception {
         Bar b = new Bar();
@@ -624,7 +627,12 @@ public class XStream2Test {
         b.s = text;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         XStream2 xs = new XStream2();
-        xs.toXMLUTF8(b, baos);
+        try {
+            xs.toXMLUTF8(b, baos);
+        } catch (RuntimeException x) {
+            assertThat("cause is com.thoughtworks.xstream.io.StreamException: Invalid character 0x0 in XML stream", Functions.printThrowable(x), containsString("0x0"));
+            return; // not supported to read either
+        }
         String xml = baos.toString(StandardCharsets.UTF_8);
         System.out.println(xml);
         assertThat(xml, containsString("version=\"1.1\""));


### PR DESCRIPTION
See [JENKINS-71139](https://issues.jenkins.io/browse/JENKINS-71139). Whether the usage that was broken was valid to begin with is open to interpretation; given https://github.com/jenkinsci/junit-plugin/pull/521 this just fails during the write rather than the read.

It is possible there are other plugins saving arbitrary user-generated text content via XStream which might be affected, though it seems unlikely any would be as widely used as `junit`.  For a general defense, `PrettyPrintWriter.writeText` (and `.writeAttributeValue`) could quietly replace NULs with some placeholder such as `^@` and not pretend to round-trip them.

### Testing done

The suppressed tests fail with

```
javax.xml.stream.XMLStreamException: ParseError at [row,col]:[3,13]
Message: The reference to entity "y" must end with the ';' delimiter.
```

If the main source change from #7778 is commented out, they pass (but then of course `testEmojiEscaped` fails).

This behavior seems to be intentional in the StAX driver: https://github.com/x-stream/xstream/blob/289ae780001c31d7d5d75e0d58608c13f44549a2/xstream/src/test/com/thoughtworks/xstream/io/xml/StaxReaderTest.java#L64-L67

### Proposed changelog entries

Do not write NUL values to XML files. A technically illegal `&#x0;` could be written to Jenkins XML files but could no longer be read. Now the write will fail as well (regression in 2.398).

### Proposed upgrade guidelines

Jenkins XML files can no longer save text content with the ASCII NUL character (U+0000). In particular, if you are using the `junit` plugin to publish test results, be sure to update it to at least `1198.ve38db_d1b_c975` to avoid problems with new builds. (Test results published with older versions of the plugin will remain unreadable.)

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7875"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

