### PR TITLE
[JENKINS-71200] Fix elements property overload in ListView

### DIFF
--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -452,7 +452,7 @@ public class ListView extends View implements DirectlyModifiableView {
             }
             for (TopLevelItem item : items) {
                 String relativeNameFrom = item.getRelativeNameFrom(getOwner().getItemGroup());
-                if (req.getParameter(relativeNameFrom) != null) {
+                if (req.getParameter("item_" + relativeNameFrom) != null) {
                     jobNames.add(relativeNameFrom);
                 }
             }

--- a/core/src/main/resources/hudson/model/ListView/configure-entries.jelly
+++ b/core/src/main/resources/hudson/model/ListView/configure-entries.jelly
@@ -44,7 +44,7 @@ THE SOFTWARE.
           <j:set var="spanStyle" value="${it.recurse?'':'display:none'}"/>
         </j:if>
         <span class="${spanClass}" style="${spanStyle}">
-          <f:checkbox name="${job.getRelativeNameFromGroup(it.ownerItemGroup)}" checked="${it.jobNamesContains(job)}" title="${h.getRelativeDisplayNameFrom(job,it.ownerItemGroup)}" tooltip="${job.fullName}" json="true"/>
+          <f:checkbox name="item_${job.getRelativeNameFromGroup(it.ownerItemGroup)}" checked="${it.jobNamesContains(job)}" title="${h.getRelativeDisplayNameFrom(job,it.ownerItemGroup)}" tooltip="${job.fullName}" json="true"/>
           <br/>
         </span>
       </j:forEach>

--- a/test/src/test/java/hudson/model/ListViewTest.java
+++ b/test/src/test/java/hudson/model/ListViewTest.java
@@ -36,7 +36,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.gargoylesoftware.htmlunit.AlertHandler;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.Functions;
 import hudson.matrix.AxisList;
@@ -59,10 +61,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -289,6 +293,23 @@ public class ListViewTest {
         // remove a not contained job
         Failure e = assertThrows(Failure.class, () -> view.doRemoveJobFromView("job2"));
         assertEquals("Query parameter 'name' does not correspond to a known and readable item", e.getMessage());
+    }
+
+    @Issue("JENKINS-71200")
+    @Test public void doApplyDoNotOverloadElements() throws Exception {
+        MockFolder folder = j.createFolder("folder");
+        FreeStyleProject job = folder.createProject(FreeStyleProject.class, "elements");
+        ListView view = new ListView("view", folder);
+        folder.addView(view);
+        view.add(job);
+
+        final AtomicBoolean alerts = new AtomicBoolean();
+        WebClient webClient = j.createWebClient();
+        webClient.setAlertHandler((AlertHandler) (page, s) -> alerts.set(true));
+        HtmlPage page = webClient.goTo(view.getUrl() + "configure");
+        HtmlForm form = page.getFormByName("viewConfig");
+        j.assertGoodStatus(j.submit(form));
+        Assert.assertFalse("No alert expected", alerts.get());
     }
 
     @Test public void getItemsNames() throws Exception {


### PR DESCRIPTION
See [JENKINS-71200](https://issues.jenkins.io/browse/JENKINS-71200).

`ListView` produces `<input ..>` elements for each items within the ItemGroup that are named directly after the item name itself. If an item name is `elements`, this kind of overloads the `form.elements` attribute which causes a bad form submission.

The propose fix is to prefix the input names with `item_` to avoid the overload. 

### Testing done

* Started Jenkins
* create an freestyle job named `elements`
* create a view and Save

### Proposed changelog entries

- Prefix the name of input elements of ListView to prevent form submission issues when an Item (job) is named `elements`.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7942"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

