### PR TITLE
Clear the queue before tearing down tests

### DIFF
--- a/test/src/test/java/hudson/cli/ConsoleCommandTest.java
+++ b/test/src/test/java/hudson/cli/ConsoleCommandTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import hudson.Functions;
 import hudson.model.FreeStyleBuild;
@@ -300,6 +301,7 @@ public class ConsoleCommandTest {
         assertThat(result, failedWith(3));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("ERROR: No such build #1"));
+        assertTrue(j.jenkins.getQueue().cancel(project));
     }
 
 }

--- a/test/src/test/java/hudson/cli/RunRangeCommand2Test.java
+++ b/test/src/test/java/hudson/cli/RunRangeCommand2Test.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import hudson.Functions;
 import hudson.model.FreeStyleBuild;
@@ -112,6 +113,7 @@ public class RunRangeCommand2Test {
                 .invokeWithArgs("aProject", "1");
         assertThat(result, succeeded());
         assertThat(result.stdout(), containsString("Builds: " + System.lineSeparator()));
+        assertTrue(j.jenkins.getQueue().cancel(project));
     }
 
 }

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -402,6 +402,7 @@ public class ProjectTest {
         QueueTaskFuture<FreeStyleBuild> b3 = waitForStart(p);
         assertThat("Build can not start because build of upstream project has not finished.", downstream.getCauseOfBlockage(), instanceOf(BecauseOfUpstreamBuildInProgress.class));
         b3.get();
+        assertTrue(j.jenkins.getQueue().cancel(downstream));
     }
 
     private static final Logger LOGGER = Logger.getLogger(ProjectTest.class.getName());
@@ -713,6 +714,7 @@ public class ProjectTest {
         Thread.sleep(1000);
         //Assert that the job IS submitted to Queue.
         assertEquals(1, j.jenkins.getQueue().getItems().length);
+        assertTrue(j.jenkins.getQueue().cancel(proj));
     }
 
     /**
@@ -785,6 +787,7 @@ public class ProjectTest {
         Thread.sleep(1000);
         //The job should be in queue
         assertEquals(1, j.jenkins.getQueue().getItems().length);
+        assertTrue(j.jenkins.getQueue().cancel(proj));
     }
 
     @Issue("JENKINS-22750")
@@ -806,7 +809,8 @@ public class ProjectTest {
         t.new Runner().run();
 
 
-        assertFalse(j.jenkins.getQueue().isEmpty());
+        assertEquals(1, j.jenkins.getQueue().getItems().length);
+        assertTrue(j.jenkins.getQueue().cancel(proj));
     }
 
     public static class TransientAction extends InvisibleAction{

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -180,6 +180,9 @@ public class QueueTest {
 
         // did it bind back to the same object?
         assertSame(q.getItems()[0].task, testProject);
+
+        // Clear the queue
+        assertTrue(q.cancel(testProject));
     }
 
     /**
@@ -198,6 +201,9 @@ public class QueueTest {
         // The current counter should be the id from the item brought back
         // from the persisted queue.xml.
         assertEquals(3, Queue.WaitingItem.getCurrentCounterValue());
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("test", FreeStyleProject.class)));
     }
 
     /**
@@ -506,6 +512,9 @@ public class QueueTest {
         assertNotNull(queueItem);
         String tagName = queueItem.getDocumentElement().getTagName();
         assertTrue(tagName.equals("blockedItem") || tagName.equals("buildableItem"));
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(p));
     }
 
     @Issue("JENKINS-28926")
@@ -963,10 +972,9 @@ public class QueueTest {
     }
 
     @Test public void waitForStartAndCancelBeforeStart() throws Exception {
-        final OneShotEvent ev = new OneShotEvent();
         FreeStyleProject p = r.createFreeStyleProject();
 
-        QueueTaskFuture<FreeStyleBuild> f = p.scheduleBuild2(10);
+        QueueTaskFuture<FreeStyleBuild> f = p.scheduleBuild2(30);
         final Queue.Item item = Queue.getInstance().getItem(p);
         assertNotNull(item);
 
@@ -1079,6 +1087,9 @@ public class QueueTest {
         r.createWebClient().withBasicApiToken(bob).goToXml(url); // OK, 200
         r.createWebClient().withBasicApiToken(james).assertFails(url, HttpURLConnection.HTTP_FORBIDDEN); // only DISCOVER → AccessDeniedException
         r.createWebClient().withBasicApiToken(alice).assertFails(url, HttpURLConnection.HTTP_NOT_FOUND); // not even DISCOVER
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(project));
     }
 
     //we force the project not to be executed so that it stays in the queue
@@ -1122,6 +1133,19 @@ public class QueueTest {
         Queue.Item[] items = q.getItems();
         assertEquals(Arrays.asList(items).toString(), 11, items.length);
         assertEquals("Loading the queue should not generate saves", 0, QueueSaveSniffer.count);
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("a", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("b", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("c", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("d", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("e", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("f", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("g", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("h", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("i", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("j", FreeStyleProject.class)));
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("k", FreeStyleProject.class)));
     }
 
     @TestExtension("load_queue_xml")
@@ -1261,6 +1285,9 @@ public class QueueTest {
 
         String tooltip = buildAndExtractTooltipAttribute();
         assertThat(tooltip, containsString(expectedLabel.substring(1, expectedLabel.length() - 1)));
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(p));
     }
 
     @Test
@@ -1274,6 +1301,9 @@ public class QueueTest {
         String tooltip = buildAndExtractTooltipAttribute();
         assertThat(tooltip, not(containsString("<img")));
         assertThat(tooltip, containsString("&lt;"));
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(p));
     }
 
     private String buildAndExtractTooltipAttribute() throws Exception {

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -322,6 +322,12 @@ public class ViewTest {
         assertNotContainsItems(view1, notInView, inView2);
         assertContainsItems(view2, inView2, inBothViews);
         assertNotContainsItems(view2, notInView, inView1);
+
+        // Clear the queue
+        assertTrue(j.jenkins.getQueue().cancel(notInView));
+        assertTrue(j.jenkins.getQueue().cancel(inView1));
+        assertTrue(j.jenkins.getQueue().cancel(inView2));
+        assertTrue(j.jenkins.getQueue().cancel(inBothViews));
     }
 
     private void assertContainsItems(View view, Task... items) {

--- a/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
+++ b/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
@@ -3,6 +3,7 @@ package hudson.model.queue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertTrue;
 
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
@@ -60,6 +61,9 @@ public class MaintainCanTakeStrengtheningTest {
 
         // The new error is shown in the logs
         assertThat(logging.getMessages(), hasItem(String.format("Exception evaluating if the node '%s' can take the task '%s'", faultyAgent.getDisplayName(), "theFaultyOne")));
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("theFaultyOne", FreeStyleProject.class)));
     }
 
     /**

--- a/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
+++ b/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
@@ -40,6 +40,9 @@ public class QueueTaskDispatcherTest {
 
         assertTrue("Not blocked", item.isBlocked());
         assertEquals("Expected CauseOfBlockage to be returned", "blocked by canRun", item.getWhy());
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(project));
     }
 
     @TestExtension("canRunBlockageIsDisplayed")
@@ -75,6 +78,9 @@ public class QueueTaskDispatcherTest {
         cob.print(l);
         l.getLogger().flush();
         assertThat(w.toString(), containsString("blocked by canTake"));
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(project));
     }
 
     @TestExtension("canTakeBlockageIsDisplayed")

--- a/test/src/test/java/hudson/slaves/NodeCanTakeTaskTest.java
+++ b/test/src/test/java/hudson/slaves/NodeCanTakeTaskTest.java
@@ -27,6 +27,7 @@ package hudson.slaves;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -73,6 +74,9 @@ public class NodeCanTakeTaskTest {
         assertEquals(project, item.task);
         assertNotNull(item.getCauseOfBlockage());
         assertEquals("rejecting everything", item.getCauseOfBlockage().getShortDescription());
+
+        // Clear the queue
+        assertTrue(r.jenkins.getQueue().cancel(project));
     }
 
     private static class RejectAllTasksProperty extends NodeProperty<Node> {


### PR DESCRIPTION
Fixes the queue-related warnings turned up by https://github.com/jenkinsci/jenkins-test-harness/pull/643, with the exception of https://github.com/jenkinsci/jenkins-test-harness/pull/643#issuecomment-1692442436 (which, as explained in that comment, is a deficiency of https://github.com/jenkinsci/jenkins-test-harness/pull/643 rather than an actual problem). Does not attempt to fix any of the executor warnings turned up by https://github.com/jenkinsci/jenkins-test-harness/pull/643 since there are _way_ too many false positives as explained in https://github.com/jenkinsci/jenkins-test-harness/pull/643#discussion_r1304946075.

### Testing done

Commented out the executor warnings from https://github.com/jenkinsci/jenkins-test-harness/pull/643 since they are so noisy as to be useless, then ran with fatal mode and a fork count equivalent to the number of physical cores on my system. The only failures were https://github.com/jenkinsci/jenkins-test-harness/pull/643#issuecomment-1692442436, which as explained in that comment is a deficiency of https://github.com/jenkinsci/jenkins-test-harness/pull/643 rather than an actual problem.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8428"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

