### PR TITLE
`replaceDescription` is not robust

### DIFF
--- a/core/src/main/resources/lib/hudson/editable-description.js
+++ b/core/src/main/resources/lib/hudson/editable-description.js
@@ -6,11 +6,7 @@
       e.preventDefault();
       let url = descriptionLink.getAttribute("data-url");
       let description = descriptionLink.getAttribute("data-description");
-      if (url == null && description == null) {
-        return replaceDescription();
-      } else {
-        return replaceDescription(description, url);
-      }
+      return replaceDescription(description, url);
     });
   });
 })();

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1950,11 +1950,11 @@ function replaceDescription(initialDescription, submissionUrl) {
   d.firstElementChild.nextElementSibling.innerHTML =
     "<div class='jenkins-spinner'></div>";
   let parameters = {};
-  if (initialDescription !== undefined && submissionUrl !== undefined) {
-    parameters = {
-      description: initialDescription,
-      submissionUrl: submissionUrl,
-    };
+  if (initialDescription !== null && initialDescription !== "") {
+    parameters["description"] = initialDescription;
+  }
+  if (submissionUrl !== null && submissionUrl !== "") {
+    parameters["submissionUrl"] = submissionUrl;
   }
   fetch("./descriptionForm", {
     method: "post",


### PR DESCRIPTION
### Problem

This is a fix for an unreleased regression. As of #8278, `hudson.tasks.junit.JUnitResultArchiverTest#setDescription` started failing in PCT with:

```
AssertionError: no form found
	at org.junit.Assert.fail(Assert.java:89)
	at hudson.tasks.junit.JUnitResultArchiverTest.findForm(JUnitResultArchiverTest.java:228)
	at hudson.tasks.junit.JUnitResultArchiverTest.testSetDescription(JUnitResultArchiverTest.java:216)
	at hudson.tasks.junit.JUnitResultArchiverTest.setDescription(JUnitResultArchiverTest.java:196)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:606)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

### Evaluation

After debugging this, I can see that #8278 exposed a pre-existing bug by making the browser's behavior more strict.

The original bug was actually introduced in jenkinsci/jenkins#6511. Here we have a Jelly editable description in the JUnit plugin that sets a permission attribute (required), a description attribute (optional), but no submission URL (also optional). This seems like a completely valid thing to do, but the code in `editable-description.js` from #6511 only handles two cases:

1. Description and submission URL are both set,
2. Neither are set.

Here the description is set, but the submission URL is not set, and the code in `editable-description.js` from #6511 does not handle this third case. It invokes `replaceDescription` with a non-null description (the one from the JUnit plugin's `getDescription()` method) and a null submission URL. The `replaceDescription` function, similarly assuming that either both are set or neither are set, sees that the submission URL is not undefined (that's right, it's defined as null) and passes this into the `parameters` object.

So far the code is buggy, but this was never a problem in practice in the Prototype implementation of `replaceDescription` (because Prototype converted null values into the empty string) or before #8278, but it is a problem after #8278. If I had to guess why #8278 made any difference, it would be that adding the header possibly puts the browser in a more strict mode. In any case the root cause of this whole problem is not #8278 but rather that #6511 failed to handle this legitimate case.

### Solution

To fix this I read [the documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute) noting that

> All modern web browsers return null when the specified attribute does not exist on the specified element.

so I fixed the (sole) caller of `replaceDescription` to always call it with the result of `Element#getAttribute` (either a valid string or null) and then set the description and parameters separately in the form object in `replaceDescription` based on whether or not those passed-in values were null and non-empty. There is no need to check for `undefined` anymore since that is never returned by `Element#getAttribute`.

### Testing done

`hudson.tasks.junit.JUnitResultArchiverTest#setDescription` failed after #8278 (not yet released) but without this PR and now passes with this PR.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8307"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

