### PR TITLE
Flake in `QueueTest.pendingsConsistenceAfterErrorDuringMaintain`

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -101,6 +101,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -882,8 +883,8 @@ public class QueueTest {
     }
 
     @Test public void pendingsConsistenceAfterErrorDuringMaintain() throws IOException, InterruptedException {
-        FreeStyleProject project1 = r.createFreeStyleProject();
-        FreeStyleProject project2 = r.createFreeStyleProject();
+        FreeStyleProject project1 = r.createFreeStyleProject("project1");
+        FreeStyleProject project2 = r.createFreeStyleProject("project2");
         TopLevelItemDescriptor descriptor = new TopLevelItemDescriptor(FreeStyleProject.class) {
          @Override
             public FreeStyleProject newInstance(ItemGroup parent, String name) {
@@ -932,7 +933,11 @@ public class QueueTest {
         for (var p : r.jenkins.allItems(FreeStyleProject.class)) {
             for (var b : p.getBuilds()) {
                 r.waitForCompletion(b);
+                b.delete();
+                Logger.getLogger(QueueTest.class.getName()).info(() -> "Waited for " + b);
             }
+            p.delete();
+            Logger.getLogger(QueueTest.class.getName()).info(() -> "Cleaned up " + p);
         }
     }
 


### PR DESCRIPTION
This test was [observed to fail](https://github.com/jenkinsci/jenkins/runs/14994773460) during cleanup (noticed in a #8259 failure). I had thought I had fixed this in #8006 but apparently not:

```
java.nio.file.DirectoryNotEmptyException: /home/jenkins/agent/workspace/Core_jenkins_PR-8259/test/target/j h3703938140270025780/jobs/test1/builds
```

I think `test1` would be `project2` (naming explicitly for clarity).

### Testing done

Passes locally; prints expected log messages.

```
FINE	hudson.model.Queue#cancel: Cancelling hudson.model.FreeStyleProject@4fec90f9[project2]
```

(after adding `Job.delete`) suggests that the problem was that while the cleanup code did process all builds which had started _by that point_, there were still queue items outstanding which may have been scheduled after the test was supposed to exit, leading to new builds.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8263"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

