### PR TITLE
Remove Prototype from `filter-build-history.js`

### DIFF
--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -16,9 +16,9 @@ const noBuildsBanner = document.getElementById("no-builds");
 const sidePanel = document.getElementById("side-panel");
 const buildHistoryPageNav = document.getElementById("buildHistoryPageNav");
 
-const pageOne = buildHistoryPageNav.querySelectorAll(".pageOne")[0];
-const pageUp = buildHistoryPageNav.querySelectorAll(".pageUp")[0];
-const pageDown = buildHistoryPageNav.querySelectorAll(".pageDown")[0];
+const pageOne = buildHistoryPageNav.querySelector(".pageOne");
+const pageUp = buildHistoryPageNav.querySelector(".pageUp");
+const pageDown = buildHistoryPageNav.querySelector(".pageDown");
 
 const leftRightPadding = 4;
 const updateBuildsRefreshInterval = 5000;
@@ -137,7 +137,7 @@ function getOldestEntryId() {
 }
 
 function getDataTable(buildHistoryDiv) {
-  return $(buildHistoryDiv).getElementsBySelector("table.pane")[0];
+  return buildHistoryDiv.querySelector("table.pane");
 }
 
 function updatePageParams(dataTable) {
@@ -208,39 +208,31 @@ function checkRowCellOverflows(row) {
     return div;
   }
   function blockUnwrap(element) {
-    var wrapped = $(element).getElementsBySelector(".wrapped");
-    for (var i = 0; i < wrapped.length; i++) {
-      var wrappedEl = wrapped[i];
+    element.querySelectorAll(".wrapped").forEach(function (wrappedEl) {
       wrappedEl.parentNode.removeChild(wrappedEl);
       element.parentNode.insertBefore(wrappedEl, element);
       wrappedEl.classList.remove("wrapped");
-    }
+    });
     element.parentNode.removeChild(element);
   }
 
-  var buildName = $(row).getElementsBySelector(".build-name")[0];
-  var buildDetails = $(row).getElementsBySelector(".build-details")[0];
+  var buildName = row.querySelector(".build-name");
+  var buildDetails = row.querySelector(".build-details");
 
   if (!buildName || !buildDetails) {
     return;
   }
 
-  var buildControls = $(row).getElementsBySelector(".build-controls")[0];
-  var desc;
-
-  var descElements = $(row).getElementsBySelector(".desc");
-  if (descElements.length > 0) {
-    desc = descElements[0];
-  }
+  var buildControls = row.querySelector(".build-controls");
+  var desc = row.querySelector(".desc");
 
   function resetCellOverflows() {
     markSingleline();
 
     // undo block wraps
-    var blockWraps = $(row).getElementsBySelector(".block.wrap");
-    for (var i = 0; i < blockWraps.length; i++) {
-      blockUnwrap(blockWraps[i]);
-    }
+    row.querySelectorAll(".block.wrap").forEach(function (blockWrap) {
+      blockUnwrap(blockWrap);
+    });
 
     buildName.classList.remove("block");
     buildName.removeAttribute("style");
@@ -273,35 +265,31 @@ function checkRowCellOverflows(row) {
   function fitToControlsHeight(element) {
     if (buildControls) {
       if (element.clientHeight < buildControls.clientHeight) {
-        $(element).setStyle({
-          height: buildControls.clientHeight.toString() + "px",
-        });
+        element.style.height = buildControls.clientHeight.toString() + "px";
       }
     }
   }
 
   function setBuildControlWidths() {
     if (buildControls) {
-      var buildBadge =
-        $(buildControls).getElementsBySelector(".build-badge")[0];
+      var buildBadge = buildControls.querySelector(".build-badge");
 
       if (buildBadge) {
         var buildControlsWidth = buildControls.clientWidth;
         var buildBadgeWidth;
 
-        var buildStop =
-          $(buildControls).getElementsBySelector(".build-stop")[0];
+        var buildStop = buildControls.querySelector(".build-stop");
         if (buildStop) {
-          $(buildStop).setStyle({ width: "24px" });
+          buildStop.style.width = "24px";
           // Minus 24 for the buildStop width,
           // minus 4 for left+right padding in the controls container
           buildBadgeWidth = buildControlsWidth - 24 - leftRightPadding;
           if (buildControls.classList.contains("indent-multiline")) {
             buildBadgeWidth = buildBadgeWidth - 20;
           }
-          $(buildBadge).setStyle({ width: buildBadgeWidth + "px" });
+          buildBadge.style.width = buildBadgeWidth + "px";
         } else {
-          $(buildBadge).setStyle({ width: "100%" });
+          buildBadge.style.width = "100%";
         }
       }
       controlsOverflowParams = getElementOverflowParams(buildControls);
@@ -323,8 +311,7 @@ function checkRowCellOverflows(row) {
       var badgesOverflowing = false;
       var nameLessThanHalf = true;
       var detailsLessThanHalf = true;
-      var buildBadge =
-        $(buildControls).getElementsBySelector(".build-badge")[0];
+      var buildBadge = buildControls.querySelector(".build-badge");
       if (buildBadge) {
         var badgeOverflowParams = getElementOverflowParams(buildBadge);
 
@@ -346,8 +333,8 @@ function checkRowCellOverflows(row) {
         rightCellOverflowParams
       ) {
         // Float them left and right...
-        $(leftCellOverFlowParams.element).setStyle({ float: "left" });
-        $(rightCellOverflowParams.element).setStyle({ float: "right" });
+        leftCellOverFlowParams.element.style.float = "left";
+        rightCellOverflowParams.element.style.float = "right";
 
         if (
           !leftCellOverFlowParams.isOverflowed &&
@@ -360,18 +347,16 @@ function checkRowCellOverflows(row) {
           leftCellOverFlowParams.isOverflowed &&
           !rightCellOverflowParams.isOverflowed
         ) {
-          $(leftCellOverFlowParams.element).setStyle({
-            width: leftCellOverFlowParams.scrollWidth + "px",
-          });
+          leftCellOverFlowParams.element.style.width =
+            leftCellOverFlowParams.scrollWidth + "px";
           return;
         }
         if (
           !leftCellOverFlowParams.isOverflowed &&
           rightCellOverflowParams.isOverflowed
         ) {
-          $(rightCellOverflowParams.element).setStyle({
-            width: rightCellOverflowParams.scrollWidth + "px",
-          });
+          rightCellOverflowParams.element.style.width =
+            rightCellOverflowParams.scrollWidth + "px";
           return;
         }
       }
@@ -432,7 +417,7 @@ function checkRowCellOverflows(row) {
   }
 
   if (buildControls && !controlsRepositioned) {
-    buildBadge = $(buildControls).getElementsBySelector(".build-badge")[0];
+    buildBadge = buildControls.querySelector(".build-badge");
     if (buildBadge) {
       badgeOverflowParams = getElementOverflowParams(buildBadge);
 
@@ -563,7 +548,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // If the build history pane is collapsed, just return immediately and don't set up
   // the build history refresh.
-  if (buildHistoryContainer.hasClassName("collapsed")) {
+  if (buildHistoryContainer.classList.contains("collapsed")) {
     return;
   }
 
@@ -573,26 +558,26 @@ document.addEventListener("DOMContentLoaded", function () {
   checkAllRowCellOverflows();
 
   // Show/hide the nav as the mouse moves into the sidepanel and build history.
-  sidePanel.observe("mouseover", function () {
+  sidePanel.addEventListener("mouseover", function () {
     buildHistoryPageNav.classList.add("mouseOverSidePanel");
   });
-  sidePanel.observe("mouseout", function () {
+  sidePanel.addEventListener("mouseout", function () {
     buildHistoryPageNav.classList.remove("mouseOverSidePanel");
   });
-  buildHistoryContainer.observe("mouseover", function () {
+  buildHistoryContainer.addEventListener("mouseover", function () {
     buildHistoryPageNav.classList.add("mouseOverSidePanelBuildHistory");
   });
-  buildHistoryContainer.observe("mouseout", function () {
+  buildHistoryContainer.addEventListener("mouseout", function () {
     buildHistoryPageNav.classList.remove("mouseOverSidePanelBuildHistory");
   });
 
-  pageOne.observe("click", function () {
+  pageOne.addEventListener("click", function () {
     loadPage();
   });
-  pageUp.observe("click", function () {
+  pageUp.addEventListener("click", function () {
     loadPage({ "newer-than": getNewestEntryId() });
   });
-  pageDown.observe("click", function () {
+  pageDown.addEventListener("click", function () {
     if (hasPageDown()) {
       cancelRefreshTimeout();
       loadPage({ "older-than": getOldestEntryId() });


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

Prototype is still used in `filter-build-history.js`.

### Solution

Remove Prototype from this file.

### Testing done

I ran this change on my project branch where Prototype.js completely removed. Before this change I had exceptions thrown when trying to view and filter build history. After this PR I can do so without exceptions being thrown.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7940"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

