### PR TITLE
Deprecate `Form.findMatchingInput` Prototype extension in favor of a new non-Prototype replacement

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2253,25 +2253,30 @@ function encode(str) {
 // when there are multiple form elements of the same name,
 // this method returns the input field of the given name that pairs up
 // with the specified 'base' input element.
+function findMatchingFormInput(base, name) {
+  // find the FORM element that owns us
+  var f = base.closest("form");
+
+  var bases = f.querySelectorAll('input[name="' + base.name + '"]');
+  var targets = f.querySelectorAll('input[name="' + name + '"]');
+
+  for (var i = 0; i < bases.length; i++) {
+    if (bases[i] == base) {
+      return targets[i];
+    }
+  }
+
+  return null; // not found
+}
+
 // TODO remove when Prototype.js is removed
 if (typeof Form === "object") {
+  /** @deprecated For backward compatibility only; use {@link findMatchingFormInput} instead. */
   Form.findMatchingInput = function (base, name) {
-    // find the FORM element that owns us
-    var f = base;
-    while (f.tagName != "FORM") {
-      f = f.parentNode;
-    }
-
-    var bases = Form.getInputs(f, null, base.name);
-    var targets = Form.getInputs(f, null, name);
-
-    for (var i = 0; i < bases.length; i++) {
-      if (bases[i] == base) {
-        return targets[i];
-      }
-    }
-
-    return null; // not found
+    console.warn(
+      "Deprecated call to Form.findMatchingInput detected; use findMatchingFormInput instead."
+    );
+    return findMatchingFormInput(base, name);
   };
 }
 


### PR DESCRIPTION
Jenkins currently extends Prototype's `Form` class with a Jenkins-specific `Form.findMatchingInput`, which currently does nothing at all when Prototype is disabled. This is [used in several plugins](https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+Form.findMatchingInput) and there is no obvious generic replacement since this is very Jenkins-specific layout. So this PR moves the logic to a new `findMatchingFormInput` function and rewrites it to not depend on Prototype. The Prototype `Form.findMatchingInput` calling convention is retained for compatibility, but consumers are encouraged to move to the new `findMatchingFormInput` once their core is bumped to include this PR. And to encourage consumers to do this, I have implemented the deprecated Prototype version in terms of the new non-deprecated version, logging a warning first that instructs the plugin developer about how to migrate.

### Testing done

I installed the Confluence Publisher plugin which uses this code path, and I set a breakpoint on the deprecated entrypoint. I verified that the warning was logged, that the code execution went into the new implementation, and that the new implementation correctly returned a non-null value.

### Proposed changelog entries

Developer: Support searches for matching form elements without the use of the Prototype JavaScript framework.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8008"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

