### PR TITLE
2nd Backporting for LTS 2.387.3

### DIFF
--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -138,7 +138,7 @@ public class XStream2 extends XStream {
 
         @Override
         public HierarchicalStreamWriter createWriter(Writer out) {
-            return new PrettyPrintWriter(out, getNameCoder());
+            return new PrettyPrintWriter(out, PrettyPrintWriter.XML_1_1, getNameCoder());
         }
 
         @Override

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -26,7 +26,9 @@ package hudson.util;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -38,10 +40,15 @@ import com.google.common.collect.ImmutableMap;
 import com.thoughtworks.xstream.XStreamException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.mapper.CannotResolveClassException;
+import hudson.Functions;
 import hudson.model.Result;
 import hudson.model.Run;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -590,4 +597,47 @@ public class XStream2Test {
         }
         assertEquals("Fox 🦊", bar.s);
     }
+
+    @Issue("JENKINS-71139")
+    @Test
+    public void nullsWithoutEncodingDeclaration() throws Exception {
+        Bar b = new Bar();
+        String text = "x\u0000y";
+        b.s = text;
+        StringWriter w = new StringWriter();
+        XStream2 xs = new XStream2();
+        try {
+            xs.toXML(b, w);
+        } catch (RuntimeException x) {
+            assertThat("cause is com.thoughtworks.xstream.io.StreamException: Invalid character 0x0 in XML stream", Functions.printThrowable(x), containsString("0x0"));
+            return; // not supported to read either
+        }
+        String xml = w.toString();
+        assertThat(xml, not(containsString("version=\"1.1\"")));
+        System.out.println(xml);
+        b = (Bar) xs.fromXML(xml);
+        assertEquals(text, b.s);
+    }
+
+    @Issue("JENKINS-71139")
+    @Test
+    public void nullsWithEncodingDeclaration() throws Exception {
+        Bar b = new Bar();
+        String text = "x\u0000y";
+        b.s = text;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        XStream2 xs = new XStream2();
+        try {
+            xs.toXMLUTF8(b, baos);
+        } catch (RuntimeException x) {
+            assertThat("cause is com.thoughtworks.xstream.io.StreamException: Invalid character 0x0 in XML stream", Functions.printThrowable(x), containsString("0x0"));
+            return; // not supported to read either
+        }
+        String xml = baos.toString(StandardCharsets.UTF_8);
+        System.out.println(xml);
+        assertThat(xml, containsString("version=\"1.1\""));
+        b = (Bar) xs.fromXML(new ByteArrayInputStream(baos.toByteArray()));
+        assertEquals(text, b.s);
+    }
+
 }


### PR DESCRIPTION
```shell
Latest core version: jenkins-2.400

Fixed
-----

JENKINS-71139           Critical                <a href="https://github.com/jenkinsci/junit-plugin/releases/tag/1198.ve38db_d1b_c975">https://github.com/jenkinsci/junit-plugin/releases/tag/1198.ve38db_d1b_c975</a>
        XStream2 unable to round-trip ASCII NUL in stdout/stderr in junitResult.xml
        regression
        https://issues.jenkins.io/browse/JENKINS-71139

JENKINS-70820           Minor                   2.396
        "New Node" button missing in Web UI
        regression
        https://issues.jenkins.io/browse/JENKINS-70820

JENKINS-70809           Minor                   2.397
        "delete build" button overflow the side-panel
        regression
        https://issues.jenkins.io/browse/JENKINS-70809

JENKINS-69489           Minor                   2.396
        plugin manager restart looks interactive but is not
        regression
        https://issues.jenkins.io/browse/JENKINS-69489

JENKINS-69129           Minor                   2.398
        DisplayName and unicode character
        https://issues.jenkins.io/browse/JENKINS-69129
                Caused https://issues.jenkins.io/browse/JENKINS-71139
```

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7885"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

