### PR TITLE
Remove usages of `IOUtils#toByteArray`

### DIFF
--- a/cli/src/main/java/hudson/cli/PlainCLIProtocol.java
+++ b/cli/src/main/java/hudson/cli/PlainCLIProtocol.java
@@ -277,7 +277,7 @@ class PlainCLIProtocol {
                 onStart();
                 return true;
             case STDIN:
-                onStdin(IOUtils.toByteArray(dis));
+                onStdin(dis.readAllBytes());
                 return true;
             case END_STDIN:
                 onEndStdin();
@@ -327,10 +327,10 @@ class PlainCLIProtocol {
                 onExit(dis.readInt());
                 return true;
             case STDOUT:
-                onStdout(IOUtils.toByteArray(dis));
+                onStdout(dis.readAllBytes());
                 return true;
             case STDERR:
-                onStderr(IOUtils.toByteArray(dis));
+                onStderr(dis.readAllBytes());
                 return true;
             default:
                 return false;

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1135,7 +1135,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 final JarEntry entry = entryName != null && jarFile != null ? jarFile.getJarEntry(entryName) : null;
                 if (entry != null) {
                     try (InputStream i = jarFile.getInputStream(entry)) {
-                        byte[] manifestBytes = IOUtils.toByteArray(i);
+                        byte[] manifestBytes = i.readAllBytes();
                         in = new ByteArrayInputStream(manifestBytes);
                     }
                 } else {

--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -46,7 +46,6 @@ import org.apache.commons.fileupload.FileItemHeaders;
 import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.fileupload.util.FileItemHeadersImpl;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -288,9 +287,7 @@ public class FileParameterValue extends ParameterValue {
         @Override
         public byte[] get() {
             try {
-                try (InputStream inputStream = Files.newInputStream(file.toPath())) {
-                    return IOUtils.toByteArray(inputStream);
-                }
+                return Files.readAllBytes(file.toPath());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -71,7 +71,6 @@ import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import jenkins.slaves.WorkspaceLocator;
 import jenkins.util.SystemProperties;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -470,7 +469,7 @@ public abstract class Slave extends Node implements Serializable {
 
         public byte[] readFully() throws IOException {
             try (InputStream in = connect().getInputStream()) {
-                return IOUtils.toByteArray(in);
+                return in.readAllBytes();
             }
         }
 

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -53,7 +53,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ObjectStreamException;
 import java.io.RandomAccessFile;
 import java.io.Serializable;
@@ -75,7 +74,6 @@ import java.util.logging.Logger;
 import jenkins.agents.AgentComputerUtil;
 import jenkins.security.SlaveToMasterCallable;
 import jenkins.util.SystemProperties;
-import org.apache.commons.io.FileUtils;
 import org.jenkinsci.remoting.SerializableOnlyOverRemoting;
 import org.jvnet.winp.WinProcess;
 import org.jvnet.winp.WinpException;
@@ -914,7 +912,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     return arguments;
                 arguments = new ArrayList<>();
                 try {
-                    byte[] cmdline = readFileToByteArray(getFile("cmdline"));
+                    byte[] cmdline = Files.readAllBytes(Util.fileToPath(getFile("cmdline")));
                     int pos = 0;
                     for (int i = 0; i < cmdline.length; i++) {
                         byte b = cmdline[i];
@@ -938,7 +936,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     return envVars;
                 envVars = new EnvVars();
                 try {
-                    byte[] environ = readFileToByteArray(getFile("environ"));
+                    byte[] environ = Files.readAllBytes(Util.fileToPath(getFile("environ")));
                     int pos = 0;
                     for (int i = 0; i < environ.length; i++) {
                         byte b = environ[i];
@@ -952,12 +950,6 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
                     // so don't report this as an error.
                 }
                 return envVars;
-            }
-        }
-
-        public byte[] readFileToByteArray(File file) throws IOException {
-            try (InputStream in = FileUtils.openInputStream(file)) {
-                return org.apache.commons.io.IOUtils.toByteArray(in);
             }
         }
     }

--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -19,7 +19,6 @@ import javax.crypto.CipherInputStream;
 import javax.crypto.CipherOutputStream;
 import javax.crypto.SecretKey;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.IOUtils;
 
 /**
  * Default portable implementation of {@link ConfidentialStore} that uses
@@ -104,7 +103,7 @@ public class DefaultConfidentialStore extends ConfidentialStore {
             sym.init(Cipher.DECRYPT_MODE, masterKey);
             try (InputStream fis = Files.newInputStream(f.toPath());
                  CipherInputStream cis = new CipherInputStream(fis, sym)) {
-                byte[] bytes = IOUtils.toByteArray(cis);
+                byte[] bytes = cis.readAllBytes();
                 return verifyMagic(bytes);
             }
         } catch (GeneralSecurityException e) {

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -405,7 +405,7 @@ public class DirectoryBrowserSupportTest {
             Map.Entry<String, String> entry = artifacts.entrySet().iterator().next();
             assertEquals("f", entry.getKey());
             try (InputStream is = workspace.child(entry.getValue()).read()) {
-                byte[] data = IOUtils.toByteArray(is);
+                byte[] data = is.readAllBytes();
                 ExtensionList.lookupSingleton(ContentAddressableStore.class).files.add(data);
                 hash = Util.getDigestOf(new ByteArrayInputStream(data));
             }
@@ -1378,7 +1378,7 @@ public class DirectoryBrowserSupportTest {
             Map.Entry<String, String> entry = artifacts.entrySet().iterator().next();
             assertEquals("f", entry.getKey());
             try (InputStream is = workspace.child(entry.getValue()).read()) {
-                byte[] data = IOUtils.toByteArray(is);
+                byte[] data = is.readAllBytes();
                 ExtensionList.lookupSingleton(ContentAddressableStore.class).files.add(data);
                 hash = Util.getDigestOf(new ByteArrayInputStream(data));
             }


### PR DESCRIPTION
Now that we require Java 11 or newer, the native `InputStream#readAllBytes` can be used to accomplish the same task without reliance on a third-party library (which is a maintenance liability).

### Testing done

Ran `mvn clean verify -DskipTests`.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8098"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

