### PR TITLE
Label parsing robustness fix

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -311,6 +311,10 @@ public abstract class Slave extends Node implements Serializable {
 
     @DataBoundSetter
     public void setNodeProperties(List<? extends NodeProperty<?>> properties) throws IOException {
+        if (nodeProperties == null) {
+            warnPlugin();
+            nodeProperties = new DescribableList<>(this);
+        }
         nodeProperties.replaceBy(properties);
     }
 
@@ -346,7 +350,15 @@ public abstract class Slave extends Node implements Serializable {
 
     @Override
     protected Set<LabelAtom> getLabelAtomSet() {
+        if (labelAtomSet == null) {
+            warnPlugin();
+            this.labelAtomSet = Collections.unmodifiableSet(Label.parse(label));
+        }
         return labelAtomSet;
+    }
+
+    private void warnPlugin() {
+        LOGGER.log(Level.WARNING, () -> getClass().getName() + " or one of its superclass overrides readResolve() without calling super implementation. Please file an issue against the plugin owning it : " + Jenkins.get().getPluginManager().whichPlugin(getClass()));
     }
 
     @Override

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -359,7 +359,7 @@ public abstract class Slave extends Node implements Serializable {
 
     private void warnPlugin() {
         LOGGER.log(Level.WARNING, () -> getClass().getName() + " or one of its superclass overrides readResolve() without calling super implementation." +
-                "Please file an issue against the plugin owning it : " + Jenkins.get().getPluginManager().whichPlugin(getClass()));
+                "Please file an issue against the plugin implementing it: " + Jenkins.get().getPluginManager().whichPlugin(getClass()));
     }
 
     @Override

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -345,7 +345,7 @@ public abstract class Slave extends Node implements Serializable {
         this.labelAtomSet = Collections.unmodifiableSet(Label.parse(label));
     }
 
-    @NonNull
+    @CheckForNull // should be @NonNull, but we've seen plugins overriding readResolve() without calling super.
     private transient Set<LabelAtom> labelAtomSet;
 
     @Override
@@ -358,7 +358,8 @@ public abstract class Slave extends Node implements Serializable {
     }
 
     private void warnPlugin() {
-        LOGGER.log(Level.WARNING, () -> getClass().getName() + " or one of its superclass overrides readResolve() without calling super implementation. Please file an issue against the plugin owning it : " + Jenkins.get().getPluginManager().whichPlugin(getClass()));
+        LOGGER.log(Level.WARNING, () -> getClass().getName() + " or one of its superclass overrides readResolve() without calling super implementation." +
+                "Please file an issue against the plugin owning it : " + Jenkins.get().getPluginManager().whichPlugin(getClass()));
     }
 
     @Override

--- a/test/src/test/java/jenkins/model/NodesRestartTest.java
+++ b/test/src/test/java/jenkins/model/NodesRestartTest.java
@@ -18,8 +18,8 @@ public class NodesRestartTest {
     public JenkinsSessionRule s = new JenkinsSessionRule();
 
     // The point of this implementation is to override readResolve so that Slave#readResolve doesn't get called.
-    public static class DummyDumbSlave extends Slave {
-        public DummyDumbSlave(@NonNull String name, String remoteFS, ComputerLauncher launcher) throws Descriptor.FormException, IOException {
+    public static class DummyAgent extends Slave {
+        public DummyAgent(@NonNull String name, String remoteFS, ComputerLauncher launcher) throws Descriptor.FormException, IOException {
             super(name, remoteFS, launcher);
         }
 
@@ -33,7 +33,7 @@ public class NodesRestartTest {
     public void checkNodeRestart() throws Throwable {
         s.then(r -> {
             assertThat(r.jenkins.getNodes(), hasSize(0));
-            var node = new DummyDumbSlave("my-node", "temp", r.createComputerLauncher(null));
+            var node = new DummyAgent("my-node", "temp", r.createComputerLauncher(null));
             r.jenkins.addNode(node);
             assertThat(r.jenkins.getNodes(), hasSize(1));
         });

--- a/test/src/test/java/jenkins/model/NodesRestartTest.java
+++ b/test/src/test/java/jenkins/model/NodesRestartTest.java
@@ -11,11 +11,11 @@ import hudson.slaves.ComputerLauncher;
 import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 public class NodesRestartTest {
     @Rule
-    public RestartableJenkinsRule s = new RestartableJenkinsRule();
+    public JenkinsSessionRule s = new JenkinsSessionRule();
 
     // The point of this implementation is to override readResolve so that Slave#readResolve doesn't get called.
     public static class DummyDumbSlave extends Slave {
@@ -30,7 +30,7 @@ public class NodesRestartTest {
     }
 
     @Test
-    public void checkNodeRestart() throws Exception {
+    public void checkNodeRestart() throws Throwable {
         s.then(r -> {
             assertThat(r.jenkins.getNodes(), hasSize(0));
             var node = new DummyDumbSlave("my-node", "temp", r.createComputerLauncher(null));

--- a/test/src/test/java/jenkins/model/NodesRestartTest.java
+++ b/test/src/test/java/jenkins/model/NodesRestartTest.java
@@ -1,0 +1,47 @@
+package jenkins.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertNotNull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Descriptor;
+import hudson.model.Slave;
+import hudson.slaves.ComputerLauncher;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class NodesRestartTest {
+    @Rule
+    public RestartableJenkinsRule s = new RestartableJenkinsRule();
+
+    // The point of this implementation is to override readResolve so that Slave#readResolve doesn't get called.
+    public static class DummyDumbSlave extends Slave {
+        public DummyDumbSlave(@NonNull String name, String remoteFS, ComputerLauncher launcher) throws Descriptor.FormException, IOException {
+            super(name, remoteFS, launcher);
+        }
+
+        @Override
+        protected Object readResolve() {
+            return this;
+        }
+    }
+
+    @Test
+    public void checkNodeRestart() throws Exception {
+        s.then(r -> {
+            assertThat(r.jenkins.getNodes(), hasSize(0));
+            var node = new DummyDumbSlave("my-node", "temp", r.createComputerLauncher(null));
+            r.jenkins.addNode(node);
+            assertThat(r.jenkins.getNodes(), hasSize(1));
+        });
+        s.then(r -> {
+            assertThat(r.jenkins.getNodes(), hasSize(1));
+            var node = r.jenkins.getNode("my-node");
+            assertNotNull(node.getNodeProperties());
+            assertNotNull(node.getAssignedLabels());
+        });
+    }
+}


### PR DESCRIPTION
Amends https://github.com/jenkinsci/jenkins/pull/8395

In case an extension of `Slave` overrides `readResolve` but does not call its super implementation, this
recover from it, and issue a warning to raise a bug against the impacted plugin.

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Prevent incorrect `readResolve` implementations from breaking agent label parsing.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8448"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

