### PR TITLE
Add test for SECURITY-3135

### DIFF
--- a/test/src/test/java/jenkins/security/Security3135Test.java
+++ b/test/src/test/java/jenkins/security/Security3135Test.java
@@ -1,18 +1,21 @@
 package jenkins.security;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import hudson.model.FreeStyleProject;
 import hudson.model.InvisibleAction;
 import hudson.model.UnprotectedRootAction;
+import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.html.DomElement;
-import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlPage;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 public class Security3135Test {
     public static final String ACTION_URL = "security3135";
@@ -24,26 +27,53 @@ public class Security3135Test {
     public void contextMenuShouldNotBypassCSRFProtection() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
         FreeStyleProject project = j.createFreeStyleProject("FreestyleProject");
+        ViewHolder viewHolder = j.jenkins.getExtensionList(ViewHolder.class).get(ViewHolder.class);
+        boolean exceptionThrown = false;
 
         HtmlPage page = wc.goTo(ACTION_URL);
-        DomElement anchor = page.getElementById("context-menu");
-        HtmlElement nextSibling = (HtmlElement) anchor.getFirstChild().getNextSibling();
-        nextSibling.click();
+        DomElement standardMenu = page.getElementById("standard-menu");
+        standardMenu.click();
+        DomElement contextMenu = page.getElementById("context-menu");
+        try {
+            contextMenu.click();
+        } catch (FailingHttpStatusCodeException e) {
+            if (e.getStatusCode() == 405) {
+                exceptionThrown = true;
+            }
+        }
 
         j.waitUntilNoActivityUpTo(2000); // Give the job 2 seconds to be submitted
+
+        assertTrue("Request was not made", viewHolder.isRequestMade());
+        assertTrue("Expected 405 Method Not Allowed", exceptionThrown);
         assertNull("Build should not be scheduled", j.jenkins.getQueue().getItem(project));
         assertNull("Build should not be scheduled", project.getBuildByNumber(1));
     }
 
     @TestExtension
     public static class ViewHolder extends InvisibleAction implements UnprotectedRootAction {
+
+        public boolean requestMade = false;
+
         @Override
         public String getUrlName() {
             return ACTION_URL;
         }
 
         public String getPayload() {
-            return "../job/FreestyleProject/build?delay=0sec";
+            return "../job/FreestyleProject/build?delay=0sec&";
+        }
+
+        public String getStandardPayload() {
+            return "../security3135/validate?";
+        }
+
+        public boolean isRequestMade() {
+            return requestMade;
+        }
+
+        public void doValidate(StaplerRequest request, StaplerResponse response) {
+            requestMade = true;
         }
     }
 }

--- a/test/src/test/java/jenkins/security/Security3135Test.java
+++ b/test/src/test/java/jenkins/security/Security3135Test.java
@@ -1,0 +1,49 @@
+package jenkins.security;
+
+import static org.junit.Assert.assertNull;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.InvisibleAction;
+import hudson.model.UnprotectedRootAction;
+import org.htmlunit.html.DomElement;
+import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlPage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+public class Security3135Test {
+    public static final String ACTION_URL = "security3135";
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("SECURITY-3135")
+    public void contextMenuShouldNotBypassCSRFProtection() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        FreeStyleProject project = j.createFreeStyleProject("FreestyleProject");
+
+        HtmlPage page = wc.goTo(ACTION_URL);
+        DomElement anchor = page.getElementById("context-menu");
+        HtmlElement nextSibling = (HtmlElement) anchor.getFirstChild().getNextSibling();
+        nextSibling.click();
+
+        j.waitUntilNoActivityUpTo(2000); // Give the job 2 seconds to be submitted
+        assertNull("Build should not be scheduled", j.jenkins.getQueue().getItem(project));
+        assertNull("Build should not be scheduled", project.getBuildByNumber(1));
+    }
+
+    @TestExtension
+    public static class ViewHolder extends InvisibleAction implements UnprotectedRootAction {
+        @Override
+        public String getUrlName() {
+            return ACTION_URL;
+        }
+
+        public String getPayload() {
+            return "../job/FreestyleProject/build?delay=0sec";
+        }
+    }
+}

--- a/test/src/test/resources/jenkins/security/Security3135Test/ViewHolder/index.jelly
+++ b/test/src/test/resources/jenkins/security/Security3135Test/ViewHolder/index.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+    <l:layout title="Security-3135">
+        <l:main-panel>
+            <a href="${rootUrl}${it.payload}" class="model-link" id="context-menu">Context Menu</a>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/test/src/test/resources/jenkins/security/Security3135Test/ViewHolder/index.jelly
+++ b/test/src/test/resources/jenkins/security/Security3135Test/ViewHolder/index.jelly
@@ -3,6 +3,7 @@
     <l:layout title="Security-3135">
         <l:main-panel>
             <a href="${rootUrl}${it.payload}" class="model-link" id="context-menu">Context Menu</a>
+            <a href="${rootUrl}${it.standardPayload}" class="model-link" id="standard-menu">Standard Menu</a>
         </l:main-panel>
     </l:layout>
 </j:jelly>


### PR DESCRIPTION
Forgotten follow-up for [SECURITY-3135](https://www.jenkins.io/security/advisory/2023-06-14/#SECURITY-3135), a regression test.

### Desired reviewers

@daniel-beck 
or
@yaroslavafenkin 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8427"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

