### PR TITLE
`DescribableList.replace` called `Saveable.save` twice

### DIFF
--- a/core/src/main/java/hudson/util/DescribableList.java
+++ b/core/src/main/java/hudson/util/DescribableList.java
@@ -100,7 +100,11 @@ public class DescribableList<T extends Describable<T>, D extends Descriptor<T>> 
      * Removes all instances of the same type, then add the new one.
      */
     public void replace(T item) throws IOException {
-        removeAll((Class) item.getClass());
+        for (T t : data) {
+            if (t.getClass() == item.getClass()) {
+                data.remove(t);
+            }
+        }
         data.add(item);
         onModified();
     }

--- a/core/src/test/java/hudson/util/DescribableListTest.java
+++ b/core/src/test/java/hudson/util/DescribableListTest.java
@@ -24,11 +24,16 @@
 
 package hudson.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Saveable;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -46,6 +51,18 @@ public class DescribableListTest {
         String xml = xs.toXML(data);
         data = (Data) xs.fromXML(xml);
         assertEquals("[1, 3]", data.toString());
+    }
+
+    @Test
+    public void replace() throws Exception {
+        AtomicInteger count = new AtomicInteger();
+        DescribableList<Datum, Descriptor<Datum>> list = new DescribableList<>((Saveable) count::incrementAndGet);
+        list.add(new Datum(1));
+        list.add(new Datum(2));
+        assertThat(count.get(), is(2));
+        list.replace(new Datum(3));
+        assertThat(list.stream().map(d -> d.val).toArray(Integer[]::new), arrayContaining(3));
+        assertThat(count.get(), is(3));
     }
 
     private static final class Data {


### PR DESCRIPTION
`PersistedList.removeAll` took care to call `onModified` only once, but `DescribableList.replace` delegated to that and then called `onModified` again. This could cause model objects to be saved twice in a row.

### Testing done

Unit testing only.

### Proposed changelog entries

- Double-save bug in `DescribableList.replace`.

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8303"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

