### PR TITLE
`hudson.model.CauseTest#broadlyNestedCauses` flaked

### DIFF
--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -32,13 +32,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import hudson.XmlFile;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.BuildTrigger;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.concurrent.Future;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
@@ -78,22 +80,29 @@ public class CauseTest {
         FreeStyleProject a = j.createFreeStyleProject("a");
         FreeStyleProject b = j.createFreeStyleProject("b");
         FreeStyleProject c = j.createFreeStyleProject("c");
+        List<QueueTaskFuture<FreeStyleBuild>> futures = new ArrayList<>();
         Run<?, ?> last = null;
         for (int i = 1; i <= 10; i++) {
             Cause cause = last == null ? null : new Cause.UpstreamCause(last);
-            Future<? extends Run<?, ?>> next1 = a.scheduleBuild2(0, cause);
-            a.scheduleBuild2(0, cause);
+            QueueTaskFuture<FreeStyleBuild> next1 = a.scheduleBuild2(0, cause);
+            futures.add(next1);
+            futures.add(a.scheduleBuild2(0, cause));
             cause = new Cause.UpstreamCause(next1.get());
-            Future<? extends Run<?, ?>> next2 = b.scheduleBuild2(0, cause);
-            b.scheduleBuild2(0, cause);
+            QueueTaskFuture<FreeStyleBuild> next2 = b.scheduleBuild2(0, cause);
+            futures.add(next2);
+            futures.add(b.scheduleBuild2(0, cause));
             cause = new Cause.UpstreamCause(next2.get());
-            Future<? extends Run<?, ?>> next3 = c.scheduleBuild2(0, cause);
-            c.scheduleBuild2(0, cause);
+            QueueTaskFuture<FreeStyleBuild> next3 = c.scheduleBuild2(0, cause);
+            futures.add(next3);
+            futures.add(c.scheduleBuild2(0, cause));
             last = next3.get();
         }
         int count = new XmlFile(Run.XSTREAM, new File(last.getRootDir(), "build.xml")).asString().split(Pattern.quote("<hudson.model.Cause_-UpstreamCause")).length;
         assertFalse("too big at " + count, count > 100);
         //j.interactiveBreak();
+        for (QueueTaskFuture<FreeStyleBuild> future : futures) {
+            j.assertBuildStatusSuccess(j.waitForCompletion(future.waitForStart()));
+        }
     }
 
 


### PR DESCRIPTION
`hudson.model.CauseTest#broadlyNestedCauses` flaked with

```
java.io.IOException: /home/jenkins/agent/workspace/Core_jenkins_PR-8414/test/target/j h17639254889720455358/jobs/c/builds/13
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:144)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.dispose(TemporaryDirectoryAllocator.java:99)
	at org.jvnet.hudson.test.TestEnvironment.dispose(TestEnvironment.java:84)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:524)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:625)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.nio.file.DirectoryNotEmptyException: /home/jenkins/agent/workspace/Core_jenkins_PR-8414/test/target/j h17639254889720455358/jobs/c/builds
	at java.base/sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:247)
	at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
	at java.base/java.nio.file.Files.deleteIfExists(Files.java:1181)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:141)
	... 9 more
```

which I fixed by waiting for the runs to finish before tearing down the test.

### Testing done

Ran the test locally.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

