### PR TITLE
[JENKINS-71880] fix notification in breadcrumb

### DIFF
--- a/war/src/main/js/components/dropdowns/jumplists.js
+++ b/war/src/main/js/components/dropdowns/jumplists.js
@@ -106,7 +106,10 @@ function mapChildrenItemsToDropdownItems(items) {
               method: "post",
               headers: crumb.wrap({}),
             });
-            notificationBar.show(item.displayName + ": Done.", notificationBar.SUCCESS);
+            notificationBar.show(
+              item.displayName + ": Done.",
+              notificationBar.SUCCESS,
+            );
           }
         }
       },

--- a/war/src/main/js/components/dropdowns/jumplists.js
+++ b/war/src/main/js/components/dropdowns/jumplists.js
@@ -106,9 +106,7 @@ function mapChildrenItemsToDropdownItems(items) {
               method: "post",
               headers: crumb.wrap({}),
             });
-            if (event.length === 1 && event[0].target != null) {
-              hoverNotification("Done.", event[0].target);
-            }
+            notificationBar.show(item.displayName + ": Done.", notificationBar.SUCCESS);
           }
         }
       },


### PR DESCRIPTION
fix the notification when e.g. triggering a build via the breadcrumb.

replace the hoverNotification with a notificationBar. When the hoverNotification appears the actual menu disappears making the notification somehow look misplaced.
Prepend the message with the actual menu entry to make it more clear what the message means.


https://github.com/jenkinsci/jenkins/assets/17767050/5e695b7f-433c-476d-b4bd-2e7961e8a918


It would be beneficial that the message contains the same message as when clicking on the "Build Now" in the side panel ("Build Scheduled") but that would require bigger changes -> something for a separate PR.

See [JENKINS-71880](https://issues.jenkins.io/browse/JENKINS-71880).

### Testing done

Triggering a build without parameters 

### Proposed changelog entries

- Show a confirmation popup when triggering l:task action from context menu.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8493"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

