### PR TITLE
[JENKINS-70922] Remove Prototype `Ajax.Request` usage from `select.js`

### DIFF
--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -43,56 +43,73 @@ function updateListBox(listBox, url, config) {
     status.innerHTML = "";
   }
   config.onSuccess = function (rsp) {
-    l.classList.remove("select-ajax-pending");
-    var currentSelection = l.value;
+    rsp.json().then((result) => {
+      l.classList.remove("select-ajax-pending");
+      var currentSelection = l.value;
 
-    // clear the contents
-    while (l.length > 0) {
-      l.options[0] = null;
-    }
-
-    var selectionSet = false; // is the selection forced by the server?
-    var possibleIndex = null; // if there's a new option that matches the current value, remember its index
-    var opts = JSON.parse(rsp.responseText).values;
-    for (var i = 0; i < opts.length; i++) {
-      l.options[i] = new Option(opts[i].name, opts[i].value);
-      if (opts[i].selected) {
-        l.selectedIndex = i;
-        selectionSet = true;
-      }
-      if (opts[i].value == currentSelection) {
-        possibleIndex = i;
-      }
-    }
-
-    // if no value is explicitly selected by the server, try to select the same value
-    if (!selectionSet && possibleIndex != null) {
-      l.selectedIndex = possibleIndex;
-    }
-
-    if (originalOnSuccess !== undefined) {
-      originalOnSuccess(rsp);
-    }
-  };
-  config.onFailure = function (rsp) {
-    l.classList.remove("select-ajax-pending");
-    status.innerHTML = rsp.responseText;
-    if (status.firstElementChild) {
-      status.firstElementChild.setAttribute("data-select-ajax-error", "true");
-    }
-    Behaviour.applySubtree(status);
-    // deleting values can result in the data loss, so let's not do that unless instructed
-    var header = rsp.getResponseHeader("X-Jenkins-Select-Error");
-    if (header && "clear" === header.toLowerCase()) {
       // clear the contents
       while (l.length > 0) {
         l.options[0] = null;
       }
-    }
+
+      var selectionSet = false; // is the selection forced by the server?
+      var possibleIndex = null; // if there's a new option that matches the current value, remember its index
+
+      var opts = result.values;
+      for (var i = 0; i < opts.length; i++) {
+        l.options[i] = new Option(opts[i].name, opts[i].value);
+        if (opts[i].selected) {
+          l.selectedIndex = i;
+          selectionSet = true;
+        }
+        if (opts[i].value === currentSelection) {
+          possibleIndex = i;
+        }
+      }
+
+      // if no value is explicitly selected by the server, try to select the same value
+      if (!selectionSet && possibleIndex != null) {
+        l.selectedIndex = possibleIndex;
+      }
+
+      if (originalOnSuccess !== undefined) {
+        originalOnSuccess(rsp);
+      }
+    });
+  };
+  config.onFailure = function (rsp) {
+    rsp.text().then((responseText) => {
+      l.classList.remove("select-ajax-pending");
+      status.innerHTML = responseText;
+      if (status.firstElementChild) {
+        status.firstElementChild.setAttribute("data-select-ajax-error", "true");
+      }
+      Behaviour.applySubtree(status);
+      // deleting values can result in the data loss, so let's not do that unless instructed
+      var header = rsp.headers.get("X-Jenkins-Select-Error");
+      if (header && "clear" === header.toLowerCase()) {
+        // clear the contents
+        while (l.length > 0) {
+          l.options[0] = null;
+        }
+      }
+    });
   };
 
   l.classList.add("select-ajax-pending");
-  new Ajax.Request(url, config);
+  fetch(url, {
+    method: "post",
+    headers: crumb.wrap({
+      "Content-Type": "application/x-www-form-urlencoded",
+    }),
+    body: objectToUrlFormEncoded(config.parameters),
+  }).then((response) => {
+    if (response.ok) {
+      config.onSuccess(response);
+    } else {
+      config.onFailure(response);
+    }
+  });
 }
 
 Behaviour.specify("SELECT.select", "select", 1000, function (e) {


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-70922](https://issues.jenkins.io/browse/JENKINS-70922).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

Manually tested by clicking through the UI where it's used adding console.log to see what was using it.
Credentials were fine.
Ran `mvn test -Dtest=hudson.RelativePathTest` which provides test coverage (and it caught an issue with parameters originally)

Draft till ran through ATH

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7982"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

