### PR TITLE
Temporarily disable selective ATH tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,7 +205,7 @@ axes.values().combinations {
     }
   }
 }
-
+/* Temporarily disable selective ATH builds due to https://github.com/jenkins-infra/helpdesk/issues/3641
 def athAxes = [
   platforms: ['linux'],
   jdks: [17],
@@ -232,12 +232,12 @@ athAxes.values().combinations {
          withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
          sh "launchable verify && launchable record tests --no-build --flavor platform=${platform} --flavor jdk=${jdk} --flavor browser=${browser} maven './target/ath-reports'"
          }
-         */
+
       }
     }
   }
 }
-
+*/
 builds.failFast = failFast
 parallel builds
 infra.maybePublishIncrementals()


### PR DESCRIPTION
As observed in https://github.com/jenkinsci/jenkins/pull/8203 and reported in https://github.com/jenkins-infra/helpdesk/issues/3641, I'd like to disable the 7 ATH tests temporarily, to resolve issues with the next weekly, incrementals, and all the other processes relying on a green build.

I don't like this solution, but the actual impact on named services outweighs my personal preference. Additionally, the UX SIG tests PRs against the entire ATH, rather than relying on the 7 tests, for their PRs.


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8206"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

