### PR TITLE
Fix PCT problem of #8250

### DIFF
--- a/core/src/main/java/jenkins/ErrorAttributeFilter.java
+++ b/core/src/main/java/jenkins/ErrorAttributeFilter.java
@@ -3,6 +3,7 @@ package jenkins;
 import java.io.IOException;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -30,6 +31,11 @@ public class ErrorAttributeFilter implements Filter {
 
     @Override
     public void destroy() {
+        // Otherwise the PCT fails
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
         // Otherwise the PCT fails
     }
 }

--- a/core/src/main/java/jenkins/ErrorAttributeFilter.java
+++ b/core/src/main/java/jenkins/ErrorAttributeFilter.java
@@ -27,4 +27,9 @@ public class ErrorAttributeFilter implements Filter {
         servletRequest.setAttribute(USER_ATTRIBUTE, authentication);
         filterChain.doFilter(servletRequest, servletResponse);
     }
+
+    @Override
+    public void destroy() {
+        // Otherwise the PCT fails
+    }
 }


### PR DESCRIPTION
Amends #8250.

Passed PCT in https://github.com/jenkinsci/bom/pull/2412.

Error looks a lot like what motivated https://github.com/jenkinsci/plugin-pom/pull/693.

### Testing done

Passed PCT in https://github.com/jenkinsci/bom/pull/2412.

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
