### PR TITLE
[JENKINS-71252][JENKINS-70793] Multiple form validation fixes

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -634,8 +634,7 @@ function updateValidationArea(validationArea, content) {
     // Only change content if different, causes an unnecessary animation otherwise
     if (validationArea.innerHTML !== content) {
       validationArea.innerHTML = content;
-      validationArea.style.height =
-        validationArea.children[0].offsetHeight + "px";
+      validationArea.style.height = "auto";
 
       // Only include the notice in the validation-error-area, move all other elements out
       if (validationArea.children.length > 1) {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -636,15 +636,6 @@ function updateValidationArea(validationArea, content) {
       validationArea.innerHTML = content;
       validationArea.style.height = "auto";
 
-      // Only include the notice in the validation-error-area, move all other elements out
-      if (validationArea.children.length > 1) {
-        Array.from(validationArea.children)
-          .slice(1)
-          .forEach((element) => {
-            validationArea.after(element);
-          });
-      }
-
       Behaviour.applySubtree(validationArea);
       // For errors with additional details, apply the subtree to the expandable details pane
       if (validationArea.nextElementSibling) {


### PR DESCRIPTION
See [JENKINS-71252](https://issues.jenkins.io/browse/JENKINS-71252) and [JENKINS-70793](https://issues.jenkins.io/browse/JENKINS-70793).

(The fix for JENKINS-70793 only works with the fix for JENKINS-71252.)

#### JENKINS-71252

Per https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight,

>  If the element is hidden (for example, by setting `style.display` on the element or one of its ancestors to "none"), then `0` is returned. 

Requesting review by @janfaracik to understand whether there's any reason to use this over `auto`.

#### JENKINS-70793

https://github.com/jenkinsci/jenkins/pull/6460/files#diff-10922aee3260853be495a09cf3bf13bf5f931bc128e334807e3008ff00b57651R523-R528 looked sus, so I deleted it.

https://github.com/jenkinsci/jenkins/pull/6460/files#r862952504 looks a little concerning, but I was unable to reproduce that with sample plugins. Requesting @timja review just in case.

### Testing done

Followed the steps to reproduce in my Jira comment to JENKINS-71252.

Installed @yaroslavafenkin's demo plugin for JENKINS-71252 and confirmed it behaved correctly.

Patched the demo plugin JENKINS-71252 to have a stack trace like described in JENKINS-70793, and tested.

### Proposed changelog entries

- Show form validation results for form elements that are initially hidden. (regression in 2.355)
- Remove previous form validation errors when the form validation is updated with new content. (regression in 2.355)


### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8422"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

