### PR TITLE
[JENKINS-72016] Define a thread pool for `ProxyConfiguration`’s `HttpClient`

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -31,7 +31,9 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
+import hudson.util.DaemonThreadFactory;
 import hudson.util.FormValidation;
+import hudson.util.NamingThreadFactory;
 import hudson.util.Scrambler;
 import hudson.util.Secret;
 import hudson.util.XStream2;
@@ -58,6 +60,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import jenkins.UserAgentURLConnectionDecorator;
@@ -370,6 +374,8 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
         return newHttpClientBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
     }
 
+    private static final Executor httpClientExecutor = Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(), "Jenkins HttpClient"));
+
     /**
      * Create a new {@link HttpClient.Builder} preconfigured with Jenkins-specific default settings.
      *
@@ -397,6 +403,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
         if (DEFAULT_CONNECT_TIMEOUT_MILLIS > 0) {
             httpClientBuilder.connectTimeout(Duration.ofMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS));
         }
+        httpClientBuilder.executor(httpClientExecutor);
         return httpClientBuilder;
     }
 

--- a/test/src/test/java/hudson/ProxyConfigurationTest.java
+++ b/test/src/test/java/hudson/ProxyConfigurationTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import hudson.model.InvisibleAction;
+import hudson.model.UnprotectedRootAction;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+
+public final class ProxyConfigurationTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void httpClientExecutor() throws Exception {
+        for (int i = 0; i < 50_000; i++) {
+            if (i % 1_000 == 0) {
+                System.err.println("#" + i);
+            }
+            assertThat(ProxyConfiguration.newHttpClient().send(ProxyConfiguration.newHttpRequestBuilder(URI.create(r.getURL() + "ping/")).build(),
+                    java.net.http.HttpResponse.BodyHandlers.discarding()).statusCode(),
+                is(200));
+        }
+    }
+
+    @TestExtension("httpClientExecutor")
+    public static final class Ping extends InvisibleAction implements UnprotectedRootAction {
+        @Override
+        public String getUrlName() {
+            return "ping";
+        }
+
+        public HttpResponse doIndex() {
+            return HttpResponses.ok();
+        }
+    }
+
+}

--- a/test/src/test/java/hudson/ProxyConfigurationTest.java
+++ b/test/src/test/java/hudson/ProxyConfigurationTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.is;
 import hudson.model.InvisibleAction;
 import hudson.model.UnprotectedRootAction;
 import java.net.URI;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -44,6 +45,7 @@ public final class ProxyConfigurationTest {
 
     @Test
     public void httpClientExecutor() throws Exception {
+        Assume.assumeFalse("Too slow on Windows", Functions.isWindows());
         for (int i = 0; i < 50_000; i++) {
             if (i % 1_000 == 0) {
                 System.err.println("#" + i);


### PR DESCRIPTION
#7398 advertises a standardized `HttpClient` factory, and says

> The returned instances of `HttpClient` […] are intended to be short-lived, not to be stored in memory in some sort of cache […].

When this advice is followed in some CloudBees CI plugins, obtaining a fresh `HttpClient` per request, under some circumstances where many requests are made the result is a gigantic number of threads with `HttpClient` in the name, eventually crashing the controller.

See [JENKINS-72016](https://issues.jenkins.io/browse/JENKINS-72016).

### Testing done

Ran the new test with

```bash
watch 'jstack $(jps -lm | fgrep booter | awk "{print \$1}")|egrep \^\"|wc -l'
```

Prior to patch: the test slows down and finally hangs without making it to 9000 requests. There are in the vicinity of 18000 threads in the JVM at this point. Sometimes the JVM crashes with `OutOfMemoryError` claiming it cannot create a new native thread. (This is pre-Loom!)

After patch: the test runs steadily to completion. The JVM thread count fluctuates around 4000 or so. A new `HttpClientImpl.SelectorManager` thread is created each time, but these seem to terminate themselves fairly soon rather than piling up indefinitely.

### Proposed changelog entries

- Do not create a large number of threads when making numerous HTTP requests.

### Proposed upgrade guideliness

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8490"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

