### PR TITLE
Use CSS variables for logger colours

### DIFF
--- a/war/src/main/scss/base/style.scss
+++ b/war/src/main/scss/base/style.scss
@@ -1248,11 +1248,11 @@ table.progress-bar.red td.progress-bar-done {
 }
 
 .logrecord-metadata-new {
-  color: #8a8;
+  color: var(--green);
 }
 
 .logrecord-metadata-old {
-  color: #aaa;
+  color: var(--text-color-secondary);
 }
 
 /* ========================= matrix configuration table ================== */


### PR DESCRIPTION
Uses CSS variables for logger colours. The advantages of this is that:
* Colours are consistent with other pages
* They adapt to different themes

**Before**
<img width="693" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/f152ee0b-a028-4151-b0ef-03c96cfb0358">
<img width="692" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/38ac76c8-2894-4551-a852-6c8b2d5f4a70">

**After**
<img width="710" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/259a9dd1-5196-48bc-9f07-933bf2e264a5">

<img width="761" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/bec5299d-eae3-489c-a6d6-bfd6fe223d18">

### Testing done

* Updated logger colours show as expected

### Proposed changelog entries

- Use CSS variables for logger colours.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8164"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

