### PR TITLE
Ignore `ProxyConfigurationTest.httpClientExecutor`

### DIFF
--- a/test/src/test/java/hudson/ProxyConfigurationTest.java
+++ b/test/src/test/java/hudson/ProxyConfigurationTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.is;
 import hudson.model.InvisibleAction;
 import hudson.model.UnprotectedRootAction;
 import java.net.URI;
-import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -43,9 +43,9 @@ public final class ProxyConfigurationTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
+    @Ignore("prone to timing out on CI")
     @Test
     public void httpClientExecutor() throws Exception {
-        Assume.assumeFalse("Too slow on Windows", Functions.isWindows());
         for (int i = 0; i < 50_000; i++) {
             if (i % 1_000 == 0) {
                 System.err.println("#" + i);


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/8490#discussion_r1326293272 in fact I saw this test time out after 27_000 iterations on a CI system, I suppose just due to differing hardware. I am not sure if there is a straightforward, fast, and reliable way to assert that the bug fix is effective.

### Testing done

N/A

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8512"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

