### PR TITLE
[JENKINS-71054] Remove the treeview option for artifactList

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1242,12 +1242,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     /**
      * Maximum number of artifacts to list before using switching to the tree view.
      */
-    public static final int LIST_CUTOFF = Integer.parseInt(SystemProperties.getString("hudson.model.Run.ArtifactList.listCutoff", "16"));
-
-    /**
-     * Maximum number of artifacts to show in tree view before just showing a link.
-     */
-    public static final int TREE_CUTOFF = Integer.parseInt(SystemProperties.getString("hudson.model.Run.ArtifactList.treeCutoff", "40"));
+    public static final int LIST_CUTOFF = Integer.parseInt(SystemProperties.getString("hudson.model.Run.ArtifactList.listCutoff", "20"));
 
     // ..and then "too many"
 

--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -39,7 +39,7 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
   <j:if test="${!h.isArtifactsPermissionEnabled() or h.isArtifactsPermissionEnabled() and h.hasPermission(it,attrs.permission)}">
-    <j:set var="artifacts" value="${build.getArtifactsUpTo(build.TREE_CUTOFF+1)}" />
+    <j:set var="artifacts" value="${build.getArtifactsUpTo(build.LIST_CUTOFF+1)}" />
     <j:if test="${!empty(artifacts)}">
       <t:summary icon="symbol-cube" href="${baseURL}artifact/">
         <a href="${baseURL}artifact/">${caption}</a>
@@ -48,67 +48,34 @@ THE SOFTWARE.
             ${%building}
           </p>
         </j:if>
-        <j:choose>
-          <j:when test="${size(artifacts) le build.LIST_CUTOFF}">
-            <!-- if not too many, just list them -->
-            <table class="fileList">
-              <j:forEach var="f" items="${artifacts}">
-                <tr>
-                  <td>
-                    <l:icon class="icon-document icon-sm"/>
-                  </td>
-                  <td>
-                    <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
-                  </td>
-                  <td class="fileSize">
-                    ${h.humanReadableByteSize(f.getFileSize())}
-                  </td>
-                  <td>
-                    <j:if test="${app.fingerprintMap.ready}">
-                      <a href="${baseURL}artifact/${f.href}/*fingerprint*/">
-                        <l:icon class="icon-fingerprint icon-sm"/>
-                      </a>
-                      <st:nbsp/>
-                    </j:if>
-                    <a href="${baseURL}artifact/${f.href}/*view*/">${%view}</a>
-                  </td>
-                </tr>
-              </j:forEach>
-            </table>
-          </j:when>
-          <j:when test="${size(artifacts) le build.TREE_CUTOFF}">
-              <!-- otherwise (unless way too many) use a tree view -->
-              <l:yui module="treeview"/>
-              <link rel="stylesheet" href="${resURL}/scripts/yui/treeview/assets/skins/sam/treeview.css" type="text/css"/>
-              <style type="text/css">#artifact-tree td { vertical-align:middle; }</style>
-              <br/>
-              <small>
-                <a href="javascript: YAHOO.widget.TreeView.getNode('artifact-tree',1).tree.expandAll()">${%Expand all}</a>
-                <st:nbsp/>
-                <a href="javascript: YAHOO.widget.TreeView.getNode('artifact-tree',1).tree.collapseAll();">${%Collapse all}</a>
-              </small>
-              <div id="artifact-tree"></div>
-              <script language="javascript">// &lt;![CDATA[
-                YAHOO.util.Event.onContentReady('artifact-tree', function () {
-                var artifactTree = new YAHOO.widget.TreeView('artifact-tree');
-                var artifactRoot = new YAHOO.widget.TextNode('${h.jsStringEscape('%View')}',
-                                                             artifactTree.getRoot(), false);
-                <j:forEach var="e" items="${artifacts.getTree().entrySet()}">
-                  <j:set var="f" value="${e.key}"/>
-                  var ${f.treeNodeId} = new YAHOO.widget.TextNode(
-                    '${h.jsStringEscape(f.fileName)}', ${e.value?:'artifactRoot'}, false);
-                        <j:if test="${f.href!=null}">
-                          <!-- Assign href property instead of passing to constructor above,
-                               as constructor does urlencoding, but f.href is already encoded -->
-                          ${f.treeNodeId}.href = '${baseURL}artifact/${h.jsStringEscape(f.href)}';
-                        </j:if>
-                </j:forEach>
-                artifactTree.draw();
-               });
-             // ]]&gt;</script>
-          </j:when>
+        <j:if test="${size(artifacts) le build.LIST_CUTOFF}">
+          <!-- if not too many, just list them -->
+          <table class="fileList">
+            <j:forEach var="f" items="${artifacts}">
+              <tr>
+                <td>
+                  <l:icon class="icon-document icon-sm"/>
+                </td>
+                <td>
+                  <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
+                </td>
+                <td class="fileSize">
+                  ${h.humanReadableByteSize(f.getFileSize())}
+                </td>
+                <td>
+                  <j:if test="${app.fingerprintMap.ready}">
+                    <a href="${baseURL}artifact/${f.href}/*fingerprint*/">
+                      <l:icon class="icon-fingerprint icon-sm"/>
+                    </a>
+                    <st:nbsp/>
+                  </j:if>
+                  <a href="${baseURL}artifact/${f.href}/*view*/">${%view}</a>
+                </td>
+              </tr>
+            </j:forEach>
+          </table>
+        </j:if>
           <!-- otherwise just show link to directory browser -->
-        </j:choose>
       </t:summary>
     </j:if>
   </j:if>


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-71054](https://issues.jenkins.io/browse/JENKINS-71054).
@daniel-beck suggested that removing the treeview option completely might be a viable solution. If this is not accepted then I'll suggest an alternative, moving JS out to a separate file.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Tested interactively.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Remove the treeview option for artifactList.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

`hudson.model.Run#TREE_CUTOFF` has been removed in favor of `hudson.model.Run#LIST_CUTOFF`.

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/core-security-review @jenkinsci/core-pr-reviewers 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8265"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

