### PR TITLE
`AbstractItem#doReload` should not be calling `SaveableListener#fireOnChange`

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -940,8 +940,6 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
             }
         });
         Jenkins.get().rebuildDependencyGraphAsync();
-
-        SaveableListener.fireOnChange(this, getConfigFile());
     }
 
 

--- a/test/src/test/java/hudson/model/AbstractItemTest.java
+++ b/test/src/test/java/hudson/model/AbstractItemTest.java
@@ -154,7 +154,7 @@ public class AbstractItemTest {
         return u.getPath().substring(j.contextPath.length() + 1);
     }
 
-    @TestExtension
+    @TestExtension("reload")
     public static class TestSaveableListener extends SaveableListener {
         private Saveable saveable;
 

--- a/test/src/test/java/hudson/model/AbstractItemTest.java
+++ b/test/src/test/java/hudson/model/AbstractItemTest.java
@@ -3,6 +3,7 @@ package hudson.model;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -10,6 +11,9 @@ import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import hudson.ExtensionList;
+import hudson.XmlFile;
+import hudson.model.listeners.SaveableListener;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.security.AccessDeniedException3;
@@ -28,6 +32,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.TestExtension;
 
 public class AbstractItemTest {
 
@@ -50,8 +55,14 @@ public class AbstractItemTest {
         Path path = p.getConfigFile().getFile().toPath();
         Files.writeString(path, Files.readString(path, StandardCharsets.UTF_8).replaceAll("Hello World", "Good Evening"), StandardCharsets.UTF_8);
 
+        TestSaveableListener testSaveableListener = ExtensionList.lookupSingleton(TestSaveableListener.class);
+        testSaveableListener.setSaveable(p);
+
         // reload away
         p.doReload();
+
+        assertFalse(SaveableListener.class.getSimpleName() + " should not have been called", testSaveableListener.wasCalled());
+
 
         assertEquals("Good Evening", p.getDescription());
 
@@ -143,4 +154,25 @@ public class AbstractItemTest {
         return u.getPath().substring(j.contextPath.length() + 1);
     }
 
+    @TestExtension
+    public static class TestSaveableListener extends SaveableListener {
+        private Saveable saveable;
+
+        private boolean called;
+
+        private void setSaveable(Saveable saveable) {
+            this.saveable = saveable;
+        }
+
+        public boolean wasCalled() {
+            return called;
+        }
+
+        @Override
+        public void onChange(Saveable o, XmlFile file) {
+            if (o == saveable) {
+                this.called = true;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Was initially added as ce7e6390ee29ab59ebff92a8f3033c9e5ef02f4e

`SaveableListener.fireOnChange` is typically called when saving an object, not when loading it.
This call should be removed as it causes unnecessary calls to listeners when in fact no change happened.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Developer: do not call `SaveableListener.fireOnChange` anymore when reloading an `AbstractItem`.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

Upgrade notes: Jenkins config history plugin users: when reloading an individual job from CLI, the event is no longer recorded by the plugin. Note that it was already the case when reloading all jobs through the "Reload configuration from disk" action.

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7984"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

