### PR TITLE
Remove usages of `org.apache.commons.io.input.NullInputStream`

### DIFF
--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -63,7 +63,6 @@ import jenkins.tasks.filters.EnvVarsFilterLocalRule;
 import jenkins.tasks.filters.EnvVarsFilterRuleWrapper;
 import jenkins.tasks.filters.EnvVarsFilterableBuilder;
 import jenkins.util.MemoryReductionUtil;
-import org.apache.commons.io.input.NullInputStream;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -1512,7 +1511,7 @@ public abstract class Launcher {
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for debugging")
     public static boolean showFullPath = false;
 
-    private static final NullInputStream NULL_INPUT_STREAM = new NullInputStream(0);
+    private static final InputStream NULL_INPUT_STREAM = InputStream.nullInputStream();
 
     private static final Logger LOGGER = Logger.getLogger(Launcher.class.getName());
 }

--- a/core/src/main/java/hudson/Proc.java
+++ b/core/src/main/java/hudson/Proc.java
@@ -51,7 +51,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.io.input.NullInputStream;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -427,7 +426,7 @@ public abstract class Proc {
             return String.join(" ", cmd);
         }
 
-        public static final InputStream SELFPUMP_INPUT = new NullInputStream(0);
+        public static final InputStream SELFPUMP_INPUT = InputStream.nullInputStream();
         public static final OutputStream SELFPUMP_OUTPUT = OutputStream.nullOutputStream();
     }
 

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -71,7 +71,6 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.NullInputStream;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Ignore;
@@ -213,7 +212,7 @@ public class VirtualFileTest {
 
         @Override
         public InputStream open() {
-            return new NullInputStream(0);
+            return InputStream.nullInputStream();
         }
     }
 


### PR DESCRIPTION
This is a minor code cleanup to replace usages of Apache Commons IO `NullInputStream(0)` with native Java Platform functionality where possible. The less we depend on third-party libraries, the easier maintenance becomes. This PR retains a usage of `NullInputStream(size)` with a non-zero value in `CLIActionTest` because there is not actually a native Java Platform equivalent for this usage.

### Testing done

`hudson.LauncherTest,hudson.ProcTest,hudson.slaves.ComputerLauncherTest,hudson.slaves.DelegatingComputerLauncherTest,hudson.slaves.JNLPLauncherTest,jenkins.util.VirtualFileTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8145"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

