### PR TITLE
Trying to deflake `DeleteBuildsCommandTest.deleteBuildsShouldSuccessEvenTheBuildIsRunning`

### DIFF
--- a/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
@@ -41,7 +41,9 @@ import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.labels.LabelAtom;
 import hudson.tasks.Shell;
+import java.io.IOException;
 import jenkins.model.Jenkins;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -150,6 +152,11 @@ public class DeleteBuildsCommandTest {
         assertThat(result.stdout(), containsString("Deleted 1 builds"));
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(0));
         assertThat(project.isBuilding(), equalTo(false));
+        try {
+            project.delete();
+        } catch (IOException | InterruptedException x) {
+            throw new AssumptionViolatedException("Could not delete test project (race condition?)", x);
+        }
     }
 
     @Test public void deleteBuildsShouldSuccessEvenTheBuildIsStuckInTheQueue() throws Exception {


### PR DESCRIPTION
As noted in https://github.com/jenkinsci/jenkins/pull/7932#issuecomment-1568534143, this test can apparently flake after https://github.com/jenkinsci/jenkins-test-harness/pull/198

```
java.io.IOException: …/test/target/j h9069129304792075330/jobs
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:139)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.dispose(TemporaryDirectoryAllocator.java:99)
	at org.jvnet.hudson.test.TestEnvironment.dispose(TestEnvironment.java:84)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:525)
	at …
Caused by: java.nio.file.DirectoryNotEmptyException: …/test/target/j h9069129304792075330
	at java.base/sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:246)
	at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
	at java.base/java.nio.file.Files.deleteIfExists(Files.java:1191)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:136)
	... 8 more
```

The first point of suspicion is that this test only runs on Linux: https://github.com/jenkinsci/jenkins/blob/299a5907a8b45d914c929940883f40751d82b76e/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java#L141

I am not sure the behavior being tested is actually intentional. https://github.com/jenkinsci/jenkins/blob/299a5907a8b45d914c929940883f40751d82b76e/core/src/main/resources/hudson/model/Run/delete.jelly#L30 blocks GUI deletion of a build if it is either running or marked to be kept. https://github.com/jenkinsci/jenkins/blob/299a5907a8b45d914c929940883f40751d82b76e/core/src/main/java/hudson/model/Run.java#L2356-L2363 also blocks REST deletion of a build marked to be kept (but not a running build). Generally speaking, things can go badly wrong if you simply delete a running build, as it may not clean up gracefully; other parts of Jenkins strive to avoid such situations, like https://github.com/jenkinsci/cloudbees-folder-plugin/blob/26e3069010434de7f1f48dae9b1da31891127e51/src/main/java/com/cloudbees/hudson/plugins/folder/AbstractFolder.java#L1407-L1410 or https://github.com/jenkinsci/cloudbees-folder-plugin/blob/26e3069010434de7f1f48dae9b1da31891127e51/src/main/java/com/cloudbees/hudson/plugins/folder/computed/DefaultOrphanedItemStrategy.java#L321-L324 for example.

At any rate, changing the CLI command behavior (and deleting this test case, or changing its assertion) would be a topic for a larger PR; for the moment I just want to avoid CI instability.

### Testing done

Passed locally. Cannot reproduce original error, so not sure this change fixes the flake. The normal fix for tests which left a build running, and thus failed with a file lock issue, is simply to wait for the build to complete before finishing the test, but that does not seem like it would work here since the test specifically wipes out the build as part of its assertion. It is not clear from the stack trace what file was left behind; there is code in `TemporaryDirectoryAllocator.delete` to try to tell you, but it does not handle a file being created by a background thread while it is running, which I guess happened here.

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8068"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

