### PR TITLE
allow string for badge attribute of l:task

### DIFF
--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:local="local">
   <st:documentation> <![CDATA[
     This tag inside <l:tasks> tag renders the left navigation bar of Jenkins.
     Each <task> tag gets an icon and link.
@@ -79,6 +79,8 @@ THE SOFTWARE.
     </st:attribute>
     <st:attribute name="badge">
       If set, displays the value as a small badge on the right side of the sidepanel item.
+      You can pass either an instance of <code>jenkins.management.Badge</code> which allows to display a tooltip,
+      or some plain String or Number.
       @since TODO
     </st:attribute>
     <st:attribute name="confirmationMessage">
@@ -90,6 +92,24 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
+  <d:taglib uri="local">
+    <d:tag name="badge">
+      <j:if test="${attrs.badge != null}">
+        <j:choose>
+          <j:when test="${attrs.badge.getClass().getName() == 'jenkins.management.Badge'}">
+            <span class="task-icon-badge" tooltip="${attrs.badge.tooltip}">
+              ${attrs.badge.text}
+            </span>
+          </j:when>
+          <j:otherwise>
+            <span class="task-icon-badge">
+              ${attrs.badge}
+            </span>
+          </j:otherwise>
+        </j:choose>
+      </j:if>
+    </d:tag>
+  </d:taglib>
   <!--
     Much of the following horrible code is to implement hierarchy support in <task> tag.
     The semantics is that when one of the nested <task> matches, the parent is also considered as a match
@@ -143,11 +163,7 @@ THE SOFTWARE.
                 <l:icon src="${icon}" />
               </span>
               <span class="task-link-text">${title}</span>
-              <j:if test="${attrs.badge != null}">
-                <span class="task-icon-badge" tooltip="${attrs.badge.tooltip}">
-                  ${attrs.badge.text}
-                </span>
-              </j:if>
+              <local:badge badge="${attrs.badge}"/>
             </span>
           </span>
         </div>
@@ -182,11 +198,7 @@ THE SOFTWARE.
                     <l:icon src="${icon}" />
                   </span>
                   <span>${title}</span>
-                  <j:if test="${attrs.badge != null}">
-                    <span class="task-icon-badge" tooltip="${attrs.badge.tooltip}">
-                      ${attrs.badge.text}
-                    </span>
-                  </j:if>
+                  <local:badge badge="${attrs.badge}"/>
                 </l:confirmationLink>
               </j:when>
 
@@ -196,11 +208,7 @@ THE SOFTWARE.
                     <l:icon src="${icon}" />
                   </span>
                   <span class="task-link-text">${title}</span>
-                  <j:if test="${attrs.badge != null}">
-                    <span class="task-icon-badge" tooltip="${attrs.badge.tooltip}">
-                      ${attrs.badge.text}
-                    </span>
-                  </j:if>
+                  <local:badge badge="${attrs.badge}"/>
                 </a>
               </j:otherwise>
             </j:choose>


### PR DESCRIPTION
The documentation can be interpreted that the badge attribute accepts a String as argument. But in reality it requires an instance of jenkins.management.Badge

The effect can be seen on the Design Library
https://weekly.ci.jenkins.io/design-library/Layouts/twoColumn 
Where a String is passed but is not shown.

This change allows either a Badge object or something else which is then just printed.


### Testing done

I tested this by modifying the sidepanel of the ComputerSet page
      <l:task href="${h.getNearestAncestorUrl(request,it)}/" icon="symbol-computer"
              title="${%Nodes}" badge="${it._all.size()}"/>
The page then properly show me the number of agents (without having a tooltip)
On the plugins page the number of updates is still shown with a tooltip.

Before:
![image](https://github.com/jenkinsci/jenkins/assets/17767050/f9ff5aef-7f06-4904-8fcc-8fc15dd85241)

After:
<img width="436" alt="image" src="https://github.com/jenkinsci/jenkins/assets/17767050/d6cee059-4b70-47fc-b372-5a62c7c1c3af">

<img width="355" alt="image" src="https://github.com/jenkinsci/jenkins/assets/17767050/81a653ee-a76a-428c-ba33-45d9e0f2cdad">

### Proposed changelog entries

- Allow string for badge attribute of <l:task ...>.

### Proposed upgrade guidelines

N/A

### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
