### PR TITLE
Frequent failures in `ExecutorTest.disconnectCause_WithoutTrace`

### DIFF
--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -171,7 +171,7 @@ public class ExecutorTest {
         Assert.assertThat(offlineCause.toString(), not(containsString(message)));
 
         b.doStop();
-        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
+        j.waitForCompletion(b);
     }
 
     /**


### PR DESCRIPTION
An assertion introduced in #8158 seems to fail frequently, for example [here](https://github.com/jenkinsci/jenkins/runs/14895513067)

```
ava.lang.AssertionError: 
unexpected build status; build log was:
------
Legacy code started this job.  No cause information is available
Running as SYSTEM
Building remotely on slave0 in workspace /home/jenkins/agent/workspace/Core_jenkins_master/test/target/j h15904540049939458581/agent-work-dirs/slave0/workspace/test0
Agent went offline during the build
ERROR: Connection was broken
Build step 'TestBuilder' marked build as failure
Finished: FAILURE

------

Expected: is <ABORTED>
     but: was <FAILURE>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1443)
	at hudson.model.ExecutorTest.disconnectCause_WithoutTrace(ExecutorTest.java:174)
```

I do not think the actual build status is important in this case; we were only waiting for the build to complete at all in order to ensure it finished writing out files such as `log` before cleanup.

### Testing done

None, leave it to CI.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8245"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

