### PR TITLE
Flake in `QuietDownCommandTest.quietDownShouldSuccessWithBlockPlusNonExpiredTimeoutAndRunningExecutor`

### DIFF
--- a/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
@@ -30,17 +30,17 @@ import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.util.OneShotEvent;
-import java.util.concurrent.Future;
 import jenkins.model.Jenkins;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**
@@ -49,6 +49,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class CancelQuietDownCommandTest {
 
     private CLICommandInvoker command;
+
+    @ClassRule
+    public static final BuildWatcher buildWatcher = new BuildWatcher();
 
     @Rule
     public final JenkinsRule j = new JenkinsRule();
@@ -110,8 +113,7 @@ public class CancelQuietDownCommandTest {
     public void cancelQuietDownShouldSuccessOnNoQuietDownedJenkinsAndRunningExecutor() throws Exception {
         final FreeStyleProject project = j.createFreeStyleProject("aProject");
         OneShotEvent finish = new OneShotEvent();
-        Future<FreeStyleBuild> build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
+        FreeStyleBuild build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
@@ -119,19 +121,16 @@ public class CancelQuietDownCommandTest {
         assertThat(result, succeededSilently());
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
         finish.signal();
-        build.get();
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
-        assertThat(project.isBuilding(), equalTo(false));
+        j.waitForCompletion(build);
+        assertThat(build.isBuilding(), equalTo(false));
         j.assertBuildStatusSuccess(build);
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
         finish = new OneShotEvent();
         build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
-        assertThat(project.isBuilding(), equalTo(true));
+        assertThat(build.isBuilding(), equalTo(true));
         finish.signal();
-        build.get();
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
-        assertThat(project.isBuilding(), equalTo(false));
+        j.waitForCompletion(build);
+        assertThat(build.isBuilding(), equalTo(false));
         j.assertBuildStatusSuccess(build);
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
     }
@@ -144,9 +143,8 @@ public class CancelQuietDownCommandTest {
     public void cancelQuietDownShouldSuccessOnQuietDownedJenkinsAndRunningExecutor() throws Exception {
         final FreeStyleProject project = j.createFreeStyleProject("aProject");
         OneShotEvent finish = new OneShotEvent();
-        Future<FreeStyleBuild> build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
-        assertThat(project.isBuilding(), equalTo(true));
+        FreeStyleBuild build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
+        assertThat(build.isBuilding(), equalTo(true));
         j.jenkins.doQuietDown();
         QuietDownCommandTest.assertJenkinsInQuietMode(j);
 
@@ -156,19 +154,16 @@ public class CancelQuietDownCommandTest {
         assertThat(result, succeededSilently());
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
         finish.signal();
-        build.get();
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
-        assertThat(project.isBuilding(), equalTo(false));
+        j.waitForCompletion(build);
+        assertThat(build.isBuilding(), equalTo(false));
         j.assertBuildStatusSuccess(build);
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
         finish = new OneShotEvent();
         build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
-        assertThat(project.isBuilding(), equalTo(true));
+        assertThat(build.isBuilding(), equalTo(true));
         finish.signal();
-        build.get();
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(2));
-        assertThat(project.isBuilding(), equalTo(false));
+        j.waitForCompletion(build);
+        assertThat(build.isBuilding(), equalTo(false));
         j.assertBuildStatusSuccess(build);
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
     }

--- a/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OnlineNodeCommandTest.java
@@ -30,7 +30,6 @@ import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -38,22 +37,21 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Computer;
-import hudson.model.Descriptor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
-import hudson.tasks.Builder;
 import hudson.util.OneShotEvent;
 import java.io.IOException;
-import java.util.concurrent.Future;
 import jenkins.model.Jenkins;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.TestBuilder;
 
 /**
  * @author pjanouse
@@ -61,6 +59,9 @@ import org.jvnet.hudson.test.TestExtension;
 public class OnlineNodeCommandTest {
 
     private CLICommandInvoker command;
+
+    @ClassRule
+    public static final BuildWatcher buildWatcher = new BuildWatcher();
 
     @Rule public final JenkinsRule j = new JenkinsRule();
 
@@ -190,8 +191,7 @@ public class OnlineNodeCommandTest {
         }
         FreeStyleProject project = j.createFreeStyleProject("aProject");
         project.setAssignedNode(slave);
-        final Future<FreeStyleBuild> build = startBlockingAndFinishingBuild(project, finish);
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
+        final FreeStyleBuild build = startBlockingAndFinishingBuild(project, finish);
 
         slave.toComputer().setTemporarilyOffline(true);
         slave.toComputer().waitUntilOffline();
@@ -206,13 +206,11 @@ public class OnlineNodeCommandTest {
             slave.toComputer().waitUntilOnline();
         }
         assertThat(slave.toComputer().isOnline(), equalTo(true));
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
-        assertThat(project.isBuilding(), equalTo(true));
+        assertThat(build.isBuilding(), equalTo(true));
 
         finish.signal();
-        build.get();
-        assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
-        assertThat(project.isBuilding(), equalTo(false));
+        j.waitForCompletion(build);
+        assertThat(build.isBuilding(), equalTo(false));
         j.assertBuildStatusSuccess(build);
     }
 
@@ -306,24 +304,24 @@ public class OnlineNodeCommandTest {
      *
      * @param project {@link FreeStyleProject} to start
      * @param finish {@link OneShotEvent} to signal to finish a build
-     * @return A {@link Future} object represents the started build
+     * @return the started build (the caller should wait for its completion)
      * @throws Exception if somethink wrong happened
      */
-    public static Future<FreeStyleBuild> startBlockingAndFinishingBuild(FreeStyleProject project, OneShotEvent finish) throws Exception {
+    public static FreeStyleBuild startBlockingAndFinishingBuild(FreeStyleProject project, OneShotEvent finish) throws Exception {
         assertFalse(finish.isSignaled());
 
         final OneShotEvent block = new OneShotEvent();
 
         project.getBuildersList().add(new BlockingAndFinishingBuilder(block, finish));
 
-        Future<FreeStyleBuild> r = project.scheduleBuild2(0);
+        FreeStyleBuild b = project.scheduleBuild2(0).waitForStart();
         block.block();  // wait until we are safe to interrupt
-        assertTrue(project.getLastBuild().isBuilding());
+        assertTrue(b.isBuilding());
 
-        return r;
+        return b;
     }
 
-    private static final class BlockingAndFinishingBuilder extends Builder {
+    private static final class BlockingAndFinishingBuilder extends TestBuilder {
         private final OneShotEvent block;
         private final OneShotEvent finish;
 
@@ -345,8 +343,5 @@ public class OnlineNodeCommandTest {
             }
             return true;
         }
-
-        @TestExtension("disconnectCause")
-        public static class DescriptorImpl extends Descriptor<Builder> {}
     }
 }


### PR DESCRIPTION
I noticed a flake in `QuietDownCommandTest.quietDownShouldSuccessWithBlockPlusNonExpiredTimeoutAndRunningExecutor` [here](https://github.com/jenkinsci/jenkins/runs/14797440044) (also showing an apparently unrelated HtmlUnit flake in `ViewTest.privateView` by the way) presumably related to a build left running past the end of the test and interfering with temporary directory cleanup. It turns out that the test utility patched in #8158 was copied (just once, that I can see), so this does an analogous cleanup.

### Testing done

Modified test classes pass locally. Unknown whether the cleanup error can be reproduced.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8261"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

