### PR TITLE
[JENKINS-66990] API documentation does not mention Content-Type requirement for requests

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
@@ -49,4 +49,10 @@ THE SOFTWARE.
     <a href="../safeRestart">this URL</a> to restart once no jobs are running. (Pipeline builds may prevent Jenkins from restarting for a short period of time in some cases, but if so, they will be paused at the next available opportunity and then resumed after Jenkins restarts.)
     All these URLs need Overall/Manage permission (typically granted via Overall/Administer).
   </p>
+
+  <h2>Posting a config.xml file</h2>
+  <p>
+    If you're trying to POST a config.xml, you should add a Content-Type header to achieve this goal.
+    (Something like: `Content-Type: text/xml`)
+  </p>
 </j:jelly>


### PR DESCRIPTION
Added the requested documentation description of JENKINS-66990
If the despription I added is incorrect, please provide more guidance! Thank you!

See [JENKINS-66990](https://issues.jenkins.io/browse/JENKINS-66990).

### Testing done
- Manually accessed the API document page


### Proposed changelog entries

- Add documentations of Content-Type header requirements in the API document page.


### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
```

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8291"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

