### PR TITLE
Introduce `jenkins.model.queue.QueueItem` interface

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -26,6 +26,7 @@
 package hudson.model;
 
 import static hudson.init.InitMilestone.JOB_CONFIG_ADAPTED;
+import static hudson.model.Item.CANCEL;
 import static hudson.util.Iterators.reverse;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -1930,25 +1931,32 @@ public class Queue extends ResourceController implements Saveable {
          * Checks the permission to see if the current user can abort this executable.
          * Returns normally from this method if it's OK.
          * <p>
-         * NOTE: If you have implemented {@link AccessControlled} this should just be
+         * NOTE: If you have implemented {@link AccessControlled} this defaults to
          * {@code checkPermission(hudson.model.Item.CANCEL);}
          *
          * @throws AccessDeniedException if the permission is not granted.
          */
-        default void checkAbortPermission() {}
+        default void checkAbortPermission() {
+            if (this instanceof AccessControlled) {
+                ((AccessControlled) this).checkPermission(CANCEL);
+            }
+        }
 
         /**
          * Works just like {@link #checkAbortPermission()} except it indicates the status by a return value,
          * instead of exception.
          * Also used by default for {@link hudson.model.Queue.Item#hasCancelPermission}.
          * <p>
-         * NOTE: If you have implemented {@link AccessControlled} this should just be
+         * NOTE: If you have implemented {@link AccessControlled} this returns by default
          * {@code return hasPermission(hudson.model.Item.CANCEL);}
          *
          * @return false
          *      if the user doesn't have the permission.
          */
         default boolean hasAbortPermission() {
+            if (this instanceof AccessControlled) {
+                return ((AccessControlled) this).hasPermission(CANCEL);
+            }
             return true;
         }
 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1935,7 +1935,7 @@ public class Queue extends ResourceController implements Saveable {
          *
          * @throws AccessDeniedException if the permission is not granted.
          */
-        void checkAbortPermission();
+        default void checkAbortPermission() {}
 
         /**
          * Works just like {@link #checkAbortPermission()} except it indicates the status by a return value,
@@ -1948,7 +1948,9 @@ public class Queue extends ResourceController implements Saveable {
          * @return false
          *      if the user doesn't have the permission.
          */
-        boolean hasAbortPermission();
+        default boolean hasAbortPermission() {
+            return true;
+        }
 
         /**
          * Returns the URL of this task relative to the context root of the application.

--- a/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/BuildHistoryWidget.java
@@ -24,11 +24,11 @@
 
 package hudson.widgets;
 
-import hudson.model.Queue.Item;
 import hudson.model.Queue.Task;
 import java.util.LinkedList;
 import java.util.List;
 import jenkins.model.Jenkins;
+import jenkins.model.queue.QueueItem;
 import jenkins.widgets.HistoryPageFilter;
 
 /**
@@ -52,17 +52,17 @@ public class BuildHistoryWidget<T> extends HistoryWidget<Task, T> {
     /**
      * Returns the first queue item if the owner is scheduled for execution in the queue.
      */
-    public Item getQueuedItem() {
+    public QueueItem getQueuedItem() {
         return Jenkins.get().getQueue().getItem(owner);
     }
 
     /**
      * Returns the queue item if the owner is scheduled for execution in the queue, in REVERSE ORDER
      */
-    public List<Item> getQueuedItems() {
-        LinkedList<Item> list = new LinkedList<>();
-        for (Item item : Jenkins.get().getQueue().getItems()) {
-            if (item.task == owner) {
+    public List<QueueItem> getQueuedItems() {
+        LinkedList<QueueItem> list = new LinkedList<>();
+        for (QueueItem item : Jenkins.get().getQueue().getItems()) {
+            if (item.getTask() == owner) {
                 list.addFirst(item);
             }
         }

--- a/core/src/main/java/jenkins/model/queue/QueueItem.java
+++ b/core/src/main/java/jenkins/model/queue/QueueItem.java
@@ -10,7 +10,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 
 /**
- * Interface used by Jelly views to render a queue item through &lt;t:queue&gt;.
+ * Interface used by Jelly views to render a queue item through {@code <t:queue>}.
  * @since TODO
  */
 @Restricted(Beta.class)
@@ -68,11 +68,11 @@ public interface QueueItem extends ModelObject {
     String getInQueueForString();
 
     /**
-     * @return a display name for this queue item. Would typically default to {@link Queue.Task#getFullDisplayName()}.
+     * @return a display name for this queue item; by default, {@link Queue.Task#getFullDisplayName()}
      */
     @CheckForNull
     @Override
     default String getDisplayName() {
-        return getTask().getDisplayName();
+        return getTask().getFullDisplayName();
     }
 }

--- a/core/src/main/java/jenkins/model/queue/QueueItem.java
+++ b/core/src/main/java/jenkins/model/queue/QueueItem.java
@@ -1,0 +1,78 @@
+package jenkins.model.queue;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Cause;
+import hudson.model.ModelObject;
+import hudson.model.Queue;
+import hudson.model.Run;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
+
+/**
+ * Interface used by Jelly views to render a queue item through &lt;t:queue&gt;.
+ * @since TODO
+ */
+@Restricted(Beta.class)
+public interface QueueItem extends ModelObject {
+    /**
+     * @return true if the item is starving for an executor for too long.
+     */
+    boolean isStuck();
+
+    /**
+     * @return The underlying {@link Queue.Task} currently in queue.
+     */
+    @NonNull
+    Queue.Task getTask();
+
+    /**
+     * Checks whether a scheduled item may be canceled.
+     * @return by default, the same as {@link Queue.Task#hasAbortPermission}
+     */
+    default boolean hasCancelPermission() {
+        return getTask().hasAbortPermission();
+    }
+
+    /**
+     * Unique ID (per controller) that tracks the {@link Queue.Task} as it moves through different stages
+     * in the queue (each represented by different implementations of {@link QueueItem} and into any subsequent
+     * {@link Run} instance (see {@link Run#getQueueId()}).
+     */
+    long getId();
+
+    /**
+     * Convenience method that returns a read only view of the {@link Cause}s associated with this item in the queue as a single string.
+     */
+    @NonNull
+    String getCausesDescription();
+
+    /**
+     * Gets a human-readable status message describing why it's in the queue.
+     * May return null if there is no cause of blockage.
+     */
+    @CheckForNull
+    String getWhy();
+
+    /**
+     * Gets a human-readable message about the parameters of this item
+     */
+    @NonNull
+    String getParams();
+
+    /**
+     * Returns a human readable presentation of how long this item is already in the queue.
+     * E.g. something like '3 minutes 40 seconds'
+     */
+    @NonNull
+    String getInQueueForString();
+
+    /**
+     * @return a display name for this queue item. Would typically default to {@link Queue.Task#getFullDisplayName()}.
+     */
+    @CheckForNull
+    @Override
+    default String getDisplayName() {
+        return getTask().getDisplayName();
+    }
+}

--- a/core/src/main/java/jenkins/widgets/HistoryPageEntry.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageEntry.java
@@ -25,14 +25,14 @@
 package jenkins.widgets;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.model.Queue;
 import hudson.model.Run;
+import jenkins.model.queue.QueueItem;
 
 /**
  * Represents an entry used by the {@link HistoryPageFilter}.
  *
  * <p>
- * Wraps {@link Queue.Item} and {@link Run} instances from the build queue, normalizing
+ * Wraps {@link QueueItem} and {@link Run} instances from the build queue, normalizing
  * access to the info required for pagination.
  *
  *
@@ -55,8 +55,8 @@ public class HistoryPageEntry<T> {
     }
 
     protected static long getEntryId(@NonNull Object entry) {
-        if (entry instanceof Queue.Item) {
-            return ((Queue.Item) entry).getId();
+        if (entry instanceof QueueItem) {
+            return ((QueueItem) entry).getId();
         } else if (entry instanceof Run) {
             Run run = (Run) entry;
             return Long.MIN_VALUE + run.getNumber();

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import jenkins.model.queue.QueueItem;
 
 /**
  * History page filter.
@@ -55,9 +56,9 @@ public class HistoryPageFilter<T> {
     private Long olderThan;
     private String searchString;
 
-    // Need to use different Lists for Queue.Items and Runs because
+    // Need to use different Lists for QueueItem and Runs because
     // we need access to them separately in the jelly files for rendering.
-    public final List<HistoryPageEntry<Queue.Item>> queueItems = new ArrayList<>();
+    public final List<HistoryPageEntry<QueueItem>> queueItems = new ArrayList<>();
     public final List<HistoryPageEntry<Run>> runs = new ArrayList<>();
 
     @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
@@ -128,7 +129,7 @@ public class HistoryPageFilter<T> {
      * @param queueItems The queue items to be added. Queue items do not need to be sorted.
      * @since 2.17
      */
-    public void add(@NonNull Iterable<T> runItems, @NonNull List<Queue.Item> queueItems) {
+    public void add(@NonNull Iterable<T> runItems, @NonNull List<QueueItem> queueItems) {
         sort(queueItems);
         addInternal(Iterables.concat(queueItems, runItems));
     }
@@ -136,7 +137,7 @@ public class HistoryPageFilter<T> {
     /**
      * Add items to the History page, internal implementation.
      * @param items The items to be added.
-     * @param <ItemT> The type of items should either be T or Queue.Item.
+     * @param <ItemT> The type of items should either be T or {@link QueueItem}.
      */
     private <ItemT> void addInternal(@NonNull Iterable<ItemT> items) {
         // Note that items can be a large lazily evaluated collection,
@@ -240,8 +241,8 @@ public class HistoryPageFilter<T> {
     }
 
     private long getNextBuildNumber(@NonNull Object entry) {
-        if (entry instanceof Queue.Item) {
-            Queue.Task task = ((Queue.Item) entry).task;
+        if (entry instanceof QueueItem) {
+            Queue.Task task = ((QueueItem) entry).getTask();
             if (task instanceof Job) {
                 return ((Job) task).getNextBuildNumber();
             }
@@ -253,8 +254,8 @@ public class HistoryPageFilter<T> {
         return HistoryPageEntry.getEntryId(entry) + 1;
     }
 
-    private void addQueueItem(Queue.Item item) {
-        HistoryPageEntry<Queue.Item> entry = new HistoryPageEntry<>(item);
+    private void addQueueItem(QueueItem item) {
+        HistoryPageEntry<QueueItem> entry = new HistoryPageEntry<>(item);
         queueItems.add(entry);
         updateNewestOldest(entry.getEntryId());
     }
@@ -279,8 +280,8 @@ public class HistoryPageFilter<T> {
     private boolean add(Object entry) {
         // Purposely not calling isFull(). May need to add a greater number of entries
         // to the page initially, newerThan then cutting it back down to size using cutLeading()
-        if (entry instanceof Queue.Item) {
-            Queue.Item item = (Queue.Item) entry;
+        if (entry instanceof QueueItem) {
+            QueueItem item = (QueueItem) entry;
             if (searchString != null && !fitsSearchParams(item)) {
                 return false;
             }
@@ -310,7 +311,7 @@ public class HistoryPageFilter<T> {
         return Math.max(0, maxEntries - size());
     }
 
-    private boolean fitsSearchParams(@NonNull Queue.Item item) {
+    private boolean fitsSearchParams(@NonNull QueueItem item) {
         if (fitsSearchString(item.getDisplayName())) {
             return true;
         } else if (fitsSearchString(item.getId())) {

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -75,7 +75,7 @@ THE SOFTWARE.
               <j:choose>
                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                   <a href="${rootURL}/${item.task.url}" class="model-link inside tl-tr" tooltip="${item.causesDescription} ${item.why} ${item.params} \n ${%WaitingFor(item.inQueueForString)}">
-                    <l:breakable value="${item.task.fullDisplayName}"/>
+                    <l:breakable value="${item.displayName}"/>
                   </a>
                   <!-- TODO include estimated number as in BuildHistoryWidget/entries.jelly if possible -->
                 <j:if test="${stuck}">
@@ -93,7 +93,7 @@ THE SOFTWARE.
             </td>
             <td class="pane" width="16" align="center" valign="middle">
               <j:if test="${item.hasCancelPermission()}">
-                <l:stopButton href="${rootURL}/queue/cancelItem?id=${item.id}" confirm="${%confirm(item.task.fullDisplayName)}" alt="${%cancel this build}"/>
+                <l:stopButton href="${rootURL}/queue/cancelItem?id=${item.id}" confirm="${%confirm(item.displayName)}" alt="${%cancel this build}"/>
               </j:if>
              </td>
           </tr>

--- a/core/src/test/java/hudson/model/MockItem.java
+++ b/core/src/test/java/hudson/model/MockItem.java
@@ -85,16 +85,6 @@ public class MockItem extends Queue.Item {
         }
 
         @Override
-        public void checkAbortPermission() {
-
-        }
-
-        @Override
-        public boolean hasAbortPermission() {
-            return false;
-        }
-
-        @Override
         public String getUrl() {
             return null;
         }

--- a/core/src/test/java/hudson/model/MockItem.java
+++ b/core/src/test/java/hudson/model/MockItem.java
@@ -34,7 +34,7 @@ import java.util.List;
 public class MockItem extends Queue.Item {
 
     public MockItem(long id) {
-        super(null, Collections.emptyList(), id, null);
+        super(new MockQueueTask(), Collections.emptyList(), id, null);
     }
 
     public MockItem(Queue.Task task) {
@@ -66,5 +66,42 @@ public class MockItem extends Queue.Item {
     @Override
     boolean leave(Queue q) {
         return true;
+    }
+
+    private static class MockQueueTask implements Queue.Task {
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getFullDisplayName() {
+            return null;
+        }
+
+        @Override
+        public void checkAbortPermission() {
+
+        }
+
+        @Override
+        public boolean hasAbortPermission() {
+            return false;
+        }
+
+        @Override
+        public String getUrl() {
+            return null;
+        }
+
+        @Override
+        public Queue.Executable createExecutable() {
+            return null;
+        }
     }
 }

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -32,7 +32,6 @@ import hudson.model.MockItem;
 import hudson.model.ModelObject;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
-import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
@@ -44,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import jenkins.model.queue.QueueItem;
 import org.junit.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -78,7 +78,7 @@ public class HistoryPageFilterTest {
     public void test_latest_partial_page() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
         Iterable<ModelObject> runs = newRuns(1, 2);
-        List<Queue.Item> queueItems = newQueueItems(3, 4);
+        var queueItems = newQueueItems(3, 4);
 
         historyPageFilter.add(runs, queueItems);
 
@@ -102,7 +102,7 @@ public class HistoryPageFilterTest {
     public void test_latest_longer_list() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
         Iterable<ModelObject> runs = newRuns(1, 10);
-        List<Queue.Item> queueItems = newQueueItems(11, 12);
+        var queueItems = newQueueItems(11, 12);
 
         historyPageFilter.add(runs, queueItems);
 
@@ -270,7 +270,7 @@ public class HistoryPageFilterTest {
     public void test_newerThan_doesntIncludeQueuedItems() throws IOException {
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, 5L, null);
         Iterable<ModelObject> runs = newRuns(1, 10);
-        List<Queue.Item> queueItems = newQueueItems(11, 12);
+        var queueItems = newQueueItems(11, 12);
 
         historyPageFilter.add(runs, queueItems);
 
@@ -313,7 +313,7 @@ public class HistoryPageFilterTest {
         //given
         HistoryPageFilter<ModelObject> historyPageFilter = newPage(5, null, null);
         Iterable<ModelObject> runs = newRuns(23, 24);
-        List<Queue.Item> queueItems = newQueueItems(25, 26);
+        var queueItems = newQueueItems(25, 26);
         //and
         historyPageFilter.setSearchString("23");
 
@@ -371,7 +371,7 @@ public class HistoryPageFilterTest {
         //and
         historyPageFilter.setSearchString(searchString);
         //and
-        List<Queue.Item> queueItems = newQueueItems(3, 4);
+        var queueItems = newQueueItems(3, 4);
 
         //when
         historyPageFilter.add(runs, queueItems);
@@ -381,8 +381,8 @@ public class HistoryPageFilterTest {
         Assert.assertEquals(HistoryPageEntry.getEntryId(2), historyPageFilter.runs.get(0).getEntryId());
     }
 
-    private List<Queue.Item> newQueueItems(long startId, long endId) {
-        List<Queue.Item> items = new ArrayList<>();
+    private List<QueueItem> newQueueItems(long startId, long endId) {
+        var items = new ArrayList<QueueItem>();
         for (long queueId = startId; queueId <= endId; queueId++) {
             items.add(new MockItem(queueId));
         }


### PR DESCRIPTION
This formalizes methods used by `<t:queue>` taglib to do the rendering of queue items.

This will allow reuse of the taglib with alternative implementations of `QueueItem`.

Introduced in beta state to let it bake for some time until the interface is frozen.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Developer: Queue items elements are now formalized using `jenkins.model.queue.QueueItem`.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7926"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

