### PR TITLE
Deprecate `findAncestor` and `findAncestorClass`

### DIFF
--- a/core/src/main/resources/lib/form/apply/apply.js
+++ b/core/src/main/resources/lib/form/apply/apply.js
@@ -29,7 +29,7 @@ Behaviour.specify(
     }
 
     e.addEventListener("click", function (e) {
-      var f = findAncestor(e.target, "FORM");
+      var f = e.target.closest("FORM");
 
       // create a throw-away IFRAME to avoid back button from loading the POST result back
       id = "iframe" + iota++;

--- a/core/src/main/resources/lib/form/radioBlock/radioBlock.js
+++ b/core/src/main/resources/lib/form/radioBlock/radioBlock.js
@@ -55,7 +55,7 @@ Behaviour.specify(
       g.buttons = [];
     }
 
-    var s = findAncestorClass(r, "radio-block-start");
+    var s = r.closest(".radio-block-start");
     s.setAttribute("ref", r.id);
 
     // find the end node

--- a/core/src/main/resources/lib/form/repeatable/repeatable.js
+++ b/core/src/main/resources/lib/form/repeatable/repeatable.js
@@ -125,7 +125,7 @@ var repeatableSupport = {
 
   // called when 'delete' button is clicked
   onDelete: function (n) {
-    n = findAncestorClass(n, "repeated-chunk");
+    n = n.closest(".repeated-chunk");
     var a = new YAHOO.util.Anim(
       n,
       {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -438,11 +438,14 @@ function qs(owner) {
   };
 }
 
-// find the nearest ancestor node that has the given tag name
+// @deprecated Use standard javascript method `e.closest(tagName)` instead
+// eslint-disable-next-line no-unused-vars
 function findAncestor(e, tagName) {
   return e.closest(tagName);
 }
 
+// @deprecated Use standard javascript method `e.closest(className)` instead
+// eslint-disable-next-line no-unused-vars
 function findAncestorClass(e, cssClass) {
   return e.closest("." + cssClass);
 }
@@ -2022,11 +2025,11 @@ function updateOptionalBlock(c) {
   if (c.name == "hudson-tools-InstallSourceProperty") {
     // Hack to hide tool home when "Install automatically" is checked.
     var homeField = findPreviousFormItem(c, "home");
+
     if (homeField != null && homeField.value == "") {
-      var tr =
-        findAncestor(homeField, "TR") || findAncestorClass(homeField, "tr");
-      if (tr != null) {
-        tr.style.display = c.checked ? "none" : "";
+      const formItem = homeField.closest(".jenkins-form-item");
+      if (formItem != null) {
+        formItem.style.display = c.checked ? "none" : "";
         layoutUpdateCallback.call();
       }
     }
@@ -2443,7 +2446,7 @@ function findFormParent(e, form, isStatic) {
 
   if (form == null) {
     // caller can pass in null to have this method compute the owning form
-    form = findAncestor(e, "FORM");
+    form = e.closest("FORM");
   }
 
   while (e != form) {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -441,12 +441,18 @@ function qs(owner) {
 // @deprecated Use standard javascript method `e.closest(tagName)` instead
 // eslint-disable-next-line no-unused-vars
 function findAncestor(e, tagName) {
+  console.warn(
+    "Deprecated call to findAncestor - use standard javascript method `e.closest(tagName)` instead",
+  );
   return e.closest(tagName);
 }
 
 // @deprecated Use standard javascript method `e.closest(className)` instead
 // eslint-disable-next-line no-unused-vars
 function findAncestorClass(e, cssClass) {
+  console.warn(
+    "Deprecated call to findAncestorClass - use standard javascript method `e.closest(className)` instead",
+  );
   return e.closest("." + cssClass);
 }
 

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2025,7 +2025,6 @@ function updateOptionalBlock(c) {
   if (c.name == "hudson-tools-InstallSourceProperty") {
     // Hack to hide tool home when "Install automatically" is checked.
     var homeField = findPreviousFormItem(c, "home");
-
     if (homeField != null && homeField.value == "") {
       const formItem = homeField.closest(".jenkins-form-item");
       if (formItem != null) {


### PR DESCRIPTION
Couple of methods that just wrap the standard Javascript method `element.closest(...)`. I've updated any usages of the method to use that instead.

### Testing done

* Had a quick scan and no console errors, Tools page 'Install automatically' optional blocks work as before

### Proposed changelog entries

- Deprecate `findAncestor` and `findAncestorClass` in `hudson-behaviour.js`.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

- none

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8357"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

