### PR TITLE
Add logging for agent usage by job

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -329,7 +329,8 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
-        LOGGER.log(Level.FINE, "Accepted {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner().getDisplayName()});
+        LOGGER.log(Level.FINER, "Accepted {0} on {1}", new Object[] {task.toString(), executor.getOwner().getDisplayName()});
+
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskAccepted(executor, task);
         }
@@ -342,7 +343,7 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskStarted(Executor executor, Queue.Task task) {
-        LOGGER.log(Level.FINE, "Started {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner().getDisplayName()});
+        LOGGER.log(Level.FINER, "Started {0} on {1}", new Object[] {task.toString(), executor.getOwner().getDisplayName()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskStarted(executor, task);
         }
@@ -354,7 +355,7 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
-        LOGGER.log(Level.INFO, "Completed {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner().getDisplayName()});
+        LOGGER.log(Level.FINE, "Completed {0} on {1}", new Object[] {task.toString(), executor.getOwner().getDisplayName()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskCompleted(executor, task, durationMS);
         }
@@ -366,7 +367,7 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
-        LOGGER.log(Level.INFO, "Completed with problems {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner().getDisplayName()});
+        LOGGER.log(Level.FINE, "Completed with problems {0} on {1}", new Object[] {task.toString(), executor.getOwner().getDisplayName()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskCompletedWithProblems(executor, task, durationMS, problems);
         }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -329,10 +329,10 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
+        LOGGER.log(Level.FINE, "Accepted {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskAccepted(executor, task);
         }
-
         //getNode() can return null at indeterminate times when nodes go offline
         Slave node = getNode();
         if (node != null && node.getRetentionStrategy() instanceof ExecutorListener) {
@@ -342,6 +342,8 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskStarted(Executor executor, Queue.Task task) {
+        LOGGER.log(Level.FINE, "Started {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner()});
+
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskStarted(executor, task);
         }
@@ -353,6 +355,8 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
+        LOGGER.log(Level.INFO, "Completed {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner()});
+
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskCompleted(executor, task, durationMS);
         }
@@ -364,6 +368,7 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
+        LOGGER.log(Level.INFO, "Completed with problems {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskCompletedWithProblems(executor, task, durationMS, problems);
         }

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -329,7 +329,7 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
-        LOGGER.log(Level.FINE, "Accepted {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner()});
+        LOGGER.log(Level.FINE, "Accepted {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner().getDisplayName()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskAccepted(executor, task);
         }
@@ -342,8 +342,7 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskStarted(Executor executor, Queue.Task task) {
-        LOGGER.log(Level.FINE, "Started {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner()});
-
+        LOGGER.log(Level.FINE, "Started {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner().getDisplayName()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskStarted(executor, task);
         }
@@ -355,8 +354,7 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
-        LOGGER.log(Level.INFO, "Completed {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner()});
-
+        LOGGER.log(Level.INFO, "Completed {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner().getDisplayName()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskCompleted(executor, task, durationMS);
         }
@@ -368,7 +366,7 @@ public class SlaveComputer extends Computer {
 
     @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
-        LOGGER.log(Level.INFO, "Completed with problems {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner()});
+        LOGGER.log(Level.INFO, "Completed with problems {0} on {1}", new Object[] {task.getFullDisplayName(), executor.getOwner().getDisplayName()});
         if (launcher instanceof ExecutorListener) {
             ((ExecutorListener) launcher).taskCompletedWithProblems(executor, task, durationMS, problems);
         }


### PR DESCRIPTION
We want to log what job used which agent. This can be useful when you want to deprecate an agent and see if there have been any builds on the particular agent.

(no Jira Issue bc minor change)

### Testing done

Create a log recorder for "SlaveComputer" and set it to "FINER"
`Completed ExecutorStepExecution.PlaceholderTask{runId=test_pipeline/main#38,label=custom_agent,context=CpsStepContext[3:node]:Owner[test_pipeline/main/38:test_pipeline/main #38],cookie=11f7dc82-eae1-45e5-9fdb-043cbd1119cd,auth=null} on custom_agent`


### Proposed changelog entries

- Log agent usage by job.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8283"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

