### PR TITLE
Migrate from deprecated finalization API to Java 9+ API

### DIFF
--- a/core/src/main/java/hudson/util/FileChannelWriter.java
+++ b/core/src/main/java/hudson/util/FileChannelWriter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.channels.Channel;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.file.OpenOption;
@@ -26,7 +27,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @see <a href="https://github.com/jenkinsci/jenkins/pull/2548">PR-2548</a>
  */
 @Restricted(NoExternalUse.class)
-public class FileChannelWriter extends Writer {
+public class FileChannelWriter extends Writer implements Channel {
 
     private static final Logger LOGGER = Logger.getLogger(FileChannelWriter.class.getName());
 
@@ -80,6 +81,11 @@ public class FileChannelWriter extends Writer {
         } else {
             LOGGER.finest("Force disabled on flush(), no-op");
         }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
     }
 
     @Override

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -72,6 +73,11 @@ public class AtomicFileWriterTest {
         afw = new AtomicFileWriter(af.toPath(), Charset.defaultCharset());
     }
 
+    @After
+    public void tearDown() throws IOException {
+        afw.abort();
+    }
+
     @Test
     public void symlinkToDirectory() throws Exception {
         assumeFalse(Functions.isWindows());
@@ -83,7 +89,7 @@ public class AtomicFileWriterTest {
 
         final Path childFileInSymlinkToDir = Paths.get(zeSymlink.toString(), "childFileInSymlinkToDir");
 
-        new AtomicFileWriter(childFileInSymlinkToDir, StandardCharsets.UTF_8);
+        new AtomicFileWriter(childFileInSymlinkToDir, StandardCharsets.UTF_8).abort();
     }
 
     @Test

--- a/test/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/test/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -53,7 +53,7 @@ public class AtomicFileWriterTest {
         Path tmpPath = ref.get().getTemporaryPath();
         assertTrue(Files.exists(tmpPath));
         assertFalse(Files.exists(destPath));
-        MemoryAssert.assertGC(ref);
+        MemoryAssert.assertGC(ref, false);
         await().atMost(30, TimeUnit.SECONDS).until(() -> !Files.exists(tmpPath));
         assertFalse(Files.exists(destPath));
         assertThat(

--- a/test/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/test/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -1,0 +1,63 @@
+package hudson.util;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.MemoryAssert;
+
+public class AtomicFileWriterTest {
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Rule
+    public LoggerRule logging =
+            new LoggerRule().record(AtomicFileWriter.class, Level.WARNING).capture(100);
+
+    @Test
+    public void noResourceLeak() throws IOException {
+        Path destPath = tmp.newFolder().toPath().resolve("file");
+        AtomicFileWriter writer = new AtomicFileWriter(destPath, StandardCharsets.UTF_8);
+        Path tmpPath = writer.getTemporaryPath();
+        assertTrue(Files.exists(tmpPath));
+        assertFalse(Files.exists(destPath));
+        try {
+            writer.commit();
+        } finally {
+            writer.abort();
+        }
+        assertFalse(Files.exists(tmpPath));
+        assertTrue(Files.exists(destPath));
+        assertThat(logging.getMessages(), empty());
+    }
+
+    @Test
+    public void resourceLeak() throws IOException {
+        Path destPath = tmp.newFolder().toPath().resolve("file");
+        WeakReference<AtomicFileWriter> ref =
+                new WeakReference<>(new AtomicFileWriter(destPath, StandardCharsets.UTF_8));
+        Path tmpPath = ref.get().getTemporaryPath();
+        assertTrue(Files.exists(tmpPath));
+        assertFalse(Files.exists(destPath));
+        MemoryAssert.assertGC(ref);
+        await().atMost(30, TimeUnit.SECONDS).until(() -> !Files.exists(tmpPath));
+        assertFalse(Files.exists(destPath));
+        assertThat(
+                logging.getMessages(),
+                contains("AtomicFileWriter for " + destPath + " was not closed before being released"));
+    }
+}


### PR DESCRIPTION
Recent versions of Java have deprecated `Object#finalize` and marked it for removal:

```
[WARNING] AtomicFileWriter.java:[229,19] [removal] finalize() in Object has been deprecated and marked for removal
[WARNING] AtomicFileWriter.java:[233,17] [removal] finalize() in Object has been deprecated and marked for removal
```

In this PR we proactively migrate away from this deprecated API in favor of its Java 9+ replacement.

As a bonus, we also implement the advice given by Joshua Bloch in _Effective Java_ (emphasis not mine):

> So what, if anything, are finalizers good for? […] One is to act as a “safety net” in case the owner of an object forgets to call its explicit termination method. While there’s no guarantee that the finalizer will be invoked promptly, it may be better to free the resource late than never, in those (hopefully rare) cases when the client fails to call the explicit termination method. But **the finalizer should log a warning if it finds that the resource has not been terminated,** as this indicates a bug in the client code, which should be fixed.

We also add test coverage for this functionality. The new test passes before the changes to `src/main`, demonstrating there is no regression.

### Testing done

Ran `AtomicFileWriterTest` on Java 17 on both Linux and Windows.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8486"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

