### PR TITLE
[JENKINS-71406] Flake in `NodeCanTakeTaskTest.becauseNodeIsBusy`

### DIFF
--- a/test/src/test/java/hudson/slaves/NodeCanTakeTaskTest.java
+++ b/test/src/test/java/hudson/slaves/NodeCanTakeTaskTest.java
@@ -95,7 +95,7 @@ public class NodeCanTakeTaskTest {
         project.setConcurrentBuild(true);
         project.getBuildersList().add(new SleepBuilder(Long.MAX_VALUE));
         FreeStyleBuild build = project.scheduleBuild2(0).waitForStart(); // consume the one executor
-        project.scheduleBuild2(0); // now try to reschedule
+        var build2F = project.scheduleBuild2(0); // now try to reschedule
         Queue.Item item;
         while ((item = r.jenkins.getQueue().getItem(project)) == null || !item.isBuildable()) {
             Thread.sleep(100);
@@ -103,6 +103,9 @@ public class NodeCanTakeTaskTest {
         assertEquals(hudson.model.Messages.Queue_WaitingForNextAvailableExecutorOn(slave.getDisplayName()), item.getWhy());
         build.doStop();
         r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(build));
+        FreeStyleBuild build2 = build2F.waitForStart();
+        build2.doStop();
+        r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(build2));
     }
 
 }


### PR DESCRIPTION
See [JENKINS-71406](https://issues.jenkins.io/browse/JENKINS-71406). Similar to #8068, adapting to https://github.com/jenkinsci/jenkins-test-harness/pull/198, though a more straightforward fix in this case: the test was indeed scheduling two builds and aborting and waiting for the first to complete, but neglected to do the same for the second before exiting.

### Testing done

Just checked that it passed locally; did not observe a local failure. Test output with fix does show it aborting build 2, matching flake error message. Saw a flake in trunk recently: https://github.com/jenkinsci/jenkins/runs/14057889710

### Proposed changelog entries

- N/A

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8115"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

