### PR TITLE
Deprecate `hudson.util.NullStream`

### DIFF
--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -33,7 +33,6 @@ import hudson.util.ClassLoaderSanityThreadFactory;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.ExceptionCatchingThreadFactory;
 import hudson.util.NamingThreadFactory;
-import hudson.util.NullStream;
 import hudson.util.ProcessTree;
 import hudson.util.StreamCopyThread;
 import java.io.File;
@@ -429,7 +428,7 @@ public abstract class Proc {
         }
 
         public static final InputStream SELFPUMP_INPUT = new NullInputStream(0);
-        public static final OutputStream SELFPUMP_OUTPUT = new NullStream();
+        public static final OutputStream SELFPUMP_OUTPUT = OutputStream.nullOutputStream();
     }
 
     /**

--- a/core/src/main/java/hudson/model/JDK.java
+++ b/core/src/main/java/hudson/model/JDK.java
@@ -34,11 +34,11 @@ import hudson.tools.ToolInstallation;
 import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
 import hudson.util.FormValidation;
-import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 import hudson.util.XStream2;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collections;
@@ -164,7 +164,7 @@ public final class JDK extends ToolInstallation implements NodeSpecific<JDK>, En
      */
     public static boolean isDefaultJDKValid(Node n) {
         try {
-            TaskListener listener = new StreamTaskListener(new NullStream());
+            TaskListener listener = new StreamTaskListener(OutputStream.nullOutputStream());
             Launcher launcher = n.createLauncher(listener);
             return launcher.launch().cmds("java", "-fullversion").stdout(listener).join() == 0;
         } catch (IOException | InterruptedException e) {

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -56,7 +56,6 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.slaves.OfflineCause.ChannelTermination;
 import hudson.util.Futures;
-import hudson.util.NullStream;
 import hudson.util.RingBufferLogHandler;
 import hudson.util.StreamTaskListener;
 import hudson.util.VersionNumber;
@@ -386,7 +385,7 @@ public class SlaveComputer extends Computer {
             return log;
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Failed to create log file " + getLogFile(), e);
-            return new NullStream();
+            return OutputStream.nullOutputStream();
         }
     }
 

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -51,7 +51,6 @@ import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.FormValidation;
-import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 import hudson.util.VariableResolver;
 import hudson.util.VariableResolver.ByMap;
@@ -59,6 +58,7 @@ import hudson.util.VariableResolver.Union;
 import hudson.util.XStream2;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -665,7 +665,7 @@ public class Maven extends Builder {
          */
         public boolean getExists() {
             try {
-                return getExecutable(new LocalLauncher(new StreamTaskListener(new NullStream()))) != null;
+                return getExecutable(new LocalLauncher(new StreamTaskListener(OutputStream.nullOutputStream()))) != null;
             } catch (IOException | InterruptedException e) {
                 return false;
             }

--- a/core/src/main/java/hudson/util/IOUtils.java
+++ b/core/src/main/java/hudson/util/IOUtils.java
@@ -35,8 +35,9 @@ public class IOUtils {
      * Drains the input stream and closes it.
      */
     public static void drain(InputStream in) throws IOException {
-        org.apache.commons.io.IOUtils.copy(in, new NullStream());
-        in.close();
+        try (in; OutputStream out = OutputStream.nullOutputStream()) {
+            org.apache.commons.io.IOUtils.copy(in, out);
+        }
     }
 
     public static void copy(File src, OutputStream out) throws IOException {

--- a/core/src/main/java/hudson/util/NullStream.java
+++ b/core/src/main/java/hudson/util/NullStream.java
@@ -28,7 +28,9 @@ import java.io.OutputStream;
 
 /**
  * @author Kohsuke Kawaguchi
+ * @deprecated use {@link OutputStream#nullOutputStream}
  */
+@Deprecated
 public final class NullStream extends OutputStream {
     public NullStream() {}
 

--- a/core/src/main/java/hudson/util/StreamTaskListener.java
+++ b/core/src/main/java/hudson/util/StreamTaskListener.java
@@ -149,7 +149,7 @@ public class StreamTaskListener extends AbstractTaskListener implements TaskList
      */
     @Deprecated
     public StreamTaskListener() throws IOException {
-        this(new NullStream());
+        this(OutputStream.nullOutputStream());
     }
 
     public static StreamTaskListener fromStdout() {

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -43,7 +43,6 @@ import hudson.model.TaskListener;
 import hudson.os.WindowsUtil;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.WorkspaceList;
-import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -78,7 +77,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Chmod;
 import org.junit.Ignore;
@@ -99,7 +97,9 @@ public class FilePathTest {
     @Test public void copyTo() throws Exception {
         File tmp = temp.newFile();
         FilePath f = new FilePath(channels.french, tmp.getPath());
-        f.copyTo(new NullStream());
+        try (OutputStream out = OutputStream.nullOutputStream()) {
+            f.copyTo(out);
+        }
         assertTrue("target does not exist", tmp.exists());
         assertTrue("could not delete target " + tmp.getPath(), tmp.delete());
     }
@@ -260,8 +260,10 @@ public class FilePathTest {
     @Test public void archiveBug() throws Exception {
             FilePath d = new FilePath(channels.french, temp.getRoot().getPath());
             d.child("test").touch(0);
-            d.zip(NullOutputStream.NULL_OUTPUT_STREAM);
-            d.zip(NullOutputStream.NULL_OUTPUT_STREAM, "**/*");
+            try (OutputStream out = OutputStream.nullOutputStream()) {
+                d.zip(out);
+                d.zip(out, "**/*");
+            }
     }
 
     @Test public void normalization() {

--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -33,7 +33,6 @@ import hudson.Functions;
 import hudson.Launcher.LocalLauncher;
 import hudson.Util;
 import hudson.model.TaskListener;
-import hudson.util.NullStream;
 import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.IOException;
@@ -117,7 +116,9 @@ public class TarArchiverTest {
         assumeFalse(Functions.isWindows());
         File dir = tmp.getRoot();
         Util.createSymlink(dir, "nonexistent", "link", TaskListener.NULL);
-        new FilePath(dir).tar(new NullStream(), "**");
+        try (OutputStream out = OutputStream.nullOutputStream()) {
+            new FilePath(dir).tar(out, "**");
+        }
     }
 
 
@@ -132,7 +133,9 @@ public class TarArchiverTest {
         Thread t1 = new Thread(runnable1);
         t1.start();
 
-        new FilePath(tmp.getRoot()).tar(new NullStream(), "**");
+        try (OutputStream out = OutputStream.nullOutputStream()) {
+            new FilePath(tmp.getRoot()).tar(out, "**");
+        }
 
         runnable1.doFinish();
         t1.join();


### PR DESCRIPTION
This functionality is now provided by the Java Platform, so stop recommending our homegrown version.

### Testing done

`mvn clean verify -Dtest=hudson.FilePathTest,hudson.LauncherTest,hudson.ProcTest,hudson.slaves.ComputerLauncherTest,hudson.tasks.MavenTest,hudson.util.io.TarArchiverTest,hudson.util.ProcessTreeTest,hudson.UtilTest,jenkins.model.JDKNameTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8128"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

