### PR TITLE
fix signup autofocus

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
@@ -73,7 +73,7 @@ THE SOFTWARE.
                   ${data.errors.containsKey('username') ? data.errors.get('username') : ''}
                 </div>
                 <input class="jenkins-input ${data.errors.containsKey('username') ? 'jenkins-input--error' : ''}"
-                       autofocus="${(data.errors.containsKey('username') || !data) ? true : null}"
+                       autofocus="${(data == null || data.errors.containsKey('username')) ? true : null}"
                        value="${data.username}"
                        type="text"
                        name="username"


### PR DESCRIPTION
the expression (`!data`) was not valid and caused an exception to be thrown.

replace the invalid expression with a null check (for the initial rendering where there is no `SignupInfo` in the page).

```
  10.912 [id=100]       WARNING h.ExpressionFactory2$JexlExpression#evaluate: Caught exception evaluating: (data.errors.containsKey('username') || !data) ? true : null in /jenkins/securityRealm/createAccount. Reason: java.lang.Exception: expression not boolean valued
java.lang.Exception: expression not boolean valued
        at org.apache.commons.jexl.parser.ASTNotNode.value(ASTNotNode.java:68)
...
        at org.kohsuke.stapler.ScriptRequestDispatcher.forward(ScriptRequestDispatcher.java:97)
        at hudson.security.HudsonPrivateSecurityRealm.createAccount(HudsonPrivateSecurityRealm.java:399)
        at hudson.security.HudsonPrivateSecurityRealm._doCreateAccount(HudsonPrivateSecurityRealm.java:269)
        at hudson.security.HudsonPrivateSecurityRealm.doCreateAccount(HudsonPrivateSecurityRealm.java:261)
```

amends #7872

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

`HudsonPrivateSecurityRealmTest#fullNameOfUnknownCantSignup` before this change has the above exception in the logs
after this change the exception is no more.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Prevent log spam when using the Jenkins security database and users signup.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
