### PR TITLE
Revert "Temporarily disable selective ATH tests"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,7 +205,7 @@ axes.values().combinations {
     }
   }
 }
-/* Temporarily disable selective ATH builds due to https://github.com/jenkins-infra/helpdesk/issues/3641
+
 def athAxes = [
   platforms: ['linux'],
   jdks: [17],
@@ -232,12 +232,12 @@ athAxes.values().combinations {
          withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
          sh "launchable verify && launchable record tests --no-build --flavor platform=${platform} --flavor jdk=${jdk} --flavor browser=${browser} maven './target/ath-reports'"
          }
-
+         */
       }
     }
   }
 }
-*/
+
 builds.failFast = failFast
 parallel builds
 infra.maybePublishIncrementals()


### PR DESCRIPTION
Reverts jenkinsci/jenkins#8206

https://github.com/jenkins-infra/helpdesk/issues/3641 has been fixed, unblocking ATH tests in core.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

