### PR TITLE
Add telemetry for Jenkins uptime

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/Uptime.java
+++ b/core/src/main/java/jenkins/telemetry/impl/Uptime.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.telemetry.impl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.time.LocalDate;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Records approximations of when Jenkins was started and the current time, to allow for computation of uptime.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class Uptime extends Telemetry {
+    private static final long START = System.nanoTime();
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Uptime";
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2023, 10, 20);
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2024, 1, 20);
+    }
+
+    @Override
+    public JSONObject createContent() {
+        return new JSONObject().element("start", START).element("now", System.nanoTime()).element("components", buildComponentInformation());
+    }
+}

--- a/core/src/main/resources/jenkins/telemetry/impl/Uptime/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/Uptime/description.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    This trial collects two timestamps:
+    <ul>
+        <li><a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/System.html#nanoTime()"><code>System#nanoTime</code></a> when the trial was initialized (corresponds roughly to when Jenkins was started)</li>
+        <li><a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/System.html#nanoTime()"><code>System#nanoTime</code></a> when the trial data was collected (i.e., when it was prepared just before submission)</li>
+    </ul>
+
+    Additionally this trial collects the list of installed plugins, their version, and the version of Jenkins.
+    This data will help understand unexpected submission frequency of other trials' data.
+</j:jelly>


### PR DESCRIPTION
@dwnusbaum and I noticed unexpected distribution of `correlator`s (see [JEP-214](https://github.com/jenkinsci/jep/tree/master/jep/214#specification)) in the submissions to our telemetry trials (my #8440 and #7470 and and Devin's #7342).

While most correlation IDs are submitted multiple times, up to once per day, there are outliers:

* A significant number of correlation IDs are only seen once, indicating very short-lived instances. JFR disables usage stats submission, so that's not it.
* A few correlation IDs are seen more than once per day during the collection period, sometimes many times per day. Our best guess so far is cloned Jenkins home directories, but some might also be frequently restarting instances.

In both cases (mostly the second though), collecting Jenkins uptime should be able to help understand what's going on.

This does not use `jenkins.model.Uptime` as data source, as that's not stable given system time changes (I filed [JENKINS-72157](https://issues.jenkins.io/browse/JENKINS-72157)).


### Testing done

```
def tel = ExtensionList.lookupSingleton(jenkins.telemetry.impl.Uptime)
def json = tel.createContent()
println ((json.get('now') - json.get('start')) / 1000 / 1000 / 1000)
```

Changed system time by 5 minutes, re-ran this, no significant jump.

Also locally changed the start date to Oct 10 and manually triggered submission (`ExtensionList.lookupSingleton(jenkins.telemetry.Telemetry.TelemetryReporter.class).run()`), then checked it in Uplink.

> <img width="1359" alt="Screenshot 2023-10-11 at 11 22 20" src="https://github.com/jenkinsci/jenkins/assets/1831569/7e429b81-77a0-4a46-a1f8-6a89c3b0abf4">


### Proposed changelog entries

- Add telemetry for Jenkins uptime.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
