### PR TITLE
[JENKINS-71345] Remove 'undefined' from system dropdown menu

### DIFF
--- a/core/src/main/java/hudson/model/ManageJenkinsAction.java
+++ b/core/src/main/java/hudson/model/ManageJenkinsAction.java
@@ -27,7 +27,6 @@ package hudson.model;
 import hudson.Extension;
 import hudson.Util;
 import java.io.IOException;
-import jenkins.management.Badge;
 import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithContextMenu;
 import org.apache.commons.jelly.JellyException;
@@ -79,13 +78,13 @@ public class ManageJenkinsAction implements RootAction, StaplerFallback, ModelOb
      * menu.
      */
     @Restricted(NoExternalUse.class)
-    public void addContextMenuItem(ContextMenu menu, String url, String icon, String iconXml, String text, boolean post, boolean requiresConfirmation, Badge badge) {
+    public void addContextMenuItem(ContextMenu menu, String url, String icon, String iconXml, String text, boolean post, boolean requiresConfirmation) {
         if (Stapler.getCurrentRequest().findAncestorObject(this.getClass()) != null || !Util.isSafeToRedirectTo(url)) {
             // Default behavior if the URL is absolute or scheme-relative, or the current object is an ancestor (i.e. would resolve correctly)
-            menu.add(url, icon, iconXml, text, post, requiresConfirmation, badge);
+            menu.add(url, icon, iconXml, text, post, requiresConfirmation);
             return;
         }
         // If neither is the case, rewrite the relative URL to point to inside the /manage/ URL space
-        menu.add("manage/" + url, icon, iconXml, text, post, requiresConfirmation, badge);
+        menu.add("manage/" + url, icon, iconXml, text, post, requiresConfirmation);
     }
 }

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -106,7 +106,6 @@ import javax.servlet.ServletException;
 import jenkins.MissingDependencyException;
 import jenkins.RestartRequiredException;
 import jenkins.install.InstallUtil;
-import jenkins.management.Badge;
 import jenkins.model.Jenkins;
 import jenkins.security.stapler.StaplerDispatchable;
 import jenkins.util.SystemProperties;
@@ -376,52 +375,6 @@ public class UpdateCenter extends AbstractModelObject implements Saveable, OnMas
                     return ij;
             }
         return null;
-    }
-
-    @Restricted(NoExternalUse.class)
-    public Badge getBadge() {
-        if (!isSiteDataReady()) {
-            // Do not display message during this page load, but possibly later.
-            return null;
-        }
-        List<Plugin> plugins = getUpdates();
-        int size = plugins.size();
-        if (size > 0) {
-            StringBuilder tooltip = new StringBuilder();
-            Badge.Severity severity = Badge.Severity.WARNING;
-            int securityFixSize = (int) plugins.stream().filter(plugin -> plugin.fixesSecurityVulnerabilities()).count();
-            int incompatibleSize = (int) plugins.stream().filter(plugin -> !plugin.isCompatibleWithInstalledVersion()).count();
-            if (size > 1) {
-                tooltip.append(jenkins.management.Messages.PluginsLink_updatesAvailable(size));
-            } else {
-                tooltip.append(jenkins.management.Messages.PluginsLink_updateAvailable());
-            }
-            switch (incompatibleSize) {
-                case 0:
-                    break;
-                case 1:
-                    tooltip.append("\n").append(jenkins.management.Messages.PluginsLink_incompatibleUpdateAvailable());
-                    break;
-                default:
-                    tooltip.append("\n").append(jenkins.management.Messages.PluginsLink_incompatibleUpdatesAvailable(incompatibleSize));
-                    break;
-            }
-            switch (securityFixSize) {
-                case 0:
-                    break;
-                case 1:
-                    tooltip.append("\n").append(jenkins.management.Messages.PluginsLink_securityUpdateAvailable());
-                    severity = Badge.Severity.DANGER;
-                    break;
-                default:
-                    tooltip.append("\n").append(jenkins.management.Messages.PluginsLink_securityUpdatesAvailable(securityFixSize));
-                    severity = Badge.Severity.DANGER;
-                    break;
-            }
-            return new Badge(Integer.toString(size), tooltip.toString(), severity);
-        }
-        return null;
-
     }
 
     /**

--- a/core/src/main/java/jenkins/management/Badge.java
+++ b/core/src/main/java/jenkins/management/Badge.java
@@ -29,8 +29,6 @@ import hudson.diagnosis.OldDataMonitor;
 import hudson.model.AdministrativeMonitor;
 import hudson.model.ManagementLink;
 import java.util.Locale;
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  *  Definition of a badge that can be returned by a {@link ManagementLink} implementation.
@@ -50,7 +48,6 @@ import org.kohsuke.stapler.export.ExportedBean;
  *
  *  @since 2.385
  */
-@ExportedBean
 public class Badge {
 
     private final String text;
@@ -78,7 +75,6 @@ public class Badge {
      *
      * @return badge text
      */
-    @Exported(visibility = 999)
     public String getText() {
         return text;
     }
@@ -88,7 +84,6 @@ public class Badge {
      *
      * @return tooltip
      */
-    @Exported(visibility = 999)
     public String getTooltip() {
         return tooltip;
     }

--- a/core/src/main/java/jenkins/management/PluginsLink.java
+++ b/core/src/main/java/jenkins/management/PluginsLink.java
@@ -28,7 +28,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.ManagementLink;
 import hudson.model.UpdateCenter;
+import hudson.model.UpdateSite.Plugin;
 import hudson.security.Permission;
+import java.util.List;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
@@ -73,6 +75,46 @@ public class PluginsLink extends ManagementLink {
     @Override
     public Badge getBadge() {
         final UpdateCenter updateCenter = Jenkins.get().getUpdateCenter();
-        return updateCenter.getBadge();
+        if (!updateCenter.isSiteDataReady()) {
+            // Do not display message during this page load, but possibly later.
+            return null;
+        }
+        List<Plugin> plugins = updateCenter.getUpdates();
+        int size = plugins.size();
+        if (size > 0) {
+            StringBuilder tooltip = new StringBuilder();
+            Badge.Severity severity = Badge.Severity.WARNING;
+            int securityFixSize = (int) plugins.stream().filter(plugin -> plugin.fixesSecurityVulnerabilities()).count();
+            int incompatibleSize = (int) plugins.stream().filter(plugin -> !plugin.isCompatibleWithInstalledVersion()).count();
+            if (size > 1) {
+                tooltip.append(Messages.PluginsLink_updatesAvailable(size));
+            } else {
+                tooltip.append(Messages.PluginsLink_updateAvailable());
+            }
+            switch (incompatibleSize) {
+                case 0:
+                    break;
+                case 1:
+                    tooltip.append("\n").append(Messages.PluginsLink_incompatibleUpdateAvailable());
+                    break;
+                default:
+                    tooltip.append("\n").append(Messages.PluginsLink_incompatibleUpdatesAvailable(incompatibleSize));
+                    break;
+            }
+            switch (securityFixSize) {
+                case 0:
+                    break;
+                case 1:
+                    tooltip.append("\n").append(Messages.PluginsLink_securityUpdateAvailable());
+                    severity = Badge.Severity.DANGER;
+                    break;
+                default:
+                    tooltip.append("\n").append(Messages.PluginsLink_securityUpdatesAvailable(securityFixSize));
+                    severity = Badge.Severity.DANGER;
+                    break;
+            }
+            return new Badge(Integer.toString(size), tooltip.toString(), severity);
+        }
+        return null;
     }
 }

--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import javax.servlet.ServletException;
-import jenkins.management.Badge;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.JellyTagException;
@@ -145,19 +144,6 @@ public interface ModelObjectWithContextMenu extends ModelObject {
                 item.iconXml = iconXml;
                 item.post = post;
                 item.requiresConfirmation = requiresConfirmation;
-                items.add(item);
-            }
-            return this;
-        }
-
-        /** @since TODO */
-        public ContextMenu add(String url, String icon, String iconXml, String text, boolean post, boolean requiresConfirmation, Badge badge) {
-            if (text != null && icon != null && url != null) {
-                MenuItem item = new MenuItem(url, icon, text);
-                item.iconXml = iconXml;
-                item.post = post;
-                item.requiresConfirmation = requiresConfirmation;
-                item.badge = badge;
                 items.add(item);
             }
             return this;
@@ -331,8 +317,6 @@ public interface ModelObjectWithContextMenu extends ModelObject {
         public boolean requiresConfirmation;
 
 
-        private Badge badge;
-
         /**
          * The type of menu item
          * @since 2.340
@@ -351,15 +335,6 @@ public interface ModelObjectWithContextMenu extends ModelObject {
         @Exported
         public String getIconXml() {
             return iconXml;
-        }
-
-        /**
-         * The badge to display for the context menu item
-         * @since TODO
-         */
-        @Exported
-        public Badge getBadge() {
-            return badge;
         }
 
         public MenuItem(String url, String icon, String displayName) {

--- a/core/src/main/resources/hudson/PluginManager/sidepanel.jelly
+++ b/core/src/main/resources/hudson/PluginManager/sidepanel.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:side-panel>
     <l:tasks>
-      <l:task href="${rootURL}/manage/pluginManager/" icon="symbol-download" title="${%Updates}" badge="${app.updateCenter.badge}"/>
+      <l:task href="${rootURL}/manage/pluginManager/" icon="symbol-download" title="${%Updates}"/>
       <l:task href="${rootURL}/manage/pluginManager/available" icon="symbol-shopping-bag" title="${%Available plugins}"/>
       <l:task href="${rootURL}/manage/pluginManager/installed" icon="symbol-plugins" title="${%Installed plugins}"/>
       <l:task href="${rootURL}/manage/pluginManager/advanced" icon="symbol-settings" title="${%Advanced settings}"/>

--- a/core/src/main/resources/hudson/model/ManageJenkinsAction/index.jelly
+++ b/core/src/main/resources/hudson/model/ManageJenkinsAction/index.jelly
@@ -60,7 +60,7 @@ THE SOFTWARE.
               <j:set var="iconXml">
                 <l:icon src="${m.iconFileName}" />
               </j:set>
-              ${taskTags!=null and attrs.contextMenu!='false' ? it.addContextMenuItem(taskTags, m.urlName, iconSrc, iconXml, m.displayName, m.requiresPOST, m.requiresConfirmation, m.badge) : null}
+              ${taskTags!=null and attrs.contextMenu!='false' ? it.addContextMenuItem(taskTags, m.urlName, iconSrc, iconXml, m.displayName, m.requiresPOST, m.requiresConfirmation) : null}
               <j:choose>
                 <j:when test="${m.requiresConfirmation}">
                   <l:confirmationLink href="${m.urlName}" post="${m.requiresPOST}" message="${%are.you.sure(m.displayName)}">

--- a/core/src/main/resources/lib/layout/breadcrumbs.js
+++ b/core/src/main/resources/lib/layout/breadcrumbs.js
@@ -22,51 +22,15 @@ window.breadcrumbs = (function () {
   var logger = function () {};
   // logger = function() { console.log.apply(console,arguments) };  // uncomment this line to enable logging
 
-  // TODO - Use util/security.js xmlEscape in #7474
-  function xmlEscape(str) {
-    if (!str) {
-      return;
-    }
-
-    return str.replace(/[<>&'"]/g, (match) => {
-      switch (match) {
-        case "<":
-          return "&lt;";
-        case ">":
-          return "&gt;";
-        case "&":
-          return "&amp;";
-        case "'":
-          return "&apos;";
-        case '"':
-          return "&quot;";
-      }
-    });
-  }
-
-  function makeMenuHtml(icon, iconXml, displayName, badge) {
+  function makeMenuHtml(icon, iconXml, displayName) {
     var displaynameSpan = "<span>" + displayName + "</span>";
-    let badgeText;
-    let badgeTooltip;
-    if (badge) {
-      badgeText = xmlEscape(badge.text);
-      badgeTooltip = xmlEscape(badge.tooltip);
-    }
-    const badgeSpan =
-      badge === null
-        ? ""
-        : `<span class="yui-menu-badge" tooltip="${badgeTooltip}">${badgeText}</span>`;
 
     if (iconXml != null) {
-      return iconXml + displaynameSpan + badgeSpan;
+      return iconXml + displaynameSpan;
     }
 
     if (icon === null) {
-      return (
-        "<span style='margin: 2px 4px 2px 2px;' />" +
-        displaynameSpan +
-        badgeSpan
-      );
+      return "<span style='margin: 2px 4px 2px 2px;' />" + displaynameSpan;
     }
 
     // TODO: move this to the API response in a clean way
@@ -77,13 +41,11 @@ window.breadcrumbs = (function () {
           icon +
           "' />" +
           "</svg>" +
-          displaynameSpan +
-          badgeSpan
+          displaynameSpan
       : "<img src='" +
           icon +
           "' width=24 height=24 style='margin: 2px 4px 2px 2px;' alt=''>" +
-          displaynameSpan +
-          badgeSpan;
+          displaynameSpan;
   }
 
   Event.observe(window, "load", function () {
@@ -194,8 +156,6 @@ window.breadcrumbs = (function () {
       menu.addItems(items);
       menu.render("breadcrumb-menu-target");
       menu.show();
-
-      Behaviour.applySubtree(menu.body);
     }
 
     // ignore the currently pending call
@@ -220,20 +180,14 @@ window.breadcrumbs = (function () {
                 e.text = makeMenuHtml(
                   e.icon,
                   e.iconXml,
-                  "<span class='header'>" + e.displayName + "</span>",
-                  e.badge
+                  "<span class='header'>" + e.displayName + "</span>"
                 );
                 e.disabled = true;
               } else if (e.type === "SEPARATOR") {
                 e.text = "<span class='separator'>--</span>";
                 e.disabled = true;
               } else {
-                e.text = makeMenuHtml(
-                  e.icon,
-                  e.iconXml,
-                  e.displayName,
-                  e.badge
-                );
+                e.text = makeMenuHtml(e.icon, e.iconXml, e.displayName);
               }
               if (e.subMenu != null) {
                 e.subMenu = {

--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -75,9 +75,6 @@ THE SOFTWARE.
       Generally used with post="true".
       (onclick supersedes this except in the context menu.)
     </st:attribute>
-    <st:attribute name="badge" since="TODO">
-      If set, displays the value as a small badge on the right side of the sidepanel item.
-    </st:attribute>
     <st:attribute name="confirmationMessage" since="1.512">
       Message to use for confirmation, if requested; defaults to title.
     </st:attribute>
@@ -136,11 +133,6 @@ THE SOFTWARE.
                 <l:icon src="${icon}" />
               </span>
               <span class="task-link-text">${title}</span>
-              <j:if test="${attrs.badge != null}">
-                <span class="task-icon-badge" tooltip="${attrs.badge.tooltip}">
-                  ${attrs.badge.text}
-                </span>
-              </j:if>
             </span>
           </span>
         </div>
@@ -172,11 +164,6 @@ THE SOFTWARE.
                     <l:icon src="${icon}" />
                   </span>
                   <span>${title}</span>
-                  <j:if test="${attrs.badge != null}">
-                    <span class="task-icon-badge" tooltip="${attrs.badge.tooltip}">
-                      ${attrs.badge.text}
-                    </span>
-                  </j:if>
                 </l:confirmationLink>
               </j:when>
 
@@ -186,11 +173,6 @@ THE SOFTWARE.
                     <l:icon src="${icon}" />
                   </span>
                   <span class="task-link-text">${title}</span>
-                  <j:if test="${attrs.badge != null}">
-                    <span class="task-icon-badge" tooltip="${attrs.badge.tooltip}">
-                      ${attrs.badge.text}
-                    </span>
-                  </j:if>
                 </a>
               </j:otherwise>
             </j:choose>

--- a/war/src/main/less/base/yui-compatibility.less
+++ b/war/src/main/less/base/yui-compatibility.less
@@ -230,18 +230,3 @@ div.yahooTree td {
 .yui-panel .bd {
   background-color: var(--background) !important;
 }
-
-.yui-menu-badge {
-  position: relative;
-  margin-left: auto;
-  font-weight: 600;
-
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0 -0.375rem;
-    background: var(--text-color-secondary);
-    opacity: 0.1;
-    border-radius: 100vmax;
-  }
-}

--- a/war/src/main/less/modules/side-panel-tasks.less
+++ b/war/src/main/less/modules/side-panel-tasks.less
@@ -108,6 +108,10 @@
 
   .task-link-text {
     display: contents;
+  }
+
+  .task-link-text {
+    display: contents;
     word-break: break-word;
   }
 


### PR DESCRIPTION
## JENKINS-71345 - Remove "undefined" from system dropdown menu

The "Manage Jenkins" / "System" dropdown menu includes the extra text "undefined" at the end of each entry.  This removes that change and removes the updates count badge from the updates sidebar.

This reverts commit 291f5edcc5942c4efc65cc96121f7624f45bf3c3 from 
* #7084

See JENKINS-71345.

## Before the fix

![before-screenshot](https://github.com/jenkinsci/jenkins/assets/156685/2c59db34-aaeb-4a9c-87ae-0c26791a7445)

## After the fix

![after-screenshot](https://github.com/jenkinsci/jenkins/assets/156685/d780ad1a-c95a-49c5-b276-a19bb5622cba)

Alternative to:

* #8051

### Testing done

Confirmed that the problem was introduced by 291f5edcc5942c4efc65cc96121f7624f45bf3c3 with a `git bisect`.  Confirmed with interactive testing of this revert that the problem is resolved by reverting 291f5edcc5942c4efc65cc96121f7624f45bf3c3.

Ran the `all-tests` profile with `mvn clean -DforkCount=1C verify` on my Linux computer.

No additional test automation due to need to complete the fix quickly.

### Proposed changelog entries

- Remove "undefined" trailing text from system dropdown menu.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@NotMyFault and @janfaracik and @daniel-beck

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
