### PR TITLE
De-flake `hudson.FilePathTest#archiveBug`

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -262,6 +262,8 @@ public class FilePathTest {
             d.child("test").touch(0);
             try (OutputStream out = OutputStream.nullOutputStream()) {
                 d.zip(out);
+            }
+            try (OutputStream out = OutputStream.nullOutputStream()) {
                 d.zip(out, "**/*");
             }
     }


### PR DESCRIPTION
Amends #8128 which introduced some flakiness in `hudson.FilePathTest#archiveBug` as observed e.g. [here](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-8154/1/testReport/junit/hudson/FilePathTest/linux_jdk17___Linux___JDK_17___Build___Test___archiveBug/). I could actually reproduce this locally by running this test in a loop in IntelliJ. The problem was a bug in #8128: creating the first ZIP archive closes the stream at the end, so each call to `zip` needs to have its own output stream. I didn't notice this while writing the code because it works (by accident) 9 out of 10 times due to the asynchronous nature of Remoting. On a fast computer, the second call to `zip` will succeed before the asynchronous Remoting logic runs to close the first stream. But on a slow computer (or even a fast computer after enough tries) the second archive attempt will fail because the first archive has already closed the stream. The solution is to use separate streams for each zip operation.

### Testing done

Could reproduce the problem in IntelliJ by running the test in a loop, typically after 10-100 iterations. After this change I ran the test in a loop for 10,000 iterations without experiencing the problem.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8155"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

