### PR TITLE
[JENKINS-72143] French translation

### DIFF
--- a/core/src/main/resources/hudson/Messages_fr.properties
+++ b/core/src/main/resources/hudson/Messages_fr.properties
@@ -20,24 +20,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-AbstractItem.NewNameInUse=Le nom "{0}" est déjà utilisé.
-AbstractItem.NewNameUnchanged=Le nouveau nom est identique au nom actuel.
-
 FilePath.did_not_manage_to_validate_may_be_too_sl=Impossible de valider {0} (peut-être est-ce trop lent)
-FilePath.validateAntFileMask.whitespaceSeprator=\
-  Les espaces ne peuvent plus être utilisés comme séparateurs. Merci d''utiliser maintenant '','' comme séparateur à la place.
+FilePath.validateAntFileMask.whitespaceSeparator=\
+  Les espaces ne peuvent plus être utilisés comme séparateurs. Merci d''utiliser maintenant ’,’ comme séparateur à la place.
 FilePath.validateAntFileMask.doesntMatchAndSuggest=\
-  ''{0}'' ne correspond à rien, mais ''{1}'' oui. Peut-être est-ce cela que vous voulez dire?
-FilePath.validateAntFileMask.portionMatchAndSuggest=''{0}'' ne correspond à rien, même si ''{1}'' existe
-FilePath.validateAntFileMask.portionMatchButPreviousNotMatchAndSuggest=''{0}'' ne correspond à rien : ''{1}'' existe mais pas ''{2}''
-FilePath.validateAntFileMask.doesntMatchAnything=''{0}'' ne correspond à rien
-FilePath.validateAntFileMask.doesntMatchAnythingAndSuggest=''{0}'' ne correspond à rien : même ''{1}'' n''existe pas
+  ’{0}’ ne correspond à rien, mais ’{1}’ oui. Peut-être est-ce cela que vous voulez dire?
+FilePath.validateAntFileMask.portionMatchAndSuggest=’{0}’ ne correspond à rien, même si ’{1}’ existe
+FilePath.validateAntFileMask.portionMatchButPreviousNotMatchAndSuggest=’{0}’ ne correspond à rien : ’{1}’ existe, mais pas ’{2}’
+FilePath.validateAntFileMask.doesntMatchAnything=’{0}’ ne correspond à rien
+FilePath.validateAntFileMask.matchWithCaseInsensitive=‘{0}’ ne correspond à rien, car considéré comme sensible à la casse. Vous pouvez désactiver la sensibilité à la casse pour trouver des correspondances
+FilePath.validateAntFileMask.doesntMatchAnythingAndSuggest=’{0}’ ne correspond à rien : même ’{1}’ n''existe pas
 
 FilePath.validateRelativePath.wildcardNotAllowed=L''utilisation des Wildcard n''est pas autorisée ici
-FilePath.validateRelativePath.notFile=''{0}'' n''est pas un fichier
-FilePath.validateRelativePath.notDirectory=''{0}'' n''est pas un répertoire
-FilePath.validateRelativePath.noSuchFile=Aucun fichier correspondant : ''{0}''
-FilePath.validateRelativePath.noSuchDirectory=Aucun répertoire correspondant : ''{0}''
+FilePath.validateRelativePath.notFile=’{0}’ n''est pas un fichier
+FilePath.validateRelativePath.notDirectory=’{0}’ n''est pas un répertoire
+FilePath.validateRelativePath.noSuchFile=Aucun fichier correspondant : ’{0}’
+FilePath.validateRelativePath.noSuchDirectory=Aucun répertoire correspondant : ’{0}’
 
 PluginManager.PluginDoesntSupportDynamicLoad.RestartRequired=Le plugin {0} ne supporte pas le chargement dynamique. Jenkins doit être redémarré pour que la mise à jour soit effective.
 PluginManager.PluginIsAlreadyInstalled.RestartRequired=Le plugin {0} est déjà installé. Jenkins doit être redémarré pour que la mise à jour soit effective.
@@ -49,16 +47,82 @@ Util.day   ={0} j
 Util.month ={0} mo.
 Util.year  ={0} an.
 
-UpdateCenter.DownloadButNotActivated=La mise à jour a été téléchargée avec succès. Elle sera activée lors du prochain démarrage
+FilePath.TildaDoesntWork=’~’ n''est supporté que sur les shells Unix.
 
-FilePath.TildaDoesntWork=''~'' n''est supporté que sur les shells Unix.
-
+PluginManager.DisplayName=Plugins
 PluginManager.PortNotANumber=Le port n''est pas un nombre
 PluginManager.PortNotInRange=Le port n''est pas dans l''intervalle de {0} à {1}
-AboutJenkins.DisplayName=A propos de Jenkins
+PluginManager.UploadPluginsPermission.Description=\
+  Obsolète - Veuillez utiliser le droit Overall/Administer à la place
+PluginManager.ConfigureUpdateCenterPermission.Description=\
+  Obsolète - Veuillez utiliser le droit Overall/Administer à la place
+PluginManager.PluginCycleDependenciesMonitor.DisplayName=Détecteur de dépendances cycliques
+PluginManager.PluginUpdateMonitor.DisplayName=Configuration de plugin invalide
+PluginManager.PluginDeprecationMonitor.DisplayName=Moniteur de plugin obsolète
+PluginManager.CheckUpdateServerError=Aucune erreur lors de la vérification du site de mise à jour : {0}
+PluginManager.UpdateSiteError=Erreur lors de la vérification des sites de mise à jour pour {0} essai(s). La dernière exception était : {1}
+PluginManager.UpdateSiteChangeLogLevel=Modifiez le niveau de log du logger {0} à WARNING ou moins pour consulter plus d''informations et le message d''erreur de chaque essai
+PluginManager.UnexpectedException=Exception inattendue lors la vérification des serveurs de mise à jour
+
+
+PluginManager.compatWarning=\
+ Avertissement : la nouvelle version de ce plugin est indiquée comme incompatible avec la version installée. \
+ C''est habituellement le cas parce que son comportement ou ses APIs ont changé, ou parce qu''il utilise un format de configuration différent de celui installé. \
+ D''autres plugins ayant une dépendance à ce plugin sont peut-être incompatibles avec cette mise à jour et ne fonctionneront plus comme attendu, les jobs utilisant ce plugin necessiteront peut-être d''être reconfigurés, et/ou vous ne serez peut-être plus capable de revenir à la version précédente sans avoir à restaurer manuellement les configurations précédentes. \
+ Veuillez consulter la note de livraison du plugin pour plus de détails.
+PluginManager.parentDepCompatWarning=Les plugins suivants sont incompatibles :
+PluginManager.parentCompatWarning=Les plugins suivants sont affectés par cela :
+PluginManager.coreWarning=\
+ Avertissement : ce plugin est compatible pour Jenkins {0} ou plus récent. \
+ Jenkins ne démarrera pas ce plugin s''il est installé.
+PluginManager.depCompatWarning=\
+ Avertissement : ce plugin nécessite des versions plus récentes de dépendances et au moins un de ces plugins n''est pas compatible avec la version installée. \
+ C''est habituellement le cas parce que son comportement ou ses APIs ont changé, ou parce qu''il utilise un format de configuration différent de celui installé. \
+ D''autres plugins ayant une dépendance à ce plugin sont peut-être incompatibles avec cette mise à jour et ne fonctionneront plus comme attendu, les jobs utilisant ce plugin necessiteront peut-être d''être reconfigurés, et/ou vous ne serez peut-être plus capable de revenir à la version précédente sans avoir à restaurer manuellement les configurations précédentes. \
+ Veuillez consulter la note de livraison du plugin pour plus de détails.
+PluginManager.depCoreWarning=\
+ Avertissement : ce plugin possède des dépendances à d''autres plugins qui requièrent Jenkins {0} ou plus récent. \
+ Jenkins refusera de charger les dépendances nécessitant une version plus récente de Jenkins, \
+ et en conséquence ce plugin échouera à se charger.
+PluginManager.securityWarning=\
+  Avertissement : cette version de plugin n''est peut-être par sûre. Veuillez vérifier les notices de sécurité suivantes :
+PluginManager.ago=Il y a {0}
+PluginManager.adoptThisPlugin=\
+  <strong>Ce plugin est à adopter!</strong> Nous recherchons de nouveaux mainteneurs. \
+  Veuillez consulter notre initiative <a href="https://www.jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" rel="noopener noreferrer" target="_blank">Adopter un plugin</a> pour plus d''informations.
+PluginManager.deprecationWarning=<strong>Ce plugin est obsolète.</strong> Généralement, cela signifie qu''il est soit obsolète, plus développé, ou ne fonctionne peut-être plus. <a href="{0}" rel="noopener noreferrer" target="_blank">En apprendre plus.</a>
+PluginManager.insecureUrl=\
+  Vous utilisez une URL non sécurisée pour télécharger le plugin, utilisez-la à vos propres risques et périls!
+PluginManager.invalidUrl=\
+  Vous utilisez une URL invalide pour télécharger le plugin. Les URLs file, https et http (non recommandé) sont supportées.
+
+PluginManager.emptyUpdateSiteUrl=\
+  Le site de mise à jour ne peut être vide. Veuillez entrer une URL valide.
+
+PluginManager.connectionFailed=\
+  Impossible de se connecter à l''URL.
+
+AboutJenkins.DisplayName=À propos de Jenkins
 AboutJenkins.Description=Afficher les informations de version et de licence
 
 ProxyConfiguration.TestUrlRequired=Une URL de test est requise.
+ProxyConfiguration.MalformedTestUrl=L''URL de test {0} n''est pas correctement formée.
 ProxyConfiguration.FailedToConnectViaProxy=Impossible de se connecter à {0}.
 ProxyConfiguration.FailedToConnect=Impossible de se connecter à {0} (code {1}).
 ProxyConfiguration.Success=Succès
+
+Functions.NoExceptionDetails=Aucun détail concernant l''exception
+
+PluginWrapper.missing=Il manque le plugin : {0} ({1})
+PluginWrapper.failed_to_load_plugin_2=Échec du chargement de : {0} ({1} {2})
+PluginWrapper.failed_to_load_dependency_2=Échec du chargement de : {0} ({1} {2})
+PluginWrapper.disabled_2=Le plugin nécessaire suivant est désactivé : {0} ({1})
+PluginWrapper.obsolete_2=Mise à jour nécessaire : {0} ({1} {2}) doit être mis à jour en {3} ou plus
+PluginWrapper.obsoleteCore=Jenkins ({1}) ou plus récent nécessaire
+PluginWrapper.PluginWrapperAdministrativeMonitor.DisplayName=Plugins échouant à charger
+PluginWrapper.Already.Disabled=Le plugin ''{0}'' était déjà désactivé
+PluginWrapper.Plugin.Has.Dependent=Le plugin ''{0}'' a au moins un plugin dépendant ({1}) et la stratégie de désactivation est {2} ainsi, il ne peut pas être désactivé
+PluginWrapper.Plugin.Disabled=Plugin ''{0}'' désactivé
+PluginWrapper.NoSuchPlugin=Aucun plugin trouvé avec le nom ''{0}''
+PluginWrapper.Error.Disabling=Une erreur a été relevée lors de la désactivation du plugin ''{0}''. Erreur : ''{1}''
+TcpSlaveAgentListener.PingAgentProtocol.displayName=Protocole de ping

--- a/core/src/main/resources/hudson/Messages_fr.properties
+++ b/core/src/main/resources/hudson/Messages_fr.properties
@@ -22,9 +22,9 @@
 
 FilePath.did_not_manage_to_validate_may_be_too_sl=Impossible de valider {0} (peut-être est-ce trop lent)
 FilePath.validateAntFileMask.whitespaceSeparator=\
-  Les espaces ne peuvent plus être utilisés comme séparateurs. Merci d''utiliser maintenant ’,’ comme séparateur à la place.
+  Les espaces ne peuvent plus être utilisés comme séparateurs. Dorénavant merci d''utiliser à la place ’,’ comme séparateur.
 FilePath.validateAntFileMask.doesntMatchAndSuggest=\
-  ’{0}’ ne correspond à rien, mais ’{1}’ oui. Peut-être est-ce cela que vous voulez dire?
+  ’{0}’ ne correspond à rien, mais ’{1}’ oui. Peut-être est-ce cela que vous vouliez dire?
 FilePath.validateAntFileMask.portionMatchAndSuggest=’{0}’ ne correspond à rien, même si ’{1}’ existe
 FilePath.validateAntFileMask.portionMatchButPreviousNotMatchAndSuggest=’{0}’ ne correspond à rien : ’{1}’ existe, mais pas ’{2}’
 FilePath.validateAntFileMask.doesntMatchAnything=’{0}’ ne correspond à rien
@@ -53,16 +53,16 @@ PluginManager.DisplayName=Plugins
 PluginManager.PortNotANumber=Le port n''est pas un nombre
 PluginManager.PortNotInRange=Le port n''est pas dans l''intervalle de {0} à {1}
 PluginManager.UploadPluginsPermission.Description=\
-  Obsolète - Veuillez utiliser le droit Overall/Administer à la place
+  Obsolète - Veuillez utiliser le droit "Overall/Administer" à la place
 PluginManager.ConfigureUpdateCenterPermission.Description=\
-  Obsolète - Veuillez utiliser le droit Overall/Administer à la place
-PluginManager.PluginCycleDependenciesMonitor.DisplayName=Détecteur de dépendances cycliques
+  Obsolète - Veuillez utiliser le droit "Overall/Administer" à la place
+PluginManager.PluginCycleDependenciesMonitor.DisplayName=Moniteur de dépendances cycliques
 PluginManager.PluginUpdateMonitor.DisplayName=Configuration de plugin invalide
 PluginManager.PluginDeprecationMonitor.DisplayName=Moniteur de plugin obsolète
 PluginManager.CheckUpdateServerError=Aucune erreur lors de la vérification du site de mise à jour : {0}
-PluginManager.UpdateSiteError=Erreur lors de la vérification des sites de mise à jour pour {0} essai(s). La dernière exception était : {1}
+PluginManager.UpdateSiteError=Erreur lors de la vérification du site de mise à jour pour {0} essai(s). La dernière exception était : {1}
 PluginManager.UpdateSiteChangeLogLevel=Modifiez le niveau de log du logger {0} à WARNING ou moins pour consulter plus d''informations et le message d''erreur de chaque essai
-PluginManager.UnexpectedException=Exception inattendue lors la vérification des serveurs de mise à jour
+PluginManager.UnexpectedException=Exception inattendue lors la vérification du serveur de mise à jour
 
 
 PluginManager.compatWarning=\
@@ -73,11 +73,11 @@ PluginManager.compatWarning=\
 PluginManager.parentDepCompatWarning=Les plugins suivants sont incompatibles :
 PluginManager.parentCompatWarning=Les plugins suivants sont affectés par cela :
 PluginManager.coreWarning=\
- Avertissement : ce plugin est compatible pour Jenkins {0} ou plus récent. \
+ Avertissement : ce plugin n''est compatible que pour Jenkins {0} ou plus récent. \
  Jenkins ne démarrera pas ce plugin s''il est installé.
 PluginManager.depCompatWarning=\
- Avertissement : ce plugin nécessite des versions plus récentes de dépendances et au moins un de ces plugins n''est pas compatible avec la version installée. \
- C''est habituellement le cas parce que son comportement ou ses APIs ont changé, ou parce qu''il utilise un format de configuration différent de celui installé. \
+ Avertissement : ce plugin nécessite des versions plus récentes de dépendances et au moins une de ces dépendances n''est pas compatible avec la version installée. \
+ C''est habituellement le cas parce que le comportement de ce plugin de dépendance ou ses APIs ont changé, ou parce qu''il utilise un format de configuration différent de celui installé. \
  D''autres plugins ayant une dépendance à ce plugin sont peut-être incompatibles avec cette mise à jour et ne fonctionneront plus comme attendu, les jobs utilisant ce plugin necessiteront peut-être d''être reconfigurés, et/ou vous ne serez peut-être plus capable de revenir à la version précédente sans avoir à restaurer manuellement les configurations précédentes. \
  Veuillez consulter la note de livraison du plugin pour plus de détails.
 PluginManager.depCoreWarning=\
@@ -94,10 +94,10 @@ PluginManager.deprecationWarning=<strong>Ce plugin est obsolète.</strong> Gén�
 PluginManager.insecureUrl=\
   Vous utilisez une URL non sécurisée pour télécharger le plugin, utilisez-la à vos propres risques et périls!
 PluginManager.invalidUrl=\
-  Vous utilisez une URL invalide pour télécharger le plugin. Les URLs file, https et http (non recommandé) sont supportées.
+  Vous utilisez une URL invalide pour télécharger le plugin. Les URLs de type "file", "https" et "http" (non recommandé) sont supportées.
 
 PluginManager.emptyUpdateSiteUrl=\
-  Le site de mise à jour ne peut être vide. Veuillez entrer une URL valide.
+  Le site de mise à jour est anormalement vide. Veuillez entrer une URL valide.
 
 PluginManager.connectionFailed=\
   Impossible de se connecter à l''URL.
@@ -120,9 +120,9 @@ PluginWrapper.disabled_2=Le plugin nécessaire suivant est désactivé : {0} ({1
 PluginWrapper.obsolete_2=Mise à jour nécessaire : {0} ({1} {2}) doit être mis à jour en {3} ou plus
 PluginWrapper.obsoleteCore=Jenkins ({1}) ou plus récent nécessaire
 PluginWrapper.PluginWrapperAdministrativeMonitor.DisplayName=Plugins échouant à charger
-PluginWrapper.Already.Disabled=Le plugin ''{0}'' était déjà désactivé
-PluginWrapper.Plugin.Has.Dependent=Le plugin ''{0}'' a au moins un plugin dépendant ({1}) et la stratégie de désactivation est {2} ainsi, il ne peut pas être désactivé
-PluginWrapper.Plugin.Disabled=Plugin ''{0}'' désactivé
-PluginWrapper.NoSuchPlugin=Aucun plugin trouvé avec le nom ''{0}''
-PluginWrapper.Error.Disabling=Une erreur a été relevée lors de la désactivation du plugin ''{0}''. Erreur : ''{1}''
+PluginWrapper.Already.Disabled=Le plugin "{0}" était déjà désactivé
+PluginWrapper.Plugin.Has.Dependent=Le plugin "{0}" a au moins un plugin dépendant ({1}) et la stratégie de désactivation est {2} ainsi, il ne peut pas être désactivé
+PluginWrapper.Plugin.Disabled=Plugin "{0}" désactivé
+PluginWrapper.NoSuchPlugin=Aucun plugin trouvé avec le nom "{0}"
+PluginWrapper.Error.Disabling=Une erreur a été relevée lors de la désactivation du plugin "{0}". Erreur : "{1}"
 TcpSlaveAgentListener.PingAgentProtocol.displayName=Protocole de ping

--- a/core/src/main/resources/hudson/Messages_fr.properties
+++ b/core/src/main/resources/hudson/Messages_fr.properties
@@ -85,7 +85,7 @@ PluginManager.depCoreWarning=\
  Jenkins refusera de charger les dépendances nécessitant une version plus récente de Jenkins, \
  et en conséquence ce plugin échouera à se charger.
 PluginManager.securityWarning=\
-  Avertissement : cette version de plugin n''est peut-être par sûre. Veuillez vérifier les notices de sécurité suivantes :
+  Avertissement : cette version de plugin n''est peut-être pas sûre. Veuillez vérifier les notices de sécurité suivantes :
 PluginManager.ago=Il y a {0}
 PluginManager.adoptThisPlugin=\
   <strong>Ce plugin est à adopter!</strong> Nous recherchons de nouveaux mainteneurs. \


### PR DESCRIPTION
See [JENKINS-72143](https://issues.jenkins.io/browse/JENKINS-72143).

Reported missing keys from hudson/Messages.properties to related Messages_fr.properties

### Testing done


### Proposed changelog entries

- Translate hudson/Messages.properties into French.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
