### PR TITLE
[Jenkinsfile] Add source directory when recording coverage results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ axes.values().combinations {
               discoverGitReferenceBuild(scm: folders[1])
             }
             recordCoverage(tools: [[parser: 'JACOCO', pattern: 'coverage/target/site/jacoco-aggregate/jacoco.xml']],
-                    sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'core/src/main/java']])
+            sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'core/src/main/java']])
 
             echo "Recording static analysis results for '${platform.capitalize()}'"
             recordIssues(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,8 @@ axes.values().combinations {
             if (folders.length > 1) {
               discoverGitReferenceBuild(scm: folders[1])
             }
-            recordCoverage(tools: [[parser: 'JACOCO', pattern: 'coverage/target/site/jacoco-aggregate/jacoco.xml']], sourceCodeRetention: 'MODIFIED')
+            recordCoverage(tools: [[parser: 'JACOCO', pattern: 'coverage/target/site/jacoco-aggregate/jacoco.xml']],
+                    sourceCodeRetention: 'MODIFIED', sourceDirectories: [[path: 'core/src/main/java']])
 
             echo "Recording static analysis results for '${platform.capitalize()}'"
             recordIssues(


### PR DESCRIPTION
JaCoCo does not store absolute paths in a coverage report, so the Jenkins coverage plugin needs to know where the source files are located. Otherwise, source code rendering and source referencing in GitHub checks does not work correctly.

### Desired reviewers

@NotMyFault 



<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7935"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

