### PR TITLE
Fix tests that the PR build did not run on Windows

### DIFF
--- a/test/src/test/java/jenkins/model/ScriptListenerTest.java
+++ b/test/src/test/java/jenkins/model/ScriptListenerTest.java
@@ -56,7 +56,7 @@ public class ScriptListenerTest {
             assertThat(messages.get(0), containsString("' with correlation: '"));
             assertThat(messages.get(0), containsString("' (no user)"));
 
-            assertThat(messages.get(1), containsString("Script output: 'hello from script console\n' in feature: 'class hudson.util.RemotingDiagnostics' and context: 'hudson.remoting.LocalChannel@"));
+            assertThat(messages.get(1), containsString("Script output: 'hello from script console" + System.lineSeparator() + "' in feature: 'class hudson.util.RemotingDiagnostics' and context: 'hudson.remoting.LocalChannel@"));
             assertThat(messages.get(1), containsString("' with correlation: '"));
             assertThat(messages.get(1), containsString("' (no user)"));
         }
@@ -92,7 +92,7 @@ public class ScriptListenerTest {
             assertThat(messages.get(1), containsString("Script output: 'hello from groovy CLI' in feature: 'class hudson.cli.GroovyCommand' and context: 'null' with correlation: '"));
             assertThat(messages.get(1), containsString("' (no user)"));
 
-            assertThat(messages.get(2), containsString("Script output: '\n' in feature: 'class hudson.cli.GroovyCommand' and context: 'null' with correlation: '"));
+            assertThat(messages.get(2), containsString("Script output: '" + System.lineSeparator() + "' in feature: 'class hudson.cli.GroovyCommand' and context: 'null' with correlation: '"));
             assertThat(messages.get(2), containsString("' (no user)"));
         }
 
@@ -133,7 +133,7 @@ public class ScriptListenerTest {
             assertThat(messages.get(5), containsString("]' in feature: 'class hudson.cli.GroovyshCommand' and context: 'null' with correlation: '"));
             assertThat(messages.get(5), containsString("' (no user)"));
 
-            assertThat(messages.get(6), containsString("Script output: 'hello from groovysh CLI\n' in feature: 'class hudson.cli.GroovyshCommand' and context: 'null' with correlation: '"));
+            assertThat(messages.get(6), containsString("Script output: 'hello from groovysh CLI" + System.lineSeparator() + "' in feature: 'class hudson.cli.GroovyshCommand' and context: 'null' with correlation: '"));
             assertThat(messages.get(6), containsString("' (no user)"));
 
             // Only match short substrings to not have to deal with color escape codes in the output


### PR DESCRIPTION
Or at least attempt to.

See https://github.com/jenkinsci/jenkins/pull/7056#issuecomment-1750173323 and following messages.

### Testing done

Autotests still pass on Mac OS. Don't have Windows.

### Proposed changelog entries

None.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
