### PR TITLE
[JENKINS-71553] Add history widget factory for job not implementing `Queue.Task`

### DIFF
--- a/core/src/main/java/hudson/widgets/HistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/HistoryWidget.java
@@ -25,11 +25,16 @@
 package hudson.widgets;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
 import hudson.Functions;
+import hudson.model.Job;
 import hudson.model.ModelObject;
+import hudson.model.Queue;
 import hudson.model.Run;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -37,6 +42,10 @@ import javax.servlet.ServletException;
 import jenkins.util.SystemProperties;
 import jenkins.widgets.HistoryPageEntry;
 import jenkins.widgets.HistoryPageFilter;
+import jenkins.widgets.WidgetFactory;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -295,6 +304,31 @@ public class HistoryWidget<O extends ModelObject, T> extends Widget {
             return Long.valueOf(paramVal);
         } catch (NumberFormatException nfe) {
             return null;
+        }
+    }
+
+    @Extension
+    @Restricted(DoNotUse.class)
+    @Symbol("history")
+    public static final class FactoryImpl extends WidgetFactory<Job, HistoryWidget> {
+        @Override
+        public Class<Job> type() {
+            return Job.class;
+        }
+
+        @Override
+        public Class<HistoryWidget> widgetType() {
+            return HistoryWidget.class;
+        }
+
+        @NonNull
+        @Override
+        public Collection<HistoryWidget> createFor(@NonNull Job target) {
+            // e.g. hudson.model.ExternalJob
+            if (!(target instanceof Queue.Task)) {
+                return List.of(new HistoryWidget<>(target, target.getBuilds(), Job.HISTORY_ADAPTER));
+            }
+            return Collections.emptySet();
         }
     }
 }


### PR DESCRIPTION
## [JENKINS-71553] Restore missing building history for external jobs

Follows up #7932. What was missed previously is that unlike other Job types, external job does NOT implement `Queue.Task` (as it is not running within Jenkins, it has no queue items). Still, it has a history widget, but it can't contain any queue item.

See [JENKINS-71553](https://issues.jenkins.io/browse/JENKINS-71553).

### Testing done

Confirmed with interactive testing that the external job history that was not visible in 2.409 is now visible with this change.

### Proposed changelog entries

- Restore missing build history for external jobs (regression in 2.409).

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@MarkEWaite

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
