### PR TITLE
[JENKINS-61452] Tolerate corrupt Base64 in `PlainTextConsoleOutputStream`

### DIFF
--- a/core/src/main/java/hudson/console/PlainTextConsoleOutputStream.java
+++ b/core/src/main/java/hudson/console/PlainTextConsoleOutputStream.java
@@ -28,6 +28,10 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang.StringEscapeUtils;
 
 /**
  * Filters out console notes.
@@ -35,6 +39,8 @@ import java.io.OutputStream;
  * @author Kohsuke Kawaguchi
  */
 public class PlainTextConsoleOutputStream extends LineTransformationOutputStream.Delegating {
+
+    private static final Logger LOGGER = Logger.getLogger(PlainTextConsoleOutputStream.class.getName());
 
     /**
      *
@@ -64,7 +70,11 @@ public class PlainTextConsoleOutputStream extends LineTransformationOutputStream
             int rest = sz - next;
             ByteArrayInputStream b = new ByteArrayInputStream(in, next, rest);
 
-            ConsoleNote.skip(new DataInputStream(b));
+            try {
+                ConsoleNote.skip(new DataInputStream(b));
+            } catch (IOException x) {
+                LOGGER.log(Level.FINE, "Failed to skip annotation from \"" + StringEscapeUtils.escapeJava(new String(in, next, rest, Charset.defaultCharset())) + "\"", x);
+            }
 
             int bytesUsed = rest - b.available(); // bytes consumed by annotations
             written += bytesUsed;

--- a/test/src/test/java/hudson/console/AnnotatedLargeTextTest.java
+++ b/test/src/test/java/hudson/console/AnnotatedLargeTextTest.java
@@ -27,6 +27,7 @@ package hudson.console;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.junit.Assert.assertEquals;
 
 import hudson.MarkupText;
@@ -52,7 +53,7 @@ public class AnnotatedLargeTextTest {
     public static JenkinsRule r = new JenkinsRule();
 
     @Rule
-    public LoggerRule logging = new LoggerRule().record(ConsoleAnnotationOutputStream.class, Level.FINE).capture(100);
+    public LoggerRule logging = new LoggerRule().record(ConsoleAnnotationOutputStream.class, Level.FINE).record(PlainTextConsoleOutputStream.class, Level.FINE).capture(100);
 
     @Test
     public void smokes() throws Exception {
@@ -136,6 +137,29 @@ public class AnnotatedLargeTextTest {
                         + "UT45ZekCpys9xWo8J3KxMDkycCWk5qXXpLhw8BcWpRTwiDkk5VYlqifk5iXr"
                         + "h9cUpSZl25dUcQghWaBM4QGGcYAAYxMDAwVBUAGZwkDq35Rfn4JABmN28qcA"
                         + "AAA\\u001B[0myour home.\\n\"")); // TODO assert that this is IOException: MAC mismatch
+    }
+
+    @Issue("JENKINS-61452")
+    @Test
+    public void corruptedNote() throws Exception {
+        ByteBuffer buf = new ByteBuffer();
+        PrintStream ps = new PrintStream(buf, true, StandardCharsets.UTF_8);
+        ps.print("Some text.\n");
+        ps.print("Go back to " + TestNote.encodeTo("/root", "your home") + ".\n");
+        ps.print("More text.\n");
+        String original = buf.toString();
+        String corrupted = original.replace("+", "\u0000");
+        buf = new ByteBuffer();
+        buf.write(corrupted.getBytes());
+        AnnotatedLargeText<Void> text = new AnnotatedLargeText<>(buf, StandardCharsets.UTF_8, true, null);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        text.writeLogTo(0, baos);
+        assertThat(baos.toString(StandardCharsets.UTF_8), matchesRegex("Some text[.]\nGo back to .*your home[.]\nMore text[.]\n"));
+        assertThat(logging.getMessages(), hasItem(matchesRegex("Failed to skip annotation from .+")));
+        StringWriter w = new StringWriter();
+        text.writeHtmlTo(0, w);
+        assertThat(w.toString(), matchesRegex("Some text[.]\nGo back to .*your home[.]\nMore text[.]\n"));
+        assertThat(logging.getMessages(), hasItem(matchesRegex("Failed to resurrect annotation from .+")));
     }
 
     /** Simplified version of {@link HyperlinkNote}. */


### PR DESCRIPTION
See [JENKINS-61452](https://issues.jenkins.io/browse/JENKINS-61452). Somewhere along the line `ConsoleAnnotationOutputStream` got fixed (perhaps because `java.util.Base64` switched from `IllegalArgumentException` to `IOException`, which was already caught?), but `PlainTextConsoleOutputStream` remained vulnerable to corrupted `ConsoleNote`s.

### Testing done

Unit tests sufficed to reproduce the error.

### Proposed changelog entries

- The plain text console log will still be printed even if some console annotations are corrupt.

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8378"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

