### PR TITLE
[JENKINS-71848] Remove admin monitors popup from `/manage/` again

### DIFF
--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.diagnosis.ReverseProxySetupMonitor;
 import hudson.model.AdministrativeMonitor;
+import hudson.model.ManageJenkinsAction;
 import hudson.model.PageDecorator;
 import hudson.util.HudsonIsLoading;
 import hudson.util.HudsonIsRestarting;
@@ -53,9 +54,6 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
     private final Collection<String> ignoredJenkinsRestOfUrls = new ArrayList<>();
 
     public AdministrativeMonitorsDecorator() {
-        // redundant
-        ignoredJenkinsRestOfUrls.add("manage");
-
         // otherwise this would be added to every internal context menu building request
         ignoredJenkinsRestOfUrls.add("contextMenu");
 
@@ -162,6 +160,11 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
 
         // don't show while Jenkins is loading
         if (o instanceof HudsonIsLoading || o instanceof HudsonIsRestarting) {
+            return null;
+        }
+
+        // Don't show on Manage Jenkins
+        if (o instanceof ManageJenkinsAction) {
             return null;
         }
 


### PR DESCRIPTION
See [JENKINS-71848](https://issues.jenkins.io/browse/JENKINS-71848). Amends #6126.

### Testing done

Navigated to `/manage/` and observed monitors on the page, but not in the header.

### Proposed changelog entries

- Hide administrative monitors icons/popup in the header of Manage Jenkins, as they're shown directly on the page.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8388"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

