### PR TITLE
[JENKINS-70972] [JENKINS-70973] [JENKINS-70974] Reduce usages of Prot…

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1928,7 +1928,7 @@ function AutoScroller(scrollContainer) {
     scrollContainer: scrollContainer,
 
     getCurrentHeight: function () {
-      var scrollDiv = $(this.scrollContainer);
+      var scrollDiv = this.scrollContainer;
 
       if (scrollDiv.scrollHeight > 0) return scrollDiv.scrollHeight;
       else if (scrollDiv.offsetHeight > 0) return scrollDiv.offsetHeight;
@@ -1938,7 +1938,7 @@ function AutoScroller(scrollContainer) {
 
     // return true if we are in the "stick to bottom" mode
     isSticking: function () {
-      var scrollDiv = $(this.scrollContainer);
+      var scrollDiv = this.scrollContainer;
       var currentHeight = this.getCurrentHeight();
 
       // when used with the BODY tag, the height needs to be the viewport height, instead of
@@ -1956,7 +1956,7 @@ function AutoScroller(scrollContainer) {
     },
 
     scrollToBottom: function () {
-      var scrollDiv = $(this.scrollContainer);
+      var scrollDiv = this.scrollContainer;
       var currentHeight = this.getCurrentHeight();
       if (document.documentElement)
         document.documentElement.scrollTop = currentHeight;

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -410,13 +410,13 @@ function findFollowingTR(node, className, nodeClass) {
       if (
         queryChildren.length > 0 &&
         (isTR(queryChildren[0]) ||
-          Element.hasClassName(queryChildren[0], className))
+          queryChildren[0].classList.contains(className))
       )
         return queryChildren[0];
     }
 
-    tr = $(tr).next();
-  } while (tr != null && (!isTR(tr) || !Element.hasClassName(tr, className)));
+    tr = tr.nextElementSibling;
+  } while (tr != null && (!isTR(tr) || !tr.classList.contains(className)));
 
   return tr;
 }
@@ -612,7 +612,7 @@ function registerValidator(e) {
     } else {
       var q = qs(this).addThis();
       if (depends.length > 0)
-        depends.split(" ").each(
+        depends.split(" ").forEach(
           TryEach(function (n) {
             q.nearBy(n);
           })
@@ -661,7 +661,7 @@ function registerValidator(e) {
 
   var v = e.getAttribute("checkDependsOn");
   if (v) {
-    v.split(" ").each(
+    v.split(" ").forEach(
       TryEach(function (name) {
         var c = findNearBy(e, name);
         if (c == null) {
@@ -674,7 +674,7 @@ function registerValidator(e) {
             );
           return;
         }
-        $(c).observe("change", checker.bind(e));
+        c.addEventListener("change", checker.bind(e));
       })
     );
   }
@@ -890,7 +890,7 @@ function isInsideRemovable(e) {
  *      if specified, skip the application of behaviour rule.
  */
 function renderOnDemand(e, callback, noBehaviour) {
-  if (!e || !Element.hasClassName(e, "render-on-demand")) return;
+  if (!e || !e.classList.contains("render-on-demand")) return;
   var proxy = eval(e.getAttribute("proxy"));
   proxy.render(function (t) {
     var contextTagName = e.parentNode.tagName;
@@ -983,8 +983,10 @@ function helpButtonOnClick() {
     findFollowingTR(this, "help-area", "help-sibling") ||
     findFollowingTR(this, "help-area", "setting-help") ||
     findFollowingTR(this, "help-area");
-  var div = $(tr).down();
-  if (!div.hasClassName("help")) div = div.next().down();
+  var div = tr.firstElementChild;
+  if (!div.classList.contains("help")) {
+    div = div.nextElementSibling.firstElementChild;
+  }
 
   if (div.style.display != "block") {
     div.style.display = "block";
@@ -1054,9 +1056,9 @@ function getParentForm(element) {
 
 // figure out the corresponding end marker
 function findEnd(e) {
-  for (var depth = 0; ; e = $(e).next()) {
-    if (Element.hasClassName(e, "rowvg-start")) depth++;
-    if (Element.hasClassName(e, "rowvg-end")) depth--;
+  for (var depth = 0; ; e = e.nextElementSibling) {
+    if (e.classList.contains("rowvg-start")) depth++;
+    if (e.classList.contains("rowvg-end")) depth--;
     if (depth == 0) return e;
   }
 }
@@ -1073,7 +1075,7 @@ function makeInnerVisible(b) {
 
 function updateVisibility() {
   var display = this.outerVisible && this.innerVisible;
-  for (var e = this.start; e != this.end; e = $(e).next()) {
+  for (var e = this.start; e != this.end; e = e.nextElementSibling) {
     if (e.rowVisibilityGroup && e != this.start) {
       e.rowVisibilityGroup.makeOuterVisible(this.innerVisible);
       e = e.rowVisibilityGroup.end; // the above call updates visibility up to e.rowVisibilityGroup.end inclusive
@@ -1093,7 +1095,7 @@ function updateVisibility() {
 
 function rowvgStartEachRow(recursive, f) {
   if (recursive) {
-    for (var e = this.start; e != this.end; e = $(e).next()) f(e);
+    for (var e = this.start; e != this.end; e = e.nextElementSibling) f(e);
   } else {
     throw "not implemented yet";
   }
@@ -1211,7 +1213,7 @@ function rowvgStartEachRow(recursive, f) {
       // form field with auto-completion support
       // insert the auto-completion container
       var div = document.createElement("DIV");
-      e.parentNode.insertBefore(div, $(e).next() || null);
+      e.parentNode.insertBefore(div, e.nextElementSibling);
       e.style.position = "relative"; // or else by default it's absolutely positioned, making "width:100%" break
 
       var ds = new YAHOO.util.XHRDataSource(e.getAttribute("autoCompleteUrl"));
@@ -1253,7 +1255,7 @@ function rowvgStartEachRow(recursive, f) {
     function (e) {
       e.onclick = helpButtonOnClick;
       e.tabIndex = 9999; // make help link unnavigable from keyboard
-      e.parentNode.parentNode.addClassName("has-help");
+      e.parentNode.parentNode.classList.add("has-help");
     }
   );
 
@@ -1261,7 +1263,7 @@ function rowvgStartEachRow(recursive, f) {
   Behaviour.specify("A.help-button", "a-help-button", ++p, function (e) {
     e.onclick = helpButtonOnClick;
     e.tabIndex = 9999; // make help link unnavigable from keyboard
-    e.parentNode.parentNode.addClassName("has-help");
+    e.parentNode.parentNode.classList.add("has-help");
   });
 
   // Script Console : settings and shortcut key
@@ -1366,7 +1368,7 @@ function rowvgStartEachRow(recursive, f) {
   // structured form submission
   Behaviour.specify("FORM", "form", ++p, function (form) {
     crumb.appendToForm(form);
-    if (Element.hasClassName(form, "no-json")) return;
+    if (form.classList.contains("no-json")) return;
     // add the hidden 'json' input field, which receives the form structure in JSON
     var div = document.createElement("div");
     div.classList.add("jenkins-!-display-contents");
@@ -1480,12 +1482,11 @@ function rowvgStartEachRow(recursive, f) {
     function (e) {
       // see rowSet.jelly and optionalBlock.jelly
       // figure out the corresponding start block
-      e = $(e);
       var end = e;
 
-      for (var depth = 0; ; e = e.previous()) {
-        if (e.hasClassName("row-set-end")) depth++;
-        if (e.hasClassName("row-set-start")) depth--;
+      for (var depth = 0; ; e = e.previousElementSibling) {
+        if (e.classList.contains("row-set-end")) depth++;
+        if (e.classList.contains("row-set-start")) depth--;
         if (depth == 0) break;
       }
       var start = e;
@@ -1552,8 +1553,8 @@ function rowvgStartEachRow(recursive, f) {
   // editableComboBox.jelly
   Behaviour.specify("INPUT.combobox", "input-combobox", ++p, function (c) {
     // Next element after <input class="combobox"/> should be <div class="combobox-values">
-    var vdiv = $(c).next();
-    if (vdiv.hasClassName("combobox-values")) {
+    var vdiv = c.nextElementSibling;
+    if (vdiv.classList.contains("combobox-values")) {
       createComboBox(c, function () {
         return vdiv.childElements().collect(function (value) {
           return value.getAttribute("value");
@@ -1578,7 +1579,7 @@ function rowvgStartEachRow(recursive, f) {
         start = start.firstElementChild;
       } while (start && !isTR(start));
 
-      if (start && !Element.hasClassName(start, "dropdownList-start"))
+      if (start && !start.classList.contains("dropdownList-start"))
         start = findFollowingTR(start, "dropdownList-start");
       while (start != null) {
         subForms.push(start);
@@ -1589,9 +1590,11 @@ function rowvgStartEachRow(recursive, f) {
       function updateDropDownList() {
         for (var i = 0; i < subForms.length; i++) {
           var show = e.selectedIndex == i;
-          var f = $(subForms[i]);
+          var f = subForms[i];
 
-          if (show) renderOnDemand(f.next());
+          if (show) {
+            renderOnDemand(f.nextElementSibling);
+          }
           f.rowVisibilityGroup.makeInnerVisible(show);
 
           // TODO: this is actually incorrect in the general case if nested vg uses field-disabled
@@ -1618,7 +1621,7 @@ function rowvgStartEachRow(recursive, f) {
   Behaviour.specify("A.showDetails", "a-showdetails", ++p, function (e) {
     e.onclick = function () {
       this.style.display = "none";
-      $(this).next().style.display = "block";
+      this.nextElementSibling.style.display = "block";
       layoutUpdateCallback.call();
       return false;
     };
@@ -1639,15 +1642,15 @@ function rowvgStartEachRow(recursive, f) {
     "-button-with-dropdown",
     ++p,
     function (e) {
-      new YAHOO.widget.Button(e, { type: "menu", menu: $(e).next() });
+      new YAHOO.widget.Button(e, { type: "menu", menu: e.nextElementSibling });
     }
   );
 
   Behaviour.specify(".track-mouse", "-track-mouse", ++p, function (element) {
     var DOM = YAHOO.util.Dom;
 
-    $(element).observe("mouseenter", function () {
-      element.addClassName("mouseover");
+    element.addEventListener("mouseenter", function () {
+      element.classList.add("mouseover");
 
       var mousemoveTracker = function (event) {
         var elementRegion = DOM.getRegion(element);
@@ -1657,11 +1660,11 @@ function rowvgStartEachRow(recursive, f) {
           event.y < elementRegion.top ||
           event.y > elementRegion.bottom
         ) {
-          element.removeClassName("mouseover");
-          Element.stopObserving(document, "mousemove", mousemoveTracker);
+          element.classList.remove("mouseover");
+          document.removeEventListener("mousemove", mousemoveTracker);
         }
       };
-      Element.observe(document, "mousemove", mousemoveTracker);
+      document.addEventListener("mousemove", mousemoveTracker);
     });
   });
 
@@ -1780,7 +1783,7 @@ function refillOnChange(e, onChange) {
 
   function h() {
     var params = {};
-    deps.each(
+    deps.forEach(
       TryEach(function (d) {
         params[d.name] = controlValue(d.control);
       })
@@ -1789,7 +1792,7 @@ function refillOnChange(e, onChange) {
   }
   var v = e.getAttribute("fillDependsOn");
   if (v != null) {
-    v.split(" ").each(
+    v.split(" ").forEach(
       TryEach(function (name) {
         var c = findNearBy(e, name);
         if (c == null) {
@@ -1802,7 +1805,7 @@ function refillOnChange(e, onChange) {
             );
           return;
         }
-        $(c).observe("change", h);
+        c.addEventListener("change", h);
         deps.push({ name: Path.tail(name), control: c });
       })
     );
@@ -1818,7 +1821,8 @@ function xor(a, b) {
 // used by editableDescription.jelly to replace the description field with a form
 function replaceDescription(initialDescription, submissionUrl) {
   var d = document.getElementById("description");
-  $(d).down().next().innerHTML = "<div class='jenkins-spinner'></div>";
+  d.firstElementChild.nextElementSibling.innerHTML =
+    "<div class='jenkins-spinner'></div>";
   let parameters = {};
   if (initialDescription !== undefined && submissionUrl !== undefined) {
     parameters = {
@@ -1845,18 +1849,18 @@ function replaceDescription(initialDescription, submissionUrl) {
  * and attached under the element identified by the specified id.
  */
 function applyNameRef(s, e, id) {
-  $(id).groupingNode = true;
+  document.getElementById(id).groupingNode = true;
   // s contains the node itself
   applyNameRefHelper(s, e, id);
 }
 
 function applyNameRefHelper(s, e, id) {
   if (s === null) return;
-  for (var x = $(s).next(); x != e; x = x.next()) {
+  for (var x = s.nextElementSibling; x != e; x = x.nextElementSibling) {
     // to handle nested <f:rowSet> correctly, don't overwrite the existing value
     if (x.getAttribute("nameRef") == null) {
       x.setAttribute("nameRef", id);
-      if (x.hasClassName("tr"))
+      if (x.classList.contains("tr"))
         applyNameRefHelper(x.firstElementChild, null, id);
     }
   }
@@ -1989,7 +1993,7 @@ function refreshPart(id, url) {
     if (isPageVisible()) {
       new Ajax.Request(url, {
         onSuccess: function (rsp) {
-          var hist = $(id);
+          var hist = document.getElementById(id);
           if (hist == null) {
             console.log("There's no element that has ID of " + id);
             if (intervalID !== null) window.clearInterval(intervalID);
@@ -2003,12 +2007,12 @@ function refreshPart(id, url) {
             );
             return;
           }
-          var p = hist.up();
+          var p = hist.parentNode;
 
           var div = document.createElement("div");
           div.innerHTML = rsp.responseText;
 
-          var node = $(div).firstDescendant();
+          var node = div.firstElementChild;
           p.replaceChild(node, hist);
 
           Behaviour.applySubtree(node);
@@ -2167,9 +2171,9 @@ function ensureVisible(e) {
   var H = viewport.height;
 
   function handleStickers(name, f) {
-    var e = $(name);
+    var e = document.getElementById(name);
     if (e) f(e);
-    document.getElementsBySelector("." + name).each(TryEach(f));
+    document.getElementsBySelector("." + name).forEach(TryEach(f));
   }
 
   // if there are any stickers around, subtract them from the viewport
@@ -2214,9 +2218,9 @@ function createSearchBox(searchURL) {
   ac.formatResult = ac.formatEscapedResult;
   ac.maxResultsDisplayed = 25;
 
-  var box = $("search-box");
-  var sizer = $("search-box-sizer");
-  var comp = $("search-box-completion");
+  var box = document.getElementById("search-box");
+  var sizer = document.getElementById("search-box-sizer");
+  var comp = document.getElementById("search-box-completion");
 
   Behaviour.addLoadEvent(function () {
     // copy font style of box to sizer
@@ -2271,7 +2275,7 @@ function findFormParent(e, form, isStatic) {
     // this is used to create a group where no single containing parent node exists,
     // like <optionalBlock>
     var nameRef = e.getAttribute("nameRef");
-    if (nameRef != null) e = $(nameRef);
+    if (nameRef != null) e = document.getElementById(nameRef);
     else e = e.parentNode;
 
     if (!isStatic && e.getAttribute("field-disabled") != null) return null; // this field shouldn't contribute to the final result
@@ -2281,7 +2285,7 @@ function findFormParent(e, form, isStatic) {
       if (
         e.tagName == "INPUT" &&
         !isStatic &&
-        !xor(e.checked, Element.hasClassName(e, "negative"))
+        !xor(e.checked, e.classList.contains("negative"))
       )
         return null; // field is not active
 
@@ -2373,7 +2377,7 @@ function buildFormTree(form) {
           break;
         case "checkbox":
           p = findParent(e);
-          var checked = xor(e.checked, Element.hasClassName(e, "negative"));
+          var checked = xor(e.checked, e.classList.contains("negative"));
           if (!e.groupingNode) {
             v = e.getAttribute("json");
             if (v) {
@@ -2435,7 +2439,7 @@ function buildFormTree(form) {
         default:
           p = findParent(e);
           addProperty(p, e.name, e.value);
-          if (e.hasClassName("complex-password-field")) {
+          if (e.classList.contains("complex-password-field")) {
             addProperty(p, "$redact", shortenName(e.name));
           }
           break;
@@ -2530,7 +2534,7 @@ function safeValidateButton(button) {
 function validateButton(checkUrl, paramList, button) {
   var parameters = {};
 
-  paramList.split(",").each(function (name) {
+  paramList.split(",").forEach(function (name) {
     var p = findPreviousFormItem(button, name);
     if (p != null) {
       if (p.type == "checkbox") parameters[name] = p.checked;
@@ -2538,8 +2542,8 @@ function validateButton(checkUrl, paramList, button) {
     }
   });
 
-  var spinner = button.up("DIV").children[0];
-  var target = spinner.next().next();
+  var spinner = button.closest("DIV").children[0];
+  var target = spinner.nextElementSibling.nextElementSibling;
   spinner.style.display = "block";
 
   new Ajax.Request(checkUrl, {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -965,7 +965,7 @@ function progressBarOnClick() {
 }
 
 function labelAttachPreviousOnClick() {
-  var e = $(this).previous();
+  var e = this.previousElementSibling;
   while (e != null) {
     if (e.classList.contains("jenkins-radio")) {
       e = e.querySelector("input");
@@ -974,7 +974,7 @@ function labelAttachPreviousOnClick() {
       e.click();
       break;
     }
-    e = e.previous();
+    e = e.previousElementSibling;
   }
 }
 
@@ -1556,7 +1556,7 @@ function rowvgStartEachRow(recursive, f) {
     var vdiv = c.nextElementSibling;
     if (vdiv.classList.contains("combobox-values")) {
       createComboBox(c, function () {
-        return vdiv.childElements().collect(function (value) {
+        return Array.from(vdiv.children).map(function (value) {
           return value.getAttribute("value");
         });
       });

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -844,7 +844,10 @@ function makeButton(e, onclick) {
   // similar to how the child nodes of a <button> are treated as HTML.
   // in standard HTML, we wouldn't expect the former case, yet here we are!
   if (e.tagName === "INPUT") {
-    attributes.label = e.value.escapeHTML();
+    attributes.label = e.value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
   }
   var btn = new YAHOO.widget.Button(e, attributes);
   if (onclick != null) btn.addListener("click", onclick);
@@ -2233,7 +2236,10 @@ function createSearchBox(searchURL) {
 
   // update positions and sizes of the components relevant to search
   function updatePos() {
-    sizer.innerHTML = box.value.escapeHTML();
+    sizer.innerHTML = box.value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
     var cssWidth,
       offsetWidth = sizer.offsetWidth;
     if (offsetWidth > 0) {


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

Usages of Prototype.js remain in `hudson-behavior.js`.

### Solution

Replace a lagre chunk of usages with modern JavaScript APIs. This was not intended to be an exhaustive replacement but a big push in the right direction.

### Testing done

I tested this change interactively by running the PR in Firefox and setting a breakpoint on every single line that I changed. I hit 95% of them eventually, and the 3-5 breakpoints that I never managed to hit all seemed to be in dead or compatibility code paths. I also ran the `lib/` unit tests locally. The CI build will run additional testing. ATH and BOM are passing.

A change this large will almost certainly cause a regression somewhere. I would rather accept this and get through the transition sooner rather than later, in contrast to being held back by fear.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7934"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

