### PR TITLE
Pass POST parameters in body rather than query string

### DIFF
--- a/core/src/main/resources/hudson/model/BuildTimelineWidget/build-timeline-widget.js
+++ b/core/src/main/resources/hudson/model/BuildTimelineWidget/build-timeline-widget.js
@@ -11,17 +11,16 @@ function getData(eventSource1, current, min, max) {
   }
   if (!eventSource1.loaded[current]) {
     eventSource1.loaded[current] = true;
-    fetch(
-      "timeline/data/?" +
-        new URLSearchParams({
-          min: current * interval,
-          max: (current + 1) * interval,
-        }),
-      {
-        method: "POST",
-        headers: crumb.wrap({}),
-      }
-    ).then((t) => {
+    fetch("timeline/data", {
+      method: "POST",
+      headers: crumb.wrap({
+        "Content-Type": "application/x-www-form-urlencoded",
+      }),
+      body: new URLSearchParams({
+        min: current * interval,
+        max: (current + 1) * interval,
+      }),
+    }).then((t) => {
       if (t.ok) {
         t.json()
           .then((json) => {

--- a/core/src/main/resources/lib/form/combobox/combobox.js
+++ b/core/src/main/resources/lib/form/combobox/combobox.js
@@ -19,10 +19,12 @@ Behaviour.specify("INPUT.combobox2", "combobox", 100, function (e) {
   );
 
   refillOnChange(e, function (params) {
-    var urlSearchParams = new URLSearchParams(params);
-    fetch(e.getAttribute("fillUrl") + "?" + urlSearchParams, {
-      headers: crumb.wrap({}),
+    fetch(e.getAttribute("fillUrl"), {
+      headers: crumb.wrap({
+        "Content-Type": "application/x-www-form-urlencoded",
+      }),
       method: "post",
+      body: new URLSearchParams(params),
     }).then((rsp) => {
       if (rsp.ok) {
         rsp.json().then((json) => {


### PR DESCRIPTION
### Context

For background, read [this page](https://rapidapi.com/guides/query-parameters-fetch). The best practices are to use the following conventions:

- If GET is being used, do not include any special headers, pass the data in the URL query string, and do not include a body.
- If POST is being used, do not pass the data in the URL query string, but rather set a `Content-Type: application/x-www-form-urlencoded` header and send the data in the body. In Jenkins, there is an additional constraint of sending the CSRF crumb in the headers.

### Problem

The old Prototype code [implicitly sent POST parameters in the body](https://github.com/prototypejs/prototype/blob/dee2f7d8611248abce81287e1be4156011953c90/src/prototype/ajax/request.js#L206-L210). In several cases our new Fetch API code sends a POST request, but sends it in the query string (as is usually done for GET requests) rather than the body.

This is valid according to the HTTP standard but somewhat frowned upon in the HTML standard. But browsers seem to accept this without any negative consequences. See:

- https://stackoverflow.com/questions/64042655/is-using-a-query-string-in-post-request-a-bad-practice
- https://stackoverflow.com/questions/14710061/is-it-valid-to-combine-a-form-post-with-a-query-string

Although I have not been able to identify any negative consequences from not sending this data in the POST body, sending it in the body as opposed to the query string seems to be a best practice, and doing so is more consistent with our other Fetch API usages and the old Prototype behavior.

### Solution

Send all POST parameters consistently in the body of the POST request.

### Note to reviewers

Please review with "Hide Whitespace Enabled" in the GitHub UI to more clearly see the changed logic.

### Testing done

Put a breakpoint in the changes to `build-timeline-widget.js` and exercised the code successfully. Since the other changes are mechanically equivalent, I consider them to be tested by induction.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8279"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

