### PR TITLE
Add note that general usage statistics submission is disabled with FIPS

### DIFF
--- a/core/src/main/resources/hudson/model/UsageStatistics/global.groovy
+++ b/core/src/main/resources/hudson/model/UsageStatistics/global.groovy
@@ -12,7 +12,9 @@ f.section(title: _("Usage Statistics")) {
             raw(_("disabledBySystemProperty"))
         }
     } else if (FIPS140.useCompliantAlgorithms()) {
-        f.optionalBlock(field: "usageStatisticsCollected", checked: app.usageStatisticsCollected, title: _("statsBlurbFIPS"))
+        f.optionalBlock(field: "usageStatisticsCollected", checked: app.usageStatisticsCollected, title: _("statsBlurbFIPS")) {
+            f.description(_("statsDescriptionFIPS"))
+        }
     } else {
         f.optionalBlock(field: "usageStatisticsCollected", checked: app.usageStatisticsCollected, title: _("statsBlurb"))
     }

--- a/core/src/main/resources/hudson/model/UsageStatistics/global.properties
+++ b/core/src/main/resources/hudson/model/UsageStatistics/global.properties
@@ -24,6 +24,8 @@ statsBlurb=\
   Help make Jenkins better by sending anonymous usage statistics and crash reports to the Jenkins project
 statsBlurbFIPS=\
   Help make Jenkins better by sending telemetry to the Jenkins project
+statsDescriptionFIPS=\
+  General usage statistics are not submitted when FIPS-140 compliance is requested.
 disabledBySystemProperty=\
   The option to send anonymous usage statistics, crash reports and telemetry to the Jenkins project is disabled by a <a href="https://www.jenkins.io/doc/book/managing/system-properties/#hudson-model-usagestatistics-disabled">System Property</a>.
 


### PR DESCRIPTION
Amends #8483 with the change suggested in https://github.com/jenkinsci/jenkins/pull/8483#discussion_r1339673531.

Unsure about wording, @jtnord WDYT?

> <img width="500" alt="Screenshot 2023-10-06 at 10 22 16" src="https://github.com/jenkinsci/jenkins/assets/1831569/f982f059-0b78-4430-ba65-9ab22fb8cc1b">


### Testing done

Opened the form.

### Proposed changelog entries

too minor

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
