### PR TITLE
Remove Prototype from `_table.js`

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -211,17 +211,12 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
 
     function addDependencyInfoRow(pluginTR, infoTR) {
       infoTR.classList.add("plugin-dependency-info");
-      pluginTR.insert({
-        after: infoTR,
-      });
+      pluginTR.parentNode.insertBefore(infoTR, pluginTR.nextElementSibling);
     }
     function removeDependencyInfoRow(pluginTR) {
-      var nextRows = pluginTR.nextSiblings();
-      if (nextRows && nextRows.length > 0) {
-        var nextRow = nextRows[0];
-        if (nextRow.classList.contains("plugin-dependency-info")) {
-          nextRow.remove();
-        }
+      var nextRow = pluginTR.nextElementSibling;
+      if (nextRow && nextRow.classList.contains("plugin-dependency-info")) {
+        nextRow.remove();
       }
     }
 

--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -11,9 +11,9 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
     for (var i = 0; i < items.length; i++) {
       if (
         (filterParts.length < 1 || filter.length < 2) &&
-        items[i].hasClassName("hidden-by-default")
+        items[i].classList.contains("hidden-by-default")
       ) {
-        items[i].addClassName("jenkins-hidden");
+        items[i].classList.add("jenkins-hidden");
         continue;
       }
       var makeVisible = true;
@@ -71,9 +71,9 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
 (function () {
   function selectAll(selector, element) {
     if (element) {
-      return $(element).select(selector);
+      return element.querySelectorAll(selector);
     } else {
-      return Element.select(undefined, selector);
+      return document.querySelectorAll(selector);
     }
   }
   function select(selector, element) {
@@ -88,7 +88,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
   /**
    * Wait for document onload.
    */
-  Element.observe(window, "load", function () {
+  window.addEventListener("load", function () {
     var pluginsTable = select("#plugins");
     var pluginTRs = selectAll(".plugin", pluginsTable);
 
@@ -129,7 +129,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
         var pluginId = span.getAttribute("data-plugin-id");
         var pluginName = getPluginName(pluginId);
 
-        span.update(pluginName);
+        span.textContent = pluginName;
         ids.push(pluginId);
       }
       return ids;
@@ -145,7 +145,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
         // dependent plugins in this case.
         // Note: This does not cover "implied" dependencies ala detached plugins. See https://goo.gl/lQHrUh
         if (dependentIds.length === 1 && dependentIds[0] === "jenkins-core") {
-          pluginTR.addClassName("all-dependents-disabled");
+          pluginTR.classList.add("all-dependents-disabled");
           return;
         }
 
@@ -155,7 +155,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
           if (dependentId === "jenkins-core") {
             // Jenkins core is always enabled. So, make sure it's not possible to disable/uninstall
             // any plugins that it "depends" on. (we sill have bundled plugins)
-            pluginTR.removeClassName("all-dependents-disabled");
+            pluginTR.classList.remove("all-dependents-disabled");
             return;
           }
 
@@ -166,13 +166,13 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
             dependentPluginTr.jenkinsPluginMetadata.enableInput.checked
           ) {
             // One of the plugins that depend on this plugin, is marked as enabled.
-            pluginTR.removeClassName("all-dependents-disabled");
+            pluginTR.classList.remove("all-dependents-disabled");
             return;
           }
         }
       }
 
-      pluginTR.addClassName("all-dependents-disabled");
+      pluginTR.classList.add("all-dependents-disabled");
     }
 
     function markHasDisabledDependencies(pluginTR) {
@@ -187,21 +187,21 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
             !dependencyPluginTr.jenkinsPluginMetadata.enableInput.checked
           ) {
             // One of the plugins that this plugin depend on, is marked as disabled.
-            pluginTR.addClassName("has-disabled-dependency");
+            pluginTR.classList.add("has-disabled-dependency");
             return;
           }
         }
       }
 
-      pluginTR.removeClassName("has-disabled-dependency");
+      pluginTR.classList.remove("has-disabled-dependency");
     }
 
     function setEnableWidgetStates() {
       for (var i = 0; i < pluginTRs.length; i++) {
         var pluginMetadata = pluginTRs[i].jenkinsPluginMetadata;
-        if (pluginTRs[i].hasClassName("has-dependents-but-disabled")) {
+        if (pluginTRs[i].classList.contains("has-dependents-but-disabled")) {
           if (pluginMetadata.enableInput.checked) {
-            pluginTRs[i].removeClassName("has-dependents-but-disabled");
+            pluginTRs[i].classList.remove("has-dependents-but-disabled");
           }
         }
         markAllDependentsDisabled(pluginTRs[i]);
@@ -210,7 +210,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
     }
 
     function addDependencyInfoRow(pluginTR, infoTR) {
-      infoTR.addClassName("plugin-dependency-info");
+      infoTR.classList.add("plugin-dependency-info");
       pluginTR.insert({
         after: infoTR,
       });
@@ -219,7 +219,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
       var nextRows = pluginTR.nextSiblings();
       if (nextRows && nextRows.length > 0) {
         var nextRow = nextRows[0];
-        if (nextRow.hasClassName("plugin-dependency-info")) {
+        if (nextRow.classList.contains("plugin-dependency-info")) {
           nextRow.remove();
         }
       }
@@ -230,19 +230,18 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
 
       // Remove all existing class info
       infoContainer.removeAttribute("class");
-      infoContainer.addClassName("enable-state-info");
+      infoContainer.classList.add("enable-state-info");
 
-      if (pluginTR.hasClassName("has-disabled-dependency")) {
+      if (pluginTR.classList.contains("has-disabled-dependency")) {
         var dependenciesDiv = pluginMetadata.dependenciesDiv;
         var dependencySpans = pluginMetadata.dependencies;
 
-        infoContainer.update(
+        infoContainer.innerHTML =
           '<div class="title">' +
-            i18n("cannot-enable") +
-            '</div><div class="subtitle">' +
-            i18n("disabled-dependencies") +
-            ".</div>"
-        );
+          i18n("cannot-enable") +
+          '</div><div class="subtitle">' +
+          i18n("disabled-dependencies") +
+          ".</div>";
 
         // Go through each dependency <span> element. Show the spans where the dependency is
         // disabled. Hide the others.
@@ -257,20 +256,20 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
           }
           if (enabled) {
             // It's enabled ... hide the span
-            dependencySpan.setStyle({ display: "none" });
+            dependencySpan.style.display = "none";
           } else {
             // It's disabled ... show the span
-            dependencySpan.setStyle({ display: "inline-block" });
+            dependencySpan.style.display = "inline-block";
           }
         }
 
-        dependenciesDiv.setStyle({ display: "inherit" });
+        dependenciesDiv.style.display = "inherit";
         infoContainer.appendChild(dependenciesDiv);
 
         return true;
       }
-      if (pluginTR.hasClassName("has-dependents")) {
-        if (!pluginTR.hasClassName("all-dependents-disabled")) {
+      if (pluginTR.classList.contains("has-dependents")) {
+        if (!pluginTR.classList.contains("all-dependents-disabled")) {
           var dependentIds = pluginMetadata.dependentIds;
 
           // If the only dependent is jenkins-core (it's a bundle plugin), then lets
@@ -278,30 +277,28 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
           // dependent plugins in this case.
           // Note: This does not cover "implied" dependencies ala detached plugins. See https://goo.gl/lQHrUh
           if (dependentIds.length === 1 && dependentIds[0] === "jenkins-core") {
-            pluginTR.addClassName("all-dependents-disabled");
+            pluginTR.classList.add("all-dependents-disabled");
             return false;
           }
 
-          infoContainer.update(
+          infoContainer.innerHTML =
             '<div class="title">' +
-              i18n("cannot-disable") +
-              '</div><div class="subtitle">' +
-              i18n("enabled-dependents") +
-              ".</div>"
-          );
+            i18n("cannot-disable") +
+            '</div><div class="subtitle">' +
+            i18n("enabled-dependents") +
+            ".</div>";
           infoContainer.appendChild(getDependentsDiv(pluginTR, true));
           return true;
         }
       }
 
-      if (pluginTR.hasClassName("possibly-has-implied-dependents")) {
-        infoContainer.update(
+      if (pluginTR.classList.contains("possibly-has-implied-dependents")) {
+        infoContainer.innerHTML =
           '<div class="title">' +
-            i18n("detached-disable") +
-            '</div><div class="subtitle">' +
-            i18n("detached-possible-dependents") +
-            "</div>"
-        );
+          i18n("detached-disable") +
+          '</div><div class="subtitle">' +
+          i18n("detached-possible-dependents") +
+          "</div>";
         infoContainer.appendChild(getDependentsDiv(pluginTR, true));
         return true;
       }
@@ -312,28 +309,26 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
     function populateUninstallInfo(pluginTR, infoContainer) {
       // Remove all existing class info
       infoContainer.removeAttribute("class");
-      infoContainer.addClassName("uninstall-state-info");
+      infoContainer.classList.add("uninstall-state-info");
 
-      if (pluginTR.hasClassName("has-dependents")) {
-        infoContainer.update(
+      if (pluginTR.classList.contains("has-dependents")) {
+        infoContainer.innerHTML =
           '<div class="title">' +
-            i18n("cannot-uninstall") +
-            '</div><div class="subtitle">' +
-            i18n("installed-dependents") +
-            ".</div>"
-        );
+          i18n("cannot-uninstall") +
+          '</div><div class="subtitle">' +
+          i18n("installed-dependents") +
+          ".</div>";
         infoContainer.appendChild(getDependentsDiv(pluginTR, false));
         return true;
       }
 
-      if (pluginTR.hasClassName("possibly-has-implied-dependents")) {
-        infoContainer.update(
+      if (pluginTR.classList.contains("possibly-has-implied-dependents")) {
+        infoContainer.innerHTML =
           '<div class="title">' +
-            i18n("detached-uninstall") +
-            '</div><div class="subtitle">' +
-            i18n("detached-possible-dependents") +
-            "</div>"
-        );
+          i18n("detached-uninstall") +
+          '</div><div class="subtitle">' +
+          i18n("detached-possible-dependents") +
+          "</div>";
         infoContainer.appendChild(getDependentsDiv(pluginTR, false));
         return true;
       }
@@ -353,21 +348,21 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
         var dependentId = dependentSpan.getAttribute("data-plugin-id");
 
         if (!hideDisabled || dependentId === "jenkins-core") {
-          dependentSpan.setStyle({ display: "inline-block" });
+          dependentSpan.style.display = "inline-block";
         } else {
           var depPluginTR = getPluginTR(dependentId);
           var depPluginMetadata = depPluginTR.jenkinsPluginMetadata;
           if (depPluginMetadata.enableInput.checked) {
             // It's enabled ... show the span
-            dependentSpan.setStyle({ display: "inline-block" });
+            dependentSpan.style.display = "inline-block";
           } else {
             // It's disabled ... hide the span
-            dependentSpan.setStyle({ display: "none" });
+            dependentSpan.style.display = "none";
           }
         }
       }
 
-      dependentsDiv.setStyle({ display: "inherit" });
+      dependentsDiv.style.display = "inherit";
       return dependentsDiv;
     }
 
@@ -407,7 +402,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
       if (enableInput) {
         // Toggling of the enable/disable checkbox requires a check and possible
         // change of visibility on the same checkbox on other plugins.
-        Element.observe(enableInput, "click", function () {
+        enableInput.addEventListener("click", function () {
           setEnableWidgetStates();
         });
       }
@@ -419,7 +414,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
       infoTR.appendChild(infoTD);
       infoTD.appendChild(infoDiv);
       infoTD.setAttribute("colspan", "6"); // This is the cell that all info will be added to.
-      infoDiv.setStyle({ display: "inherit" });
+      infoDiv.style.display = "inherit";
 
       // We don't want the info row to appear immediately. We wait for e.g. 1 second and if the mouse
       // is still in there (hasn't left the cell) then we show. The following code is for clearing the
@@ -434,16 +429,16 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
 
       // Handle mouse in/out of the enable/disable cell (left most cell).
       if (enableTD) {
-        Element.observe(enableTD, "mouseenter", function () {
+        enableTD.addEventListener("mouseenter", function () {
           showInfoTimeout = setTimeout(function () {
             showInfoTimeout = undefined;
-            infoDiv.update("");
+            infoDiv.textContent = "";
             if (populateEnableDisableInfo(pluginTR, infoDiv)) {
               addDependencyInfoRow(pluginTR, infoTR);
             }
           }, 1000);
         });
-        Element.observe(enableTD, "mouseleave", function () {
+        enableTD.addEventListener("mouseleave", function () {
           clearShowInfoTimeout();
           removeDependencyInfoRow(pluginTR);
         });
@@ -451,16 +446,16 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
 
       // Handle mouse in/out of the uninstall cell (right most cell).
       if (uninstallTD) {
-        Element.observe(uninstallTD, "mouseenter", function () {
+        uninstallTD.addEventListener("mouseenter", function () {
           showInfoTimeout = setTimeout(function () {
             showInfoTimeout = undefined;
-            infoDiv.update("");
+            infoDiv.textContent = "";
             if (populateUninstallInfo(pluginTR, infoDiv)) {
               addDependencyInfoRow(pluginTR, infoTR);
             }
           }, 1000);
         });
-        Element.observe(uninstallTD, "mouseleave", function () {
+        uninstallTD.addEventListener("mouseleave", function () {
           clearShowInfoTimeout();
           removeDependencyInfoRow(pluginTR);
         });
@@ -475,7 +470,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
   });
 })();
 
-Element.observe(window, "load", function () {
+window.addEventListener("load", function () {
   const compatibleCheckbox = document.querySelector(
     "[data-select='compatible']"
   );


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

Prototype is still used in `_table.js`.

### Solution

Remove Prototype from this file.

### Testing done

I ran this change on my project branch where Prototype.js completely removed. Before this change I had exceptions thrown when trying to view and install plugins. After this PR the exceptions are no longer thrown.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7941"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

