### PR TITLE
Minor correction in UpdateCenter restart UI internals

### DIFF
--- a/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
@@ -51,12 +51,7 @@ THE SOFTWARE.
           </div>
           <j:if test="${app.lifecycle.canRestart()}">
             <p class="info">
-              <j:if test="${app.isQuietingDown() or it.isRestartScheduled()}">
-                <f:checkbox checked="true" id="scheduleRestartCheckbox" name="scheduleRestart" title="${%warning}" />
-              </j:if>
-              <j:if test="${!app.isQuietingDown() and !it.isRestartScheduled()}">
-                <f:checkbox readonly="true" id="scheduleRestartCheckbox" name="scheduleRestart" title="${%warning}" />
-              </j:if>
+              <f:checkbox checked="${app.isQuietingDown() or it.isRestartScheduled()}" id="scheduleRestartCheckbox" name="scheduleRestart" title="${%warning}" />
             </p>
           </j:if>
         </l:isAdmin>

--- a/core/src/main/resources/hudson/model/UpdateCenter/update-center.js
+++ b/core/src/main/resources/hudson/model/UpdateCenter/update-center.js
@@ -3,7 +3,7 @@ Behaviour.specify(
   "scheduleRestartCheckbox",
   0,
   function (el) {
-    el.addEventListener("click", function () {
+    el.addEventListener("change", function () {
       var form = document.getElementById("scheduleRestart");
       form.action = el.checked ? "safeRestart" : "cancelRestart";
       crumb.appendToForm(form);


### PR DESCRIPTION
#6870 improperly migrated inline JS in `onchange` to a `click` event handler set by Behaviour.  This PR fixes that.

Also removes the (non-functional) `readonly` attribute introduced in #7740 which was overridden by the above bug (the attribute does not disable the checkbox, only sets an `onclick` handler for some reason). Fixing only the JS and not this would mean that the checkbox can never be checked to schedule a restart.

Finally, simplify Jelly.

### Testing done

* With only JS fixed, confirmed the checkbox could never be clicked.
* With both changes and the minimized UI, checked the box and confirmed restart was scheduled. Then unchecked it and confirmed restart was canceled.

### Proposed changelog entries

(too minor, no notable user-visible change)

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
