### PR TITLE
Remove '.tr' from advanced-button

### DIFF
--- a/core/src/main/resources/lib/form/advanced.jelly
+++ b/core/src/main/resources/lib/form/advanced.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
-  <div data-type="advanced-button-group" class='jenkins-form-item'>
+  <div data-type="jenkins-advanced-button-group" class='jenkins-form-item'>
     <st:adjunct includes="lib.form.advanced.advanced"/>
 
     <div class="advancedLink jenkins-buttons-row">

--- a/core/src/main/resources/lib/form/advanced.jelly
+++ b/core/src/main/resources/lib/form/advanced.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
-  <div class='jenkins-form-item tr'>
+  <div data-type="advanced-button-group" class='jenkins-form-item'>
     <st:adjunct includes="lib.form.advanced.advanced"/>
 
     <div class="advancedLink jenkins-buttons-row">

--- a/core/src/main/resources/lib/form/advanced/advanced.js
+++ b/core/src/main/resources/lib/form/advanced/advanced.js
@@ -22,7 +22,7 @@ Behaviour.specify(
           while (hiddenContent && !hiddenContent.matches("div.advancedBody")) {
             hiddenContent = hiddenContent.nextElementSibling;
           }
-          tr = parentContainer.closest("[data-type='advanced-button-group']");
+          tr = parentContainer.closest("[data-type='jenkins-advanced-button-group']");
         }
 
         // move the contents of the advanced portion into the main table

--- a/core/src/main/resources/lib/form/advanced/advanced.js
+++ b/core/src/main/resources/lib/form/advanced/advanced.js
@@ -22,7 +22,9 @@ Behaviour.specify(
           while (hiddenContent && !hiddenContent.matches("div.advancedBody")) {
             hiddenContent = hiddenContent.nextElementSibling;
           }
-          tr = parentContainer.closest("[data-type='jenkins-advanced-button-group']");
+          tr = parentContainer.closest(
+            "[data-type='jenkins-advanced-button-group']",
+          );
         }
 
         // move the contents of the advanced portion into the main table

--- a/core/src/main/resources/lib/form/advanced/advanced.js
+++ b/core/src/main/resources/lib/form/advanced/advanced.js
@@ -22,7 +22,7 @@ Behaviour.specify(
           while (hiddenContent && !hiddenContent.matches("div.advancedBody")) {
             hiddenContent = hiddenContent.nextElementSibling;
           }
-          tr = parentContainer.closest(".tr");
+          tr = parentContainer.closest("[data-type='advanced-button-group']");
         }
 
         // move the contents of the advanced portion into the main table


### PR DESCRIPTION
Would be good to get some discussion on this.

Shifting Jenkins away from depending on classnames for JS selectors would be a beneficial move. Classnames tend to be unwieldy and can complicate refactoring and comprehension. This PR tackles one such area by replacing the class selector (`.TR`) with a new attribute:`data-type='jenkins-advanced-button-group'`. This makes the code easier to search and keeps the class attribute just for styling.

### Testing done

* Advanced button works as before, no usages found on GitHub

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8390"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

