### PR TITLE
Inline taglib documentation site (#8226)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,24 @@
       "matchStrings": ["ARG MAVEN_VERSION=(?<currentValue>.*?)\n"],
       "depNameTemplate": "org.apache.maven:maven-core",
       "datasourceTemplate": "maven"
+    },
+    {
+      "fileMatch": ["core/src/site/site.xml"],
+      "matchStrings": ["lit@(?<currentValue>.*?)/"],
+      "depNameTemplate": "lit",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "fileMatch": ["core/src/site/site.xml"],
+      "matchStrings": ["webcomponentsjs@(?<currentValue>.*?)/"],
+      "depNameTemplate": "@webcomponents/webcomponentsjs",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "fileMatch": ["core/src/site/site.xml"],
+      "matchStrings": ["<version>(?<currentValue>.*?)<\/version>"],
+      "depNameTemplate": "org.apache.maven.skins:maven-fluido-skin",
+      "datasourceTemplate": "maven"
     }
   ],
   "labels": ["dependencies", "skip-changelog"],

--- a/core/src/site/markdown/index.md
+++ b/core/src/site/markdown/index.md
@@ -1,1 +1,1 @@
-Collection of Maven auto-generated reports. The primary interest is probably [Jelly tag library reference](jelly-taglib-ref.html).
+[View the Jenkins core Jelly tag library reference](jelly-taglib-ref.html)

--- a/core/src/site/site.xml
+++ b/core/src/site/site.xml
@@ -1,0 +1,59 @@
+<!-- This maven skin decorates the taglib documentation located at https://reports.jenkins.io/core-taglib/jelly-taglib-ref.html -->
+<project name="Jenkins">
+    <body>
+        <breadcrumbs>
+            <item name="Homepage" href="https://jenkins.io/" target="_blank"/>
+        </breadcrumbs>
+        <head>
+            <![CDATA[
+                <script src="https://cdn.jsdelivr.net/npm/lit@2.6.1/polyfill-support.js"></script>
+                <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.6.0/webcomponents-loader.js"></script>
+                <script data="jio" src="https://cdn.jsdelivr.net/npm/@jenkinsci/jenkins-io-components/+esm" type="module"></script>
+                <script data="jio" nomodule="" src="https://cdn.jsdelivr.net/npm/@jenkinsci/jenkins-io-components"></script>
+                <jio-navbar class="fixed-top" property="https://reports.jenkins.io"></jio-navbar>
+                <!-- Overwrite bootstrap classes from maven-fluido-skin to put the jio-components in place -->
+                <style>
+                  .container-fluid {
+                    padding-right: 0px;
+                    padding-left: 0px;
+                  }
+                  hr {
+                    border-top: 0px;
+                    border-bottom: 0px;
+                    margin: 0px;
+                  }
+                  #poweredBy {
+                    display: none;
+                  }
+                </style>
+            ]]>
+        </head>
+        <footer>
+            <![CDATA[
+                <jio-footer property="https://reports.jenkins.io"></jio-footer>
+            ]]>
+        </footer>
+    </body>
+    <bannerLeft>
+        <name>Jenkins Taglib Documentation</name>
+    </bannerLeft>
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.11.2</version>
+    </skin>
+    <custom>
+        <matomo>
+            <siteId>3</siteId>
+            <url>https://jenkins-matomo.do.g4v.dev</url>
+            <options>
+                <disableCookies/>
+                <trackPageView/>
+                <enableLinkTracking/>
+            </options>
+        </matomo>
+        <fluidoSkin>
+            <sideBarEnabled>false</sideBarEnabled>
+        </fluidoSkin>
+    </custom>
+</project>

--- a/war/.prettierignore
+++ b/war/.prettierignore
@@ -24,3 +24,6 @@ src/main/scss/_bootstrap.scss
 *.hbs
 
 .yarn
+
+# Incorrectly flagging forwarding slashes in regex
+../.github/renovate.json


### PR DESCRIPTION
(cherry picked from commit ab918b424d61490ab6b72c3cea1a3fa17b279b12)

I forgot to include https://github.com/jenkinsci/jenkins/pull/8226 in https://github.com/jenkinsci/jenkins/pull/8301.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

