### PR TITLE
[JENKINS-71813] Run tests on Java 21 instead of 19

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ properties([
 
 def axes = [
   platforms: ['linux', 'windows'],
-  jdks: [11, 17, 19],
+  jdks: [11, 17, 21],
 ]
 
 stage('Record build') {


### PR DESCRIPTION
Replace Java 19 with 21 as per GA on our infra today: https://groups.google.com/g/jenkinsci-dev/c/XjR48-1oVfw

### Testing done

Let's see how ci.jenkins.io handles it.

### Proposed changelog entries

- N/A, skip changelog