### PR TITLE
Implement Launchable subsetting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,9 +108,9 @@ axes.values().combinations {
               def excludesFile
               def target
               if (platform == 'windows') {
-                target = '33%'
+                target = '30%'
               } else if (platform == 'linux' && jdk == 11) {
-                target = '75%'
+                target = '80%'
               } else {
                 target = '100%'
               }
@@ -138,9 +138,6 @@ axes.values().combinations {
         // Once we've built, archive the artifacts and the test results.
         stage("${platform.capitalize()} - JDK ${jdk} - Publish") {
           archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
-          if (!fileExists('test/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
-            error 'JUnit 4 tests are no longer being run for the test package'
-          }
           // cli and war have been migrated to JUnit 5
           if (failFast && currentBuild.result == 'UNSTABLE') {
             error 'There were test failures; halting early'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,9 +138,6 @@ axes.values().combinations {
         // Once we've built, archive the artifacts and the test results.
         stage("${platform.capitalize()} - JDK ${jdk} - Publish") {
           archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/surefire-reports/*.dumpstream'
-          if (!fileExists('core/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
-            error 'JUnit 4 tests are no longer being run for the core package'
-          }
           if (!fileExists('test/target/surefire-reports/TEST-jenkins.Junit4TestsRanTest.xml')) {
             error 'JUnit 4 tests are no longer being run for the test package'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,14 +106,22 @@ axes.values().combinations {
             ]
             if (env.CHANGE_ID && !pullRequest.labels.contains('full-test')) {
               def excludesFile
+              def target
+              if (platform == 'windows') {
+                target = '33%'
+              } else if (platform == 'linux' && jdk == 11) {
+                target = '75%'
+              } else {
+                target = '100%'
+              }
               withCredentials([string(credentialsId: 'launchable-jenkins-jenkins', variable: 'LAUNCHABLE_TOKEN')]) {
                 if (isUnix()) {
                   excludesFile = "${tmpDir}/excludes.txt"
-                  sh "launchable verify && launchable subset --session ${session} --time 180m --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
+                  sh "launchable verify && launchable subset --session ${session} --target ${target} --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
                 } else {
                   excludesFile = "${tmpDir}\\excludes.txt"
                   // TODO launchable.exe still not working for some reason
-                  bat "python -m launchable verify && python -m launchable subset --session ${session} --time 180m --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
+                  bat "python -m launchable verify && python -m launchable subset --session ${session} --target ${target} --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
                 }
               }
               mavenOptions.add(0, "-Dsurefire.excludesFile=${excludesFile}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ axes.values().combinations {
                 } else {
                   excludesFile = "${tmpDir}\\excludes.txt"
                   // TODO launchable.exe still not working for some reason
-                  bat "python -m launchable verify && python -m launchable subset --session ${session} --target ${target} --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
+                  bat "python -m launchable verify && python -m launchable subset --session ${session} --target ${target}% --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
                 }
               }
               mavenOptions.add(0, "-Dsurefire.excludesFile=${excludesFile}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,8 +113,7 @@ axes.values().combinations {
                   sh "launchable verify && launchable subset --session ${session} --target ${target} --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
                 } else {
                   excludesFile = "${tmpDir}\\excludes.txt"
-                  // TODO launchable.exe still not working for some reason
-                  bat "python -m launchable verify && python -m launchable subset --session ${session} --target ${target}% --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
+                  bat "launchable verify && launchable subset --session ${session} --target ${target}% --get-tests-from-previous-sessions --output-exclusion-rules maven >${excludesFile}"
                 }
               }
               mavenOptions.add(0, "-Dsurefire.excludesFile=${excludesFile}")
@@ -189,8 +188,7 @@ axes.values().combinations {
             if (isUnix()) {
               sh "launchable verify && launchable record tests --session ${session} --flavor platform=${platform} --flavor jdk=${jdk} maven './**/target/surefire-reports'"
             } else {
-              // TODO launchable.exe still not working for some reason
-              bat "python -m launchable verify && python -m launchable record tests --session ${session} --flavor platform=${platform} --flavor jdk=${jdk} maven ./**/target/surefire-reports"
+              bat "launchable verify && launchable record tests --session ${session} --flavor platform=${platform} --flavor jdk=${jdk} maven ./**/target/surefire-reports"
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,14 +106,7 @@ axes.values().combinations {
             ]
             if (env.CHANGE_ID && !pullRequest.labels.contains('full-test')) {
               def excludesFile
-              def target
-              if (platform == 'windows') {
-                target = '30%'
-              } else if (platform == 'linux' && jdk == 11) {
-                target = '80%'
-              } else {
-                target = '100%'
-              }
+              def target = platform == 'windows' ? '30%' : '100%'
               withCredentials([string(credentialsId: 'launchable-jenkins-jenkins', variable: 'LAUNCHABLE_TOKEN')]) {
                 if (isUnix()) {
                   excludesFile = "${tmpDir}/excludes.txt"


### PR DESCRIPTION
### Problem

Core PR builds take too long. This is particularly frustrating when waiting for an incremental to do further testing in BOM or ATH.

### Solution

For PR builds that do _not_ have the `full-test` label, run a subset of tests to ensure that the test run finishes in 90 minutes. The full test suite will be run on the main branch. In the unlikely case that a test failure is introduced, it will be caught on the main branch. This should be extremely rare, since the full test suite on Linux/JDK 17 can still fit in 90 minutes, and we rarely see a test that passes in Linux and fails on Windows.

To create the subsets I am using Launchable. I started by using Launchable's fixed duration optimization target, but this did not work because it was estimating duration using an average of all flavors (platform + JDK). I have reported this problem to Launchable and they have filed an internal RFE to improve this use case. But in the meantime a fixed duration optimization target is not usable for us.

Instead I am hardcoding some percentage based optimization targets: 30% for Windows and 100% for everything else. These numbers were determined empirically by studying a number of test runs. 30% of the Windows test consistently gets us to about an hour and a half of execution time.

Since the subsets may or may not include the `jenkins.Junit4TestsRanTest` test, I am removing the assertions that check these tests ran in the `Jenkinsfile`. I do not think these assertions had much value anyway.

### Testing done

https://ci.jenkins.io/job/Core/job/jenkins/job/PR-8020/8/ completed in 1 hour and 39 minutes.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8020"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

