### PR TITLE
Turkish localization for "Build with Parameters" link

### DIFF
--- a/core/src/main/resources/hudson/model/Messages_tr.properties
+++ b/core/src/main/resources/hudson/model/Messages_tr.properties
@@ -111,4 +111,4 @@ ManagementLink.Category.TROUBLESHOOTING=Sorun Giderme
 ManagementLink.Category.TOOLS=Araçlar ve Aksiyonlar
 ManagementLink.Category.MISC=Diğer
 ManagementLink.Category.UNCATEGORIZED=Sınıflandırılmamış
-ParametersDefinitionProperty.BuildButtonText=Yapılandırma
+ParametersDefinitionProperty.BuildButtonText=Yapılandır

--- a/core/src/main/resources/jenkins/model/Messages_tr.properties
+++ b/core/src/main/resources/jenkins/model/Messages_tr.properties
@@ -30,6 +30,7 @@ Hudson.NoJavaInPath=java, PATH içerisinde değil. <a href=''{0}/configure''>JDK
 Hudson.NoName=İsim belirtilmedi
 Hudson.UnsafeChar=''{0}'' güvenli olmayan bir karakter
 Hudson.ViewName=Hepsi
+ParameterizedJobMixIn.build_with_parameters=Parametrelerle Yapılandır
 ParameterizedJobMixIn.build_now=Şimdi Yapılandır
 BlockedBecauseOfBuildInProgress.shortDescription=Yapılandırma #{0} zaten işlemde {1}
 BlockedBecauseOfBuildInProgress.ETA=\ (ETA: {0})


### PR DESCRIPTION
### Testing done

<img width="912" alt="Screen Shot 2023-09-22 at 19 44 49" src="https://github.com/jenkinsci/jenkins/assets/881222/ce763e41-0b9b-4759-ae42-e1d4cfaad120">

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8519"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

