### PR TITLE
Tweak changelog entry placeholder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,12 +28,15 @@ For refactoring and code cleanup changes, exercise the code before and after the
 
 ### Proposed changelog entries
 
-- Entry 1: Issue, human-readable text
-- […]
+- \<replace with Issue ID if it exists or remove\>, human-readable text
 
 <!-- Comment:
 The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
 For examples, see: https://www.jenkins.io/changelog/
+
+You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
+- First changelog entry
+- Second changelog entry
 -->
 
 ### Proposed upgrade guidelines


### PR DESCRIPTION
(head branch, delete on merge)

I'm constantly removing `Entry 1:` from entries, otherwise they end up in the changelog by accident...
This should hopefully work better?

<a href="https://gitpod.io/#https://github.com/jenkinsci/jenkins/pull/8532"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

