### PR TITLE
Fix mistranslation of  noPrincipal_ja.properties

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/noPrincipal_ja.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/noPrincipal_ja.properties
@@ -22,4 +22,4 @@
 
 blurb=\
         ウェブコンテナーが認証するように設定されていないようです。\
-        コンテナーのドキュメントを参考にするか、<code>jenkinsci-users@googlegroups.com</code>か。
+        コンテナーのドキュメントを参考にするか、<code>jenkinsci-users@googlegroups.com</code>に問い合わせてください。


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

This is a revised version of the pull#8300 "Remove invalid Japanese mailing list URL".

Current Japanese messages has a grammatical problem.
"コンテナーのドキュメントを参考にするか、jenkinsci-users@googlegroups.comか。"

The trailing "か" means "or", and the word to inquire is missing.

Therefore translating this into English would be:
"Check the container documentation jenkinsci-users@googlegroups.com or."

The translation of the original English message
"Check the container documentation and/or also consult jenkinsci-users@googlegroups.com" is:
"コンテナーのドキュメントを参考にするか、jenkinsci-users@googlegroups.comに問い合わせてください。"

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

Modified message seems to only be used from the LegacySecurityRealm.  Tested only by ci.jenkins.io and by review of the message.

### Proposed changelog entries

- Fix mistranslation of Japanese message in mailing list reference.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8324"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

