### PR TITLE
Flake in `ExecutorTest.disconnectCause`

### DIFF
--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -210,6 +210,7 @@ public class ExecutorTest {
         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
             VirtualChannel channel = launcher.getChannel();
             Node node = build.getBuiltOn();
+            channel.call(node.getClockDifferenceCallable()); // warm up class loading
 
             e.signal(); // we are safe to be interrupted
             for (;;) {

--- a/test/src/test/java/hudson/model/ExecutorTest.java
+++ b/test/src/test/java/hudson/model/ExecutorTest.java
@@ -1,6 +1,5 @@
 package hudson.model;
 
-import hudson.Functions;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -10,6 +9,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;


### PR DESCRIPTION
Checked for recent test flakes in follow-up to #8245 and noticed some (I think only on Windows) in `ExecutorTest.disconnectCause` like [this one](https://github.com/jenkinsci/jenkins/runs/14897162805)

```
…
Building remotely on slave0 in workspace C:\Jenkins\agent\workspace\Core_jenkins_master\test\target\j h18374839023964160991\agent-work-dirs\slave0\workspace\test0
FATAL: Cannot locate RemoteClassLoader.ClassLoaderProxy(2) in the channel exported table
java.util.concurrent.ExecutionException: Invalid object ID 2 iota=4
 at hudson.remoting.ExportTable.diagnoseInvalidObjectId(ExportTable.java:441)
 at hudson.remoting.ExportTable.get(ExportTable.java:358)
 at hudson.remoting.Channel.getExportedObject(Channel.java:824)
 at hudson.remoting.MultiClassLoaderSerializer$Input.readClassLoader(MultiClassLoaderSerializer.java:107)
Caused: java.io.IOException: Cannot locate RemoteClassLoader.ClassLoaderProxy(2) in the channel exported table
 at hudson.remoting.MultiClassLoaderSerializer$Input.readClassLoader(MultiClassLoaderSerializer.java:109)
 at hudson.remoting.MultiClassLoaderSerializer$Input.resolveClass(MultiClassLoaderSerializer.java:130)
 at java.base/java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:2034)
 at java.base/java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1898)
 at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2224)
 at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
 at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:509)
 at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:467)
 at hudson.remoting.UserRequest.deserialize(UserRequest.java:289)
 at hudson.remoting.UserRequest$NormalResponse.retrieve(UserRequest.java:325)
 at hudson.remoting.Channel.call(Channel.java:1000)
 at hudson.model.ExecutorTest$BlockingBuilder.perform(ExecutorTest.java:211)
 at …
Finished: FAILURE
…
```

I suspect a race condition, that the channel is being disconnected while the agent is still loading `Slave.GetClockDifference1` or related classes for the first time.

Related test code was edited recently in #8158 but I cannot find any reason why that would have introduced the flake, so I am guessing it is longstanding and was just not noticed before. It is possible that the slower CI environment on Windows (which IIRC was only turned back on a few months ago) is a contributing factor.

### Testing done

Test passes locally.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8259"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

