### PR TITLE
Add a placeholder to specify the last tested commit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,8 @@ If the issue is not fully described in Jira, add more information here (justific
 
 ### Testing done
 
+**Last tested commit:** (Insert commit ID here, e.g. `1245abcdef`)
+
 <!-- Comment:
 Provide a clear description of how this change was tested.
 At minimum this should include proof that a computer has executed the changed lines.


### PR DESCRIPTION
PRs regularly evolve substantially in response to review feedback. In some cases, there's little resemblance between what was originally submitted, and what the final state is.

I think it would be useful to make explicit which commit most recently underwent the specified manual testing. That can help identify when the current state of the PR is essentially untested.

Thoughts?

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8421"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

