### PR TITLE
Upgrade from Guice 5.1.0 to 6.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,11 @@ updates:
       # Starting with 6.x, Spring Security requires Java 17 at a minimum.
       - dependency-name: "org.springframework.security:spring-security-bom"
         versions: [">=6.0.0"]
+
+      # Starting with 7.x, Guice switches from javax.* to jakarta.* bindings.
+      # See https://github.com/google/guice/wiki/Guice700
+      - dependency-name: "com.google.inject:guice-bom"
+        versions: [">=6.0.0"]
   - package-ecosystem: "maven"
     directory: "/"
     target-branch: "stable-2.375"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,7 @@ updates:
       # Starting with 7.x, Guice switches from javax.* to jakarta.* bindings.
       # See https://github.com/google/guice/wiki/Guice700
       - dependency-name: "com.google.inject:guice-bom"
-        versions: [">=6.0.0"]
+        versions: [">=7.0.0"]
   - package-ecosystem: "maven"
     directory: "/"
     target-branch: "stable-2.375"

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -49,7 +49,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice-bom</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Guice 6 smooths the way for Jakarta bindings, by keeping compatibility with javax.* and adding support for jakarta.* alongside, where Guice 7 ended support for javax.* bindings while supporting jakarta.* only.
Going from 5 to 6, over 5 to 7, is the safer approach because we can adapt jakarta when we're ready for it, without immediately cutting support for javax.

Additionally, it supports Java 21, which I'm really looking forward to :)

Closes https://github.com/jenkinsci/jenkins/pull/7987

### Testing done

Compiling Jenkins against guice 6, while inspecting our methods bound properly.
Built a couple of pipeline and freestyle jobs and clicked around UI elements.
CI tests are passing too.

### Proposed changelog entries

- Upgrade from Guice 5 to [6](https://github.com/google/guice/wiki/Guice600).

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7990"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

