### PR TITLE
[JENKINS-70940] [JENKINS-70963] Remove Prototype.js usages from `advanced.js`

### DIFF
--- a/core/src/main/resources/lib/form/advanced/advanced.js
+++ b/core/src/main/resources/lib/form/advanced/advanced.js
@@ -8,15 +8,21 @@ Behaviour.specify(
       let expanded = button.dataset.expanded;
 
       if (expanded === undefined) {
-        let hiddenContent = parentContainer.next("table.advancedBody");
+        let hiddenContent = parentContainer.nextElementSibling;
+        while (hiddenContent && !hiddenContent.matches("table.advancedBody")) {
+          hiddenContent = hiddenContent.nextElementSibling;
+        }
         let tr;
 
         if (hiddenContent) {
-          hiddenContent = hiddenContent.down(); // TABLE -> TBODY
-          tr = parentContainer.up("TR");
+          hiddenContent = hiddenContent.firstElementChild; // TABLE -> TBODY
+          tr = parentContainer.closest("TR");
         } else {
-          hiddenContent = parentContainer.next("div.advancedBody");
-          tr = parentContainer.up(".tr");
+          hiddenContent = parentContainer.nextElementSibling;
+          while (hiddenContent && !hiddenContent.matches("div.advancedBody")) {
+            hiddenContent = hiddenContent.nextElementSibling;
+          }
+          tr = parentContainer.closest(".tr");
         }
 
         // move the contents of the advanced portion into the main table
@@ -27,7 +33,7 @@ Behaviour.specify(
           if (nameRef != null && row.getAttribute("nameref") == null) {
             row.setAttribute("nameref", nameRef);
           }
-          tr.parentNode.insertBefore(row, $(tr).next());
+          tr.parentNode.insertBefore(row, tr.nextElementSibling);
         }
 
         const oneOrMoreFieldsEditedNotice = parentContainer.querySelector(
@@ -86,7 +92,7 @@ Behaviour.specify(
   0,
   function (element) {
     const id = element.getAttribute("data-id");
-    const oneOrMoreFieldsEditedNotice = $(id);
+    const oneOrMoreFieldsEditedNotice = document.getElementById(id);
     if (oneOrMoreFieldsEditedNotice != null) {
       oneOrMoreFieldsEditedNotice.classList.remove("jenkins-hidden");
     } else if (console && console.log) {


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

Usage of Prototype.js remain in `advanced.js`.

### Solution

Replace these usages with modern JavaScript APIs.

### Testing done

Ran `hudson.model.ProjectTest,hudson.PluginManagerTest,jenkins.scm.SCMCheckoutStrategyTest,lib.form.AdvancedButtonTest,lib.form.HeteroListTest,lib.form.OptionTest` and also clicked on the Advanced button in the Freestyle project page while stepping through the changed lines in the debugger to ensure the code was executed without printing a stack trace.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7930"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

