### PR TITLE
Deleting unused `ConfidentialStore.TEST`

### DIFF
--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -68,8 +68,6 @@ public abstract class ConfidentialStore {
      * Retrieves the currently active singleton instance of {@link ConfidentialStore}.
      */
     public static @NonNull ConfidentialStore get() {
-        if (TEST != null) return TEST.get();
-
         Jenkins j = Jenkins.getInstanceOrNull();
         if (j == null) {
             return Mock.INSTANCE;
@@ -99,12 +97,6 @@ public abstract class ConfidentialStore {
         }
         return cs;
     }
-
-   /**
-     * @deprecated No longer needed.
-     */
-    @Deprecated
-    /*package*/ static ThreadLocal<ConfidentialStore> TEST = null;
 
     static final class Mock extends ConfidentialStore {
 


### PR DESCRIPTION
Cleaning up a package-scoped field that apparently should have been deleted in #4603 but was merely deprecated.

### Testing done

N/A

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7925"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

