### PR TITLE
Update link design

### DIFF
--- a/war/src/main/scss/abstracts/mixins.scss
+++ b/war/src/main/scss/abstracts/mixins.scss
@@ -1,6 +1,8 @@
 @mixin link {
   text-decoration: var(--link-text-decoration);
   font-weight: var(--link-font-weight);
+  text-underline-offset: 2px;
+  text-decoration-thickness: 2px;
 
   &:link {
     color: var(--link-color);
@@ -19,6 +21,14 @@
   &:active {
     color: var(--link-color--active);
     text-decoration: var(--link-text-decoration--active);
+  }
+
+  @media (prefers-contrast: more) {
+    text-decoration: underline;
+
+    &:hover{
+      text-decoration-thickness: 3px;
+    }
   }
 }
 

--- a/war/src/main/scss/abstracts/mixins.scss
+++ b/war/src/main/scss/abstracts/mixins.scss
@@ -26,7 +26,7 @@
   @media (prefers-contrast: more) {
     text-decoration: underline;
 
-    &:hover{
+    &:hover {
       text-decoration-thickness: 3px;
     }
   }

--- a/war/src/main/scss/abstracts/theme.scss
+++ b/war/src/main/scss/abstracts/theme.scss
@@ -183,7 +183,7 @@ $semantics: (
   --link-text-decoration: none;
   --link-text-decoration--hover: underline;
   --link-text-decoration--active: underline;
-  --link-font-weight: 600;
+  --link-font-weight: 500;
 
   // Tooltips
   --tooltip-backdrop-filter: contrast(0.6) brightness(2.4) saturate(2)

--- a/war/src/main/scss/base/style.scss
+++ b/war/src/main/scss/base/style.scss
@@ -1,5 +1,3 @@
-@use "../abstracts/mixins";
-
 /*
  * The MIT License
  *
@@ -116,27 +114,6 @@ td.no-wrap {
     color: #ccc;
 } */
 
-a {
-  @include mixins.link;
-}
-
-.jenkins-link--with-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-
-  svg {
-    width: 16px;
-    height: 16px;
-    flex: 0 0 auto;
-    color: var(--text-color) !important;
-  }
-}
-
-p a {
-  text-decoration: underline;
-}
-
 a.lowkey:link {
   text-decoration: none;
   color: inherit;
@@ -239,7 +216,6 @@ pre {
   line-height: 1.66;
 
   a {
-    font-weight: inherit;
     word-wrap: break-word;
   }
 }
@@ -558,10 +534,6 @@ pre.console {
   p:last-of-type {
     margin-bottom: 0;
   }
-}
-
-.help a {
-  text-decoration: underline;
 }
 
 .help .from-plugin {

--- a/war/src/main/scss/base/typography.scss
+++ b/war/src/main/scss/base/typography.scss
@@ -1,3 +1,5 @@
+@use "../abstracts/mixins";
+
 body,
 p {
   font-family: var(--font-family-sans);
@@ -94,5 +96,21 @@ h6,
   &--tertiary {
     color: var(--text-color-secondary);
     opacity: 0.7;
+  }
+}
+
+a {
+  @include mixins.link;
+}
+
+.jenkins-link--with-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+
+  svg {
+    width: 16px;
+    height: 16px;
+    color: var(--text-color) !important;
   }
 }


### PR DESCRIPTION
Small PR to refresh the design of the link `<a>` element. Decreases the weight slightly and makes the underline chunkier on hover/focus. When `prefers-contrast: more` is enabled in Settings the underline appears by default.

**Before**
<img width="1063" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/a9ae9cd1-1f63-40ae-a5f9-b4d7f50b2ab7">

**After**
<img width="1065" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/5aedabd4-07ed-4c28-8943-d2292c5395d6">

**After (with increase contrast enabled)**
<img width="1070" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/fdafee13-d9ee-484b-baaa-e86403c2d00d">

### Testing done

* Standard links use the updated style, complex links (such as table links, breadcrumbs etc) us look the same

### Proposed changelog entries

- Refresh link design.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8375"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

