### PR TITLE
Address javadoc warning and setup quality gates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,12 +127,21 @@ axes.values().combinations {
             echo "Recording static analysis results for '${platform.capitalize()}'"
             recordIssues(
                 enabledForFailure: true,
-                tools: [java(), javaDoc()],
+                tools: [java()],
                 filters: [excludeFile('.*Assert.java')],
                 sourceCodeEncoding: 'UTF-8',
                 skipBlames: true,
                 trendChartType: 'TOOLS_ONLY'
                 )
+            recordIssues(
+                enabledForFailure: true,
+                tools: [javaDoc()],
+                filters: [excludeFile('.*Assert.java')],
+                sourceCodeEncoding: 'UTF-8',
+                skipBlames: true,
+                trendChartType: 'TOOLS_ONLY',
+                qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]
+            )
             recordIssues([tool: spotBugs(pattern: '**/target/spotbugsXml.xml'),
               sourceCodeEncoding: 'UTF-8',
               skipBlames: true,

--- a/core/src/main/java/jenkins/model/GlobalCloudConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalCloudConfiguration.java
@@ -11,7 +11,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 /**
  * Redirects from /configureClouds to /cloud/.
  * Previously was the form for clouds.
- * <p>
  * @deprecated Replaced by {@link jenkins.agents.CloudsLink} and {@link jenkins.agents.CloudSet}.
  */
 @Extension


### PR DESCRIPTION
The [reference build](https://github.com/jenkinsci/jenkins/runs/13629048773) on the master branch highlights a warning from a recent PR.
The change proposed addresses the warning and sets up quality gates, matching the other analysis tools in place, to prevent future introductions.

### Testing done

`mvn clean verify package` no longer complains about this line.

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8024"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

