### PR TITLE
Update appearance of buttons for password and secretTextarea matching 'jenkins-button's

### DIFF
--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -91,7 +91,7 @@ THE SOFTWARE.
                     <span>${%Concealed}</span>
                   </div>
                   <div class="hidden-password-update">
-                    <button class="hidden-password-update-btn jenkins-button jenkins-button--primary">${%Change Password}</button>
+                    <button type="button" class="hidden-password-update-btn jenkins-button jenkins-button--primary">${%Change Password}</button>
                   </div>
                 </div>
               </div>

--- a/core/src/main/resources/lib/form/password.jelly
+++ b/core/src/main/resources/lib/form/password.jelly
@@ -91,7 +91,7 @@ THE SOFTWARE.
                     <span>${%Concealed}</span>
                   </div>
                   <div class="hidden-password-update">
-                    <input type="button" class="hidden-password-update-btn" value="${%Change Password}"/>
+                    <button class="hidden-password-update-btn jenkins-button jenkins-button--primary">${%Change Password}</button>
                   </div>
                 </div>
               </div>

--- a/core/src/main/resources/lib/form/password/password.css
+++ b/core/src/main/resources/lib/form/password/password.css
@@ -42,18 +42,6 @@
   margin-left: 0.5em;
 }
 
-.hidden-password input[type="button"] {
-  background: #4b99d0;
-  background: var(--btn-primary-bg);
-  color: #fff;
-  color: var(--btn-text-color);
-  border-radius: 4px;
-  border: none;
-  padding: 7px;
+.hidden-password-update-btn {
   margin-left: 5px;
-}
-
-.hidden-password input[type="button"]:hover {
-  background: #5092be;
-  cursor: pointer;
 }

--- a/core/src/main/resources/lib/form/secretTextarea.jelly
+++ b/core/src/main/resources/lib/form/secretTextarea.jelly
@@ -81,7 +81,7 @@ Example usage:
                 </j:choose>
             </div>
             <div class="secret-update">
-                <input type="button" class="secret-update-btn" value="${buttonText}"/>
+                <button class="secret-update-btn jenkins-button jenkins-button--primary">${buttonText}</button>
             </div>
         </div>
     </div>

--- a/core/src/main/resources/lib/form/secretTextarea.jelly
+++ b/core/src/main/resources/lib/form/secretTextarea.jelly
@@ -81,7 +81,7 @@ Example usage:
                 </j:choose>
             </div>
             <div class="secret-update">
-                <button class="secret-update-btn jenkins-button jenkins-button--primary">${buttonText}</button>
+                <button type="button" class="secret-update-btn jenkins-button jenkins-button--primary">${buttonText}</button>
             </div>
         </div>
     </div>

--- a/core/src/main/resources/lib/form/secretTextarea/secret.css
+++ b/core/src/main/resources/lib/form/secretTextarea/secret.css
@@ -65,18 +65,3 @@
   border: none;
   padding: 1em;
 }
-
-.secret input[type="button"] {
-  background: #4b99d0;
-  background: var(--btn-primary-bg);
-  color: #fff;
-  color: var(--btn-text-color);
-  border-radius: 4px;
-  border: none;
-  padding: 1em 2em;
-}
-
-.secret input[type="button"]:hover {
-  background: #5092be;
-  cursor: pointer;
-}

--- a/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
@@ -79,7 +79,7 @@ public class PasswordParameterDefinitionTest {
 
         // Another control case: anyone can enter a different value.
         HtmlForm form = wc.withBasicApiToken(dev).getPage(p, "build?delay=0sec").getFormByName("parameters");
-        form.getElementsByAttribute("button", "class", "hidden-password-update-btn").get(0).click();
+        form.getOneHtmlElementByAttribute("button", "class", "hidden-password-update-btn jenkins-button jenkins-button--primary").click();
         HtmlPasswordInput input = form.getInputByName("value");
         input.setText("rumor");
         j.submit(form);
@@ -97,7 +97,7 @@ public class PasswordParameterDefinitionTest {
 
         // Another control case: blank values.
         form = wc.withBasicApiToken(dev).getPage(p, "build?delay=0sec").getFormByName("parameters");
-        form.getElementsByAttribute("input", "class", "hidden-password-update-btn").get(0).click();
+        form.getOneHtmlElementByAttribute("button", "class", "hidden-password-update-btn jenkins-button jenkins-button--primary").click();
         input = form.getInputByName("value");
         input.setText("");
         j.submit(form);

--- a/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import hudson.Launcher;
 import java.io.IOException;
 import jenkins.model.Jenkins;
+import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPasswordInput;
 import org.junit.Rule;
@@ -79,7 +80,7 @@ public class PasswordParameterDefinitionTest {
 
         // Another control case: anyone can enter a different value.
         HtmlForm form = wc.withBasicApiToken(dev).getPage(p, "build?delay=0sec").getFormByName("parameters");
-        form.getOneHtmlElementByAttribute("button", "class", "hidden-password-update-btn jenkins-button jenkins-button--primary").click();
+        ((HtmlElement) form.querySelector("button.hidden-password-update-btn")).click();
         HtmlPasswordInput input = form.getInputByName("value");
         input.setText("rumor");
         j.submit(form);
@@ -97,7 +98,7 @@ public class PasswordParameterDefinitionTest {
 
         // Another control case: blank values.
         form = wc.withBasicApiToken(dev).getPage(p, "build?delay=0sec").getFormByName("parameters");
-        form.getOneHtmlElementByAttribute("button", "class", "hidden-password-update-btn jenkins-button jenkins-button--primary").click();
+        ((HtmlElement) form.querySelector("button.hidden-password-update-btn")).click();
         input = form.getInputByName("value");
         input.setText("");
         j.submit(form);

--- a/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
+++ b/test/src/test/java/hudson/model/PasswordParameterDefinitionTest.java
@@ -79,7 +79,7 @@ public class PasswordParameterDefinitionTest {
 
         // Another control case: anyone can enter a different value.
         HtmlForm form = wc.withBasicApiToken(dev).getPage(p, "build?delay=0sec").getFormByName("parameters");
-        form.getElementsByAttribute("input", "class", "hidden-password-update-btn").get(0).click();
+        form.getElementsByAttribute("button", "class", "hidden-password-update-btn").get(0).click();
         HtmlPasswordInput input = form.getInputByName("value");
         input.setText("rumor");
         j.submit(form);

--- a/test/src/test/java/lib/form/SecretTextareaTest.java
+++ b/test/src/test/java/lib/form/SecretTextareaTest.java
@@ -35,6 +35,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.Secret;
 import java.io.IOException;
+import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlHiddenInput;
 import org.htmlunit.html.HtmlTextInput;
@@ -115,7 +116,7 @@ public class SecretTextareaTest {
     }
 
     private static void clickSecretUpdateButton(HtmlForm configForm) throws IOException {
-        configForm.getOneHtmlElementByAttribute("button", "class", "secret-update-btn jenkins-button jenkins-button--primary").click();
+        ((HtmlElement) configForm.querySelector("button.secret-update-btn")).click();
     }
 
     private static String getHiddenSecretValue(HtmlForm configForm) {

--- a/test/src/test/java/lib/form/SecretTextareaTest.java
+++ b/test/src/test/java/lib/form/SecretTextareaTest.java
@@ -115,7 +115,7 @@ public class SecretTextareaTest {
     }
 
     private static void clickSecretUpdateButton(HtmlForm configForm) throws IOException {
-        configForm.getOneHtmlElementByAttribute("button", "class", "secret-update-btn").click();
+        configForm.getOneHtmlElementByAttribute("button", "class", "secret-update-btn jenkins-button jenkins-button--primary").click();
     }
 
     private static String getHiddenSecretValue(HtmlForm configForm) {

--- a/test/src/test/java/lib/form/SecretTextareaTest.java
+++ b/test/src/test/java/lib/form/SecretTextareaTest.java
@@ -115,7 +115,7 @@ public class SecretTextareaTest {
     }
 
     private static void clickSecretUpdateButton(HtmlForm configForm) throws IOException {
-        configForm.getOneHtmlElementByAttribute("input", "class", "secret-update-btn").click();
+        configForm.getOneHtmlElementByAttribute("button", "class", "secret-update-btn").click();
     }
 
     private static String getHiddenSecretValue(HtmlForm configForm) {


### PR DESCRIPTION
replace old style buttons with new jenkins-button


Before: 
![image](https://github.com/jenkinsci/jenkins/assets/17767050/09f2fe0c-ab29-4e26-b6ae-d980d6af3e32)
![image](https://github.com/jenkinsci/jenkins/assets/17767050/13fdf065-1c9a-42d2-8626-ce601ca2b802)

After:
![image](https://github.com/jenkinsci/jenkins/assets/17767050/902fbdad-039b-4358-8779-b1320cb26ffa)
<img width="369" alt="image" src="https://github.com/jenkinsci/jenkins/assets/17767050/871bb188-b50b-45be-8c03-37507de1ceec">

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->



<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Manual testing
create password credential and update it
create ssh username with private key credential and update it
Verified that things still work as expected

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Update appearance of buttons for password and secretTextarea matching 'jenkins-button's.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8179"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

