### PR TITLE
`MaintainCanTakeStrengtheningTest` is flaky

### DIFF
--- a/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
+++ b/test/src/test/java/hudson/model/queue/MaintainCanTakeStrengtheningTest.java
@@ -4,13 +4,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.NodeProperty;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,7 +26,7 @@ public class MaintainCanTakeStrengtheningTest {
     @Rule
     public LoggerRule logging = new LoggerRule().record(Node.class.getName(), Level.ALL).capture(100);
 
-    private QueueTaskFuture scheduleBuild(String name, String label) throws Exception {
+    private QueueTaskFuture<FreeStyleBuild> scheduleBuild(String name, String label) throws Exception {
         FreeStyleProject project = r.createFreeStyleProject(name);
 
         project.setAssignedLabel(Label.get(label));
@@ -44,15 +44,9 @@ public class MaintainCanTakeStrengtheningTest {
         r.createOnlineSlave(Label.get("good"));
 
         // Only the good ones will be run and the latest doesn't get hung because of the second
-        QueueTaskFuture[] taskFuture = new QueueTaskFuture[3];
-        taskFuture[0] = scheduleBuild("good1", "good");
-        taskFuture[1] = scheduleBuild("theFaultyOne", "faulty");
-        taskFuture[2] = scheduleBuild("good2", "good");
-
-        // Wait for a while until the good ones start, no need to wait for their completion to guarantee
-        // the fix works
-        taskFuture[0].getStartCondition().get(15, TimeUnit.SECONDS);
-        taskFuture[2].getStartCondition().get(15, TimeUnit.SECONDS);
+        FreeStyleBuild good1 = scheduleBuild("good1", "good").waitForStart();
+        scheduleBuild("theFaultyOne", "faulty");
+        FreeStyleBuild good2 = scheduleBuild("good2", "good").waitForStart();
 
         // The faulty one is the only one in the queue
         assertThat(r.getInstance().getQueue().getBuildableItems().size(), equalTo(1));
@@ -60,6 +54,10 @@ public class MaintainCanTakeStrengtheningTest {
 
         // The new error is shown in the logs
         assertThat(logging.getMessages(), hasItem(String.format("Exception evaluating if the node '%s' can take the task '%s'", faultyAgent.getDisplayName(), "theFaultyOne")));
+
+        // Tear down
+        r.assertBuildStatusSuccess(r.waitForCompletion(good1));
+        r.assertBuildStatusSuccess(r.waitForCompletion(good2));
     }
 
     /**


### PR DESCRIPTION
The comment says

> Wait for a while until the good ones start, no need to wait for their completion to guarantee the fix works

which is technically correct, but on the other hand we _do_ need to wait for the completion to ensure we don't get a failure when tearing down the test.

### Testing done

Ran `mvn clean verify -Dtest=hudson.model.queue.MaintainCanTakeStrengtheningTest` locally.

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8429"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

