### PR TITLE
Remove the 'row-group-end' class from various files

### DIFF
--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -85,7 +85,7 @@ THE SOFTWARE.
           <d:invokeBody />
         </div>
         <!-- end marker -->
-        <div class="tr ${attrs.inline?'':'row-set-end'} rowvg-end optional-block-end row-group-end"></div>
+        <div class="tr ${attrs.inline?'':'row-set-end'} rowvg-end optional-block-end"></div>
       </div>
     </j:when>
 

--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -70,7 +70,7 @@ THE SOFTWARE.
   <j:choose>
     <j:when test="${attrs.title!=null}">
       <div class="optionalBlock-container jenkins-form-item">
-        <div class="help-sibling tr optional-block-start row-group-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
+        <div class="help-sibling tr optional-block-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
           <div class="jenkins-checkbox-help-wrapper">
             <f:checkbox name="${attrs.name}" class="optional-block-control block-control optional-block-event-item"
                         negative="${attrs.negative}" checked="${attrs.checked}" field="${attrs.field}" title="${title}" />

--- a/core/src/main/resources/lib/form/radioBlock.jelly
+++ b/core/src/main/resources/lib/form/radioBlock.jelly
@@ -82,6 +82,6 @@ THE SOFTWARE.
       <d:invokeBody />
     </div>
     <!-- end marker -->
-    <div class="tr ${attrs.inline?'':'row-set-end'} radio-block-end row-group-end" style="display:none"></div>
+    <div class="tr ${attrs.inline?'':'row-set-end'} radio-block-end" style="display:none"></div>
   </div>
 </j:jelly>

--- a/core/src/main/resources/lib/form/radioBlock.jelly
+++ b/core/src/main/resources/lib/form/radioBlock.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
   <st:adjunct includes="lib.form.radioBlock.radioBlock"/>
 
   <div class="radioBlock-container">
-    <div class="tr help-sibling radio-block-start row-group-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
+    <div class="tr help-sibling radio-block-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
       <div class="jenkins-radio-help-wrapper">
         <div class="jenkins-radio">
           <input type="radio"

--- a/core/src/main/resources/lib/form/rowSet.jelly
+++ b/core/src/main/resources/lib/form/rowSet.jelly
@@ -49,7 +49,7 @@ THE SOFTWARE.
       <j:if test="${contents.length() != 0}">
         <div ref="${attrs.ref}" class="row-set-start row-group-start tr" style="display:none" name="${attrs.name}"></div>
         <j:out value="${contents}" />
-        <div class="row-set-end row-group-end tr jenkins-!-display-contents"></div>
+        <div class="row-set-end tr jenkins-!-display-contents"></div>
       </j:if>
     </j:otherwise>
   </j:choose>

--- a/core/src/main/resources/lib/form/rowSet.jelly
+++ b/core/src/main/resources/lib/form/rowSet.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
     </j:when>
     <j:otherwise>
       <j:if test="${contents.length() != 0}">
-        <div ref="${attrs.ref}" class="row-set-start row-group-start tr" style="display:none" name="${attrs.name}"></div>
+        <div ref="${attrs.ref}" class="row-set-start tr" style="display:none" name="${attrs.name}"></div>
         <j:out value="${contents}" />
         <div class="row-set-end tr jenkins-!-display-contents"></div>
       </j:if>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2675,7 +2675,7 @@ window.addEventListener("load", function () {
   document.querySelectorAll(".jenkins-form-item").forEach(function (element) {
     if (
       element.querySelector(
-        ".optionalBlock-container > .row-group-start input[type='checkbox'], .optional-block-start input[type='checkbox'], div > .jenkins-checkbox",
+        ".optionalBlock-container > div input[type='checkbox'], .optional-block-start input[type='checkbox'], div > .jenkins-checkbox",
       ) != null
     ) {
       element.classList.add("jenkins-form-item--tight");


### PR DESCRIPTION
The `row-group-end` class is being used unnecessarily (as in no styling is applied/nor logic/nor being checked in tests). It would be good to remove this to simplify forms.

### Testing done

* Controls work as before
* Searched GitHub for usages - https://github.com/search?q=org%3Ajenkinsci+row-group-end&type=code

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8356"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

