### PR TITLE
Inline taglib documentation site

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,24 @@
       "matchStrings": ["ARG MAVEN_VERSION=(?<currentValue>.*?)\n"],
       "depNameTemplate": "org.apache.maven:maven-core",
       "datasourceTemplate": "maven"
+    },
+    {
+      "fileMatch": ["core/src/site/site.xml"],
+      "matchStrings": ["lit@(?<currentValue>.*?)/"],
+      "depNameTemplate": "lit",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "fileMatch": ["core/src/site/site.xml"],
+      "matchStrings": ["webcomponentsjs@(?<currentValue>.*?)/"],
+      "depNameTemplate": "@webcomponents/webcomponentsjs",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "fileMatch": ["core/src/site/site.xml"],
+      "matchStrings": ["<version>(?<currentValue>.*?)<\/version>"],
+      "depNameTemplate": "org.apache.maven.skins:maven-fluido-skin",
+      "datasourceTemplate": "maven"
     }
   ],
   "labels": ["dependencies", "skip-changelog"],

--- a/core/src/site/markdown/index.md
+++ b/core/src/site/markdown/index.md
@@ -1,1 +1,1 @@
-Collection of Maven auto-generated reports. The primary interest is probably [Jelly tag library reference](jelly-taglib-ref.html).
+[View the Jenkins core Jelly tag library reference](jelly-taglib-ref.html)

--- a/core/src/site/site.xml
+++ b/core/src/site/site.xml
@@ -1,0 +1,59 @@
+<!-- This maven skin decorates the taglib documentation located at https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html -->
+<project name="Jenkins">
+    <body>
+        <breadcrumbs>
+            <item name="Homepage" href="https://jenkins.io/" target="_blank"/>
+        </breadcrumbs>
+        <head>
+            <![CDATA[
+                <script src="https://cdn.jsdelivr.net/npm/lit@2.6.1/polyfill-support.js"></script>
+                <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.6.0/webcomponents-loader.js"></script>
+                <script data="jio" src="https://cdn.jsdelivr.net/npm/@jenkinsci/jenkins-io-components/+esm" type="module"></script>
+                <script data="jio" nomodule="" src="https://cdn.jsdelivr.net/npm/@jenkinsci/jenkins-io-components"></script>
+                <jio-navbar class="fixed-top" property="https://reports.jenkins.io"></jio-navbar>
+                <!-- Overwrite bootstrap classes from maven-fluido-skin to put the jio-components in place -->
+                <style>
+                  .container-fluid {
+                    padding-right: 0px;
+                    padding-left: 0px;
+                  }
+                  hr {
+                    border-top: 0px;
+                    border-bottom: 0px;
+                    margin: 0px;
+                  }
+                  #poweredBy {
+                    display: none;
+                  }
+                </style>
+            ]]>
+        </head>
+        <footer>
+            <![CDATA[
+                <jio-footer property="https://reports.jenkins.io"></jio-footer>
+            ]]>
+        </footer>
+    </body>
+    <bannerLeft>
+        <name>Jenkins Taglib Documentation</name>
+    </bannerLeft>
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.11.2</version>
+    </skin>
+    <custom>
+        <matomo>
+            <siteId>3</siteId>
+            <url>https://jenkins-matomo.do.g4v.dev</url>
+            <options>
+                <disableCookies/>
+                <trackPageView/>
+                <enableLinkTracking/>
+            </options>
+        </matomo>
+        <fluidoSkin>
+            <sideBarEnabled>false</sideBarEnabled>
+        </fluidoSkin>
+    </custom>
+</project>

--- a/war/.prettierignore
+++ b/war/.prettierignore
@@ -24,3 +24,6 @@ src/main/scss/_bootstrap.scss
 *.hbs
 
 .yarn
+
+# Incorrectly flagging forwarding slashes in regex
+../.github/renovate.json


### PR DESCRIPTION
The change proposed inlines the couple of file modifications coming from https://github.com/jenkins-infra/core-taglibs-report-generator/tree/master/site, when generating the taglib documentation for LTS releases.

Given, we don't use the maven-site-plugin at all for any terms of site generation within core, I'd like to propose to inline the couple of file modifications the tooling repo does.

### Testing done

I ran the pipeline locally checking out 2.401.1 with the modifications suggested, to ensure the page generated looks like the current generation.

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8226"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

