### PR TITLE
Stop shipping `metainf-services` in the WAR

### DIFF
--- a/websocket/jetty10/pom.xml
+++ b/websocket/jetty10/pom.xml
@@ -67,6 +67,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
In https://github.com/jenkinsci/jenkins/pull/6780#discussion_r915092070 I had noticed that we started shipping this JAR in the WAR file and expressed some discomfort about it, implying the question: "is this really necessary?" to which I did not receive a reply. After thinking about it some more recently, I have concluded that it is not only unnecessary but also undesirable, for the following reasons:

- Inconsistent with the code in `core/pom.xml` which marks this `optional` so that it is excluded (undone by `websocket/jetty10/pom.xml`)
- Inconsistent with plugins that require this library, which directly declare a dependency on `metainf-services` rather than relying on core's copy

I did a search of both open-source and proprietary plugins and could not find one that was relying on core's copy rather than its own. In other words, plugins were directly declaring their dependency on this library before core started bundling it, and none of them have dropped that dependency in favor of core's copy.

If someone felt strongly about managing this via core and wanted to update all plugins to consume core's copy rather than their own, and make `core/pom.xml` consistent with `websocket/jetty10/pom.xml`, I would not oppose that. This PR is the exact opposite: making `websocket/jetty10/pom.xml` consistent with `core/pom.xml` and the status quo in plugins by removing `metainf-services` from the WAR file (in other words, restoring the status quo as it was prior to #6780).

### Testing done

Built the WAR and ensured that the services files were generated as before but that we were no longer shipping the `metainf-services` JAR in the WAR file.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8174"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

