### PR TITLE
Replace MD5 digest with SHA256 while logging payload in Mock class called from tests

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1929,12 +1929,21 @@ public class Util {
     }
 
     /**
-     * Returns Hex string of SHA-256 Digest of input bytes
+     * Returns SHA-256 Digest of input bytes
      */
-    public static String getHexStringOfSHA256DigestOf(@NonNull byte[] input) throws NoSuchAlgorithmException
+    @Restricted(NoExternalUse.class)
+    public static byte[] getSHA256DigestOf(@NonNull byte[] input)
     {
-        MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
-        sha256Digest.update(input);
-        return toHexString(sha256Digest.digest());
+        try {
+            if (input != null) {
+                MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
+                sha256Digest.update(input);
+                return sha256Digest.digest();
+            }
+        } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+            LOGGER.log(Level.WARNING, "Failed to instantiate SHA-256 message digest algorithm", noSuchAlgorithmException);
+            throw new IllegalStateException("Failed to instantiate SHA-256 message digest algorithm");
+        }
+            return null;
     }
 }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1927,4 +1927,14 @@ public class Util {
     private static PathRemover newPathRemover(@NonNull PathRemover.PathChecker pathChecker) {
         return PathRemover.newFilteredRobustRemover(pathChecker, DELETION_RETRIES, GC_AFTER_FAILED_DELETE, WAIT_BETWEEN_DELETION_RETRIES);
     }
+
+    /**
+     * Returns Hex string of SHA-256 Digest of input bytes
+     */
+    public static String getHexStringOfSHA256DigestOf(@NonNull byte[] input) throws NoSuchAlgorithmException
+    {
+        MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
+        sha256Digest.update(input);
+        return toHexString(sha256Digest.digest());
+    }
 }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -136,7 +136,6 @@ public class Util {
     private static final long ONE_DAY_MS = 24 * ONE_HOUR_MS;
     private static final long ONE_MONTH_MS = 30 * ONE_DAY_MS;
     private static final long ONE_YEAR_MS = 365 * ONE_DAY_MS;
-    public static final String SHA_256_ALGORITHM = "SHA-256";
 
     /**
      * Creates a filtered sublist.
@@ -1930,19 +1929,19 @@ public class Util {
     }
 
     /**
-     * Returns Digest of input bytes using specified algorithm
+     * Returns SHA-256 Digest of input bytes
      */
     @Restricted(NoExternalUse.class)
-    public static byte[] getDigestOf(@NonNull byte[] input, @NonNull String algorithm) {
-        if (input == null || algorithm == null) {
+    public static byte[] getSHA256DigestOf(@NonNull byte[] input) {
+        if (input == null) {
             return null;
         }
         try {
-                MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
+                MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
                 messageDigest.update(input);
                 return messageDigest.digest();
         } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
-            throw new IllegalStateException(algorithm + " could not be instantiated, but is required to" +
+            throw new IllegalStateException("SHA-256 could not be instantiated, but is required to" +
                     " be implemented by the language specification", noSuchAlgorithmException);
         }
     }
@@ -1953,7 +1952,7 @@ public class Util {
     @Restricted(NoExternalUse.class)
     public static String getHexOfSHA256DigestOf(byte[] input) throws IOException {
         //get hex string of sha 256 of payload
-        byte[] payloadDigest = Util.getDigestOf(input, SHA_256_ALGORITHM);
+        byte[] payloadDigest = Util.getSHA256DigestOf(input);
         return (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;
     }
 }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1932,18 +1932,16 @@ public class Util {
      * Returns SHA-256 Digest of input bytes
      */
     @Restricted(NoExternalUse.class)
-    public static byte[] getSHA256DigestOf(@NonNull byte[] input)
-    {
+    public static byte[] getSHA256DigestOf(@NonNull byte[] input) {
+        if (input == null) {
+            return null;
+        }
         try {
-            if (input != null) {
                 MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
                 sha256Digest.update(input);
                 return sha256Digest.digest();
-            }
         } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
-            LOGGER.log(Level.WARNING, "Failed to instantiate SHA-256 message digest algorithm", noSuchAlgorithmException);
-            throw new IllegalStateException("Failed to instantiate SHA-256 message digest algorithm");
+            throw new IllegalStateException("SHA-256 could not be instantiated, but is required to be implemented by the language specification", noSuchAlgorithmException);
         }
-            return null;
     }
 }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -136,6 +136,7 @@ public class Util {
     private static final long ONE_DAY_MS = 24 * ONE_HOUR_MS;
     private static final long ONE_MONTH_MS = 30 * ONE_DAY_MS;
     private static final long ONE_YEAR_MS = 365 * ONE_DAY_MS;
+    public static final String SHA_256_ALGORITHM = "SHA-256";
 
     /**
      * Creates a filtered sublist.
@@ -1929,20 +1930,30 @@ public class Util {
     }
 
     /**
-     * Returns SHA-256 Digest of input bytes
+     * Returns Digest of input bytes using specified algorithm
      */
     @Restricted(NoExternalUse.class)
-    public static byte[] getSHA256DigestOf(@NonNull byte[] input) {
-        if (input == null) {
+    public static byte[] getDigestOf(@NonNull byte[] input, @NonNull String algorithm) {
+        if (input == null || algorithm == null) {
             return null;
         }
         try {
-                MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
-                sha256Digest.update(input);
-                return sha256Digest.digest();
+                MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
+                messageDigest.update(input);
+                return messageDigest.digest();
         } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
-            throw new IllegalStateException("SHA-256 could not be instantiated, but is required to" +
+            throw new IllegalStateException(algorithm + " could not be instantiated, but is required to" +
                     " be implemented by the language specification", noSuchAlgorithmException);
         }
+    }
+
+    /**
+     * Returns Hex string of SHA-256 Digest of passed input
+     */
+    @Restricted(NoExternalUse.class)
+    public static String getHexOfSHA256DigestOf(byte[] input) throws IOException {
+        //get hex string of sha 256 of payload
+        byte[] payloadDigest = Util.getDigestOf(input, SHA_256_ALGORITHM);
+        return (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;
     }
 }

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1933,9 +1933,6 @@ public class Util {
      */
     @Restricted(NoExternalUse.class)
     public static byte[] getSHA256DigestOf(@NonNull byte[] input) {
-        if (input == null) {
-            return null;
-        }
         try {
                 MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
                 messageDigest.update(input);

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1941,7 +1941,8 @@ public class Util {
                 sha256Digest.update(input);
                 return sha256Digest.digest();
         } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
-            throw new IllegalStateException("SHA-256 could not be instantiated, but is required to be implemented by the language specification", noSuchAlgorithmException);
+            throw new IllegalStateException("SHA-256 could not be instantiated, but is required to" +
+                    " be implemented by the language specification", noSuchAlgorithmException);
         }
     }
 }

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -123,7 +123,7 @@ public abstract class ConfidentialStore {
         @Override
         protected void store(ConfidentialKey key, byte[] payload) throws IOException {
             //called only from tests, get hex string of sha 256 for logging payload
-            LOGGER.log(Level.FINER, "storing {0} {1}",  new Object[]{key.getId(), getHexOfSHA256DigestOf(payload)});
+            LOGGER.log(Level.FINER, "storing {0} {1}",  new Object[]{key.getId(), Util.getHexOfSHA256DigestOf(payload)});
             data.put(key.getId(), payload);
         }
 
@@ -131,14 +131,8 @@ public abstract class ConfidentialStore {
         protected byte[] load(ConfidentialKey key) throws IOException {
             byte[] payload = data.get(key.getId());
             //called only from tests, get hex string of sha 256 for logging payload
-            LOGGER.log(Level.FINER, "loading {0} {1}",  new Object[]{key.getId(), getHexOfSHA256DigestOf(payload)});
+            LOGGER.log(Level.FINER, "loading {0} {1}",  new Object[]{key.getId(), Util.getHexOfSHA256DigestOf(payload)});
             return payload;
-        }
-
-        private String getHexOfSHA256DigestOf(byte[] payload) throws IOException {
-            //get hex string of sha 256 of payload
-            byte[] payloadDigest = Util.getSHA256DigestOf(payload);
-            return (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;
         }
 
         @Override

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -124,6 +124,7 @@ public abstract class ConfidentialStore {
         protected void store(ConfidentialKey key, byte[] payload) throws IOException {
             try {
                 String payloadDigest = Util.getHexStringOfSHA256DigestOf(payload);
+                //called from tests
                 LOGGER.fine("storing " + key.getId() + " " + payloadDigest);
             } catch (NoSuchAlgorithmException e) {
                 throw new IOException(e);
@@ -135,6 +136,7 @@ public abstract class ConfidentialStore {
         protected byte[] load(ConfidentialKey key) throws IOException {
             byte[] payload = data.get(key.getId());
             String payloadDigest = null;
+            //called only from tests
              if (payload != null) {
                 try {
                     payloadDigest = Util.getHexStringOfSHA256DigestOf(payload);

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -123,7 +123,7 @@ public abstract class ConfidentialStore {
         @Override
         protected void store(ConfidentialKey key, byte[] payload) throws IOException {
             //called only from tests, get hex string of sha 256 for logging payload
-            LOGGER.log(Level.FINER, "storing {0} {1}",  new Object[]{key.getId(), Util.getHexOfSHA256DigestOf(payload)});
+            logPayload("storing", key.getId(), payload);
             data.put(key.getId(), payload);
         }
 
@@ -131,8 +131,17 @@ public abstract class ConfidentialStore {
         protected byte[] load(ConfidentialKey key) throws IOException {
             byte[] payload = data.get(key.getId());
             //called only from tests, get hex string of sha 256 for logging payload
-            LOGGER.log(Level.FINER, "loading {0} {1}",  new Object[]{key.getId(), Util.getHexOfSHA256DigestOf(payload)});
+            logPayload("loading", key.getId(), payload);
             return payload;
+        }
+
+        private void logPayload(String msg, String keyId, byte[] payload) throws IOException
+        {
+            //get hex string of sha 256 for logging payload
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "{0} {1} {2}",
+                        new Object[]{msg, keyId, Util.getHexOfSHA256DigestOf(payload)});
+            }
         }
 
         @Override

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -124,7 +124,7 @@ public abstract class ConfidentialStore {
         protected void store(ConfidentialKey key, byte[] payload) throws IOException {
             try {
                 String payloadDigest = Util.getHexStringOfSHA256DigestOf(payload);
-                //called from tests
+                //called only from tests
                 LOGGER.fine("storing " + key.getId() + " " + payloadDigest);
             } catch (NoSuchAlgorithmException e) {
                 throw new IOException(e);

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -123,7 +123,7 @@ public abstract class ConfidentialStore {
         @Override
         protected void store(ConfidentialKey key, byte[] payload) throws IOException {
             //called only from tests, get hex string of sha 256 for logging payload
-            LOGGER.log(Level.FINER, "storing {0} {1}",  new Object[]{key.getId(), getDigestOfPayload(payload)});
+            LOGGER.log(Level.FINER, "storing {0} {1}",  new Object[]{key.getId(), getHexOfSHA256DigestOf(payload)});
             data.put(key.getId(), payload);
         }
 
@@ -131,11 +131,11 @@ public abstract class ConfidentialStore {
         protected byte[] load(ConfidentialKey key) throws IOException {
             byte[] payload = data.get(key.getId());
             //called only from tests, get hex string of sha 256 for logging payload
-            LOGGER.log(Level.FINER, "loading {0} {1}",  new Object[]{key.getId(), getDigestOfPayload(payload)});
+            LOGGER.log(Level.FINER, "loading {0} {1}",  new Object[]{key.getId(), getHexOfSHA256DigestOf(payload)});
             return payload;
         }
 
-        private String getDigestOfPayload(byte[] payload) throws IOException {
+        private String getHexOfSHA256DigestOf(byte[] payload) throws IOException {
             //get hex string of sha 256 of payload
             byte[] payloadDigest = Util.getSHA256DigestOf(payload);
             return (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -121,22 +121,24 @@ public abstract class ConfidentialStore {
         }
 
         @Override
-        protected void store(ConfidentialKey key, byte[] payload) throws IllegalStateException {
-                byte[] payloadDigest = Util.getSHA256DigestOf(payload);
-                String payloadDigestHexString = (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;
-                //called only from tests
-                LOGGER.fine("storing " + key.getId() + " " + payloadDigestHexString);
-                data.put(key.getId(), payload);
+        protected void store(ConfidentialKey key, byte[] payload) throws IOException {
+            //called only from tests, get hex string of sha 256 for logging payload
+            LOGGER.log(Level.FINER, "storing {0} {1}",  new Object[]{key.getId(), getDigestOfPayload(payload)});
+            data.put(key.getId(), payload);
         }
 
         @Override
-        protected byte[] load(ConfidentialKey key) throws IllegalStateException {
+        protected byte[] load(ConfidentialKey key) throws IOException {
             byte[] payload = data.get(key.getId());
             //called only from tests, get hex string of sha 256 for logging payload
-            byte[] payloadDigest = Util.getSHA256DigestOf(payload);
-            String payloadDigestHexString = (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;
-            LOGGER.fine("loading " + key.getId() + " " + payloadDigestHexString);
+            LOGGER.log(Level.FINER, "loading {0} {1}",  new Object[]{key.getId(), getDigestOfPayload(payload)});
             return payload;
+        }
+
+        private String getDigestOfPayload(byte[] payload) throws IOException {
+            //get hex string of sha 256 of payload
+            byte[] payloadDigest = Util.getSHA256DigestOf(payload);
+            return (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;
         }
 
         @Override

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -121,30 +121,21 @@ public abstract class ConfidentialStore {
         }
 
         @Override
-        protected void store(ConfidentialKey key, byte[] payload) throws IOException {
-            try {
-                String payloadDigest = Util.getHexStringOfSHA256DigestOf(payload);
+        protected void store(ConfidentialKey key, byte[] payload) throws IllegalStateException {
+                byte[] payloadDigest = Util.getSHA256DigestOf(payload);
+                String payloadDigestHexString = (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;
                 //called only from tests
-                LOGGER.fine("storing " + key.getId() + " " + payloadDigest);
-            } catch (NoSuchAlgorithmException e) {
-                throw new IOException(e);
-            }
-            data.put(key.getId(), payload);
+                LOGGER.fine("storing " + key.getId() + " " + payloadDigestHexString);
+                data.put(key.getId(), payload);
         }
 
         @Override
-        protected byte[] load(ConfidentialKey key) throws IOException {
+        protected byte[] load(ConfidentialKey key) throws IllegalStateException {
             byte[] payload = data.get(key.getId());
-            String payloadDigest = null;
-            //called only from tests
-             if (payload != null) {
-                try {
-                    payloadDigest = Util.getHexStringOfSHA256DigestOf(payload);
-                } catch (NoSuchAlgorithmException e) {
-                    throw new IOException(e);
-                }
-            }
-            LOGGER.fine("loading " + key.getId() + " " + payloadDigest);
+            //called only from tests, get hex string of sha 256 for logging payload
+            byte[] payloadDigest = Util.getSHA256DigestOf(payload);
+            String payloadDigestHexString = (payloadDigest != null) ? Util.toHexString(payloadDigest) : null;
+            LOGGER.fine("loading " + key.getId() + " " + payloadDigestHexString);
             return payload;
         }
 

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -123,7 +123,7 @@ public abstract class ConfidentialStore {
         @Override
         protected void store(ConfidentialKey key, byte[] payload) throws IOException {
             //called only from tests, get hex string of sha 256 for logging payload
-            logPayload("storing", key.getId(), payload);
+            LOGGER.fine("storing " + key.getId() + " " + Util.getHexOfSHA256DigestOf(payload));
             data.put(key.getId(), payload);
         }
 
@@ -131,17 +131,8 @@ public abstract class ConfidentialStore {
         protected byte[] load(ConfidentialKey key) throws IOException {
             byte[] payload = data.get(key.getId());
             //called only from tests, get hex string of sha 256 for logging payload
-            logPayload("loading", key.getId(), payload);
+            LOGGER.fine("loading " + key.getId() + " " + (payload != null ? Util.getHexOfSHA256DigestOf(payload) : "null"));
             return payload;
-        }
-
-        private void logPayload(String msg, String keyId, byte[] payload) throws IOException
-        {
-            //get hex string of sha 256 for logging payload
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, "{0} {1} {2}",
-                        new Object[]{msg, keyId, Util.getHexOfSHA256DigestOf(payload)});
-            }
         }
 
         @Override

--- a/core/src/main/java/jenkins/security/ConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/ConfidentialStore.java
@@ -122,14 +122,27 @@ public abstract class ConfidentialStore {
 
         @Override
         protected void store(ConfidentialKey key, byte[] payload) throws IOException {
-            LOGGER.fine(() -> "storing " + key.getId() + " " + Util.getDigestOf(Util.toHexString(payload)));
+            try {
+                String payloadDigest = Util.getHexStringOfSHA256DigestOf(payload);
+                LOGGER.fine("storing " + key.getId() + " " + payloadDigest);
+            } catch (NoSuchAlgorithmException e) {
+                throw new IOException(e);
+            }
             data.put(key.getId(), payload);
         }
 
         @Override
         protected byte[] load(ConfidentialKey key) throws IOException {
             byte[] payload = data.get(key.getId());
-            LOGGER.fine(() -> "loading " + key.getId() + " " + (payload != null ? Util.getDigestOf(Util.toHexString(payload)) : "null"));
+            String payloadDigest = null;
+             if (payload != null) {
+                try {
+                    payloadDigest = Util.getHexStringOfSHA256DigestOf(payload);
+                } catch (NoSuchAlgorithmException e) {
+                    throw new IOException(e);
+                }
+            }
+            LOGGER.fine("loading " + key.getId() + " " + payloadDigest);
             return payload;
         }
 

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -28,6 +28,7 @@ package hudson;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -53,7 +54,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -742,8 +742,7 @@ public class UtilTest {
         byte[] expected = new byte[]
                 { 19, 79, -17, -67, 50, -103, -122, 114, 100, 7, -91, 32, -127, 7, -17, 7, -55, -29, 61, -89, 121, -11,
                 6, -117, -1, 25, 23, 51, 38, -113, -23, -105};
-        boolean isSame = Arrays.equals(sha256DigestActual, expected);
-        assertEquals(isSame, true);
+        assertArrayEquals(expected, sha256DigestActual);
     }
 
     public static class BaseClass {

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -53,6 +53,7 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -728,27 +729,22 @@ public class UtilTest {
 
     @Test
     public void testGetHexOfSHA256DigestOf() throws IOException {
-        byte input[]=new byte[] {12,34,16};
+        byte[] input = new byte[] {12, 34, 16};
         String str = Util.getHexOfSHA256DigestOf(input);
-        assertNotNull(str);
-    }
-
-    @Test
-    public void testGetHexOfSHA256DigestOfNull() throws IOException {
-        assertNull( Util.getHexOfSHA256DigestOf(null));
+        assertEquals(str, "134fefbd329986726407a5208107ef07c9e33da779f5068bff191733268fe997");
     }
 
     @Test
     public void testGetSHA256DigestOf() {
-        byte input[]=new byte[] {12,34,16};
-        assertNotNull(Util.getSHA256DigestOf(input));
-    }
+        byte[] input = new byte[] {12, 34, 16};
+        byte[] sha256DigestActual = Util.getSHA256DigestOf(input);
 
-    @Test
-    public void testGetSHA256DigestOfNull() {
-        assertNull(Util.getSHA256DigestOf(null));
+        byte[] expected = new byte[]
+                { 19, 79, -17, -67, 50, -103, -122, 114, 100, 7, -91, 32, -127, 7, -17, 7, -55, -29, 61, -89, 121, -11,
+                6, -117, -1, 25, 23, 51, 38, -113, -23, -105};
+        boolean isSame = Arrays.equals(sha256DigestActual, expected);
+        assertEquals(isSame, true);
     }
-
 
     public static class BaseClass {
         protected String method() {

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -726,6 +726,30 @@ public class UtilTest {
         assertEquals("The class " + DerivedClassFailure.class.getName() + " must override at least one of the BaseClass.method methods", error.getMessage());
     }
 
+    @Test
+    public void testGetHexOfSHA256DigestOf() throws IOException {
+        byte input[]=new byte[] {12,34,16};
+        String str = Util.getHexOfSHA256DigestOf(input);
+        assertNotNull(str);
+    }
+
+    @Test
+    public void testGetHexOfSHA256DigestOfNull() throws IOException {
+        assertNull( Util.getHexOfSHA256DigestOf(null));
+    }
+
+    @Test
+    public void testGetSHA256DigestOf() {
+        byte input[]=new byte[] {12,34,16};
+        assertNotNull(Util.getSHA256DigestOf(input));
+    }
+
+    @Test
+    public void testGetSHA256DigestOfNull() {
+        assertNull(Util.getSHA256DigestOf(null));
+    }
+
+
     public static class BaseClass {
         protected String method() {
             return "base";


### PR DESCRIPTION
Mock class is currently being called from tests which is inside ConfidentialStore. store and load methods of Mock class log MD5 digest of hexstring of payload being passed. This change, is to replace MD5 with SHA 256. New utility method is added in hudson.util which will return digest of data being passed using sha-256. Modified code to call digest method  from store() and load() of Mock.class while logging payload. 


<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Tested by triggering tests which call store() and load() of Mock.class and ensured getSHA256DigestOf is called internally.

Example: 
       jenkins.security.CryptoConfidentialKeyTest
       jenkins.security.HexStringConfidentialKeyTest


### Proposed changelog entries

N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jtnord 


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8319"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

