### PR TITLE
Remove Prototype from various form elements

### DIFF
--- a/core/src/main/resources/lib/form/apply/apply.js
+++ b/core/src/main/resources/lib/form/apply/apply.js
@@ -33,12 +33,12 @@ Behaviour.specify(
 
       // create a throw-away IFRAME to avoid back button from loading the POST result back
       id = "iframe" + iota++;
-      target = Element("iframe", {
-        id: id,
-        name: id,
-        style: "height:100%; width:100%",
-      });
-      $(containerId).appendChild(target);
+      target = document.createElement("iframe");
+      target.setAttribute("id", id);
+      target.setAttribute("name", id);
+      target.style.height = "100%";
+      target.style.width = "100%";
+      document.getElementById(containerId).appendChild(target);
 
       attachIframeOnload(target, function () {
         if (
@@ -56,26 +56,29 @@ Behaviour.specify(
           var contentWidth = r.width / 2;
           if (!error) {
             // fallback if it's not a regular error dialog from oops.jelly: use the entire body
-            error = Element("div", { id: "error-description" });
+            error = document.createElement("div");
+            error.setAttribute("id", "error-description");
             error.appendChild(doc.getElementsByTagName("body")[0]);
             contentHeight = (r.height * 3) / 4;
             contentWidth = (r.width * 3) / 4;
           }
 
-          let oldError = $("error-description");
+          let oldError = document.getElementById("error-description");
           if (oldError) {
             // Remove old error if there is any
-            $(containerId).removeChild(oldError);
+            document.getElementById(containerId).removeChild(oldError);
           }
 
-          $(containerId).appendChild(error);
+          document.getElementById(containerId).appendChild(error);
 
           var dialogStyleHeight = contentHeight + 40;
           var dialogStyleWidth = contentWidth + 20;
 
-          $(containerId).style.height = contentHeight + "px";
-          $(containerId).style.width = contentWidth + "px";
-          $(containerId).style.overflow = "scroll";
+          document.getElementById(containerId).style.height =
+            contentHeight + "px";
+          document.getElementById(containerId).style.width =
+            contentWidth + "px";
+          document.getElementById(containerId).style.overflow = "scroll";
 
           responseDialog.cfg.setProperty("width", dialogStyleWidth + "px");
           responseDialog.cfg.setProperty("height", dialogStyleHeight + "px");
@@ -84,13 +87,13 @@ Behaviour.specify(
         }
         window.setTimeout(function () {
           // otherwise Firefox will fail to leave the "connecting" state
-          $(id).remove();
+          document.getElementById(id).remove();
         }, 0);
       });
 
       f.target = target.id;
       f.elements["core:apply"].value = "true";
-      Event.fire(f, "jenkins:apply"); // give everyone a chance to write back to DOM
+      f.dispatchEvent(new Event("jenkins:apply")); // give everyone a chance to write back to DOM
       try {
         buildFormTree(f);
         f.submit();

--- a/core/src/main/resources/lib/form/confirm.js
+++ b/core/src/main/resources/lib/form/confirm.js
@@ -17,24 +17,24 @@
   }
 
   function isIgnoringConfirm(element) {
-    if (element.hasClassName("force-dirty")) {
+    if (element.classList.contains("force-dirty")) {
       return false;
     }
-    if (element.hasClassName("ignore-dirty")) {
+    if (element.classList.contains("ignore-dirty")) {
       return true;
     }
     // to allow sub-section of the form to ignore confirm
     // especially useful for "pure" JavaScript area
     // we try to gather the first parent with a marker,
-    var dirtyPanel = element.up(".ignore-dirty-panel,.force-dirty-panel");
+    var dirtyPanel = element.closest(".ignore-dirty-panel,.force-dirty-panel");
     if (!dirtyPanel) {
       return false;
     }
 
-    if (dirtyPanel.hasClassName("force-dirty-panel")) {
+    if (dirtyPanel.classList.contains("force-dirty-panel")) {
       return false;
     }
-    if (dirtyPanel.hasClassName("ignore-dirty-panel")) {
+    if (dirtyPanel.classList.contains("ignore-dirty-panel")) {
       return true;
     }
 
@@ -69,7 +69,7 @@
       configForm = document.getElementsByName("viewConfig")[0];
     }
 
-    YAHOO.util.Event.on($(configForm), "submit", clearConfirm, this);
+    configForm.addEventListener("submit", clearConfirm);
 
     var buttons = configForm.getElementsByTagName("button");
     var name;
@@ -117,5 +117,5 @@
   }
 
   window.onbeforeunload = confirmExit;
-  Event.on(window, "load", initConfirm);
+  window.addEventListener("load", initConfirm);
 })();

--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -120,7 +120,7 @@ Behaviour.specify(
             });
 
             function o(did) {
-              if (Object.isElement(did)) {
+              if (did instanceof Element) {
                 did = did.getAttribute("descriptorId");
               }
               for (var i = 0; i < templates.length; i++) {

--- a/core/src/main/resources/lib/form/repeatable/repeatable.js
+++ b/core/src/main/resources/lib/form/repeatable/repeatable.js
@@ -18,12 +18,11 @@ var repeatableSupport = {
 
   // do the initialization
   init: function (container, master, insertionPoint) {
-    this.container = $(container);
+    this.container = container;
     this.container.tag = this;
-    master = $(master);
     this.blockHTML = master.innerHTML;
     master.parentNode.removeChild(master);
-    this.insertionPoint = $(insertionPoint);
+    this.insertionPoint = insertionPoint;
     this.name = master.getAttribute("name");
     if (this.container.getAttribute("enableTopButton") == "true") {
       this.enableTopButton = true;
@@ -43,7 +42,7 @@ var repeatableSupport = {
 
     // importNode isn't supported in IE.
     // nc = document.importNode(node,true);
-    var nc = $(document.createElement("div"));
+    var nc = document.createElement("div");
     nc.className = "repeated-chunk";
     nc.setOpacity(0);
     nc.setAttribute("name", this.name);
@@ -51,11 +50,9 @@ var repeatableSupport = {
     if (!addOnTop) {
       this.insertionPoint.parentNode.insertBefore(nc, this.insertionPoint);
     } else if (this.enableTopButton) {
-      var children = $(this.container)
-        .childElements()
-        .findAll(function (n) {
-          return n.hasClassName("repeated-chunk");
-        });
+      var children = Array.from(this.container.children).filter(function (n) {
+        return n.classList.contains("repeated-chunk");
+      });
       this.container.insertBefore(nc, children[0]);
     }
     // Initialize drag & drop for this element
@@ -78,18 +75,16 @@ var repeatableSupport = {
 
   // update CSS classes associated with repeated items.
   update: function () {
-    var children = $(this.container)
-      .childElements()
-      .findAll(function (n) {
-        return n.hasClassName("repeated-chunk");
-      });
+    var children = Array.from(this.container.children).filter(function (n) {
+      return n.classList.contains("repeated-chunk");
+    });
 
     if (children.length == 0) {
-      var addButtonElements = $(this.container)
-        .childElements()
-        .findAll(function (b) {
-          return b.hasClassName("repeatable-add");
-        });
+      var addButtonElements = Array.from(this.container.children).filter(
+        function (b) {
+          return b.classList.contains("repeatable-add");
+        }
+      );
 
       if (addButtonElements.length == 2) {
         var buttonElement = addButtonElements[0];
@@ -98,11 +93,11 @@ var repeatableSupport = {
       }
     } else {
       if (children.length == 1) {
-        addButtonElements = $(this.container)
-          .childElements()
-          .findAll(function (b) {
-            return b.hasClassName("repeatable-add");
-          });
+        addButtonElements = Array.from(this.container.children).filter(
+          function (b) {
+            return b.classList.contains("repeatable-add");
+          }
+        );
 
         if (addButtonElements.length == 1 && this.enableTopButton) {
           buttonElement = addButtonElements[0];
@@ -156,7 +151,7 @@ var repeatableSupport = {
     var addOnTop = false;
     while (n.tag == null) {
       n = n.parentNode;
-      if (n.hasClassName("repeatable-add-top")) {
+      if (n.classList.contains("repeatable-add-top")) {
         addOnTop = true;
       }
     }
@@ -181,9 +176,9 @@ Behaviour.specify("DIV.repeated-container", "repeatable", -100, function (e) {
   }
 
   // compute the insertion point
-  var ip = $(e.lastElementChild);
-  while (!ip.hasClassName("repeatable-insertion-point")) {
-    ip = ip.previous();
+  var ip = e.lastElementChild;
+  while (!ip.classList.contains("repeatable-insertion-point")) {
+    ip = ip.previousElementSibling;
   }
   // set up the logic
   object(repeatableSupport).init(e, e.firstChild, ip);

--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -4,7 +4,7 @@ function updateListBox(listBox, url, config) {
   config = config || {};
   config = object(config);
   var originalOnSuccess = config.onSuccess;
-  var l = $(listBox);
+  var l = listBox;
 
   // Hacky function to retrofit compatibility with tables-to-divs
   // If the <select> tag parent is a <td> element we can consider it's following a
@@ -43,7 +43,7 @@ function updateListBox(listBox, url, config) {
     status.innerHTML = "";
   }
   config.onSuccess = function (rsp) {
-    l.removeClassName("select-ajax-pending");
+    l.classList.remove("select-ajax-pending");
     var currentSelection = l.value;
 
     // clear the contents
@@ -75,7 +75,7 @@ function updateListBox(listBox, url, config) {
     }
   };
   config.onFailure = function (rsp) {
-    l.removeClassName("select-ajax-pending");
+    l.classList.remove("select-ajax-pending");
     status.innerHTML = rsp.responseText;
     if (status.firstElementChild) {
       status.firstElementChild.setAttribute("data-select-ajax-error", "true");
@@ -91,7 +91,7 @@ function updateListBox(listBox, url, config) {
     }
   };
 
-  l.addClassName("select-ajax-pending");
+  l.classList.add("select-ajax-pending");
   new Ajax.Request(url, config);
 }
 

--- a/core/src/main/resources/lib/form/textarea/textarea.js
+++ b/core/src/main/resources/lib/form/textarea/textarea.js
@@ -28,7 +28,7 @@ Behaviour.specify("TEXTAREA.codemirror", "textarea", 0, function (e) {
   // the form needs to be populated before the "Apply" button
   if (e.closest("form")) {
     // Protect against undefined element
-    Element.on(e.closest("form"), "jenkins:apply", function () {
+    e.closest("form").addEventListener("jenkins:apply", function () {
       e.value = codemirror.getValue();
     });
   }


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

Prototype is still used in various `lib/form` elements.

### Solution

Remove Prototype from these elements.

### Testing done

I ran this change on my project branch where Prototype.js completely removed. Before this change I had exceptions thrown when trying to view various pages. The changes here came from repeatedly refreshing pages until they loaded without Prototype.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7943"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

