### PR TITLE
Remove Prototype from miscellaneous files

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -284,7 +284,7 @@ THE SOFTWARE.
       <script>
         <!-- function to toggle the enable/disable state -->
         function flip(o) {
-          btn = Event.element(o);
+          btn = o.target;
 
           <!-- trigger -->
           fetch(btn.getAttribute('url')+"/make"+(btn.checked?"Enabled":"Disabled"), {
@@ -292,7 +292,7 @@ THE SOFTWARE.
             headers: crumb.wrap({}),
           }).then(rsp => {
             if (!rsp.ok) {
-              $('needRestart').innerHTML = req.responseText;
+              document.getElementById('needRestart').innerHTML = req.responseText;
             }
             updateMsg();
           })
@@ -300,14 +300,14 @@ THE SOFTWARE.
 
         function updateMsg() {
           <!-- is anything changed since its original state? -->
-          var e = $A(Form.getInputs('plugins', 'checkbox')).find(function(e) {
+          var e = Array.from(document.getElementById('plugins').querySelectorAll('input[type="checkbox"]')).find(function(e) {
             return String(e.checked)!=e.getAttribute('original');
           });
 
           <j:if test="${app.updateCenter.isRestartRequiredForCompletion()}">
             e = true;
           </j:if>
-          $('needRestart').style.display = (e!=null?"block":"none");
+          document.getElementById('needRestart').style.display = (e!=null?"block":"none");
         }
 
         updateMsg(); // set the initial state

--- a/core/src/main/resources/hudson/model/View/AsynchPeople/people-resources.js
+++ b/core/src/main/resources/hudson/model/View/AsynchPeople/people-resources.js
@@ -1,6 +1,6 @@
 window.display = function (data) {
   var p = document.getElementById("people");
-  p.show();
+  p.style.display = "";
   var rootURL = document.head.getAttribute("data-rooturl");
   for (var x = 0; data.length > x; x++) {
     var e = data[x];

--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.js
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.js
@@ -22,8 +22,8 @@
  * THE SOFTWARE.
  */
 window.revokeToken = function (anchorRevoke) {
-  var repeatedChunk = anchorRevoke.up(".repeated-chunk");
-  var tokenList = repeatedChunk.up(".token-list");
+  var repeatedChunk = anchorRevoke.closest(".repeated-chunk");
+  var tokenList = repeatedChunk.closest(".token-list");
   var confirmMessage = anchorRevoke.getAttribute("data-confirm");
   var targetUrl = anchorRevoke.getAttribute("data-target-url");
 
@@ -56,14 +56,14 @@ window.revokeToken = function (anchorRevoke) {
 };
 
 window.saveApiToken = function (button) {
-  if (button.hasClassName("request-pending")) {
+  if (button.classList.contains("request-pending")) {
     // avoid multiple requests to be sent if user is clicking multiple times
     return;
   }
-  button.addClassName("request-pending");
+  button.classList.add("request-pending");
   var targetUrl = button.getAttribute("data-target-url");
-  var repeatedChunk = button.up(".repeated-chunk ");
-  var tokenList = repeatedChunk.up(".token-list");
+  var repeatedChunk = button.closest(".repeated-chunk ");
+  var tokenList = repeatedChunk.closest(".token-list");
   var nameInput = repeatedChunk.querySelector('[name="tokenName"]');
   var tokenName = nameInput.value;
 
@@ -77,11 +77,11 @@ window.saveApiToken = function (button) {
         var errorSpan = repeatedChunk.querySelector(".error");
         if (json.status === "error") {
           errorSpan.innerHTML = json.message;
-          errorSpan.addClassName("visible");
+          errorSpan.classList.add("visible");
 
-          button.removeClassName("request-pending");
+          button.classList.remove("request-pending");
         } else {
-          errorSpan.removeClassName("visible");
+          errorSpan.classList.remove("visible");
 
           var tokenName = json.data.tokenName;
           // in case the name was empty, the application will propose a default one
@@ -90,14 +90,14 @@ window.saveApiToken = function (button) {
           var tokenValue = json.data.tokenValue;
           var tokenValueSpan = repeatedChunk.querySelector(".new-token-value");
           tokenValueSpan.innerText = tokenValue;
-          tokenValueSpan.addClassName("visible");
+          tokenValueSpan.classList.add("visible");
 
           // show the copy button
           var tokenCopyButton = repeatedChunk.querySelector(
             ".jenkins-copy-button"
           );
           tokenCopyButton.setAttribute("text", tokenValue);
-          tokenCopyButton.removeClassName("jenkins-hidden");
+          tokenCopyButton.classList.remove("jenkins-hidden");
 
           var tokenUuid = json.data.tokenUuid;
           var uuidInput = repeatedChunk.querySelector('[name="tokenUuid"]');
@@ -106,18 +106,18 @@ window.saveApiToken = function (button) {
           var warningMessage = repeatedChunk.querySelector(
             ".display-after-generation"
           );
-          warningMessage.addClassName("visible");
+          warningMessage.classList.add("visible");
 
           // we do not want to allow user to create twice a token using same name by mistake
           button.remove();
 
           var revokeButton = repeatedChunk.querySelector(".token-revoke");
-          revokeButton.removeClassName("hidden-button");
+          revokeButton.classList.remove("hidden-button");
 
           var cancelButton = repeatedChunk.querySelector(".token-cancel");
-          cancelButton.addClassName("hidden-button");
+          cancelButton.classList.add("hidden-button");
 
-          repeatedChunk.addClassName("token-list-fresh-item");
+          repeatedChunk.classList.add("token-list-fresh-item");
 
           adjustTokenEmptyListMessage(tokenList);
         }
@@ -134,12 +134,12 @@ function adjustTokenEmptyListMessage(tokenList) {
     ".token-list-existing-item, .token-list-fresh-item"
   ).length;
   if (numOfToken >= 1) {
-    if (!emptyListMessage.hasClassName("hidden-message")) {
-      emptyListMessage.addClassName("hidden-message");
+    if (!emptyListMessage.classList.contains("hidden-message")) {
+      emptyListMessage.classList.add("hidden-message");
     }
   } else {
-    if (emptyListMessage.hasClassName("hidden-message")) {
-      emptyListMessage.removeClassName("hidden-message");
+    if (emptyListMessage.classList.contains("hidden-message")) {
+      emptyListMessage.classList.remove("hidden-message");
     }
   }
 }

--- a/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/resources.js
+++ b/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/resources.js
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 window.selectAll = function (anchor) {
-  var parent = anchor.up(".legacy-token-usage");
+  var parent = anchor.closest(".legacy-token-usage");
   var allCheckBoxes = parent.querySelectorAll(".token-to-revoke");
   var concernedCheckBoxes = allCheckBoxes;
 
@@ -30,7 +30,7 @@ window.selectAll = function (anchor) {
 };
 
 window.selectFresh = function (anchor) {
-  var parent = anchor.up(".legacy-token-usage");
+  var parent = anchor.closest(".legacy-token-usage");
   var allCheckBoxes = parent.querySelectorAll(".token-to-revoke");
   var concernedCheckBoxes = parent.querySelectorAll(
     ".token-to-revoke.fresh-token"
@@ -40,7 +40,7 @@ window.selectFresh = function (anchor) {
 };
 
 window.selectRecent = function (anchor) {
-  var parent = anchor.up(".legacy-token-usage");
+  var parent = anchor.closest(".legacy-token-usage");
   var allCheckBoxes = parent.querySelectorAll(".token-to-revoke");
   var concernedCheckBoxes = parent.querySelectorAll(
     ".token-to-revoke.recent-token"
@@ -75,7 +75,7 @@ function checkTheDesiredOne(allCheckBoxes, concernedCheckBoxes) {
 }
 
 window.confirmAndRevokeAllSelected = function (button) {
-  var parent = button.up(".legacy-token-usage");
+  var parent = button.closest(".legacy-token-usage");
   var allCheckBoxes = parent.querySelectorAll(".token-to-revoke");
   var allCheckedCheckBoxes = [];
   for (let i = 0; i < allCheckBoxes.length; i++) {
@@ -133,7 +133,7 @@ function onLineClicked(event) {
 }
 
 function onCheckChanged(checkBox) {
-  var line = checkBox.up("tr");
+  var line = checkBox.closest("tr");
   if (checkBox.checked) {
     line.classList.add("selected");
   } else {

--- a/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/resources.js
+++ b/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/resources.js
@@ -135,9 +135,9 @@ function onLineClicked(event) {
 function onCheckChanged(checkBox) {
   var line = checkBox.up("tr");
   if (checkBox.checked) {
-    line.addClassName("selected");
+    line.classList.add("selected");
   } else {
-    line.removeClassName("selected");
+    line.classList.remove("selected");
   }
 }
 
@@ -146,7 +146,7 @@ function onCheckChanged(checkBox) {
     var allLines = document.querySelectorAll(".legacy-token-usage table tr");
     for (let i = 0; i < allLines.length; i++) {
       let line = allLines[i];
-      if (!line.hasClassName("no-token-line")) {
+      if (!line.classList.contains("no-token-line")) {
         line.onclick = onLineClicked;
       }
     }

--- a/core/src/main/resources/jenkins/security/seed/UserSeedProperty/resources.js
+++ b/core/src/main/resources/jenkins/security/seed/UserSeedProperty/resources.js
@@ -22,14 +22,14 @@
  * THE SOFTWARE.
  */
 window.resetSeed = function (button) {
-  var userSeedPanel = button.up(".user-seed-panel");
+  var userSeedPanel = button.closest(".user-seed-panel");
   var confirmMessage = button.getAttribute("data-confirm");
   var targetUrl = button.getAttribute("data-target-url");
   var redirectAfterClick = button.getAttribute("data-redirect-url");
 
   var warningMessage = userSeedPanel.querySelector(".display-after-reset");
-  if (warningMessage.hasClassName("visible")) {
-    warningMessage.removeClassName("visible");
+  if (warningMessage.classList.contains("visible")) {
+    warningMessage.classList.remove("visible");
   }
 
   if (confirm(confirmMessage)) {
@@ -41,8 +41,8 @@ window.resetSeed = function (button) {
         if (redirectAfterClick) {
           window.location.href = redirectAfterClick;
         } else {
-          if (!warningMessage.hasClassName("visible")) {
-            warningMessage.addClassName("visible");
+          if (!warningMessage.classList.contains("visible")) {
+            warningMessage.classList.add("visible");
           }
         }
       }

--- a/core/src/main/resources/lib/hudson/build-caption.js
+++ b/core/src/main/resources/lib/hudson/build-caption.js
@@ -20,6 +20,6 @@
   }
 
   window.addEventListener("load", function () {
-    Event.observe(window, "jenkins:consoleFinished", updateBuildCaptionIcon);
+    window.addEventListener("jenkins:consoleFinished", updateBuildCaptionIcon);
   });
 })();

--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -63,16 +63,17 @@ Behaviour.specify(
             }, 1000);
           } else {
             if (spinner !== "") {
-              $(spinner).style.display = "none";
+              document.getElementById(spinner).style.display = "none";
             }
             if (onFinishEvent) {
-              Event.fire(window, onFinishEvent);
+              window.dispatchEvent(new Event(onFinishEvent));
             }
           }
         });
       });
     }
-    $(idref).fetchedBytes = startOffset !== "" ? Number(startOffset) : 0;
-    fetchNext($(idref), href, onFinishEvent);
+    document.getElementById(idref).fetchedBytes =
+      startOffset !== "" ? Number(startOffset) : 0;
+    fetchNext(document.getElementById(idref), href, onFinishEvent);
   }
 );


### PR DESCRIPTION
### Context

See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, we ought to eliminate our dependency on it in favor of modern JavaScript APIs.

### Problem

Prototype is still used in various files.

### Solution

Remove Prototype from these files.

### Testing done

I ran this change on my project branch where Prototype.js completely removed. Before this change I had exceptions thrown when trying to view various pages. The changes here came from repeatedly refreshing pages until they loaded without Prototype.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7944"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

