### PR TITLE
[JENKINS-14749] Errors in `styles.css`

### DIFF
--- a/test/src/test/java/jenkins/bugs/Jenkins14749Test.java
+++ b/test/src/test/java/jenkins/bugs/Jenkins14749Test.java
@@ -1,0 +1,83 @@
+package jenkins.bugs;
+
+import hudson.model.FreeStyleProject;
+import org.htmlunit.cssparser.parser.CSSErrorHandler;
+import org.htmlunit.cssparser.parser.CSSException;
+import org.htmlunit.cssparser.parser.CSSParseException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class Jenkins14749Test {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public ErrorCollector errors = new ErrorCollector();
+
+    @Test
+    public void dashboard() throws Exception {
+        JenkinsRule.WebClient webClient = createErrorReportingWebClient();
+        webClient.goTo("");
+    }
+
+    @Test
+    public void project() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        JenkinsRule.WebClient webClient = createErrorReportingWebClient();
+        webClient.getPage(p);
+    }
+
+    @Test
+    public void configureProject() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        JenkinsRule.WebClient webClient = createErrorReportingWebClient();
+        webClient.getPage(p, "configure");
+    }
+
+    @Test
+    public void manage() throws Exception {
+        JenkinsRule.WebClient webClient = createErrorReportingWebClient();
+        webClient.goTo("manage");
+    }
+
+    @Test
+    public void system() throws Exception {
+        JenkinsRule.WebClient webClient = createErrorReportingWebClient();
+        webClient.goTo("manage/configure");
+    }
+
+    private JenkinsRule.WebClient createErrorReportingWebClient() {
+        JenkinsRule.WebClient webClient = j.createWebClient();
+        webClient.setCssErrorHandler(new CSSErrorHandler() {
+            @Override
+            public void warning(final CSSParseException exception) throws CSSException {
+                if (!ignore(exception)) {
+                    errors.addError(exception);
+                }
+            }
+
+            @Override
+            public void error(final CSSParseException exception) throws CSSException {
+                if (!ignore(exception)) {
+                    errors.addError(exception);
+                }
+            }
+
+            @Override
+            public void fatalError(final CSSParseException exception) throws CSSException {
+                if (!ignore(exception)) {
+                    errors.addError(exception);
+                }
+            }
+
+            private boolean ignore(final CSSParseException exception) {
+                // Keep in sync with HudsonTestCase/JenkinsRule
+                return exception.getURI().contains("/yui/");
+            }
+        });
+        return webClient;
+    }
+}

--- a/war/src/main/scss/modules/side-panel-tasks.scss
+++ b/war/src/main/scss/modules/side-panel-tasks.scss
@@ -45,12 +45,10 @@ $background-outset: 0.7rem;
       padding-left: 2.8rem;
     }
   }
+}
 
-  &:has(.jenkins-search__results-container--visible) {
-    .task-link {
-      opacity: 0.3;
-    }
-  }
+#side-panel .jenkins-search__results-container--visible .task-link {
+  opacity: 0.3;
 }
 
 #tasks .task {


### PR DESCRIPTION
This PR adds a test that fails without the change to `src/main` and passes with it. The test opens various common pages in HtmlUnit and verifies that there are no CSS errors (except for YUI CSS errors, which we ignore both here and in the test harness). This will prevent any new CSS that HtmlUnit cannot understand from being introduced in the future. It will also ensure that the logs stay clean going forward. To fix the existing violation, I removed the use of `:has` (which HtmlUnit does not understand) in favor of a simpler CSS construct.

### Alternative approach that I considered

I tried setting up [PostCSS Preset Env](https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env) with the `has-pseudo-class` polyfill to allow us to continue using this modern CSS while appeasing HtmlUnit. However the polyfill has two parts: a CSS part and a JavaScript part, and HtmlUnit choked on the JavaScript part of the polyfill. So I found it simpler to eliminate the use of `:has` instead.

### Testing done

New unit test fails without the changes to `src/main` and passes with them.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8148"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

