### PR TITLE
Improve WebSocket `Provider` interface

### DIFF
--- a/core/src/main/java/jenkins/websocket/WebSocketSession.java
+++ b/core/src/main/java/jenkins/websocket/WebSocketSession.java
@@ -69,7 +69,8 @@ public abstract class WebSocketSession {
         if (PING_INTERVAL_SECONDS != 0) {
             pings = Timer.get().scheduleAtFixedRate(() -> {
                 try {
-                    handler.sendPing(ByteBuffer.wrap(new byte[0]));
+                    Future<Void> f = handler.sendPing(ByteBuffer.wrap(new byte[0]));
+                    // TODO do something interesting with the future
                 } catch (Exception x) {
                     error(x);
                     pings.cancel(true);

--- a/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
+++ b/websocket/jetty10/src/main/java/jenkins/websocket/Jetty10Provider.java
@@ -104,10 +104,10 @@ public class Jetty10Provider implements Provider {
             }
 
             @Override
-            public void sendPing(ByteBuffer applicationData) throws IOException {
+            public Future<Void> sendPing(ByteBuffer applicationData) throws IOException {
                 CompletableFuture<Void> f = new CompletableFuture<>();
                 session().getRemote().sendPing(applicationData, new WriteCallbackImpl(f));
-                // TODO return f;
+                return f;
             }
 
             @Override

--- a/websocket/spi/src/main/java/jenkins/websocket/Provider.java
+++ b/websocket/spi/src/main/java/jenkins/websocket/Provider.java
@@ -69,7 +69,7 @@ interface Provider {
 
         Future<Void> sendText(String text) throws IOException;
 
-        void sendPing(ByteBuffer applicationData) throws IOException;
+        Future<Void> sendPing(ByteBuffer applicationData) throws IOException;
 
         void close() throws IOException;
 


### PR DESCRIPTION
This PR improves the WebSocket `Provider` interface to return the future from its `sendPing` method. Previously the future was being hidden from callers only in order to support Jetty 9, which did not expose the future. Now that Jetty 9 support there is no reason not to return the future to consumers, and doing so makes this method consistent with the other methods in the same interface which also expose the future. In addition this provides consumers the option of doing something interesting with the future. In order to eliminate any risk of regression, I am not actually changing the behavior of the (single) consumer of this API in this PR, but I left a comment to indicate the future improvement that could now be made. So in essence this is moving the TODO comment from the producer to the consumer. This is a very minor but net positive change, as it makes the interface boundary more clear.

### Testing done

A local build passed, and the CI build should be sufficient to ensure there are no regressions.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7915"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

