### PR TITLE
`LazyBuildMixIn.getEstimatedDurationCandidates` duplication

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -277,6 +277,9 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
         List<RunT> candidates = new ArrayList<>(3);
         for (Result threshold : List.of(Result.UNSTABLE, Result.FAILURE)) {
             for (RunT build : loadedBuilds) {
+                if (candidates.contains(build)) {
+                    continue;
+                }
                 if (!build.isBuilding()) {
                     Result result = build.getResult();
                     if (result != null && result.isBetterOrEqualTo(threshold)) {

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -282,12 +282,14 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
                     if (result != null && result.isBetterOrEqualTo(threshold)) {
                         candidates.add(build);
                         if (candidates.size() == 3) {
+                            LOGGER.fine(() -> "Candidates: " + candidates);
                             return candidates;
                         }
                     }
                 }
             }
         }
+        LOGGER.fine(() -> "Candidates: " + candidates);
         return candidates;
     }
 

--- a/test/src/test/java/hudson/model/SimpleJobTest.java
+++ b/test/src/test/java/hudson/model/SimpleJobTest.java
@@ -28,13 +28,14 @@ public class SimpleJobTest {
 
         var b1 = r.buildAndAssertSuccess(project);
         b1.duration = 20;
+        assertEquals(20, project.getEstimatedDuration());
 
         var b2 = r.buildAndAssertSuccess(project);
         b2.duration = 15;
+        assertEquals(18, project.getEstimatedDuration());
 
         var b3 = r.buildAndAssertSuccess(project);
         b3.duration = 40;
-
         assertEquals(25, project.getEstimatedDuration());
     }
 
@@ -44,7 +45,6 @@ public class SimpleJobTest {
 
         var b1 = r.buildAndAssertSuccess(project);
         b1.duration = 42;
-
         assertEquals(42, project.getEstimatedDuration());
     }
 
@@ -55,7 +55,6 @@ public class SimpleJobTest {
         var b1 = r.buildAndAssertSuccess(project);
         b1.result = Result.FAILURE;
         b1.duration = 42;
-
         assertEquals(42, project.getEstimatedDuration());
     }
 
@@ -73,26 +72,29 @@ public class SimpleJobTest {
         var b1 = r.buildAndAssertSuccess(project);
         b1.result = Result.UNSTABLE;
         b1.duration = 10;
+        assertEquals(10, project.getEstimatedDuration());
 
         var b2 = r.buildAndAssertSuccess(project);
         b2.duration = 20;
+        assertEquals(15, project.getEstimatedDuration());
 
         var b3 = r.buildAndAssertSuccess(project);
         b3.duration = 30;
+        assertEquals(20, project.getEstimatedDuration());
 
         var b4 = r.buildAndAssertSuccess(project);
         b4.result = Result.FAILURE;
         b4.duration = 50;
+        assertEquals(20, project.getEstimatedDuration());
 
         var b5 = r.buildAndAssertSuccess(project);
         b5.result = Result.FAILURE;
         b5.duration = 50;
+        assertEquals(20, project.getEstimatedDuration());
 
         var b6 = r.buildAndAssertSuccess(project);
         b6.result = Result.FAILURE;
         b6.duration = 50;
-
-        // failed builds must not be used, if there are successfulBuilds available.
         assertEquals(20, project.getEstimatedDuration());
     }
 
@@ -103,7 +105,6 @@ public class SimpleJobTest {
         var b1 = r.buildAndAssertSuccess(project);
         b1.result = Result.FAILURE;
         b1.duration = 50;
-
         assertEquals(50, project.getEstimatedDuration());
     }
 

--- a/test/src/test/java/hudson/model/SimpleJobTest.java
+++ b/test/src/test/java/hudson/model/SimpleJobTest.java
@@ -27,16 +27,16 @@ public class SimpleJobTest {
         var project = r.createFreeStyleProject("testGetEstimatedDuration");
 
         var b1 = r.buildAndAssertSuccess(project);
-        b1.duration = 20;
-        assertEquals(20, project.getEstimatedDuration());
+        b1.duration = 200;
+        assertEquals(200, project.getEstimatedDuration());
 
         var b2 = r.buildAndAssertSuccess(project);
-        b2.duration = 15;
-        assertEquals(18, project.getEstimatedDuration());
+        b2.duration = 150;
+        assertEquals(175, project.getEstimatedDuration());
 
         var b3 = r.buildAndAssertSuccess(project);
-        b3.duration = 40;
-        assertEquals(25, project.getEstimatedDuration());
+        b3.duration = 400;
+        assertEquals(250, project.getEstimatedDuration());
     }
 
     @Test
@@ -44,8 +44,8 @@ public class SimpleJobTest {
         var project = r.createFreeStyleProject("testGetEstimatedDurationWithOneRun");
 
         var b1 = r.buildAndAssertSuccess(project);
-        b1.duration = 42;
-        assertEquals(42, project.getEstimatedDuration());
+        b1.duration = 420;
+        assertEquals(420, project.getEstimatedDuration());
     }
 
     @Test
@@ -54,8 +54,8 @@ public class SimpleJobTest {
 
         var b1 = r.buildAndAssertSuccess(project);
         b1.result = Result.FAILURE;
-        b1.duration = 42;
-        assertEquals(42, project.getEstimatedDuration());
+        b1.duration = 420;
+        assertEquals(420, project.getEstimatedDuration());
     }
 
     @Test
@@ -71,31 +71,31 @@ public class SimpleJobTest {
 
         var b1 = r.buildAndAssertSuccess(project);
         b1.result = Result.UNSTABLE;
-        b1.duration = 10;
-        assertEquals(10, project.getEstimatedDuration());
+        b1.duration = 100;
+        assertEquals(100, project.getEstimatedDuration());
 
         var b2 = r.buildAndAssertSuccess(project);
-        b2.duration = 20;
-        assertEquals(15, project.getEstimatedDuration());
+        b2.duration = 200;
+        assertEquals(150, project.getEstimatedDuration());
 
         var b3 = r.buildAndAssertSuccess(project);
-        b3.duration = 30;
-        assertEquals(20, project.getEstimatedDuration());
+        b3.duration = 300;
+        assertEquals(200, project.getEstimatedDuration());
 
         var b4 = r.buildAndAssertSuccess(project);
         b4.result = Result.FAILURE;
-        b4.duration = 50;
-        assertEquals(20, project.getEstimatedDuration());
+        b4.duration = 500;
+        assertEquals(200, project.getEstimatedDuration());
 
         var b5 = r.buildAndAssertSuccess(project);
         b5.result = Result.FAILURE;
-        b5.duration = 50;
-        assertEquals(20, project.getEstimatedDuration());
+        b5.duration = 500;
+        assertEquals(200, project.getEstimatedDuration());
 
         var b6 = r.buildAndAssertSuccess(project);
         b6.result = Result.FAILURE;
-        b6.duration = 50;
-        assertEquals(20, project.getEstimatedDuration());
+        b6.duration = 500;
+        assertEquals(200, project.getEstimatedDuration());
     }
 
     @Test
@@ -104,8 +104,8 @@ public class SimpleJobTest {
 
         var b1 = r.buildAndAssertSuccess(project);
         b1.result = Result.FAILURE;
-        b1.duration = 50;
-        assertEquals(50, project.getEstimatedDuration());
+        b1.duration = 500;
+        assertEquals(500, project.getEstimatedDuration());
     }
 
 }

--- a/test/src/test/java/hudson/model/SimpleJobTest.java
+++ b/test/src/test/java/hudson/model/SimpleJobTest.java
@@ -1,7 +1,6 @@
 package hudson.model;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.logging.Level;
 import jenkins.model.lazy.LazyBuildMixIn;
@@ -34,12 +33,9 @@ public class SimpleJobTest {
         b2.duration = 15;
 
         var b3 = r.buildAndAssertSuccess(project);
-        b3.duration = 42;
+        b3.duration = 40;
 
-        // without assuming to know too much about the internal calculation
-        // we can only assume that the result is between the maximum and the minimum
-        assertTrue("Expected < 42, but was " + project.getEstimatedDuration(), project.getEstimatedDuration() < 42);
-        assertTrue("Expected > 15, but was " + project.getEstimatedDuration(), project.getEstimatedDuration() > 15);
+        assertEquals(25, project.getEstimatedDuration());
     }
 
     @Test
@@ -76,13 +72,13 @@ public class SimpleJobTest {
 
         var b1 = r.buildAndAssertSuccess(project);
         b1.result = Result.UNSTABLE;
-        b1.duration = 1;
+        b1.duration = 10;
 
         var b2 = r.buildAndAssertSuccess(project);
-        b2.duration = 1;
+        b2.duration = 20;
 
         var b3 = r.buildAndAssertSuccess(project);
-        b3.duration = 1;
+        b3.duration = 30;
 
         var b4 = r.buildAndAssertSuccess(project);
         b4.result = Result.FAILURE;
@@ -97,7 +93,7 @@ public class SimpleJobTest {
         b6.duration = 50;
 
         // failed builds must not be used, if there are successfulBuilds available.
-        assertEquals(1, project.getEstimatedDuration());
+        assertEquals(20, project.getEstimatedDuration());
     }
 
     @Test

--- a/test/src/test/java/hudson/model/SimpleJobTest.java
+++ b/test/src/test/java/hudson/model/SimpleJobTest.java
@@ -3,10 +3,7 @@ package hudson.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -16,24 +13,21 @@ import org.jvnet.hudson.test.JenkinsRule;
 @SuppressWarnings("rawtypes")
 public class SimpleJobTest {
 
-    @Rule
-    public JenkinsRule rule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
 
     @Test
-    public void testGetEstimatedDuration() throws IOException {
+    public void testGetEstimatedDuration() throws Exception {
+        var project = r.createFreeStyleProject("testGetEstimatedDuration");
 
-        final SortedMap<Integer, TestBuild> runs = new TreeMap<>();
+        var b1 = r.buildAndAssertSuccess(project);
+        b1.duration = 20;
 
-        Job project = createMockProject(runs);
+        var b2 = r.buildAndAssertSuccess(project);
+        b2.duration = 15;
 
-        TestBuild previousPreviousBuild = new TestBuild(project, Result.SUCCESS, 20, null);
-        runs.put(3, previousPreviousBuild);
-
-        TestBuild previousBuild = new TestBuild(project, Result.SUCCESS, 15, previousPreviousBuild);
-        runs.put(2, previousBuild);
-
-        TestBuild lastBuild = new TestBuild(project, Result.SUCCESS, 42, previousBuild);
-        runs.put(1, lastBuild);
+        var b3 = r.buildAndAssertSuccess(project);
+        b3.duration = 42;
 
         // without assuming to know too much about the internal calculation
         // we can only assume that the result is between the maximum and the minimum
@@ -42,147 +36,72 @@ public class SimpleJobTest {
     }
 
     @Test
-    public void testGetEstimatedDurationWithOneRun() throws IOException {
+    public void testGetEstimatedDurationWithOneRun() throws Exception {
+        var project = r.createFreeStyleProject("testGetEstimatedDurationWithOneRun");
 
-        final SortedMap<Integer, TestBuild> runs = new TreeMap<>();
-
-        Job project = createMockProject(runs);
-
-        TestBuild lastBuild = new TestBuild(project, Result.SUCCESS, 42, null);
-        runs.put(1, lastBuild);
+        var b1 = r.buildAndAssertSuccess(project);
+        b1.duration = 42;
 
         assertEquals(42, project.getEstimatedDuration());
     }
 
     @Test
-    public void testGetEstimatedDurationWithFailedRun() throws IOException {
+    public void testGetEstimatedDurationWithFailedRun() throws Exception {
+        var project = r.createFreeStyleProject("testGetEstimatedDurationWithFailedRun");
 
-        final SortedMap<Integer, TestBuild> runs = new TreeMap<>();
-
-        Job project = createMockProject(runs);
-
-        TestBuild lastBuild = new TestBuild(project, Result.FAILURE, 42, null);
-        runs.put(1, lastBuild);
+        var b1 = r.buildAndAssertSuccess(project);
+        b1.result = Result.FAILURE;
+        b1.duration = 42;
 
         assertEquals(42, project.getEstimatedDuration());
     }
 
     @Test
-    public void testGetEstimatedDurationWithNoRuns() {
-
-        final SortedMap<Integer, TestBuild> runs = new TreeMap<>();
-
-        Job project = createMockProject(runs);
+    public void testGetEstimatedDurationWithNoRuns() throws Exception {
+        var project = r.createFreeStyleProject("testGetEstimatedDurationWithNoRuns");
 
         assertEquals(-1, project.getEstimatedDuration());
     }
 
     @Test
-    public void testGetEstimatedDurationIfPrevious3BuildsFailed() throws IOException {
+    public void testGetEstimatedDurationIfPrevious3BuildsFailed() throws Exception {
+        var project = r.createFreeStyleProject("testGetEstimatedDurationIfPrevious3BuildsFailed");
 
-        final SortedMap<Integer, TestBuild> runs = new TreeMap<>();
+        var b1 = r.buildAndAssertSuccess(project);
+        b1.result = Result.UNSTABLE;
+        b1.duration = 1;
 
-        Job project = createMockProject(runs);
+        var b2 = r.buildAndAssertSuccess(project);
+        b2.duration = 1;
 
-        TestBuild prev5Build = new TestBuild(project, Result.UNSTABLE, 1, null);
-        runs.put(6, prev5Build);
+        var b3 = r.buildAndAssertSuccess(project);
+        b3.duration = 1;
 
-        TestBuild prev4Build = new TestBuild(project, Result.SUCCESS, 1, prev5Build);
-        runs.put(5, prev4Build);
+        var b4 = r.buildAndAssertSuccess(project);
+        b4.result = Result.FAILURE;
+        b4.duration = 50;
 
-        TestBuild prev3Build = new TestBuild(project, Result.SUCCESS, 1, prev4Build);
-        runs.put(4, prev3Build);
+        var b5 = r.buildAndAssertSuccess(project);
+        b5.result = Result.FAILURE;
+        b5.duration = 50;
 
-        TestBuild previous2Build = new TestBuild(project, Result.FAILURE, 50, prev3Build);
-        runs.put(3, previous2Build);
-
-        TestBuild previousBuild = new TestBuild(project, Result.FAILURE, 50, previous2Build);
-        runs.put(2, previousBuild);
-
-        TestBuild lastBuild = new TestBuild(project, Result.FAILURE, 50, previousBuild);
-        runs.put(1, lastBuild);
+        var b6 = r.buildAndAssertSuccess(project);
+        b6.result = Result.FAILURE;
+        b6.duration = 50;
 
         // failed builds must not be used, if there are successfulBuilds available.
         assertEquals(1, project.getEstimatedDuration());
     }
 
     @Test
-    public void testGetEstimatedDurationIfNoSuccessfulBuildTakeDurationOfFailedBuild() throws IOException {
+    public void testGetEstimatedDurationIfNoSuccessfulBuildTakeDurationOfFailedBuild() throws Exception {
+        var project = r.createFreeStyleProject("testGetEstimatedDurationIfNoSuccessfulBuildTakeDurationOfFailedBuild");
 
-        final SortedMap<Integer, TestBuild> runs = new TreeMap<>();
-
-        Job project = createMockProject(runs);
-
-        TestBuild lastBuild = new TestBuild(project, Result.FAILURE, 50, null);
-        runs.put(1, lastBuild);
+        var b1 = r.buildAndAssertSuccess(project);
+        b1.result = Result.FAILURE;
+        b1.duration = 50;
 
         assertEquals(50, project.getEstimatedDuration());
     }
 
-    private Job createMockProject(final SortedMap<Integer, TestBuild> runs) {
-        return new TestJob(runs);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static class TestBuild extends Run {
-
-        TestBuild(Job project, Result result, long duration, TestBuild previousBuild) throws IOException {
-            super(project);
-            this.result = result;
-            this.duration = duration;
-            this.previousBuild = previousBuild;
-        }
-
-        @Override
-        public int compareTo(Run o) {
-            return 0;
-        }
-
-        @Override
-        public Result getResult() {
-            return result;
-        }
-
-        @Override
-        public boolean isBuilding() {
-            return false;
-        }
-
-    }
-
-    private class TestJob extends Job implements TopLevelItem {
-
-        int i;
-        private final SortedMap<Integer, TestBuild> runs;
-
-        TestJob(SortedMap<Integer, TestBuild> runs) {
-            super(rule.jenkins, "name");
-            this.runs = runs;
-            i = 1;
-        }
-
-        @Override
-        public int assignBuildNumber() {
-            return i++;
-        }
-
-        @Override
-        public SortedMap<Integer, ? extends Run> _getRuns() {
-            return runs;
-        }
-
-        @Override
-        public boolean isBuildable() {
-            return true;
-        }
-
-        @Override
-        protected void removeRun(Run run) {
-        }
-
-        @Override
-        public TopLevelItemDescriptor getDescriptor() {
-            throw new AssertionError();
-        }
-    }
 }

--- a/test/src/test/java/hudson/model/SimpleJobTest.java
+++ b/test/src/test/java/hudson/model/SimpleJobTest.java
@@ -3,9 +3,13 @@ package hudson.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.logging.Level;
+import jenkins.model.lazy.LazyBuildMixIn;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 
 /**
  * Unit test for {@link Job}.
@@ -15,6 +19,9 @@ public class SimpleJobTest {
 
     @ClassRule
     public static JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule().record(LazyBuildMixIn.class, Level.FINE);
 
     @Test
     public void testGetEstimatedDuration() throws Exception {


### PR DESCRIPTION
@jtnord spotted a mistake in a recent reimplementation of the method used to estimate the duration of new builds: https://github.com/jenkinsci/jenkins/pull/7998#discussion_r1242446688

### Testing done

Looked in vain for any direct test coverage of `Job.getEstimatedDurationCandidates`. Did find test coverage of `Job.getEstimatedDuration`, which is as good (perhaps better, since that is the only caller at least in core of this method). Unfortunately this `SimpleJobTest` used a cumbersome mock system introduced in 40ffa913f8c4e6f644a248c5c943275426aada52, which was amended to run with a live Jenkins server in 1774927de2c87e9f8142649e93901b1340380f59 but still using a mock which did not pick up my `AbstractProject.getEstimatedDurationCandidates` override from #7998. After fixing that, the test still failed to reproduce the problem, because it was too weak: calculated the estimate only after running all builds (when some of the interesting logic occurs only earlier, when there are fewer than three candidates); and also asserting an “average” only when there was only a single value or repeated identical value, never exercising https://github.com/jenkinsci/jenkins/blob/32c51fb7fe05a08a386cf1835b97e33fb65bf3c3/core/src/main/java/hudson/model/Job.java#L1060 outside of these degenerate cases. After introducing logging and strengthening the test, I was able to confirm the bug and its fix.

From what I can tell, the practical impact is pretty small: the more recent of two candidates was being weighted more than the preceding candidate. This is actually a mistake in the direction of my intuition (more recent builds are a better gauge of future behavior), but not consistent or intentional.

### Proposed changelog entries

- Estimate project duration accurately in more cases (regression in 2.407).

### Proposed upgrade guidelines

N/A

### Maintainer checklist

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8233"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

