### PR TITLE
`StringIndexOutOfBoundsException` in `AbstractItem.getUrl`

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -555,9 +555,15 @@ public abstract class AbstractItem extends Actionable implements Item, HttpDelet
                     View view = (View) last.getObject();
                     if (view.getOwner().getItemGroup() == getParent() && !view.isDefault()) {
                         // Showing something inside a view, so should use that as the base URL.
-                        String base = last.getUrl().substring(req.getContextPath().length() + 1) + '/';
-                        LOGGER.log(Level.FINER, "using {0}{1} for {2} from {3}", new Object[] {base, shortUrl, this, uri});
-                        return base + shortUrl;
+                        String prefix = req.getContextPath() + "/";
+                        String url = last.getUrl();
+                        if (url.startsWith(prefix)) {
+                            String base = url.substring(prefix.length()) + '/';
+                            LOGGER.log(Level.FINER, "using {0}{1} for {2} from {3} given {4}", new Object[] {base, shortUrl, this, uri, prefix});
+                            return base + shortUrl;
+                        } else {
+                            LOGGER.finer(() -> url + " does not start with " + prefix + " as expected");
+                        }
                     } else {
                         LOGGER.log(Level.FINER, "irrelevant {0} for {1} from {2}", new Object[] {view.getViewName(), this, uri});
                     }

--- a/test/src/test/java/jenkins/widgets/BuildListTableTest.java
+++ b/test/src/test/java/jenkins/widgets/BuildListTableTest.java
@@ -26,21 +26,25 @@ package jenkins.widgets;
 
 import static org.junit.Assert.assertEquals;
 
+import hudson.model.AbstractItem;
 import hudson.model.FreeStyleProject;
 import hudson.model.ListView;
 import java.net.URI;
 import java.net.URL;
+import java.util.logging.Level;
 import org.htmlunit.html.HtmlAnchor;
 import org.htmlunit.html.HtmlPage;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.MockFolder;
 
 public class BuildListTableTest {
 
     @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public LoggerRule logging = new LoggerRule().record(AbstractItem.class, Level.FINER);
 
     @Issue("JENKINS-19310")
     @Test public void linksFromFolders() throws Exception {


### PR DESCRIPTION
Noticed numerous stack traces in a log file of the form

```
WARNING	h.ExpressionFactory2$JexlExpression#evaluate: Caught exception evaluating: item.task.url in /controllername/. Reason: java.lang.reflect.InvocationTargetException
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.base/java.lang.String.substring(String.java:1841)
	at hudson.model.AbstractItem.getUrl(AbstractItem.java:559)
	at hudson.model.AbstractItem.getUrl(AbstractItem.java:575)
	at hudson.model.Run.getUrl(Run.java:1055)
	at org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask.getUrl(ExecutorStepExecution.java:655)
```

Does not seem like it should be possible given `Ancestor.getUrl` Javadoc, but there it is. This whole block of logic from ea95434938b2111d8768528823990a78bdc58d3e is optional—we should not throw an exception if it does not work out.


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8481"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

