### PR TITLE
Remove incorrect text from JENKINS_HOME help page

### DIFF
--- a/war/src/main/webapp/help/system-config/homeDirectory.html
+++ b/war/src/main/webapp/help/system-config/homeDirectory.html
@@ -3,39 +3,15 @@
 
   <ul>
     <li>
-      Edit the
+      Set the
       <code>JENKINS_HOME</code>
-      variable in your Jenkins configuration file (e.g.
-      <code>/etc/sysconfig/jenkins</code>
-      on Red Hat Linux).
-    </li>
-
-    <li>
-      Use your web container's admin tool to set the
-      <code>JENKINS_HOME</code>
-      environment variable.
-    </li>
-
-    <li>
-      Set the environment variable
-      <code>JENKINS_HOME</code>
-      before launching your web container, or before launching Jenkins directly
-      from the WAR file.
+      environment variable when launching Jenkins.
     </li>
 
     <li>
       Set the
       <code>JENKINS_HOME</code>
-      Java system property when launching your web container, or when launching
-      Jenkins directly from the WAR file.
-    </li>
-
-    <li>
-      Modify
-      <code>web.xml</code>
-      in
-      <code>jenkins.war</code>
-      (or its expanded image in your web container). This is not recommended.
+      Java system property when launching Jenkins.
     </li>
   </ul>
 


### PR DESCRIPTION
## Remove incorrect text from JENKINS_HOME help page

Since the transition to systemd, we no longer read the contents of /etc/sysconfig/jenkins on Red Hat Enterprise Linux systems.  The changes that a user can make with systemd are either modifying the environment variable or they are modifying a Java property.  Since those two cases are already covered, let's not mention the different ways of starting the controller.

We don't actively promote the use of alternate web containers and setting the environment variable in the web container admin tool is already covered by the simpler statement that the environment variable needs to be set.

We absolutely should not suggest that they modify the contents of the jenkins.war file.  That type of change will likely be erased on the next upgrade.

https://github.com/jenkins-infra/jenkins.io/pull/6409 review process showed this issue.

### Testing done

Ran Jenkins with this change and confirmed the help is correctly displayed.

No automated test because we don't generally perform automated tests of online help content.

### Proposed changelog entries

- Remove incorrect text from JENKINS_HOME help.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
