### PR TITLE
Fill in since annotations

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -542,7 +542,7 @@ public class LogRecorder extends AbstractModelObject implements Saveable {
     /**
      * Deletes this log recorder.
      * @throws IOException In case anything went wrong while deleting the configuration file.
-     * @since TODO
+     * @since 2.425
      */
     public void delete() throws IOException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);

--- a/core/src/main/java/hudson/util/HudsonIsRestarting.java
+++ b/core/src/main/java/hudson/util/HudsonIsRestarting.java
@@ -44,7 +44,7 @@ public class HudsonIsRestarting {
     private boolean safeRestart;
 
     /**
-     * @since TODO
+     * @since 2.414
      */
     public HudsonIsRestarting(boolean safeRestart) {
         this.safeRestart = safeRestart;
@@ -61,7 +61,7 @@ public class HudsonIsRestarting {
     }
 
     /**
-     * @since TODO
+     * @since 2.414
      */
     public boolean isSafeRestart() {
         return safeRestart;

--- a/core/src/main/java/jenkins/cli/SafeRestartCommand.java
+++ b/core/src/main/java/jenkins/cli/SafeRestartCommand.java
@@ -36,7 +36,7 @@ import org.kohsuke.args4j.Option;
 /**
  * Safe Restart Jenkins - do not accept any new jobs and try to pause existing.
  *
- * @since TODO
+ * @since 2.414
  */
 @Extension
 @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -2974,7 +2974,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     /**
      * Returns if the quietingDown is a safe restart.
-     * @since TODO
+     * @since 2.414
      */
     @Restricted(NoExternalUse.class)
     @NonNull
@@ -4161,7 +4161,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @param message Quiet reason that will be visible to user
      * @deprecated use {@link #doQuietDown(boolean, int, String, boolean)} instead.
      */
-    @Deprecated(since = "TODO")
+    @Deprecated(since = "2.414")
     public HttpRedirect doQuietDown(boolean block,
                                     int timeout,
                                     @CheckForNull String message) throws InterruptedException, IOException {
@@ -4176,7 +4176,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @param timeout If non-zero, only block up to the specified number of milliseconds
      * @param message Quiet reason that will be visible to user
      * @param safeRestart If the quietDown is for a safeRestart
-     * @since TODO
+     * @since 2.414
      */
     @RequirePOST
     public HttpRedirect doQuietDown(@QueryParameter boolean block,
@@ -4607,7 +4607,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @deprecated use {@link #doSafeRestart(StaplerRequest, String)} instead.
      *
      */
-    @Deprecated(since = "TODO")
+    @Deprecated(since = "2.414")
     public HttpResponse doSafeRestart(StaplerRequest req) throws IOException, ServletException, RestartNotSupportedException {
         return doSafeRestart(req, null);
     }
@@ -4615,7 +4615,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Queues up a safe restart of Jenkins. Jobs have to finish or pause before it can proceed. No new jobs are accepted.
      *
-     * @since TODO
+     * @since 2.414
      */
     public HttpResponse doSafeRestart(StaplerRequest req, @QueryParameter("message") String message) throws IOException, ServletException, RestartNotSupportedException {
         checkPermission(MANAGE);
@@ -4676,7 +4676,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 1.332
      * @deprecated use {@link #safeRestart(String)} instead.
      */
-    @Deprecated(since = "TODO")
+    @Deprecated(since = "2.414")
     public void safeRestart() throws RestartNotSupportedException {
         safeRestart(null);
     }
@@ -4684,7 +4684,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Queues up a restart to be performed once there are no builds currently running.
      * @param message the message to show to users in the shutdown banner.
-     * @since TODO
+     * @since 2.414
      */
     public void safeRestart(String message) throws RestartNotSupportedException {
         final Lifecycle lifecycle = restartableLifecycle();

--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -165,7 +165,7 @@ public interface ModelObjectWithContextMenu extends ModelObject {
             return this;
         }
 
-        /** @since TODO */
+        /** @since 2.415 */
         public ContextMenu add(String url, String icon, String iconXml, String text, boolean post, boolean requiresConfirmation, Badge badge, String message) {
             if (text != null && icon != null && url != null) {
                 MenuItem item = new MenuItem(url, icon, text);

--- a/core/src/main/resources/lib/form/submit.jelly
+++ b/core/src/main/resources/lib/form/submit.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
       @since 2.376
     </s:attribute>
     <s:attribute name="icon">
-      @since 2.413
+      @since 2.411
     </s:attribute>
     <s:attribute name="clazz" />
   </s:documentation>

--- a/core/src/main/resources/lib/form/submit.jelly
+++ b/core/src/main/resources/lib/form/submit.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
       @since 2.376
     </s:attribute>
     <s:attribute name="icon">
-      @since TODO
+      @since 2.413
     </s:attribute>
     <s:attribute name="clazz" />
   </s:documentation>

--- a/core/src/main/resources/lib/layout/delete.jelly
+++ b/core/src/main/resources/lib/layout/delete.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     Creates a delete link with confirmation and trashcan icon in the left navigation pane of Jenkins.
     Requires that the target has implemented the doDoDelete method.
 
-    @since TODO
+    @since 2.415
     ]]>
     <st:attribute name="title" use="required">
       Human readable text that follows the icon.


### PR DESCRIPTION
```
➜  jenkins git:(since-todo) ./update-since-todo.py      
Analyzing core/src/main/java/hudson/logging/LogRecorder.java:545
        first sha: 7d285718c2b56f7c0ffe486ccbf1bc8c1c10bc52
        first tag was jenkins-2.425
Analyzing core/src/main/java/hudson/model/View.java:409
        first sha: 105951c11c670fad5904a3a2d64caba7d109bd96
        Not updating file, no tag found. Normal if the associated PR/commit is not merged and released yet; otherwise make sure to fetch tags from jenkinsci/jenkins
Analyzing core/src/main/java/hudson/model/View.java:424
        first sha: 105951c11c670fad5904a3a2d64caba7d109bd96
        Not updating file, no tag found. Normal if the associated PR/commit is not merged and released yet; otherwise make sure to fetch tags from jenkinsci/jenkins
Analyzing core/src/main/java/hudson/util/HudsonIsRestarting.java:47
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/hudson/util/HudsonIsRestarting.java:64
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/cli/SafeRestartCommand.java:39
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/model/Jenkins.java:2977
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/model/Jenkins.java:4164
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/model/Jenkins.java:4179
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/model/Jenkins.java:4610
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/model/Jenkins.java:4618
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/model/Jenkins.java:4679
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/model/Jenkins.java:4687
        first sha: df4972fb70e37fa2a9a15d574d2d35ba17899fb7
        first tag was jenkins-2.414
Analyzing core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java:168
        first sha: 1ec59c737a547aeae7c6cd0b38ad2810f02c3891
        first tag was jenkins-2.415
Analyzing core/src/main/java/jenkins/security/FIPS140.java:35
        first sha: db48740dd21e55b38578c8d1a681a13eb253e176
        Not updating file, no tag found. Normal if the associated PR/commit is not merged and released yet; otherwise make sure to fetch tags from jenkinsci/jenkins
Analyzing core/src/main/resources/lib/form/submit.jelly:51
        first sha: ac1b8a13a951771763af9eb365bdece866b1db9b
        first tag was jenkins-2.413
Analyzing core/src/main/resources/lib/layout/delete.jelly:31
        first sha: 1ec59c737a547aeae7c6cd0b38ad2810f02c3891
        first tag was jenkins-2.415
```

List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.413
  - https://github.com/jenkinsci/jenkins/commit/ac1b8a13a951771763af9eb365bdece866b1db9b
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.414
  - https://github.com/jenkinsci/jenkins/commit/df4972fb70e37fa2a9a15d574d2d35ba17899fb7
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.415
  - https://github.com/jenkinsci/jenkins/commit/1ec59c737a547aeae7c6cd0b38ad2810f02c3891
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.425
  - https://github.com/jenkinsci/jenkins/commit/7d285718c2b56f7c0ffe486ccbf1bc8c1c10bc52