### PR TITLE
Fix compiler warnings

### DIFF
--- a/cli/src/test/java/hudson/cli/PlainCLIProtocolTest.java
+++ b/cli/src/test/java/hudson/cli/PlainCLIProtocolTest.java
@@ -72,10 +72,11 @@ public class PlainCLIProtocolTest {
             }
 
             void newop() throws IOException {
-                DataOutputStream dos = new DataOutputStream(upload);
-                dos.writeInt(0);
-                dos.writeByte(99);
-                dos.flush();
+                try (DataOutputStream dos = new DataOutputStream(upload)) {
+                    dos.writeInt(0);
+                    dos.writeByte(99);
+                    dos.flush();
+                }
             }
         }
 
@@ -129,10 +130,11 @@ public class PlainCLIProtocolTest {
             }
 
             void newop() throws IOException {
-                DataOutputStream dos = new DataOutputStream(download);
-                dos.writeInt(0);
-                dos.writeByte(99);
-                dos.flush();
+                try (DataOutputStream dos = new DataOutputStream(download)) {
+                    dos.writeInt(0);
+                    dos.writeByte(99);
+                    dos.flush();
+                }
             }
         }
 

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1587,12 +1587,13 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
         if (req.hasParameter("remove")) {
             UpdateCenter uc = Jenkins.get().getUpdateCenter();
-            BulkChange bc = new BulkChange(uc);
-            try {
-                for (String id : req.getParameterValues("sources"))
-                    uc.getSites().remove(uc.getById(id));
-            } finally {
-                bc.commit();
+            try (BulkChange bc = new BulkChange(uc)) {
+                try {
+                    for (String id : req.getParameterValues("sources"))
+                        uc.getSites().remove(uc.getById(id));
+                } finally {
+                    bc.commit();
+                }
             }
         } else
         if (req.hasParameter("add"))

--- a/core/src/main/java/hudson/cli/DisablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/DisablePluginCommand.java
@@ -131,7 +131,7 @@ public class DisablePluginCommand extends CLICommand {
             System.arraycopy(arguments, 0, newArgs, 1, arguments.length);
 
             String f = "%" + indent + "s" + format + "%n";
-            stdout.format(f, newArgs);
+            stdout.format(f, (Object[]) newArgs);
         }
     }
 

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -127,7 +127,7 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * and filter them by the given type.
      * @since 2.93
      */
-    default <T extends Item> List<T> getAllItems(Class<T> type) {
+    default <R extends Item> List<R> getAllItems(Class<R> type) {
         return Items.getAllItems(this, type);
     }
 
@@ -135,7 +135,7 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * Similar to {@link #getAllItems(Class)} with additional predicate filtering
      * @since 2.221
      */
-    default <T extends Item> List<T> getAllItems(Class<T> type, Predicate<T> pred) {
+    default <R extends Item> List<R> getAllItems(Class<R> type, Predicate<R> pred) {
         return Items.getAllItems(this, type, pred);
     }
 
@@ -144,7 +144,7 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * and filter them by the given type.
      * @since 2.93
      */
-    default <T extends Item> Iterable<T> allItems(Class<T> type) {
+    default <R extends Item> Iterable<R> allItems(Class<R> type) {
         return Items.allItems(this, type);
     }
 
@@ -153,7 +153,7 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * and filter them by the given type and given predicate
      * @since 2.221
      */
-    default <T extends Item> Iterable<T> allItems(Class<T> type, Predicate<T> pred) {
+    default <R extends Item> Iterable<R> allItems(Class<R> type, Predicate<R> pred) {
         return Items.allItems(this, type, pred);
     }
 

--- a/core/src/main/java/jenkins/model/GlobalCloudConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalCloudConfiguration.java
@@ -9,9 +9,9 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
- * Redirects from /configureClouds to /cloud/.
+ * Redirects from {@code /configureClouds} to {@code /cloud/}.
  * Previously was the form for clouds.
- * <p>
+ *
  * @deprecated Replaced by {@link jenkins.agents.CloudsLink} and {@link jenkins.agents.CloudSet}.
  */
 @Extension

--- a/core/src/test/java/hudson/BulkChangeTest.java
+++ b/core/src/test/java/hudson/BulkChangeTest.java
@@ -84,11 +84,12 @@ public class BulkChangeTest {
     @Test
     public void bulkChange() throws Exception {
         Point pt = new Point();
-        BulkChange bc = new BulkChange(pt);
-        try {
-            pt.set(0, 0);
-        } finally {
-            bc.commit();
+        try (BulkChange bc = new BulkChange(pt)) {
+            try {
+                pt.set(0, 0);
+            } finally {
+                bc.commit();
+            }
         }
         assertEquals(1, pt.saveCount);
     }
@@ -100,22 +101,25 @@ public class BulkChangeTest {
     public void nestedBulkChange() throws Exception {
         Point pt = new Point();
         Point pt2 = new Point();
-        BulkChange bc1 = new BulkChange(pt);
-        try {
-            BulkChange bc2 = new BulkChange(pt2);
+        try (BulkChange bc1 = new BulkChange(pt)) {
             try {
-                BulkChange bc3 = new BulkChange(pt);
-                try {
-                    pt.set(0, 0);
-                } finally {
-                    bc3.commit();
+                try (BulkChange bc2 = new BulkChange(pt2)) {
+                    try {
+                        try (BulkChange bc3 = new BulkChange(pt)) {
+                            try {
+                                pt.set(0, 0);
+                            } finally {
+                                bc3.commit();
+                            }
+                        }
+                    } finally {
+                        bc2.commit();
+                    }
                 }
+                pt.set(0, 0);
             } finally {
-                bc2.commit();
+                bc1.commit();
             }
-            pt.set(0, 0);
-        } finally {
-            bc1.commit();
         }
         assertEquals(1, pt.saveCount);
     }

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -83,7 +83,7 @@ public class AtomicFileWriterTest {
 
         final Path childFileInSymlinkToDir = Paths.get(zeSymlink.toString(), "childFileInSymlinkToDir");
 
-        new AtomicFileWriter(childFileInSymlinkToDir, StandardCharsets.UTF_8);
+        new AtomicFileWriter(childFileInSymlinkToDir, StandardCharsets.UTF_8).close();
     }
 
     @Test
@@ -168,14 +168,15 @@ public class AtomicFileWriterTest {
         Path filePath = newFile.toPath();
 
         // when
-        AtomicFileWriter w = new AtomicFileWriter(filePath, StandardCharsets.UTF_8);
-        w.write("whatever");
-        w.commit();
+        try (AtomicFileWriter w = new AtomicFileWriter(filePath, StandardCharsets.UTF_8)) {
+            w.write("whatever");
+            w.commit();
 
-        // then
-        assertFalse(w.getTemporaryPath().toFile().exists());
-        assertTrue(filePath.toFile().exists());
+            // then
+            assertFalse(w.getTemporaryPath().toFile().exists());
+            assertTrue(filePath.toFile().exists());
 
-        assertThat(Files.getPosixFilePermissions(filePath), equalTo(DEFAULT_GIVEN_PERMISSIONS));
+            assertThat(Files.getPosixFilePermissions(filePath), equalTo(DEFAULT_GIVEN_PERMISSIONS));
+        }
     }
 }

--- a/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
+++ b/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
@@ -50,14 +50,15 @@ public class RewindableRotatingFileOutputStreamTest {
             + "file open, so this case should never occur", Functions.isWindows());
         File dir = tmp.newFolder("dir");
         File base = new File(dir, "x.log");
-        RewindableRotatingFileOutputStream os = new RewindableRotatingFileOutputStream(base, 3);
-        for (int i = 0; i < 2; i++) {
-            FileUtils.deleteDirectory(dir);
-            os.write('.');
-            FileUtils.deleteDirectory(dir);
-            os.write('.');
-            FileUtils.deleteDirectory(dir);
-            os.rewind();
+        try (RewindableRotatingFileOutputStream os = new RewindableRotatingFileOutputStream(base, 3)) {
+            for (int i = 0; i < 2; i++) {
+                FileUtils.deleteDirectory(dir);
+                os.write('.');
+                FileUtils.deleteDirectory(dir);
+                os.write('.');
+                FileUtils.deleteDirectory(dir);
+                os.rewind();
+            }
         }
     }
 

--- a/test/src/test/java/jenkins/security/Security3030Test.java
+++ b/test/src/test/java/jenkins/security/Security3030Test.java
@@ -323,7 +323,7 @@ public class Security3030Test {
         }
 
         protected HttpResponse processMultipart(StaplerRequest req) throws ServletException {
-            new MultipartFormDataParser(req);
+            new MultipartFormDataParser(req).close();
             return HttpResponses.ok();
         }
     }


### PR DESCRIPTION
This change fixes several compiler warnings, with one commit per type of warning. Together with https://github.com/jenkinsci/acceptance-test-harness/pull/1180 this should fix all warnings of the master branch build on ci.jenkins.org (except for the retention warning).

### Testing done

Local maven build behaves as before. No additional testing.

### Proposed changelog entries

no changelog entries

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8017"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

