### PR TITLE
Fixed some minor deprecation warnings in Tests

### DIFF
--- a/test/src/test/java/hudson/util/SecretCompatTest.java
+++ b/test/src/test/java/hudson/util/SecretCompatTest.java
@@ -56,7 +56,7 @@ public class SecretCompatTest {
     @Issue("SECURITY-304")
     public void encryptedValueStaysTheSameAfterRoundtrip() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
-        project.addProperty(new ParametersDefinitionProperty(new PasswordParameterDefinition("p", "s3cr37", "Keep this a secret")));
+        project.addProperty(new ParametersDefinitionProperty(new PasswordParameterDefinition("p", Secret.fromString("s3cr37"), "Keep this a secret")));
         project.getAllActions(); // initialize Actionable.actions; otherwise first made nonnull while rendering sidepanel after redirect after round #1 has been saved, so only round #2 has <actions/>
         project = j.configRoundtrip(project);
         String round1 = project.getConfigFile().asString();
@@ -68,7 +68,7 @@ public class SecretCompatTest {
         //But reconfiguring will make it a new value
         project = j.jenkins.getItemByFullName(project.getFullName(), FreeStyleProject.class);
         project.removeProperty(ParametersDefinitionProperty.class);
-        project.addProperty(new ParametersDefinitionProperty(new PasswordParameterDefinition("p", "s3cr37", "Keep this a secret")));
+        project.addProperty(new ParametersDefinitionProperty(new PasswordParameterDefinition("p", Secret.fromString("s3cr37"), "Keep this a secret")));
         project = j.configRoundtrip(project);
         String round3 = project.getConfigFile().asString();
         assertNotEquals(round2, round3);

--- a/test/src/test/java/jenkins/model/JenkinsBuildsAndWorkspacesDirectoriesTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsBuildsAndWorkspacesDirectoriesTest.java
@@ -23,9 +23,11 @@ import java.util.logging.Level;
 import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.MockFolder;
@@ -49,6 +51,9 @@ public class JenkinsBuildsAndWorkspacesDirectoriesTest {
 
     @Rule
     public LoggerRule loggerRule = new LoggerRule();
+
+    @ClassRule
+    public static TemporaryFolder tmp = new TemporaryFolder();
 
     @Before
     public void before() {
@@ -284,7 +289,7 @@ public class JenkinsBuildsAndWorkspacesDirectoriesTest {
         final List<String> builds = new ArrayList<>();
 
         story.then(steps -> {
-            builds.add(story.j.createTmpDir().toString());
+            builds.add(tmp.newFolder().toString());
             assertTrue(story.j.getInstance().isDefaultBuildDir());
             setBuildsDirProperty(builds.get(0) + "/${ITEM_FULL_NAME}");
         });


### PR DESCRIPTION
Fixed some deprecation warnings in Tests:
* used `Secret.fromString` instead of the deprecated `string` method
* used `TemporaryFolder` instead of deprecated `createTmpDir()` from `JenkinsRule`

### Testing done

Unit tests passed locally

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8436"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

