### PR TITLE
Read end of life data file less often

### DIFF
--- a/core/src/main/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor.java
@@ -38,6 +38,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -74,6 +75,11 @@ public class OperatingSystemEndOfLifeAdminMonitor extends AdministrativeMonitor 
     private String operatingSystemName = System.getProperty("os.name", "Unknown");
     private String endOfLifeDate = "2099-12-31";
     private String documentationUrl = "https://www.jenkins.io/redirect/operating-system-end-of-life";
+
+    /* Remember the last dataFile to avoid reading it again */
+    private File lastDataFile = null;
+    /* Remember the lines of the last dataFile */
+    private List<String> lastLines = null;
 
     public OperatingSystemEndOfLifeAdminMonitor(String id) throws IOException {
         super(id);
@@ -153,6 +159,10 @@ public class OperatingSystemEndOfLifeAdminMonitor extends AdministrativeMonitor 
                 }
             }
         }
+        if (lastLines != null) {
+            // Discard the cached contents of the last read file
+            lastLines.clear();
+        }
     }
 
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN",
@@ -177,12 +187,16 @@ public class OperatingSystemEndOfLifeAdminMonitor extends AdministrativeMonitor 
         Pattern pattern = Pattern.compile("^PRETTY_NAME=[\"](" + patternStr + ".*)[\"]");
         String name = "";
         try {
-            List<String> lines = Files.readAllLines(dataFile.toPath());
+            List<String> lines = dataFile.equals(lastDataFile) ? lastLines : Files.readAllLines(dataFile.toPath());
             for (String line : lines) {
                 Matcher matcher = pattern.matcher(line);
                 if (matcher.matches()) {
                     name = matcher.group(1);
                 }
+            }
+            if (!dataFile.equals(lastDataFile)) {
+                lastDataFile = dataFile;
+                lastLines = new ArrayList<>(lines);
             }
         } catch (IOException ioe) {
             LOGGER.log(Level.SEVERE, "File read exception", ioe);


### PR DESCRIPTION
## Read end of life data file less often

Remember the lines that were read from the file and the last file that was read so that the next iteration can reuse the data that was already read.  No need to read `/etc/os-release` once for each entry in the JSON file.  The contents of the file won't change from the first entry to the last entry in the JSON file.

This won't change much, since the read operation is probably already cached by the operating system with a file as small as `/etc/os-release`.

Cached file content is deleted at the end of the loop over the JSON file.

### Testing done

Automated tests continue to pass with this change.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8220"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

