### PR TITLE
Broken `toArray` implementations in `BuildReferenceMapAdapter`

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
@@ -3,7 +3,6 @@ package jenkins.model.lazy;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.util.AdaptedIterator;
 import hudson.util.Iterators;
-import java.lang.reflect.Array;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -192,25 +191,16 @@ class BuildReferenceMapAdapter<R> implements SortedMap<Integer, R> {
 
         @Override
         public Object[] toArray() {
-            List<Object> list = new ArrayList<>(this);
+            List<Object> list = new ArrayList<>(size());
+            for (var e : this) {
+                list.add(e);
+            }
             return list.toArray();
         }
 
         @Override
         public <T> T[] toArray(T[] a) {
-            int size = size();
-            T[] r = a;
-            if (r.length > size)
-                r = (T[]) Array.newInstance(a.getClass().getComponentType(), size);
-
-            Iterator<R> itr = iterator();
-            int i = 0;
-
-            while (itr.hasNext()) {
-                r[i++] = (T) itr.next();
-            }
-
-            return r;
+            return new ArrayList<>(this).toArray(a);
         }
 
         @Override
@@ -309,25 +299,16 @@ class BuildReferenceMapAdapter<R> implements SortedMap<Integer, R> {
 
         @Override
         public Object[] toArray() {
-            List<Object> list = new ArrayList<>(this);
+            List<Object> list = new ArrayList<>(size());
+            for (var e : this) {
+                list.add(e);
+            }
             return list.toArray();
         }
 
         @Override
         public <T> T[] toArray(T[] a) {
-            int size = size();
-            T[] r = a;
-            if (r.length > size)
-                r = (T[]) Array.newInstance(a.getClass().getComponentType(), size);
-
-            Iterator<Entry<Integer, R>> itr = iterator();
-            int i = 0;
-
-            while (itr.hasNext()) {
-                r[i++] = (T) itr.next();
-            }
-
-            return r;
+            return new ArrayList<>(this).toArray(a);
         }
 
         @Override

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -24,6 +24,9 @@
 
 package jenkins.model.lazy;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -382,6 +385,19 @@ public class AbstractLazyLoadRunMapTest {
         for (Map.Entry<Integer, Build> e : a.entrySet()) {
             assertTrue(a.entrySet().contains(e));
         }
+    }
+
+    @Test
+    public void toArray() {
+        var es = a.entrySet();
+        assertThat(es.size(), is(3));
+        assertThat(es.toArray(), arrayWithSize(3));
+        assertThat(es.toArray(Object[]::new), arrayWithSize(3));
+        var c = a.getLoadedBuilds().values();
+        assertThat(c.size(), is(3));
+        assertThat(c.toArray(), arrayWithSize(3));
+        assertThat(c.toArray(Object[]::new), arrayWithSize(3));
+        // TODO check behavior of subMap
     }
 
     @Issue("JENKINS-22767")


### PR DESCRIPTION
While working on #7998 in some earlier iterations I had stumbled across errors in the collection types used in `BuildReferenceMapAdapter` which I presume were never tested before and are not used in production code.

### Testing done

Without patches, the test fails with the following stack traces:

```
java.lang.StackOverflowError
	at java.base/java.util.ArrayList.<init>(ArrayList.java:179)
	at jenkins.model.lazy.BuildReferenceMapAdapter$SetAdapter.toArray(BuildReferenceMapAdapter.java:312)
	at java.base/java.util.ArrayList.<init>(ArrayList.java:179)
	at …
java.lang.StackOverflowError
	at jenkins.model.lazy.BuildReferenceMapAdapter$CollectionAdapter.toArray(BuildReferenceMapAdapter.java:195)
	at java.base/java.util.ArrayList.<init>(ArrayList.java:179)
	at jenkins.model.lazy.BuildReferenceMapAdapter$CollectionAdapter.toArray(BuildReferenceMapAdapter.java:195)
	at …
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at jenkins.model.lazy.BuildReferenceMapAdapter$SetAdapter.toArray(BuildReferenceMapAdapter.java:333)
	at jenkins.model.lazy.LazyLoadRunMapEntrySet.toArray(LazyLoadRunMapEntrySet.java:109)
	at java.base/java.util.Collection.toArray(Collection.java:381)
	at jenkins.model.lazy.AbstractLazyLoadRunMapTest.entrySetToArray(AbstractLazyLoadRunMapTest.java:396)
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at jenkins.model.lazy.BuildReferenceMapAdapter$CollectionAdapter.toArray(BuildReferenceMapAdapter.java:213)
	at java.base/java.util.Collection.toArray(Collection.java:381)
	at java.base/java.util.Collections$UnmodifiableCollection.toArray(Collections.java:1039)
	at jenkins.model.lazy.AbstractLazyLoadRunMapTest.entrySetToArray(AbstractLazyLoadRunMapTest.java:401)
```

### Proposed changelog entries

- Fixing some `toArray` implementations in probably unused code.

### Proposed upgrade guidelines

N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/7999"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

