### PR TITLE
Better assertion in `jenkins.model.lazy.Build`

### DIFF
--- a/core/src/test/java/jenkins/model/lazy/Build.java
+++ b/core/src/test/java/jenkins/model/lazy/Build.java
@@ -35,7 +35,7 @@ class Build {
     }
 
     public void asserts(int n) {
-        assert this.n == n;
+        assert this.n == n : "expected " + n + " but was " + this.n;
     }
 
     @Override public String toString() {


### PR DESCRIPTION
Noticed that this test utility had an unhelpful assertion.

### Testing done

N/A

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7966"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

