### PR TITLE
Add missing `application/x-www-form-urlencoded` header

### DIFF
--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.js
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.js
@@ -61,7 +61,9 @@ function revokeToken(anchorRevoke) {
         fetch(targetUrl, {
           body: new URLSearchParams({ tokenUuid: tokenUuid }),
           method: "post",
-          headers: crumb.wrap({}),
+          headers: crumb.wrap({
+            "Content-Type": "application/x-www-form-urlencoded",
+          }),
         }).then((rsp) => {
           if (rsp.ok) {
             if (repeatedChunk.querySelectorAll(".legacy-token").length > 0) {
@@ -97,7 +99,9 @@ function saveApiToken(button) {
   fetch(targetUrl, {
     body: new URLSearchParams({ newTokenName: tokenName }),
     method: "post",
-    headers: crumb.wrap({}),
+    headers: crumb.wrap({
+      "Content-Type": "application/x-www-form-urlencoded",
+    }),
   }).then((rsp) => {
     if (rsp.ok) {
       rsp.json().then((json) => {

--- a/core/src/main/resources/lib/form/textarea/textarea.js
+++ b/core/src/main/resources/lib/form/textarea/textarea.js
@@ -67,7 +67,9 @@ Behaviour.specify(
 
       fetch(rootURL + showPreview.getAttribute("previewEndpoint"), {
         method: "post",
-        headers: crumb.wrap({}),
+        headers: crumb.wrap({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
         body: new URLSearchParams({
           text: text,
         }),

--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -18,7 +18,9 @@ Behaviour.specify(
       Where to retrieve additional text from
   */
     function fetchNext(e, href, onFinishEvent) {
-      var headers = crumb.wrap({});
+      var headers = crumb.wrap({
+        "Content-Type": "application/x-www-form-urlencoded",
+      });
       if (e.consoleAnnotator !== undefined) {
         headers["X-ConsoleAnnotator"] = e.consoleAnnotator;
       }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1958,7 +1958,9 @@ function replaceDescription(initialDescription, submissionUrl) {
   }
   fetch("./descriptionForm", {
     method: "post",
-    headers: crumb.wrap({}),
+    headers: crumb.wrap({
+      "Content-Type": "application/x-www-form-urlencoded",
+    }),
     body: objectToUrlFormEncoded(parameters),
   }).then((rsp) => {
     rsp.text().then((responseText) => {


### PR DESCRIPTION
### Context

For background, read [this page](https://rapidapi.com/guides/query-parameters-fetch). The best practices are to use the following conventions:

- If GET is being used, do not include any special headers, pass the data in the URL query string, and do not include a body.
- If POST is being used, do not pass the data in the URL query string, but rather set a `Content-Type: application/x-www-form-urlencoded` header and send the data in the body. In Jenkins, there is an additional constraint of sending the CSRF crumb in the headers.

### Problem

The old Prototype code [implicitly set the content type to `application/x-www-form-urlencoded`](https://github.com/prototypejs/prototype/blob/dee2f7d8611248abce81287e1be4156011953c90/src/prototype/ajax/base.js#L7) when POST parameters were provided (and sent them in the body). In several cases our new Fetch API code sets the POST parameters in the body but does not explicit set the content type to `application/x-www-form-urlencoded`.

The Fetch Standard states that if the body is a `URLSearchParams` object then it should be serialised as `application/x-www-form-urlencoded`. However, due to HtmlUnit not supporting `URLSearchParams` we have our own `objectToUrlFormEncoded` instead. This, in turn, obliges us to explicitly set the `application/x-www-form-urlencoded` header.

Although I have not been able to identify any negative consequences from not setting this header, setting it explicitly throughout the codebase makes our code more consistent and conforms to best practices.

### Solution

Explicitly set the `application/x-www-form-urlencoded` in all places where we send POST parameters in the body.

### Testing done

Put a breakpoint in the changes to `textarea.js` and exercised the code successfully. Since the other changes are mechanically equivalent, I consider them to be tested by induction.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8278"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

