### PR TITLE
Add telemetry for security-related settings

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/SecurityConfiguration.java
+++ b/core/src/main/java/jenkins/telemetry/impl/SecurityConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.telemetry.impl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import java.time.LocalDate;
+import jenkins.model.Jenkins;
+import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+
+@Extension
+public class SecurityConfiguration extends Telemetry {
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Basic information about security-related settings";
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2023, 8, 1);
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2023, 12, 1);
+    }
+
+    @Override
+    public JSONObject createContent() {
+        final Jenkins j = Jenkins.get();
+        final JSONObject o = new JSONObject();
+        o.put("authorizationStrategy", j.getAuthorizationStrategy().getClass().getName());
+        o.put("securityRealm", j.getSecurityRealm().getClass().getName());
+        o.put("crumbIssuer", j.getCrumbIssuer().getClass().getName());
+        o.put("markupFormatter", j.getMarkupFormatter().getClass().getName());
+        o.put("inboundAgentListener", j.getTcpSlaveAgentListener().configuredPort != -1);
+
+        final ApiTokenPropertyConfiguration apiTokenPropertyConfiguration = ExtensionList.lookupSingleton(ApiTokenPropertyConfiguration.class);
+        o.put("apiTokenCreationOfLegacyTokenEnabled", apiTokenPropertyConfiguration.isCreationOfLegacyTokenEnabled());
+        o.put("apiTokenTokenGenerationOnCreationEnabled", apiTokenPropertyConfiguration.isTokenGenerationOnCreationEnabled());
+        o.put("apiTokenUsageStatisticsEnabled", apiTokenPropertyConfiguration.isUsageStatisticsEnabled());
+        return o;
+    }
+}

--- a/core/src/main/java/jenkins/telemetry/impl/SecurityConfiguration.java
+++ b/core/src/main/java/jenkins/telemetry/impl/SecurityConfiguration.java
@@ -57,6 +57,8 @@ public class SecurityConfiguration extends Telemetry {
     public JSONObject createContent() {
         final Jenkins j = Jenkins.get();
         final JSONObject o = new JSONObject();
+        o.put("components", buildComponentInformation());
+
         o.put("authorizationStrategy", j.getAuthorizationStrategy().getClass().getName());
         o.put("securityRealm", j.getSecurityRealm().getClass().getName());
         o.put("crumbIssuer", j.getCrumbIssuer().getClass().getName());
@@ -67,6 +69,7 @@ public class SecurityConfiguration extends Telemetry {
         o.put("apiTokenCreationOfLegacyTokenEnabled", apiTokenPropertyConfiguration.isCreationOfLegacyTokenEnabled());
         o.put("apiTokenTokenGenerationOnCreationEnabled", apiTokenPropertyConfiguration.isTokenGenerationOnCreationEnabled());
         o.put("apiTokenUsageStatisticsEnabled", apiTokenPropertyConfiguration.isUsageStatisticsEnabled());
+
         return o;
     }
 }

--- a/core/src/main/java/jenkins/telemetry/impl/SecurityConfiguration.java
+++ b/core/src/main/java/jenkins/telemetry/impl/SecurityConfiguration.java
@@ -27,6 +27,8 @@ package jenkins.telemetry.impl;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.TcpSlaveAgentListener;
+import hudson.security.csrf.CrumbIssuer;
 import java.time.LocalDate;
 import jenkins.model.Jenkins;
 import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
@@ -61,9 +63,11 @@ public class SecurityConfiguration extends Telemetry {
 
         o.put("authorizationStrategy", j.getAuthorizationStrategy().getClass().getName());
         o.put("securityRealm", j.getSecurityRealm().getClass().getName());
-        o.put("crumbIssuer", j.getCrumbIssuer().getClass().getName());
+        final CrumbIssuer crumbIssuer = j.getCrumbIssuer();
+        o.put("crumbIssuer", crumbIssuer == null ? null : crumbIssuer.getClass().getName());
         o.put("markupFormatter", j.getMarkupFormatter().getClass().getName());
-        o.put("inboundAgentListener", j.getTcpSlaveAgentListener().configuredPort != -1);
+        final TcpSlaveAgentListener tcpSlaveAgentListener = j.getTcpSlaveAgentListener();
+        o.put("inboundAgentListener", tcpSlaveAgentListener == null ? null : tcpSlaveAgentListener.configuredPort != -1);
 
         final ApiTokenPropertyConfiguration apiTokenPropertyConfiguration = ExtensionList.lookupSingleton(ApiTokenPropertyConfiguration.class);
         o.put("apiTokenCreationOfLegacyTokenEnabled", apiTokenPropertyConfiguration.isCreationOfLegacyTokenEnabled());

--- a/core/src/main/resources/jenkins/telemetry/impl/SecurityConfiguration/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/SecurityConfiguration/description.jelly
@@ -12,6 +12,6 @@
         <li>Whether the API token option labeled <em>Enable API Token usage statistics</em> is enabled or disabled</li>
     </ul>
 
-    Additionally this trial collects the list of installed plugins.
+    Additionally this trial collects the list of installed plugins, their version, and the version of Jenkins.
     This data will be used to understand the popularity of the various implementations for each of these features.
 </j:jelly>

--- a/core/src/main/resources/jenkins/telemetry/impl/SecurityConfiguration/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/SecurityConfiguration/description.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    This trial collects basic information about security settings:
+    <ul>
+        <li>The type of the currently configured security realm, e.g., <code>hudson.security.HudsonPrivateSecurityRealm</code></li>
+        <li>The type of the currently configured authorization strategy, e.g., <code>hudson.security.ProjectMatrixAuthorizationStrategy</code></li>
+        <li>The type of the currently configured crumb issuer, e.g., <code>hudson.security.csrf.DefaultCrumbIssuer</code></li>
+        <li>The type of the currently configured markup formatter, e.g., <code>hudson.markup.RawHtmlMarkupFormatter</code></li>
+        <li>Whether the TCP port for inbound agents is enabled (fixed or random) or disabled</li>
+        <li>Whether the API token option labeled <em>Generate a legacy API token for each newly created user (Not recommended)</em> is enabled or disabled</li>
+        <li>Whether the API token option labeled <em>Allow users to manually create a legacy API token (Not recommended)</em> is enabled or disabled</li>
+        <li>Whether the API token option labeled <em>Enable API Token usage statistics</em> is enabled or disabled</li>
+    </ul>
+
+    Additionally this trial collects the list of installed plugins.
+    This data will be used to understand the popularity of the various implementations for each of these features.
+</j:jelly>


### PR DESCRIPTION
What it says in the title.

Help UI rendered:

> <img width="1329" alt="Screenshot 2023-08-28 at 17 07 41" src="https://github.com/jenkinsci/jenkins/assets/1831569/84b09117-83ec-4907-8bb1-d17487fe0ac1">

### Testing done

Checked the help text of the usage stats option (see screenshot)

Confirmed that the output of `ExtensionList.lookupSingleton(jenkins.telemetry.impl.SecurityConfiguration).createContent()` makes sense:

```
{
    "components": {
        "csp": "1.2",
        "jenkins-core": "2.421-SNAPSHOT",
        "sample-plugin": "1.0-SNAPSHOT (private-c3d7e2df-danielbeck)"
    },
    "authorizationStrategy": "hudson.security.AuthorizationStrategy$Unsecured",
    "securityRealm": "hudson.security.SecurityRealm$None",
    "crumbIssuer": "hudson.security.csrf.DefaultCrumbIssuer",
    "markupFormatter": "hudson.markup.EscapedMarkupFormatter",
    "inboundAgentListener": true,
    "apiTokenCreationOfLegacyTokenEnabled": false,
    "apiTokenTokenGenerationOnCreationEnabled": false,
    "apiTokenUsageStatisticsEnabled": true
}
```

### Proposed changelog entries

- Add telemetry collecting basic information about the security configuration.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8440"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

