### PR TITLE
Remove Rebuilder Plugin from setup wizard options (LTS backport)

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -17,7 +17,6 @@
       { "name": "config-file-provider" },
       { "name": "credentials-binding", "suggested": true },
       { "name": "embeddable-build-status" },
-      { "name": "rebuild" },
       { "name": "ssh-agent" },
       { "name": "throttle-concurrents" },
       { "name": "timestamper", "suggested": true },


### PR DESCRIPTION
Co-authored-by: Daniel Beck <daniel-beck@users.noreply.github.com>
(cherry picked from commit 71a100d7c89204b0367350c1c6df8da7064b6af5)

Any objections about including this change in the upcoming 2.401.3 release?
I don't think we should recommend plugins with open security vulnerabilities in LTS either.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8270"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

