### PR TITLE
[JENKINS-71153] Remove top level error icons

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractItem/noWorkspace.jelly
+++ b/core/src/main/resources/hudson/model/AbstractItem/noWorkspace.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:breadcrumb title="${%Error}" />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/>${%Error: no workspace}</h1>
+      <h1>${%Error: no workspace}</h1>
       <j:choose>
         <j:when test="${it.lastBuild==null}">
           <p>

--- a/core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:breadcrumb title="${%Error}" />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/>${%Error: Wipe Out Workspace blocked by SCM}</h1>
+      <h1>${%Error: Wipe Out Workspace blocked by SCM}</h1>
       <p>
         ${%The SCM for this project has blocked this attempt to wipe out the project's workspace.}
       </p>

--- a/core/src/main/resources/hudson/util/AWTProblem/index.jelly
+++ b/core/src/main/resources/hudson/util/AWTProblem/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
+      <h1>${%Error}</h1>
       <p>
         ${%errorMessage}
       </p>

--- a/core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly
+++ b/core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
+      <h1>${%Error}</h1>
       <pre>${it.stackTraceString}</pre>
     </l:main-panel>
   </l:layout>

--- a/core/src/main/resources/hudson/util/IncompatibleAntVersionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleAntVersionDetected/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
+      <h1>${%Error}</h1>
       <p>
         ${%errorMessage(it.whereAntIsLoaded)}
       </p>

--- a/core/src/main/resources/hudson/util/IncompatibleServletVersionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleServletVersionDetected/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
+      <h1>${%Error}</h1>
       <p>
         ${%errorMessage(it.whereServletIsLoaded)}
       </p>

--- a/core/src/main/resources/hudson/util/IncompatibleVMDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/IncompatibleVMDetected/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
+      <h1>${%Error}</h1>
       <p>
         ${%errorMessage}
       </p>

--- a/core/src/main/resources/hudson/util/InsufficientPermissionDetected/index.jelly
+++ b/core/src/main/resources/hudson/util/InsufficientPermissionDetected/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
+      <h1>${%Error}</h1>
       <p>
          ${%errorMessage.1}
       </p>

--- a/core/src/main/resources/hudson/util/NoHomeDir/index.jelly
+++ b/core/src/main/resources/hudson/util/NoHomeDir/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
+      <h1>${%Error}</h1>
       <p>
         ${%errorMessage.1(it.home)}
       </p>

--- a/core/src/main/resources/hudson/util/NoTempDir/index.jelly
+++ b/core/src/main/resources/hudson/util/NoTempDir/index.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <l:header title="Jenkins" />
     <l:side-panel />
     <l:main-panel>
-      <h1><l:icon class="icon-error icon-xlg"/><st:nbsp/>${%Error}</h1>
+      <h1>${%Error}</h1>
       <p>${%description(it.tempDir)}</p>
       <pre>${it.stackTraceString}</pre>
     </l:main-panel>

--- a/core/src/main/resources/jenkins/model/Jenkins/configureExecutors.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/configureExecutors.jelly
@@ -32,7 +32,6 @@ THE SOFTWARE.
   <st:include page="sidepanel.jelly" />
   <l:main-panel>
     <h1>
-      <l:icon class="icon-error icon-xlg"/>
       This page has moved
     </h1>
     <p>


### PR DESCRIPTION
This PR addresses a point in the accessibility research in [JENKINS-71153](https://issues.jenkins.io/browse/JENKINS-71153).

### Testing done

Example pattern how the change proposed looks like:

Before:
![Screenshot 2023-05-24 at 10 55 28](https://github.com/jenkinsci/jenkins/assets/13383509/82a00a1c-d70b-477e-bf87-e21c51f0faa4)

After:
![Screenshot 2023-05-24 at 10 53 45](https://github.com/jenkinsci/jenkins/assets/13383509/c08e0d91-7216-4fb2-835c-0c18417bf953)

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8045"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

