### PR TITLE
[JENKINS-71238] New login page breaks `login-theme-plugin`

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
@@ -52,10 +52,15 @@ THE SOFTWARE.
         <script src="${resURL}/jsbundles/pages/register.js" type="text/javascript" defer="true" />
       </head>
       <body class="app-sign-in-register">
-        <st:include it="${simpleDecorator}" page="simple-header.jelly" optional="true" />
+        <section class="app-sign-in-register__branding">
+          <div class="app-sign-in-register__branding__starburst"></div>
+          <img src="${imagesURL}/svgs/logo.svg" alt="${%logo}"/>
+        </section>
         <main id="main-panel" class="app-sign-in-register__content">
           <div class="app-sign-in-register__content-inner">
             <h1>${%Register}</h1>
+
+            <st:include it="${simpleDecorator}" page="simple-header.jelly" optional="true" />
 
             <template id="i18n" data-strength-strong="${%Strong}"
                                 data-strength-moderate="${%Moderate}"

--- a/core/src/main/resources/jenkins/model/DefaultSimplePageDecorator/simple-header.jelly
+++ b/core/src/main/resources/jenkins/model/DefaultSimplePageDecorator/simple-header.jelly
@@ -22,9 +22,4 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core">
-  <section class="app-sign-in-register__branding">
-    <div class="app-sign-in-register__branding__starburst"></div>
-    <img src="${imagesURL}/svgs/logo.svg" alt="${%logo}"/>
-  </section>
-</j:jelly>
+<j:jelly xmlns:j="jelly:core" />

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -67,10 +67,15 @@ THE SOFTWARE.
             <st:include it="${it.setupWizard}" page="authenticate-security-token"/>
           </j:when>
           <j:otherwise>
-            <st:include it="${simpleDecorator}" page="simple-header.jelly" optional="true" />
+            <section class="app-sign-in-register__branding">
+              <div class="app-sign-in-register__branding__starburst"></div>
+              <img src="${imagesURL}/svgs/logo.svg" alt="${%logo}"/>
+            </section>
             <main id="main-panel" class="app-sign-in-register__content">
               <div class="app-sign-in-register__content-inner">
                 <h1>Sign in to Jenkins</h1>
+
+                <st:include it="${simpleDecorator}" page="simple-header.jelly" optional="true" />
 
                 <form name="login" action="${it.securityRealm.authenticationGatewayUrl}"
                     method="post">


### PR DESCRIPTION
See [JENKINS-71238](https://issues.jenkins.io/browse/JENKINS-71238).

This PR updates the login/register pages so that the 'header' element appears under the page title, as expected by its help text _'This HTML snippet will be inserted below the welcome message on the default login form'_. Previously the text would appear on the left of the page.

**Before (image from ticket)**
![](https://issues.jenkins.io/secure/attachment/60398/60398_login_break.PNG)

**After**
<img width="1440" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/4689dc38-4f05-47e5-8dae-f792f8923546">

I have left the 'head' element as is (as I'm assuming it's usage is just for `<head />` tags).

### Testing done

* The login/register pages behave as before, but custom text in the 'header' element is now positioned correctly

### Proposed changelog entries

- New login page breaks login theme plugin.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8341"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

