### PR TITLE
Add more operating system end of life dates

### DIFF
--- a/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/end-of-life-data.json
+++ b/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/end-of-life-data.json
@@ -4,6 +4,10 @@
     "endOfLife": "2029-03-31"
   },
   {
+    "pattern": "AlmaLinux.* 9",
+    "endOfLife": "2032-05-31"
+  },
+  {
     "pattern": "Alpine Linux v3.14",
     "endOfLife": "2023-05-01"
   },
@@ -66,6 +70,10 @@
     "endOfLife": "2029-03-31"
   },
   {
+    "pattern": "Oracle Linux.* 9",
+    "endOfLife": "2034-06-30"
+  },
+  {
     "pattern": "Red Hat Enterprise Linux.* 7",
     "start": "2023-05-01",
     "endOfLife": "2023-11-16"
@@ -75,13 +83,25 @@
     "endOfLife": "2029-03-31"
   },
   {
+    "pattern": "Red Hat Enterprise Linux.* 9",
+    "endOfLife": "2032-05-31"
+  },
+  {
     "pattern": "Rocky Linux.* 8",
     "endOfLife": "2029-03-31"
+  },
+  {
+    "pattern": "Rocky Linux.* 9",
+    "endOfLife": "2032-05-31"
   },
   {
     "pattern": "Scientific Linux.* 7",
     "start": "2023-05-01",
     "endOfLife": "2023-11-16"
+  },
+  {
+    "pattern": "Ubuntu.* 16.04",
+    "endOfLife": "2021-04-02"
   },
   {
     "pattern": "Ubuntu.* 18.04",
@@ -92,7 +112,27 @@
     "endOfLife": "2025-04-02"
   },
   {
+    "pattern": "Ubuntu.* 20.10",
+    "endOfLife": "2021-07-22"
+  },
+  {
+    "pattern": "Ubuntu.* 21.04",
+    "endOfLife": "2022-01-20"
+  },
+  {
+    "pattern": "Ubuntu.* 21.10",
+    "endOfLife": "2022-07-14"
+  },
+  {
     "pattern": "Ubuntu.* 22.04",
     "endOfLife": "2027-04-01"
+  },
+  {
+    "pattern": "Ubuntu.* 22.10",
+    "endOfLife": "2023-07-20"
+  },
+  {
+    "pattern": "Ubuntu.* 23.04",
+    "endOfLife": "2024-01-20"
   }
 ]


### PR DESCRIPTION
## Add more operating system end of life dates

Users have reported bugs on additional operating systems that are already end of life, like Ubuntu 20.10.  Include outdated Ubuntu operating systems in the list so that the users are warned.

* [Ubuntu end of life data](https://endoflife.date/ubuntu)

Red Hat Enterprise Linux 9 has released along with its derivatives, AlmaLinux, Rocky Linux, and Oracle Linux.  Include them in the end of life data.

* [Red Hat Enterprise Linux end of life data](https://endoflife.date/rhel)
* [AlmaLinux  end of life data](https://endoflife.date/almalinux)
* [Oracle Linux end of life data](https://endoflife.date/oraclelinux)
* [Rocky Linux end of life data](https://endoflife.date/rocky-linux)

### Testing done

Reviewed end of life data site and confirmed the entered dates are correct.

No additional automated tests added because the existing automated tests already cover the functionality.

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/a

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8438"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

