### PR TITLE
[JENKINS-71186] - Avoid a warning from web application scanners

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -314,6 +314,7 @@ public final class TcpSlaveAgentListener extends Thread {
                 if (header.startsWith("GET / ")) {
                     response = "HTTP/1.0 200 OK\r\n" +
                             "Content-Type: text/plain;charset=UTF-8\r\n" +
+                            "X-Content-Type-Options: nosniff\r\n" +
                             "\r\n" +
                             "Jenkins-Agent-Protocols: " + getAgentProtocolNames() + "\r\n" +
                             "Jenkins-Version: " + Jenkins.VERSION + "\r\n" +


### PR DESCRIPTION
Add X-Content-Type-Options header to avoid web application scanner to flag a potential vulnerability

See [JENKINS-71186](https://issues.jenkins.io/browse/JENKINS-71186).

### Testing done

- Tested interactively

### Proposed changelog entries

-  Add the `X-Content-Type-Options` HTTP header to the response from the agent listener.  Silence security scanners that incorrectly report an issue when the HTTP header is missing.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] There is automated testing or an explanation as to why this change has no tests.
```

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8288"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

