### PR TITLE
[JENKINS-71429] Fix deleting users via trashcan symbol

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -71,9 +71,10 @@ THE SOFTWARE.
               <td>
                 <j:if test="${user.canDelete()}">
                   <div class="jenkins-table__cell__button-wrapper">
-                    <a href="${user.url}/delete" class="jenkins-table__button jenkins-!-destructive-color">
+                    <l:confirmationLink href="${user.url}/doDelete" class="jenkins-table__button jenkins-!-destructive-color"
+                                        post="true" message="${%delete.user(user.displayName)}">
                       <l:icon src="symbol-trash" />
-                    </a>
+                    </l:confirmationLink>
                   </div>
                 </j:if>
               </td>

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.properties
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.properties
@@ -24,3 +24,4 @@ blurb=\
 These users can log into Jenkins. This is a sub set of <a href="../asynchPeople">this list</a>, \
 which also contains auto-created users who really just made some commits on some projects and have no \
 direct Jenkins access.
+delete.user=Delete Jenkins user ‘{0}’?


### PR DESCRIPTION
On manage -> Users, clicking the trash can icon lead to the old delete.jelly page that was deleted when replacing the page with a confirmation popup.
Replaced it with a confirmation link.

See [JENKINS-71429](https://issues.jenkins.io/browse/JENKINS-71429).

### Testing done

Manual testing:
- Go to "Manage" -> "User"
- Create a new user
- click on the trash can of the new user -> confirmation dialog appears
- click "OK"
- user is deleted

No automated test because this portion of the code is pending further changes in:

* #7938 

### Proposed changelog entries

- Allow user deletion from the trash can icon (regression in 2.405).

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
