### PR TITLE
Remove usages of `org.apache.commons.io.output.NullOutputStream`

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -40,6 +40,7 @@ import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -60,7 +61,6 @@ import jenkins.ClassLoaderReflectionToolkit;
 import jenkins.ExtensionFilter;
 import jenkins.plugins.DetachedPluginsUtil;
 import jenkins.util.URLClassLoader2;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Expand;
@@ -503,7 +503,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
 
         final long dirTime = archive.lastModified();
         // this ZipOutputStream is reused and not created for each directory
-        try (ZipOutputStream wrappedZOut = new ZipOutputStream(NullOutputStream.NULL_OUTPUT_STREAM) {
+        try (OutputStream nos = OutputStream.nullOutputStream(); ZipOutputStream wrappedZOut = new ZipOutputStream(nos) {
             @Override
             public void putNextEntry(ZipEntry ze) throws IOException {
                 ze.setTime(dirTime + 1999);   // roundup

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -24,8 +24,6 @@
 
 package hudson;
 
-import static org.apache.commons.io.output.NullOutputStream.NULL_OUTPUT_STREAM;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -192,7 +190,7 @@ public abstract class Launcher {
         @CheckForNull
         protected FilePath pwd;
         @CheckForNull
-        protected OutputStream stdout = NULL_OUTPUT_STREAM, stderr;
+        protected OutputStream stdout = OutputStream.nullOutputStream(), stderr;
         @CheckForNull
         private TaskListener stdoutListener;
         @CheckForNull

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -56,7 +56,6 @@ import jenkins.security.stapler.StaplerAccessibleType;
 import jenkins.slaves.RemotingVersionInfo;
 import jenkins.util.SystemProperties;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -330,7 +329,9 @@ public final class TcpSlaveAgentListener extends Thread {
                 s.shutdownOutput();
 
                 InputStream i = s.getInputStream();
-                IOUtils.copy(i, NullOutputStream.NULL_OUTPUT_STREAM);
+                try (OutputStream o = OutputStream.nullOutputStream()) {
+                    IOUtils.copy(i, o);
+                }
                 s.shutdownInput();
             }
         }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -110,7 +110,6 @@ import jenkins.util.io.PathRemover;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang.time.FastDateFormat;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -627,10 +626,11 @@ public class Util {
     public static String getDigestOf(@NonNull InputStream source) throws IOException {
         try (source) {
             MessageDigest md5 = getMd5();
-            DigestInputStream in = new DigestInputStream(source, md5);
-            // Note: IOUtils.copy() buffers the input internally, so there is no
-            // need to use a BufferedInputStream.
-            IOUtils.copy(in, NullOutputStream.NULL_OUTPUT_STREAM);
+            try (InputStream in = new DigestInputStream(source, md5); OutputStream out = OutputStream.nullOutputStream()) {
+                // Note: IOUtils.copy() buffers the input internally, so there is no
+                // need to use a BufferedInputStream.
+                IOUtils.copy(in, out);
+            }
             return toHexString(md5.digest());
         } catch (NoSuchAlgorithmException e) {
             throw new IOException("MD5 not installed", e);    // impossible

--- a/core/src/main/java/jenkins/util/JSONSignatureValidator.java
+++ b/core/src/main/java/jenkins/util/JSONSignatureValidator.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -34,7 +35,6 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.jvnet.hudson.crypto.CertificateUtil;
 import org.jvnet.hudson.crypto.SignatureOutputStream;
@@ -159,7 +159,8 @@ public class JSONSignatureValidator {
      */
     private FormValidation checkSpecificSignature(JSONObject json, JSONObject signatureJson, MessageDigest digest, String digestEntry, Signature signature, String signatureEntry, String digestName) throws IOException {
         // this is for computing a digest to check sanity
-        DigestOutputStream dos = new DigestOutputStream(NullOutputStream.NULL_OUTPUT_STREAM, digest);
+        OutputStream nos = OutputStream.nullOutputStream();
+        DigestOutputStream dos = new DigestOutputStream(nos, digest);
         SignatureOutputStream sos = new SignatureOutputStream(signature);
 
         String providedDigest = signatureJson.optString(digestEntry, null);

--- a/core/src/test/java/hudson/slaves/ComputerLauncherTest.java
+++ b/core/src/test/java/hudson/slaves/ComputerLauncherTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.nio.charset.Charset;
-import org.apache.commons.io.output.NullOutputStream;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -78,7 +78,7 @@ public class ComputerLauncherTest {
             IOException.class,
             () ->
                 ComputerLauncher.checkJavaVersion(
-                    new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM),
+                    new PrintStream(OutputStream.nullOutputStream()),
                     "-",
                     new BufferedReader(
                         new StringReader(
@@ -92,7 +92,7 @@ public class ComputerLauncherTest {
             IOException.class,
             () ->
                 ComputerLauncher.checkJavaVersion(
-                    new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM),
+                    new PrintStream(OutputStream.nullOutputStream()),
                     "-",
                     new BufferedReader(
                         new StringReader(


### PR DESCRIPTION
This is a minor code cleanup to replace usages of Apache Commons IO `NullOutputStream` with native Java Platform functionality where possible. The less we depend on third-party libraries, the easier maintenance becomes.

### Testing done

`hudson.ClassicPluginStrategyTest,hudson.cli.CLIActionTest,hudson.LauncherTest,hudson.slaves.ComputerLauncherTest,hudson.slaves.DelegatingComputerLauncherTest,hudson.slaves.JNLPLauncherRealTest,hudson.slaves.JNLPLauncherTest,hudson.TcpSlaveAgentListenerTest,hudson.UtilTest,jenkins.install.SetupWizardTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8144"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

