### PR TITLE
Optimization for `AbstractLazyLoadRunMap.loadNumberOnDisk`

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -51,6 +51,7 @@ import java.util.TreeMap;
 import java.util.function.IntConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import jenkins.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -332,6 +333,8 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
         loadNumberOnDisk();
     }
 
+    private static final Pattern BUILD_NUMBER = Pattern.compile("[0-9]+");
+
     private void loadNumberOnDisk() {
         String[] kids = dir.list();
         if (kids == null) {
@@ -340,10 +343,14 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
         }
         SortedIntList list = new SortedIntList(kids.length / 2);
         for (String s : kids) {
+            if (!BUILD_NUMBER.matcher(s).matches()) {
+                // not a build directory
+                continue;
+            }
             try {
                 list.add(Integer.parseInt(s));
             } catch (NumberFormatException e) {
-                // this isn't a build dir
+                // matched BUILD_NUMBER but not an int?
             }
         }
         list.sort();


### PR DESCRIPTION
Was looking at a thread dump with some performance issues and noticed

```
java.base@11.0.20/java.lang.Throwable.fillInStackTrace(Native Method)
java.base@11.0.20/java.lang.Throwable.fillInStackTrace(Throwable.java:787)
java.base@11.0.20/java.lang.Throwable.<init>(Throwable.java:270)
java.base@11.0.20/java.lang.Exception.<init>(Exception.java:66)
java.base@11.0.20/java.lang.RuntimeException.<init>(RuntimeException.java:62)
java.base@11.0.20/java.lang.IllegalArgumentException.<init>(IllegalArgumentException.java:52)
java.base@11.0.20/java.lang.NumberFormatException.<init>(NumberFormatException.java:55)
java.base@11.0.20/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
java.base@11.0.20/java.lang.Integer.parseInt(Integer.java:638)
java.base@11.0.20/java.lang.Integer.parseInt(Integer.java:770)
jenkins.model.lazy.AbstractLazyLoadRunMap.loadNumberOnDisk(AbstractLazyLoadRunMap.java:344)
```

There are surely other things going on, but it occurred to me that it is wasteful to construct a stack trace (which can be relatively expensive) just to skip a directory entry which does not look like a number.

### Testing done

None.

### Proposed changelog entries

- Small speculative optimization in build loading.

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8494"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

