### PR TITLE
Do not use `errorPanel` if the UC is offline

### DIFF
--- a/war/src/main/js/pluginSetupWizardGui.js
+++ b/war/src/main/js/pluginSetupWizardGui.js
@@ -1324,17 +1324,12 @@ var createPluginSetupWizard = function (appendTarget) {
       handleGenericError(function (isConnected, isFatal, errorMessage) {
         if (!isConnected) {
           if (isFatal) {
-            // We cannot continue, show error
-            setPanel(errorPanel, {
-              errorMessage:
-                "Default update site connectivity check failed with fatal error: " +
-                errorMessage +
-                ". If you see this issue for the custom Jenkins WAR bundle, consider setting the correct value of the hudson.model.UpdateCenter.defaultUpdateSiteId system property (requires Jenkins restart). Otherwise please create a bug in Jenkins JIRA.",
-            });
-          } else {
-            // The update center is offline, no problem
-            setPanel(offlinePanel);
+            console.log(
+              "Default update site connectivity check failed with fatal error: " +
+                errorMessage
+            );
           }
+          setPanel(offlinePanel);
           return;
         }
 


### PR DESCRIPTION
#2319 made a number of changes, among them a condition under which the setup wizard would completely halt, with no recourse. As tracked in @cloudbees as FNDJEN-1758, this can cause a headache when there are uninteresting problems with a custom update site like a missing signature from `hpi:run`.

### Testing done

```bash
mvn hpi:run -Dhudson.Main.development=false -Djenkins.version=…
```

from a CloudBees CI proprietary plugin and log in to the setup wizard. Without the patch, you will get the error screen and be unable to continue (only **Retry** is offered). With the patch, you can continue with **Skip Plugin Installations** and complete the setup wizard.

### Proposed changelog entries

- N/A (unlikely to affect production use cases)

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7968"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

