### PR TITLE
Avoid saving disabled status when deleting a project

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -351,7 +351,10 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
     @Override
     protected void performDelete() throws IOException, InterruptedException {
         // prevent a new build while a delete operation is in progress
-        makeDisabled(true);
+        if (supportsMakeDisabled()) {
+            setDisabled(true);
+            Jenkins.get().getQueue().cancel(this);
+        }
         FilePath ws = getWorkspace();
         if (ws != null) {
             Node on = getLastBuiltOn();


### PR DESCRIPTION
`performDelete` was calling `makeDisabled` to ensure that no new builds were scheduled for a project while it was being deleted. Unfortunately this API-level method was intended for general purposes, such as flipping the disabled flag on a valid project, and includes https://github.com/jenkinsci/jenkins/blob/da99f119b53de149ea1b0ed7a627e5e2d5cf75fc/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java#L481-L482 which save `config.xml` to disk and fire a change, neither of which is necessary or desirable on a project which is about to be deleted.

### Testing done

None directly, but seems to solve a race condition seen in a CloudBees CI proprietary test.

### Proposed changelog entries

- Optimized project deletion.

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
