### PR TITLE
Simpler `Jenkins.getComputers`

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -225,6 +225,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -2049,13 +2050,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Gets the read-only list of all {@link Computer}s.
      */
     public Computer[] getComputers() {
-        Computer[] r = computers.values().toArray(new Computer[0]);
-        Arrays.sort(r, (lhs, rhs) -> {
-            if (lhs.getNode() == Jenkins.this)  return -1;
-            if (rhs.getNode() == Jenkins.this)  return 1;
-            return lhs.getName().compareTo(rhs.getName());
-        });
-        return r;
+        return computers.values().stream().sorted(Comparator.comparing(Computer::getName)).toArray(Computer[]::new);
     }
 
     @CLIResolver

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -51,6 +51,7 @@ import hudson.model.Node;
 import hudson.model.RestartListener;
 import hudson.model.RootAction;
 import hudson.model.Saveable;
+import hudson.model.Slave;
 import hudson.model.TaskListener;
 import hudson.model.UnprotectedRootAction;
 import hudson.model.User;
@@ -68,8 +69,10 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.Socket;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import jenkins.AgentProtocol;
@@ -705,9 +708,13 @@ public class JenkinsTest {
 
     @Test
     public void getComputers() throws Exception {
-        j.waitOnline(j.createSlave("zestful", null, null));
-        j.waitOnline(j.createSlave("bilking", null, null));
-        j.waitOnline(j.createSlave("grouchiest", null, null));
+        List<Slave> agents = new ArrayList<>();
+        for (String n : List.of("zestful", "bilking", "grouchiest")) {
+            agents.add(j.createSlave(n, null, null));
+        }
+        for (Slave agent : agents) {
+            j.waitOnline(agent);
+        }
         assertThat(Stream.of(j.jenkins.getComputers()).map(Computer::getName).toArray(String[]::new),
             arrayContaining("", "bilking", "grouchiest", "zestful"));
     }

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -25,6 +25,7 @@
 package jenkins.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -70,6 +71,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 import jenkins.AgentProtocol;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.HttpMethod;
@@ -699,6 +701,15 @@ public class JenkinsTest {
         public void handle(Socket socket) throws IOException, InterruptedException {
             throw new IOException("This is a mock agent protocol. It cannot be used for connection");
         }
+    }
+
+    @Test
+    public void getComputers() throws Exception {
+        j.waitOnline(j.createSlave("zestful", null, null));
+        j.waitOnline(j.createSlave("bilking", null, null));
+        j.waitOnline(j.createSlave("grouchiest", null, null));
+        assertThat(Stream.of(j.jenkins.getComputers()).map(Computer::getName).toArray(String[]::new),
+            arrayContaining("", "bilking", "grouchiest", "zestful"));
     }
 
     @Issue("JENKINS-42577")


### PR DESCRIPTION
While looking at a profiling snapshot of a controller running numerous builds with cloud agents, I noticed that `FilePath.toComputer` was called a lot, and most of its time was calling `SlaveComputer.getNode`.

![getComputers](https://github.com/jenkinsci/jenkins/assets/154109/51fd1ad7-da25-4d66-898a-eb02bcf05723)

This was done solely to sort `MasterComputer` at the top. However that is silly because `MasterComputer.name` is the empty string, which would sort first anyway. Simplifying to just compare `Computer.name`, which should be cheaper.

Better still might be to introduce a separate (internal?) method to get an unsorted `Collection<? extends Computer>`, since most of the callers inside core (including `FilePath.toComputer`) do not actually need sorting, but I am hoping the new sort should be cheap enough it does not matter much.

### Testing done

Added test coverage, checking that it passed on the original version, and fails if the sorting in the new implementation is omitted or reversed.

### Proposed changelog entries

- Small optimization in computer list.