### PR TITLE
Avoid usage of Guava from `ProcessTree`

### DIFF
--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -29,7 +29,6 @@ import static hudson.util.jna.GNUCLibrary.LIBC;
 import static java.util.logging.Level.FINER;
 import static java.util.logging.Level.FINEST;
 
-import com.google.common.primitives.Ints;
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Memory;
 import com.sun.jna.Native;
@@ -750,7 +749,12 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         @CheckForNull
         @Override
         public OSProcess get(@NonNull Process proc) {
-            return get(Ints.checkedCast(proc.pid()));
+            long longPid = proc.pid();
+            int intPid = (int) longPid;
+            if (intPid != longPid) {
+              throw new IllegalArgumentException("Out of range: " + longPid);
+            }
+            return get(intPid);
         }
 
         @Override

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -749,12 +749,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         @CheckForNull
         @Override
         public OSProcess get(@NonNull Process proc) {
-            long longPid = proc.pid();
-            int intPid = (int) longPid;
-            if (intPid != longPid) {
-              throw new IllegalArgumentException("Out of range: " + longPid);
-            }
-            return get(intPid);
+            return get(Math.toIntExact(proc.pid()));
         }
 
         @Override


### PR DESCRIPTION
Amends #6762. While running `NodeProvisionerTest` I saw this warning:

```
2023-09-05 22:09:31.388+0000 [id=99]    SEVERE  hudson.remoting.Channel#terminate: Listener org.jvnet.hudson.test.SimpleCommandLauncher$1@3f175823 propagated an exception for channel hudson.remoting.Channel@638a976b:slave0s close: {2}
java.lang.ClassNotFoundException: com.google.common.primitives.Ints$IntConverter
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        at org.eclipse.jetty.webapp.WebAppClassLoader.loadClass(WebAppClassLoader.java:511)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
Caused: java.lang.NoClassDefFoundError: com/google/common/primitives/Ints$IntConverter
        at hudson.util.ProcessTree$Unix.get(ProcessTree.java:753)
        at hudson.util.ProcessTree.killAll(ProcessTree.java:180)
        at org.jvnet.hudson.test.SimpleCommandLauncher$1.onClosed(SimpleCommandLauncher.java:86)
        at hudson.remoting.Channel.terminate(Channel.java:1104)
        at hudson.remoting.Channel$CloseCommand.execute(Channel.java:1316)
        at hudson.remoting.Channel$1.handle(Channel.java:609)
        at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:81)
```

While non-fatal, this indicates that by the time we were running the `onClosed` handler the Remoting channel had already shut down and was unable to load new classes, such as the Guava `Ints` class used by `ProcessTree` in the `onClosed` handler. To make `ProcessTree` more robust, it would be better not to consume any Guava classes that force the Guava JAR to be shipped to the agent.

### Testing done

Ran `NodeProvisionerTest` again with these changes and no longer saw the warning I was seeing before.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8467"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

