### PR TITLE
Fix link from `/threadDump` to agent

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
         </j:if>
         <j:if test="${e.key != null and e.key.length() > 0}">
           <h1 id="id${e.key.hashCode()}">
-            <l:icon class="symbol-computer icon-lg"/> <a class="model-link inside" href="/computer/${e.key}">${e.key}</a>
+            <l:icon class="symbol-computer icon-lg"/> <a class="model-link inside" href="${rootURL}/computer/${e.key}">${e.key}</a>
           </h1>
         </j:if>
         <j:forEach var="t" items="${e.value.entrySet()}">


### PR DESCRIPTION
This currently only works with an empty context path.

### Testing done

* `java -jar Jenkins/wars/jenkins-2.390.war --prefix=/jenkins`: Link from http://localhost:8080/jenkins/threadDump to http://localhost:8080/computer/a1, context menu does not work.
* `java -jar jenkins-war-2.411-rc33863.a_2573019a_29f.war`: Link from http://localhost:8080/threadDump to http://localhost:8080/computer/a1, context menu works.
* `java -jar jenkins-war-2.411-rc33863.a_2573019a_29f.war --prefix=/jenkins`: Link from http://localhost:8080/jenkins/threadDump to http://localhost:8080/jenkins/computer/a1, context menu works.

### Proposed changelog entries

(too minor)

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8143"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

