### PR TITLE
`ReverseProxySetupMonitor` changed from POST to GET

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/resources.js
@@ -9,13 +9,16 @@
 
   var urlToTest = redirectForm.getAttribute("data-url");
   var callUrlToTest = function (testWithContext, callback) {
+    var headers = {};
     var body = null;
     if (testWithContext === true) {
+      headers["Content-Type"] = "application/x-www-form-urlencoded";
       body = new URLSearchParams({ testWithContext: "true" });
     }
     fetch(urlToTest, {
+      method: "POST",
       cache: "no-cache",
-      headers: crumb.wrap({}),
+      headers: crumb.wrap(headers),
       body,
     })
       .then((rsp) => callback(rsp))


### PR DESCRIPTION
### Problem

In #7842 the new code makes a GET request with the data in the body. The old code had made a POST request with the data in the body. Putting the data in the body rather than the URL query string is unusual for a GET request. It seems that this change was unintentional, so move back to POST. Note that there are no negative user-facing or security issues with using GET, so this is simply a code cleanup.

### Solution

Switch back to POST, with an explicit `application/x-www-form-urlencoded` header (not strictly necessary, since the data is being passed in the body with `URLSearchParams`, but done to create a consistent coding style within this repository).

### Testing done

- Configured Jenkins URL to an invalid URL
- Configured Jenkins URL to a URL of another website
- Configured Jenkins URL to another Jenkins instance

Verified that the monitor behaved as expected in all cases and disappeared when issues were corrected.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8280"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

