### PR TITLE
Remove finalization from `RegistryKey`

### DIFF
--- a/core/src/main/java/hudson/util/jna/RegistryKey.java
+++ b/core/src/main/java/hudson/util/jna/RegistryKey.java
@@ -277,12 +277,6 @@ public class RegistryKey implements AutoCloseable {
     }
 
 
-    @Override
-    protected void finalize() throws Throwable {
-        super.finalize();
-        dispose();
-    }
-
     public void dispose() {
         if (handle != 0)
             Advapi32.INSTANCE.RegCloseKey(handle);


### PR DESCRIPTION
Recent versions of Java have deprecated `Object#finalize` and marked it for removal. In this PR we are removing finalization from `RegistryKey`, which already implemented explicit termination via `AutoCloseable`. Unlike #8486, there were only [a handful of usages](https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+%22hudson.util.jna.RegistryKey%22) throughout the ecosystem (I checked the `cloudbees` GitHub organization as well), and I audited each and every one to ensure it was already using the explicit terminator, either via try-with-resources or try-finally. Furthermore, all usages outside core were in extremely ancient plugins that are not relevant anymore. For core itself, SpotBugs would warn us if we introduced a new resource leak by forgetting to use try-with-resources. Weighing all of this against the complexity of reimplementing this (untested) functionality with the `Cleaner` API, it seemed best to simply dispense with this unused fallback mechanism rather than to port it to Java 9+.

### Testing done

`mvn clean verify -DskipTests`

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8488"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

