### PR TITLE
[JENKINS-71190] Remove Prototype.js usages from `sortable.js`

### DIFF
--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -52,7 +52,7 @@ var Sortable = (function () {
     if (!firstRow) return;
 
     // We have a first row: assume it's the header, and make its contents clickable links
-    firstRow.each(
+    firstRow.forEach(
       function (cell) {
         var noSort = cell.getAttribute("data-sort-disable");
         if (noSort) {
@@ -86,7 +86,7 @@ var Sortable = (function () {
     // figure out the initial sort preference
     this.pref = this.getStoredPreference();
     if (this.pref == null) {
-      firstRow.each(
+      firstRow.forEach(
         function (cell, i) {
           var initialSortDir = cell.getAttribute("initialSortDir");
           if (initialSortDir != null) {
@@ -112,7 +112,7 @@ var Sortable = (function () {
 
     getFirstRow: function () {
       if (this.table.rows && this.table.rows.length > 0) {
-        return $A(this.table.rows[0].cells);
+        return Array.from(this.table.rows[0].cells);
       }
       return null;
     },
@@ -121,7 +121,7 @@ var Sortable = (function () {
       var newRows = [];
       var rows = this.table.rows;
       for (var j = 1; j < rows.length; j++) {
-        newRows.push($(rows[j]));
+        newRows.push(rows[j]);
       }
       return newRows;
     },
@@ -211,8 +211,8 @@ var Sortable = (function () {
       // we allow some rows to stick to the top and bottom, so that is our first sort criteria
       // regardless of the sort function
       function rowPos(r) {
-        if (r.hasClassName("sorttop")) return 0;
-        if (r.hasClassName("sortbottom")) return 2;
+        if (r.classList.contains("sorttop")) return 0;
+        if (r.classList.contains("sortbottom")) return 2;
         return 1;
       }
 
@@ -229,14 +229,14 @@ var Sortable = (function () {
         }.bind(this)
       );
 
-      rows.each(
+      rows.forEach(
         function (e) {
           this.table.tBodies[0].appendChild(e);
         }.bind(this)
       );
 
       // update arrow rendering
-      this.arrows.each(function (e, i) {
+      this.arrows.forEach(function (e, i) {
         // to check the columns with sort disabled
         if (e) {
           e.innerHTML = (i == column ? dir : arrowTable.none).text;
@@ -245,7 +245,9 @@ var Sortable = (function () {
     },
 
     getIndexOfSortableTable: function () {
-      return $(document.body).select("TABLE.sortable").indexOf(this.table);
+      return Array.from(document.querySelectorAll("TABLE.sortable")).indexOf(
+        this.table
+      );
     },
 
     getInnerText: function (el) {


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

Usage of Prototype.js remain in `sortable.js`.

### Solution

Replace these usages with modern JavaScript APIs.

### Testing done

No automated testing seems to exist. I stepped through the changed lines in the debugger to make sure no errors were thrown. I also sorted a bunch of rows in the job list on the main Jenkins home page to make sure sorting worked as expected.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7929"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

