### PR TITLE
Fix Launchable test result collection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,14 +156,6 @@ axes.values().combinations {
               skipBlames: true,
               trendChartType: 'TOOLS_ONLY',
               qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]]])
-            launchable.install()
-            withCredentials([string(credentialsId: 'launchable-jenkins-jenkins', variable: 'LAUNCHABLE_TOKEN')]) {
-              launchable('verify')
-              def sessionFile = "launchable-session-${platform}-jdk${jdk}.txt"
-              unstash sessionFile
-              def session = readFile(sessionFile).trim()
-              launchable("record tests --session ${session} --flavor platform=${platform} --flavor jdk=${jdk} --link \"View session in CI\"=${env.BUILD_URL} maven './**/target/surefire-reports'")
-            }
             if (failFast && currentBuild.result == 'UNSTABLE') {
               error 'Static analysis quality gates not passed; halting early'
             }
@@ -176,6 +168,14 @@ axes.values().combinations {
                   fingerprint: true
                   )
             }
+          }
+          launchable.install()
+          withCredentials([string(credentialsId: 'launchable-jenkins-jenkins', variable: 'LAUNCHABLE_TOKEN')]) {
+            launchable('verify')
+            def sessionFile = "launchable-session-${platform}-jdk${jdk}.txt"
+            unstash sessionFile
+            def session = readFile(sessionFile).trim()
+            launchable("record tests --session ${session} --flavor platform=${platform} --flavor jdk=${jdk} --link \"View session in CI\"=${env.BUILD_URL} maven './**/target/surefire-reports'")
           }
         }
       }


### PR DESCRIPTION
Observed in a recent test run:

```
+ launchable/bin/launchable record tests --build jenkins-Core-jenkins-master-4851 --flavor platform=linux --flavor jdk=11 --link 'View session in CI=https://ci.jenkins.io/job/Core/job/jenkins/job/master/4851/' maven './**/target/surefire-reports'
Traceback (most recent call last):
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/launchable/commands/record/tests.py", line 198, in tests
    session_id = str(find_or_create_session(
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/launchable/commands/helper.py", line 54, in find_or_create_session
    raise click.UsageError(
click.exceptions.UsageError: No saved build name found.
To fix this, run `launchable record build`.
If you already ran this command on a different machine, use the --session option. See https://docs.launchableinc.com/sending-data-to-launchable/managing-complex-test-session-layouts
Traceback (most recent call last):
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/bin/launchable", line 8, in <module>
    sys.exit(main())
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/jenkins/agent/workspace/Core_jenkins_master/launchable/lib/python3.10/site-packages/launchable/test_runners/launchable.py", line 117, in record_tests
    client.scan(t, file_mask)
AttributeError: 'AppBase' object has no attribute 'scan'
script returned exit code 1
```

### Testing done

Will check the CI build of this PR to ensure the error is gone.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7919"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

