### PR TITLE
Update legacyapitoken revoke button style matching 'jenkins-button's

### DIFF
--- a/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/manage.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/manage.jelly
@@ -155,16 +155,12 @@ THE SOFTWARE.
                     <a href="#" class="action" id="legacy-api-token-monitor-select-recent">${%only recent}</a>
                 </div>
                 
-                <div class="action-panel">
-                    <span class="yui-button">
-                        <button class="action-revoke-selected"
-                                data-url="${rootURL}/${it.url}/revokeAllSelected"
-                                data-confirm-template="${%RevokeAllSelected_confirm}" 
-                                data-nothing-selected="${%RevokeAllSelected_nothing}">
-                            ${%RevokeAllSelected}
-                        </button>
-                    </span>
-                </div>
+                <button type="button" class="action-revoke-selected jenkins-button jenkins-button--primary"
+                        data-url="${rootURL}/${it.url}/revokeAllSelected"
+                        data-confirm-template="${%RevokeAllSelected_confirm}"
+                        data-nothing-selected="${%RevokeAllSelected_nothing}">
+                    ${%RevokeAllSelected}
+                </button>
             </div>
         </l:main-panel>
     </l:layout>

--- a/test/src/test/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitorTest.java
+++ b/test/src/test/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitorTest.java
@@ -336,7 +336,8 @@ public class LegacyApiTokenAdministrativeMonitorTest {
 
     private HtmlButton getRevokeSelected(HtmlPage page) {
         HtmlElement document = page.getDocumentElement();
-        HtmlButton revokeSelected = document.getOneHtmlElementByAttribute("button", "class", "action-revoke-selected");
+
+        HtmlButton revokeSelected = document.querySelector("button.action-revoke-selected");
         assertNotNull(revokeSelected);
         return revokeSelected;
     }


### PR DESCRIPTION
Change the button style on the legacyapitoken admin monitor page to conform to new look

After:
<img width="233" alt="image" src="https://github.com/jenkinsci/jenkins/assets/17767050/d522c255-b97d-4d26-ac55-497f4d76e2ab">

### Testing done

- Allow to create legacy apitokens in Security
- create a legacy apitoken for yourself
- visit <rooturl>/manage/administrativeMonitor/legacyApiToken/manage
- check the token
- Click on `Revoke the selected token(s)`
- token is removed

### Proposed changelog entries

* Make the style of the legacy API token revoke button consistent with other buttons.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
