### PR TITLE
Introduced utility `HttpServletFilter`

### DIFF
--- a/core/src/main/java/hudson/util/PluginServletFilter.java
+++ b/core/src/main/java/hudson/util/PluginServletFilter.java
@@ -43,6 +43,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import jenkins.model.Jenkins;
+import jenkins.util.HttpServletFilter;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -96,6 +97,11 @@ public final class PluginServletFilter implements Filter, ExtensionPoint {
         config.getServletContext().setAttribute(KEY, this);
     }
 
+    /**
+     * Dynamically register a new filter.
+     * May be paired with {@link #removeFilter}.
+     * <p>For most purposes you can instead use {@link HttpServletFilter}.
+     */
     public static void addFilter(Filter filter) throws ServletException {
         Jenkins j = Jenkins.getInstanceOrNull();
 

--- a/core/src/main/java/jenkins/security/ResourceDomainFilter.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainFilter.java
@@ -24,6 +24,7 @@
 
 package jenkins.security;
 
+import hudson.Extension;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -42,6 +43,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  *
  * @since 2.200
  */
+@Extension
 @Restricted(NoExternalUse.class)
 public class ResourceDomainFilter implements HttpServletFilter {
 

--- a/core/src/main/java/jenkins/security/ResourceDomainFilter.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainFilter.java
@@ -24,22 +24,15 @@
 
 package jenkins.security;
 
-import hudson.init.InitMilestone;
-import hudson.init.Initializer;
-import hudson.util.PluginServletFilter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import jenkins.util.HttpServletFilter;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -50,44 +43,25 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @since 2.200
  */
 @Restricted(NoExternalUse.class)
-public class ResourceDomainFilter implements Filter {
+public class ResourceDomainFilter implements HttpServletFilter {
 
     private static final Logger LOGGER = Logger.getLogger(ResourceDomainFilter.class.getName());
 
     private static final Set<String> ALLOWED_PATHS = new HashSet<>(Arrays.asList("/" + ResourceDomainRootAction.URL, "/favicon.ico", "/favicon.svg", "/robots.txt"));
     public static final String ERROR_RESPONSE = "Jenkins serves only static files on this domain.";
 
-    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
-    public static void init() throws ServletException {
-        PluginServletFilter.addFilter(new ResourceDomainFilter());
-    }
-
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
-            throws IOException, ServletException {
-        if (servletRequest instanceof HttpServletRequest) {
-            HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-            HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
-            if (ResourceDomainConfiguration.isResourceRequest(httpServletRequest)) {
-                String path = httpServletRequest.getPathInfo();
-                if (!path.startsWith("/" + ResourceDomainRootAction.URL + "/") && !ALLOWED_PATHS.contains(path)) {
-                    LOGGER.fine(() -> "Rejecting request to " + httpServletRequest.getRequestURL() + " from " + httpServletRequest.getRemoteAddr() + " on resource domain");
-                    httpServletResponse.sendError(404, ERROR_RESPONSE);
-                    return;
-                }
-                LOGGER.finer(() -> "Accepting request to " + httpServletRequest.getRequestURL() + " from " + httpServletRequest.getRemoteAddr() + " on resource domain");
+    public boolean handle(HttpServletRequest req, HttpServletResponse rsp) throws IOException, ServletException {
+        if (ResourceDomainConfiguration.isResourceRequest(req)) {
+            String path = req.getPathInfo();
+            if (!path.startsWith("/" + ResourceDomainRootAction.URL + "/") && !ALLOWED_PATHS.contains(path)) {
+                LOGGER.fine(() -> "Rejecting request to " + req.getRequestURL() + " from " + req.getRemoteAddr() + " on resource domain");
+                rsp.sendError(404, ERROR_RESPONSE);
+                return true;
             }
+            LOGGER.finer(() -> "Accepting request to " + req.getRequestURL() + " from " + req.getRemoteAddr() + " on resource domain");
         }
-        filterChain.doFilter(servletRequest, servletResponse);
+        return false;
     }
 
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-
-    }
-
-    @Override
-    public void destroy() {
-
-    }
 }

--- a/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
+++ b/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
@@ -26,25 +26,18 @@ package jenkins.telemetry.impl;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.init.InitMilestone;
-import hudson.init.Initializer;
-import hudson.util.PluginServletFilter;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import jenkins.telemetry.Telemetry;
+import jenkins.util.HttpServletFilter;
 import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -95,30 +88,13 @@ public class UserLanguages extends Telemetry {
         return payload;
     }
 
-    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
-    public static void setUpFilter() {
-        Filter filter = new AcceptLanguageFilter();
-        if (!PluginServletFilter.hasFilter(filter)) {
-            try {
-                PluginServletFilter.addFilter(filter);
-            } catch (ServletException ex) {
-                LOGGER.log(Level.WARNING, "Failed to set up languages servlet filter", ex);
-            }
-        }
-    }
-
-    public static final class AcceptLanguageFilter implements Filter {
+    @Extension
+    public static final class AcceptLanguageFilter implements HttpServletFilter {
 
         @Override
-        public void init(FilterConfig filterConfig) {
-
-        }
-
-        @Override
-        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-            if (request instanceof HttpServletRequest && !Telemetry.isDisabled()) {
-                HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-                String language = httpServletRequest.getHeader("Accept-Language");
+        public boolean handle(HttpServletRequest req, HttpServletResponse rsp) throws IOException, ServletException {
+            if (!Telemetry.isDisabled()) {
+                String language = req.getHeader("Accept-Language");
                 if (language != null) {
                     if (!requestsByLanguage.containsKey(language)) {
                         requestsByLanguage.put(language, new AtomicLong(0));
@@ -126,23 +102,8 @@ public class UserLanguages extends Telemetry {
                     requestsByLanguage.get(language).incrementAndGet();
                 }
             }
-            chain.doFilter(request, response);
+            return false;
         }
 
-        @Override
-        public void destroy() {
-
-        }
-
-        @Override
-        public boolean equals(Object obj) { // support PluginServletFilter#hasFilter
-            return obj != null && obj.getClass() == AcceptLanguageFilter.class;
-        }
-
-        // findbugs
-        @Override
-        public int hashCode() {
-            return 42;
-        }
     }
 }

--- a/core/src/main/java/jenkins/util/HttpServletFilter.java
+++ b/core/src/main/java/jenkins/util/HttpServletFilter.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.util;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.init.Initializer;
+import hudson.security.csrf.CrumbExclusion;
+import hudson.util.PluginServletFilter;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+/**
+ * More convenient and declarative way to use {@link PluginServletFilter}.
+ * Register an implementation if you wish to intercept certain HTTP requests.
+ * Typical implementations will inspect {@link HttpServletRequest#getPathInfo} to determine if they should be active.
+ * @since TODO
+ * @see CrumbExclusion
+ */
+public interface HttpServletFilter extends ExtensionPoint {
+
+    /**
+     * Potentially intercepts or otherwise modifies an HTTP request.
+     * @param req as in {@link Filter#doFilter}
+     * @param rsp as in {@link Filter#doFilter}
+     * @return true if this request was handled; false to proceed with other handlers ({@link FilterChain})
+     * @throws IOException as in {@link Filter#doFilter}
+     * @throws ServletException as in {@link Filter#doFilter}
+     */
+    boolean handle(HttpServletRequest req, HttpServletResponse rsp) throws IOException, ServletException;
+
+    @Restricted(DoNotUse.class)
+    @Initializer
+    static void register() throws ServletException {
+        PluginServletFilter.addFilter(new Filter() {
+            @Override
+            public void doFilter(ServletRequest req, ServletResponse rsp, FilterChain chain) throws IOException, ServletException {
+                if (req instanceof HttpServletRequest && rsp instanceof HttpServletResponse) {
+                    for (HttpServletFilter filter : ExtensionList.lookup(HttpServletFilter.class)) {
+                        if (filter.handle((HttpServletRequest) req, (HttpServletResponse) rsp)) {
+                            return;
+                        }
+                    }
+                }
+                chain.doFilter(req, rsp);
+            }
+
+            @Override
+            public void init(FilterConfig filterConfig) {
+            }
+
+            @Override
+            public void destroy() {
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
I have come across a number of uses of `PluginServletFilter.addFilter` over the years. While it works, it has some minor drawbacks:

* Since it is a procedural call, you must do a little extra work to run an `@Initializer`. Most plugin contributions are expressed as `@Extension`s (which are also orderable if the need arises).
* You get a `ServletRequest` and `ServletResponse` and have to cast, even though Jetty is never going to be handling any other kind of request.
* The `FilterChain` idiom is somewhat low-level. Most implementations wind up either delegating at the end, or not.
* When a lot of filters are installed, the stack of an HTTP handler thread can get pretty deep. For someone looking at a thread dump, most if not all of those methods are irrelevant because they are in a tail call.

This new utility makes for simpler usage in typical cases. Shown here with a couple of example usages in core. Usages from `SetupWizard` and `HudsonPrivateSecurityRealm` would not be good candidates since they involve dynamically inserting or retracting a filter. There are other cases where the chain delegation is not a tail call ([example](https://github.com/jenkinsci/timemachine-plugin/blob/d2f32fd9cf424e4a0605535df1c6d2e52c9bbd21/src/main/java/fr/loof/jenkins/timemachine/TimeMachineFilter.java#L32-L35)) which would likewise not be suited to the new API.

### Testing done

Copied from a utility used successfully in a proprietary plugin (with tests).

### Proposed changelog entries

- Added a utility `HttpServletFilter` to the API.

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7892"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

