### PR TITLE
Remove Prototype usages in `BehaviorTest`

### DIFF
--- a/test/src/test/java/scripts/BehaviorTest.java
+++ b/test/src/test/java/scripts/BehaviorTest.java
@@ -50,16 +50,16 @@ public class BehaviorTest {
         HtmlPage p = j.createWebClient().goTo("self/testCssSelectors");
 
         // basic class selector, that we use the most often
-        assertEquals(2, asInt(p.executeJavaScript("findElementsBySelector($('test1'),'.a',true).length")));
-        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector($('test1'),'.a',false).length")));
+        assertEquals(2, asInt(p.executeJavaScript("findElementsBySelector(document.getElementById('test1'),'.a',true).length")));
+        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector(document.getElementById('test1'),'.a',false).length")));
 
         // 'includeSelf' should only affect the first axis and not afterward
-        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector($('test2'),'.a .b',true).length")));
-        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector($('test2'),'.a .b',false).length")));
+        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector(document.getElementById('test2'),'.a .b',true).length")));
+        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector(document.getElementById('test2'),'.a .b',false).length")));
 
         // tag.class. Should exclude itself anyway even if it's included
-        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector($('test3'),'P.a',true).length")));
-        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector($('test3'),'P.a',false).length")));
+        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector(document.getElementById('test3'),'P.a',true).length")));
+        assertEquals(1, asInt(p.executeJavaScript("findElementsBySelector(document.getElementById('test3'),'P.a',false).length")));
     }
 
     private int asInt(ScriptResult r) {


### PR DESCRIPTION
Replace usages of Prototype `$` in test code with `document.getElementById`.

### Testing done

Ran this test successfully with and without `prototype.js` included.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8018"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

