### PR TITLE
Revert inlining 'since' tags in stapler documentation

### DIFF
--- a/core/src/main/resources/lib/form/submit.jelly
+++ b/core/src/main/resources/lib/form/submit.jelly
@@ -27,8 +27,10 @@ THE SOFTWARE.
   <s:documentation> <![CDATA[
     Submit button. This should be always used instead of the plain <button> tag.
     ]]>
-    <s:attribute name="id" since="2.376">
+    <s:attribute name="id">
       If specified the ID of the button.
+
+      @since 2.376
     </s:attribute>
     <s:attribute name="name">
       If specified, becomes the value of the name attribute.
@@ -39,11 +41,15 @@ THE SOFTWARE.
       The text of the submit button, defaults to 'Submit'
       It's recommended to be more descriptive when possible, e.g. 'Create', 'Next'
     </s:attribute>
-    <s:attribute name="primary" since="2.376">
+    <s:attribute name="primary">
       Sets whether this button is a primary button or not.
       Defaults to true.
+
+      @since 2.376
     </s:attribute>
-    <s:attribute name="icon" since="TODO" />
+    <s:attribute name="icon">
+      @since TODO
+    </s:attribute>
     <s:attribute name="clazz" />
   </s:documentation>
 

--- a/core/src/main/resources/lib/hudson/propertyTable.jelly
+++ b/core/src/main/resources/lib/hudson/propertyTable.jelly
@@ -30,8 +30,8 @@ THE SOFTWARE.
     <st:attribute name="items" use="required">
       A Map object that gets rendered as a table.
     </st:attribute>
-    <st:attribute name="sensitive" use="optional" since="2.385">
-      Set to true if the information shown in the table is sensitive and should be hidden by default.
+    <st:attribute name="sensitive" use="optional">
+      Set to true if the information shown in the table is sensitive and should be hidden by default. Since 2.385.
     </st:attribute>
   </st:documentation>
   <j:if test="${attrs.sensitive}">

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -36,9 +36,9 @@ THE SOFTWARE.
       If specified, this ID will be assigned to the LI element.
       This is useful for programmatically adding the context menu
     </st:attribute>
-    <st:attribute name="hasMenu" since="2.361">
+    <st:attribute name="hasMenu">
       If true, this breadcrumb item will include a '⌄' symbol to display a dropdown menu with items
-      from the '{breadcrumb.href}/contextMenu' path.
+      from the '{breadcrumb.href}/contextMenu' path. Since 2.361.
     </st:attribute>
   </st:documentation>
 

--- a/core/src/main/resources/lib/layout/icon.jelly
+++ b/core/src/main/resources/lib/layout/icon.jelly
@@ -38,8 +38,8 @@ THE SOFTWARE.
       The icon class specification e.g. 'icon-help icon-sm', 'icon-blue icon-md', 'icon-blue-anime icon-xlg'.
     </st:attribute>
 
-    <st:attribute name="id" since="2.360">
-      ID of the icon element.
+    <st:attribute name="id">
+      ID of the icon element. Since 2.360.
     </st:attribute>
 
     <st:attribute name="onclick" deprecated="true">onclick handler. Deprecated; assign an ID and look up the element that way to attach event handlers.</st:attribute>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -57,8 +57,8 @@ THE SOFTWARE.
       If given, this page is made available to users who have one or more of the specified permissions.
       (The permissions will be checked against the "it" object.)
     </st:attribute>
-    <st:attribute name="type" use="optional" since="2.53">
-      Available values: two-column (by default), one-column (full-width size) or full-screen.
+    <st:attribute name="type" use="optional">
+      Available values: two-column (by default), one-column (full-width size) or full-screen (since 2.53).
     </st:attribute>
     <st:attribute name="nogrid" use="optional">
       Do not include Bootstrap 3 grid. When a plugin wants to use a more recent version of Bootstrap then

--- a/core/src/main/resources/lib/layout/svgIcon.jelly
+++ b/core/src/main/resources/lib/layout/svgIcon.jelly
@@ -15,8 +15,8 @@
             Extra CSS classes passed to the icon. Currently only the 'svg-icon' class is applied by default.
         </st:attribute>
 
-        <st:attribute name="id" since="2.289">
-            ID of the icon element.
+        <st:attribute name="id">
+            ID of the icon element. Since 2.289.
         </st:attribute>
 
         <st:attribute name="href">

--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -66,20 +66,24 @@ THE SOFTWARE.
 
       If both permission and permissions is set, then permissions will be used
     </st:attribute>
-    <st:attribute name="post" type="boolean" since="1.504">
+    <st:attribute name="post" type="boolean">
       If true, send a POST rather than a GET request.
       (onclick supersedes this except in the context menu.)
+      (since 1.504)
     </st:attribute>
-    <st:attribute name="requiresConfirmation" type="boolean" since="1.512">
+    <st:attribute name="requiresConfirmation" type="boolean">
       If true, require confirmation before clicking.
       Generally used with post="true".
       (onclick supersedes this except in the context menu.)
+      (since 1.512)
     </st:attribute>
-    <st:attribute name="badge" since="TODO">
+    <st:attribute name="badge">
       If set, displays the value as a small badge on the right side of the sidepanel item.
+      @since TODO
     </st:attribute>
-    <st:attribute name="confirmationMessage" since="1.512">
+    <st:attribute name="confirmationMessage">
       Message to use for confirmation, if requested; defaults to title.
+      (since 1.512)
     </st:attribute>
   </st:documentation>
 


### PR DESCRIPTION
In https://github.com/jenkinsci/jenkins/pull/7737 I inlined the `since` tags to use the stapler `since` tag in Jelly. When testing this locally, I must have looked for something else because the maven-fluido-skin doesn't consider these at all, causing the vanishing of inlined since annotations in the published Jelly taglib reference.

The change proposed reverts my PR restoring the introduction date in the Jelly taglib reference.

### Testing done

Using the https://github.com/jenkins-infra/core-taglibs-report-generator pipeline locally based on my changes submitted, restores the since tags.

### Proposed changelog entries

- Developer: Restore the introduction date of Jelly methods in the documentation.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8218"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

