### PR TITLE
Make Jenkins compile in Eclipse out of the box

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -547,6 +547,9 @@ THE SOFTWARE.
             <phase>generate-sources</phase>
             <configuration>
               <sources>
+                <!-- The antlr4 sources are found automatically by the maven compiler,
+                but listing them explicitly avoids a missing classpath entry when importing the maven project in eclipse. -->
+                <source>${project.build.directory}/generated-sources/antlr4</source>
                 <source>${project.build.directory}/generated-sources/localizer</source>
                 <source>${project.build.directory}/generated-sources/taglib-interface</source>
               </sources>

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -78,7 +78,8 @@ public class RunTest {
                 }).get();
                 TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
                 id = r.getId();
-                assertEquals(id, svc.submit(r::getId).get());
+                // explicitly cast to callable to make the Eclipse compiler happy
+                assertEquals(id, svc.submit((Callable) r::getId).get());
             } finally {
                 svc.shutdown();
             }
@@ -86,7 +87,8 @@ public class RunTest {
             svc = Executors.newSingleThreadExecutor();
             try {
                 assertEquals(id, r.getId());
-                assertEquals(id, svc.submit(r::getId).get());
+                // explicitly cast to callable to make the Eclipse compiler happy
+                assertEquals(id, svc.submit((Callable) r::getId).get());
             } finally {
                 svc.shutdown();
             }


### PR DESCRIPTION
When importing the Jenkins sources in Eclipse there are some compiler errors that cannot easily be fixed by changing preferences:
* There are 2 ambigious method call overloads, which need an additional type cast to compile in ECJ.
* All generated lexer and parser classes are missing. This is because the antlr generated code is found automatically in the maven compilation, but not in m2e (the eclipse maven integration), unless the generated source path is mentioned explicitly.

### Testing done

There are no functional changes (the Java code change is only an explicit type cast).
Compiles in Eclipse and Maven now.

It might be useful to have someone using Netbeans or IntelliJ check whether that causes bad side effects on their side (and whether some SuppressWarning or similar is needed in the modified Java class).

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7993"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

