### PR TITLE
 Make toggleLogKeep button primary

### DIFF
--- a/core/src/main/resources/hudson/model/Run/logKeep.jelly
+++ b/core/src/main/resources/hudson/model/Run/logKeep.jelly
@@ -30,10 +30,10 @@ THE SOFTWARE.
   <j:if test="${it.canToggleLogKeep()}">
     <form method="post" action="toggleLogKeep" style="margin-top:1em">
       <j:if test="${it.keepLog and h.hasPermission(it,it.DELETE)}">
-        <f:submit value="${%Don't keep this build forever}" primary="false" />
+        <f:submit value="${%Don't keep this build forever}" primary="true" />
       </j:if>
       <j:if test="${!it.keepLog and h.hasPermission(it,it.UPDATE)}">
-        <f:submit value="${%Keep this build forever}" primary="false" />
+        <f:submit value="${%Keep this build forever}" primary="true" />
       </j:if>
     </form>
   </j:if>


### PR DESCRIPTION
This matches the appearance in earlier Jenkins versions, and makes the button more visible. The button doesn’t have any associated more primary button, nor much else to draw attention to it (it’s just kind of floating on the page).

No associated Jira issue.

### Testing done

I added the `jenkins-button--primary` class in dev tools, on a random build in Wikimedia’s CI infrastructure.
Before:
![image](https://github.com/janfaracik/jenkins/assets/2346599/f563e6f6-7b3a-4d38-830c-6ab2adbee725)
After:
![image](https://github.com/janfaracik/jenkins/assets/2346599/0183363d-0e3b-411d-82ab-46fc3ed50630)

(I’m just assuming that `primary="true"` will result in that class being added, I haven’t set up a local test environment.)

### Proposed changelog entries

- Style the "Keep this build forever" and "Don't keep this build forever" buttons as primary.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described. – There is no Jira issue.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests. – I don’t expect there are any tests covering this markup. (If there are, I guess CI will point them out?) 
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. – N/A
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. – N/A
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. – N/A
- [x] For new APIs and extension points, there is a link to at least one consumer. – N/A
```

### Desired reviewers

CC @janfaracik, who had added the `primary="false"` in https://github.com/jenkinsci/jenkins/pull/7203/commits/b7b37d54d975a908ccfb0ca2c57bfe9b1fbe01e4 (part of https://github.com/jenkinsci/jenkins/pull/7203) – I’m not sure if it was intentional or just part of a large-scale update of all sorts of buttons. Also CC @hashar who helped digging up the relevant code :)

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8178"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

