### PR TITLE
Update hamcrest imports

### DIFF
--- a/test/src/test/java/jenkins/bugs/Jenkins64991Test.java
+++ b/test/src/test/java/jenkins/bugs/Jenkins64991Test.java
@@ -24,9 +24,9 @@
 
 package jenkins.bugs;
 
-import static org.hamcrest.CoreMatchers.containsStringIgnoringCase;
-import static org.hamcrest.CoreMatchers.endsWithIgnoringCase;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.endsWithIgnoringCase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Changes needed weren't picked up by https://github.com/jenkinsci/jenkins/pull/8038's CI checks. The change proposed restores the functionality, apologizes.
Alternatively, I would revert the other PR, if checks aren't good.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8040"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

