### PR TITLE
Backport 2.414.1

### DIFF
--- a/.github/workflows/announce-lts-rc.yml
+++ b/.github/workflows/announce-lts-rc.yml
@@ -1,0 +1,30 @@
+name: Announce LTS RCs
+
+on:
+  release:
+    types: [prereleased]
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post on Discourse
+        uses: roots/discourse-topic-github-release-action@fc9e50fa1a1ce6255ba4d03f104382845b79ad5f # v1.0.0
+        with:
+          discourse-api-key: ${{ secrets.DISCOURSE_RELEASES_API_KEY }}
+          discourse-base-url: https://community.jenkins.io/
+          discourse-author-username: jenkins-release-bot
+          discourse-category: 23
+      - name: Post on mailing list
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+          secure: true
+          subject: ${{ github.event.release.tag_name }} has been released
+          to: jenkinsci-dev@googlegroups.com
+          from: Jenkins Release Bot
+          html_body: ${{ github.event.release.body }}
+          convert_markdown: true

--- a/.github/workflows/label-lts-prs.yaml
+++ b/.github/workflows/label-lts-prs.yaml
@@ -1,0 +1,23 @@
+name: Label PRs targeting LTS branches
+
+on: [pull_request_target]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR targets LTS branch
+        if: startsWith(github.event.pull_request.base.ref, 'stable-')
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              issue_number: context.payload.pull_request.number,
+              labels: ['into-lts']
+            });

--- a/core/src/main/java/hudson/AbstractMarkupText.java
+++ b/core/src/main/java/hudson/AbstractMarkupText.java
@@ -83,7 +83,7 @@ public abstract class AbstractMarkupText {
      * @since 1.349
      */
     public void addHyperlink(int startPos, int endPos, String url) {
-        addMarkup(startPos, endPos, "<a href='" + url + "'>", "</a>");
+        addMarkup(startPos, endPos, "<a href='" + Functions.htmlAttributeEscape(url) + "'>", "</a>");
     }
 
     /**
@@ -93,7 +93,7 @@ public abstract class AbstractMarkupText {
      * @since 1.395
      */
     public void addHyperlinkLowKey(int startPos, int endPos, String url) {
-        addMarkup(startPos, endPos, "<a class='lowkey' href='" + url + "'>", "</a>");
+        addMarkup(startPos, endPos, "<a class='lowkey' href='" + Functions.htmlAttributeEscape(url) + "'>", "</a>");
     }
 
     /**

--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -17,7 +17,6 @@
       { "name": "config-file-provider" },
       { "name": "credentials-binding", "suggested": true },
       { "name": "embeddable-build-status" },
-      { "name": "rebuild" },
       { "name": "ssh-agent" },
       { "name": "throttle-concurrents" },
       { "name": "timestamper", "suggested": true },

--- a/test/src/test/java/jenkins/security/Security3188Test.java
+++ b/test/src/test/java/jenkins/security/Security3188Test.java
@@ -1,0 +1,52 @@
+package jenkins.security;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import hudson.Functions;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.tasks.BatchFile;
+import hudson.tasks.CommandInterpreter;
+import hudson.tasks.Shell;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.htmlunit.html.HtmlPage;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class Security3188Test {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Issue("SECURITY-3188")
+    @Test
+    public void linkCannotAttributeEscape() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject("p");
+        p.getBuildersList().add(getScript("echo \"https://acme.com/search?q='onmouseover=alert(1);'Hello World\""));
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+
+        AtomicBoolean alerts = new AtomicBoolean();
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            wc.setAlertHandler((pr, s) -> alerts.set(true));
+            final HtmlPage page = wc.goTo(build.getUrl() + "console");
+            String content = page.getWebResponse().getContentAsString();
+            assertThat(content, containsString("<a href='https://acme.com/search?q=&#39;onmouseover=alert(1);&#39;Hello'"));
+
+            // Execute JavaScript code to simulate mouseover event
+            String jsCode = "document.querySelector('pre.console-output a:nth-child(2)').dispatchEvent(new MouseEvent('mouseover'));";
+            page.executeJavaScript(jsCode);
+
+            Assert.assertFalse("Alert not expected", alerts.get());
+        }
+    }
+
+    private static CommandInterpreter getScript(String script) {
+        return Functions.isWindows()
+                ? new BatchFile(script)
+                : new Shell(script);
+    }
+}

--- a/war/src/main/js/plugin-manager-ui.js
+++ b/war/src/main/js/plugin-manager-ui.js
@@ -92,8 +92,10 @@ function updateInstallButtonState() {
   const installAfterRestartButton = document.querySelector(
     "#button-install-after-restart"
   );
-  installButton.disabled = true;
-  installAfterRestartButton.disabled = true;
+  if (!anyCheckboxesSelected()) {
+    installButton.disabled = true;
+    installAfterRestartButton.disabled = true;
+  }
   const checkboxes = document.querySelectorAll("input[type='checkbox']");
   checkboxes.forEach((checkbox) => {
     checkbox.addEventListener("click", () => {


### PR DESCRIPTION
```
Latest core version: jenkins-2.416

Fixed
-----

JENKINS-71630           Minor                   2.415
        Remove Rebuilder Plugin from setup wizard options
        https://issues.jenkins.io/browse/JENKINS-71630

JENKINS-71714           Major                   2.416
        SECURITY-3188
        https://issues.jenkins.io/browse/JENKINS-71714

JENKINS-71698           Minor                   2.417
        install button in plugin manager is sometimes incorrectly disabled
        https://issues.jenkins.io/browse/JENKINS-71698

```
The workflow is a tooling change and shouldn't be mentioned in the user-facing changelog.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8301"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

