### PR TITLE
Flake in `AbstractBuildTest.workspaceLock`

### DIFF
--- a/test/src/test/java/hudson/model/AbstractBuildTest.java
+++ b/test/src/test/java/hudson/model/AbstractBuildTest.java
@@ -52,6 +52,8 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.htmlunit.Page;
@@ -65,6 +67,7 @@ import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.FakeChangeLogSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.UnstableBuilder;
@@ -80,6 +83,9 @@ public class AbstractBuildTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule();
 
     @Test
     @Issue("JENKINS-30730")
@@ -287,6 +293,7 @@ public class AbstractBuildTest {
     @Test
     @Issue("JENKINS-10615")
     public void workspaceLock() throws Exception {
+        logging.record(Run.class, Level.FINER);
         FreeStyleProject p = j.createFreeStyleProject();
         p.setConcurrentBuild(true);
         OneShotEvent e1 = new OneShotEvent();
@@ -330,6 +337,10 @@ public class AbstractBuildTest {
         assertNotEquals(b1.getStartCondition().get().getWorkspace(), b2.getStartCondition().get().getWorkspace());
 
         done.signal();
+        Logger.getLogger(AbstractBuildTest.class.getName()).info("Test done, letting builds complete…");
+        j.waitForCompletion(b1.get());
+        j.waitForCompletion(b2.get());
+        Logger.getLogger(AbstractBuildTest.class.getName()).info("…done.");
     }
 
     @Test


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/runs/15117282925 flake after https://github.com/jenkinsci/jenkins-test-harness/pull/198 due to the usual test mistake.

### Testing done

Test logs confirm that the builds were still completing when the original test method exited:

```
…
   3.579 [id=58]	FINE	hudson.model.Run#execute: test0 #2 main build action completed: SUCCESS
   3.580 [id=58]	FINER	hudson.model.Run#execute: moving into POST_PRODUCTION on test0 #2
   3.580 [id=20]	INFO	hudson.model.AbstractBuildTest#workspaceLock: Test done, letting builds complete…
   3.580 [id=57]	FINER	hudson.model.Run#execute: moving into POST_PRODUCTION on test0 #1
   3.959 [id=58]	FINER	hudson.model.Run#onEndBuilding: moving to COMPLETED on test0 #2
   3.959 [id=57]	FINER	hudson.model.Run#onEndBuilding: moving to COMPLETED on test0 #1
   3.962   3.962  [test0 #1] [test0 #2] Finished: SUCCESS
Finished: SUCCESS
   3.963 [id=20]	INFO	hudson.model.AbstractBuildTest#workspaceLock: …done.
   3.972 [id=20]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
…
```

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8309"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

