### PR TITLE
Fix compilation error with `maven.compiler.release=21`

### DIFF
--- a/core/src/main/java/hudson/tasks/Publisher.java
+++ b/core/src/main/java/hudson/tasks/Publisher.java
@@ -130,10 +130,7 @@ public abstract class Publisher extends BuildStepCompatibilityLayer implements D
      *
      * @see DescriptorExtensionList#createDescriptorList(hudson.model.Hudson, Class)
      */
-    @SuppressFBWarnings(value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE", justification = "Since the publisher is not Serializable, " +
-            "no need for the Comparator")
-    public static final class DescriptorExtensionListImpl extends DescriptorExtensionList<Publisher, Descriptor<Publisher>>
-            implements Comparator<ExtensionComponent<Descriptor<Publisher>>> {
+    public static final class DescriptorExtensionListImpl extends DescriptorExtensionList<Publisher, Descriptor<Publisher>> {
 
         public DescriptorExtensionListImpl(Jenkins hudson) {
             super(hudson, Publisher.class);
@@ -142,10 +139,14 @@ public abstract class Publisher extends BuildStepCompatibilityLayer implements D
         @Override
         protected List<ExtensionComponent<Descriptor<Publisher>>> sort(List<ExtensionComponent<Descriptor<Publisher>>> r) {
             List<ExtensionComponent<Descriptor<Publisher>>> copy = new ArrayList<>(r);
-            copy.sort(this);
+            copy.sort(new ExtensionComponentComparator());
             return copy;
         }
+    }
 
+    @SuppressFBWarnings(value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE", justification = "Since the publisher is not Serializable, " +
+            "no need for the Comparator")
+    private static final class ExtensionComponentComparator implements Comparator<ExtensionComponent<Descriptor<Publisher>>> {
         @Override
         public int compare(ExtensionComponent<Descriptor<Publisher>> lhs, ExtensionComponent<Descriptor<Publisher>> rhs) {
             int r = classify(lhs.getInstance()) - classify(rhs.getInstance());


### PR DESCRIPTION
While compiling with `-Dmaven.compiler.release=21` I got the following compilation failure:

```
Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project jenkins-core: Compilation failure
/home/basil/src/jenkinsci/jenkins/core/src/main/java/hudson/tasks/Publisher.java:[135,24] error: types Comparator<T> and List<E> are incompatible;
  class DescriptorExtensionListImpl inherits unrelated defaults for reversed() from types Comparator and List
  where T,E are type-variables:
    T extends Object declared in interface Comparator
    E extends Object declared in interface List
```

This is because of the addition of incompatible `reversed()` methods between these two interfaces. Thinking about this more closely, it makes little sense for anything to implement both `List` and `Comparator` so I split out the comparator into its own class to solve the conflict.

### Testing done

`mvn clean verify -DskipTests -Dmaven.compiler.release=21 -Dmaven.compiler.testRelease=21` failed before this PR and passed after it.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8520"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

