### PR TITLE
Fix Null Pointer Issues

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -711,7 +711,12 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         }
 
         Manifest manifest = parsePluginManifest(hpiResUrl);
-        String dependencySpec = manifest.getMainAttributes().getValue("Plugin-Dependencies");
+        String dependencySpec = null;
+        
+        if(manifest != null){
+            dependencySpec = manifest.getMainAttributes().getValue("Plugin-Dependencies");
+        }
+          
         if (dependencySpec != null) {
             String[] dependencyTokens = dependencySpec.split(",");
             ServletContext context = Jenkins.get().servletContext;


### PR DESCRIPTION
In file: `PluginManager.java`, class: `PluginManager`, the method `addDependencies` contains a potential Null pointer dereference on the following line. This may throw an unexpected null pointer exception which, if unhandled, may crash the program.

```java
// File: PluginManager.java, Line: 713
protected static void addDependencies(URL hpiResUrl, String fromPath, Set<URL> dependencySet) throws URISyntaxException, MalformedURLException {
        ...

        Manifest manifest = parsePluginManifest(hpiResUrl);
        String dependencySpec = manifest.getMainAttributes().getValue(\"Plugin-Dependencies\");

        ...
}
```
`manifest` object is obtained by calling `parsePluginManifest` which can return a null value.

```java
static @CheckForNull Manifest parsePluginManifest(URL bundledJpi) {
        try (URLClassLoader cl = new URLClassLoader(new URL[]{bundledJpi})) {
            InputStream in = null;
            try {
                URL res = cl.findResource(PluginWrapper.MANIFEST_FILENAME);
                if (res != null) {
                    in = getBundledJpiManifestStream(res);
                    return new Manifest(in);
                }
            } finally {
                Util.closeAndLogFailures(in, LOGGER, PluginWrapper.MANIFEST_FILENAME, bundledJpi.toString());
            }
        } catch (IOException e) {
            LOGGER.log(WARNING, \"Failed to parse manifest of \" + bundledJpi, e);
        }
        return null;
    }
```

### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.