### PR TITLE
Explicit log levels

### DIFF
--- a/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
     </l:app-bar>
 
     <div class="alert alert-info">
-      Log messages at a level lower than INFO (i.e., CONFIG, FINE, FINER, FINEST) are never recorded in the Jenkins log. Use <a href=".">log recorders</a> to record these log messages.
+      Log messages at a level more verbose than INFO (i.e., CONFIG, FINE, FINER, FINEST) are never recorded in the Jenkins log. Use <a href=".">log recorders</a> to record these log messages.
     </div>
     <t:logRecords logRecords="${h.logRecords}"/>
   </l:main-panel>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
@@ -37,9 +37,8 @@ THE SOFTWARE.
     </l:app-bar>
 
     <div class="alert alert-info">
-      Log messages at a level lower than INFO are never recorded in the Jenkins log. Use <a href=".">log recorders</a> to record these log messages.
+      Log messages at a level lower than INFO (i.e., CONFIG, FINE, FINER, FINEST) are never recorded in the Jenkins log. Use <a href=".">log recorders</a> to record these log messages.
     </div>
-
     <t:logRecords logRecords="${h.logRecords}"/>
   </l:main-panel>
 </l:layout>


### PR DESCRIPTION
The default Jenkins log recorder captures logs at the `SEVERE`, `WARNING`, and `INFO` levels. To view logs at different levels, you'll need to create a new log recorder.

The existing message explaining this is somewhat unclear, as "lower than INFO" can be interpreted in two different ways. To avoid this confusion, I've listed the log levels explicitly.

UI:
![image](https://github.com/jenkinsci/jenkins/assets/91883215/eb04a394-a353-49ca-a713-f3cd7671d4ad)


<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
N/A
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Entry 1: Issue, human-readable text
- […]

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/
-->

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8509"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

