### PR TITLE
Allow location of `queue.xml` to be overridden

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -499,6 +499,10 @@ public class Queue extends ResourceController implements Saveable {
     }
 
     /*package*/ File getXMLQueueFile() {
+        String id = SystemProperties.getString(Queue.class.getName() + ".id");
+        if (id != null) {
+            return new File(Jenkins.get().getRootDir(), "queue/" + id + ".xml");
+        }
         return new File(Jenkins.get().getRootDir(), "queue.xml");
     }
 


### PR DESCRIPTION
Allows the location of the queue persistence file for the controller to be overridden on a per-session basis. This is required for functionality in CloudBees CI but I do not foresee any use case in OSS Jenkins, so it should not be documented for Jenkins administrators.

### Testing done

Tested in the context of CloudBees CI.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
