### PR TITLE
Extraneous `waitOnline` calls with `InboundAgentRule`

### DIFF
--- a/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
+++ b/test/src/test/java/hudson/bugs/JnlpAccessWithSecuredHudsonTest.java
@@ -98,7 +98,6 @@ public class JnlpAccessWithSecuredHudsonTest {
     @Test
     public void serviceUsingDirectSecret() throws Exception {
         Slave slave = inboundAgents.createAgent(r, InboundAgentRule.Options.newBuilder().name("test").secret().build());
-        r.waitOnline(slave);
         try {
             r.createWebClient().goTo("computer/test/jenkins-agent.jnlp?encrypt=true", "application/octet-stream");
             Channel channel = slave.getComputer().getChannel();

--- a/test/src/test/java/hudson/slaves/JNLPLauncherRealTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherRealTest.java
@@ -100,7 +100,6 @@ public class JNLPLauncherRealTest {
             }
             assertThat(ExtensionList.lookupSingleton(JNLPLauncher.DescriptorImpl.class).doCheckWebSocket(webSocket, null).kind, is(FormValidation.Kind.OK));
             Slave agent = (Slave) r.jenkins.getNode(agentName);
-            r.waitOnline(agent);
             FreeStyleProject p = r.createFreeStyleProject();
             p.setAssignedNode(agent);
             FreeStyleBuild b = r.buildAndAssertSuccess(p);

--- a/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
+++ b/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
@@ -79,7 +79,6 @@ public class WebSocketAgentsTest {
     @Test
     public void smokes() throws Exception {
         Slave s = inboundAgents.createAgent(r, InboundAgentRule.Options.newBuilder().secret().webSocket().build());
-        r.waitOnline(s);
         try {
             assertEquals("response", s.getChannel().call(new DummyTask()));
             assertNotNull(s.getChannel().call(new FatTask()));

--- a/test/src/test/java/jenkins/security/Security218Test.java
+++ b/test/src/test/java/jenkins/security/Security218Test.java
@@ -48,7 +48,6 @@ public class Security218Test implements Serializable {
     @Test
     public void jnlpSlave() throws Exception {
         DumbSlave a = (DumbSlave) inboundAgents.createAgent(j, InboundAgentRule.Options.newBuilder().secret().build());
-        j.waitOnline(a);
         try {
             j.createWebClient().goTo("computer/" + a.getNodeName() + "/jenkins-agent.jnlp?encrypt=true", "application/octet-stream");
             check(a);

--- a/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
+++ b/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
@@ -69,7 +69,6 @@ public class JnlpSlaveRestarterInstallerTest {
                     builder.webSocket();
                 }
                 Slave s = inboundAgents.createAgent(r, builder.build());
-                r.waitOnline(s);
                 assertEquals(1, s.getChannel().call(new JVMCount()).intValue());
                 while (logging.getMessages().stream().noneMatch(msg -> msg.contains("Effective SlaveRestarter on remote:"))) {
                     Thread.sleep(100);


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins-test-harness/pull/577#discussion_r1198023319, minor cleanup after #8002.

### Testing done

Looked for usages of `InboundAgentRule` which also called `waitOnline` in the same JVM session, and deleted that call. Ran the modified tests.

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8021"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

