### PR TITLE
[JENKINS-72156] Backport Upgrade to Winstone 6.14 which contains an upgrade to Jetty 10.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,12 @@ THE SOFTWARE.
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>
 
-    <access-modifier.version>1.32</access-modifier.version>
-    <antlr.version>4.13.0</antlr.version>
-    <bridge-method-injector.version>1.27</bridge-method-injector.version>
+    <access-modifier.version>1.33</access-modifier.version>
+    <antlr.version>4.13.1</antlr.version>
+    <bridge-method-injector.version>1.29</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>6.12</winstone.version>
+    <winstone.version>6.14</winstone.version>
   </properties>
 
   <!--

--- a/pom.xml
+++ b/pom.xml
@@ -93,9 +93,9 @@ THE SOFTWARE.
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>
 
-    <access-modifier.version>1.33</access-modifier.version>
-    <antlr.version>4.13.1</antlr.version>
-    <bridge-method-injector.version>1.29</bridge-method-injector.version>
+    <access-modifier.version>1.32</access-modifier.version>
+    <antlr.version>4.13.0</antlr.version>
+    <bridge-method-injector.version>1.27</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
     <winstone.version>6.14</winstone.version>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -636,7 +636,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>10.0.15</version>
+        <version>10.0.17</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

A backport of 

* #8587 

### Testing done

* Started Jenkins with Winstone 6.14 from this pull request on a Linux computer running Java 17
* Confirmed the markdown plugin worked as expected
* Confirmed the embeddable build status plugin worked as expected
* Confirmed that declarative Pipeline ran as expected on an inbound agent

### Proposed changelog entries

- Upgrade to Winstone 6.14 which contains an upgrade to Jetty [10.0.17](https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.17) 

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
