### PR TITLE
Backport update of org.jenkins-ci.plugins:cloudbees-folder from 6.846.v23698686f0f6 to 6.848.ve3b_fd7839a_81

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -185,7 +185,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>6.815.v0dd5a_cb_40e0e</version>
+      <version>6.848.ve3b_fd7839a_81</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Backports https://github.com/jenkinsci/jenkins/pull/8383 to the upcoming stable line because of the published security advisory, keeping security scanners and Jira issues calm.

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8392"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

