### PR TITLE
[JENKINS-71152] The System page breadcrumb no longer displays a list of page sections

### DIFF
--- a/war/src/main/js/components/dropdowns/inpage-jumplist.js
+++ b/war/src/main/js/components/dropdowns/inpage-jumplist.js
@@ -12,7 +12,7 @@ function init() {
     chevron.classList.add("children");
     chevron.items = Array.from(
       document.querySelectorAll(
-        "form > div > div > .jenkins-section > .jenkins-section__title"
+        "form > div > .jenkins-section > .jenkins-section__title"
       )
     ).map((section) => {
       section.id = toId(section.textContent);


### PR DESCRIPTION
See [JENKINS-71152](https://issues.jenkins.io/browse/JENKINS-71152).

Clicking the System breadcrumb used to display the list of sections on that page, it no longer does. This PR fixes that so that it lists them.

**Before**
<img width="189" alt="image" src="https://user-images.githubusercontent.com/43062514/234593640-4cdaca9d-9306-4d2c-89d9-fc7e944dac96.png">

**After** 
<img width="416" alt="image" src="https://user-images.githubusercontent.com/43062514/234593716-8e0871bc-6fe7-4c80-ae96-cf3df63feade.png">

### Testing done

* On the System page the breadcrumb now displays the sections, clicking one takes you to that section

### Proposed changelog entries

- Do not display a list of page sections on the System page breadcrumb.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7887"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

