### PR TITLE
[JENKINS-72170] fix nested hetero-list entries with mixture of inputs and buttons

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -1,0 +1,4 @@
+/*
+  Intentionally empty. This file just exists so plugins that explicitly include the
+  hetero-list adjunct do not print a warning.
+*/

--- a/core/src/main/resources/lib/form/hetero-list/hetero-list.js
+++ b/core/src/main/resources/lib/form/hetero-list/hetero-list.js
@@ -1,4 +1,0 @@
-/*
-  Intentionally empty. This file just exists so plugins that explicitly include the
-  hetero-list adjunct do not print a warning.
-*/

--- a/war/src/main/js/components/dropdowns/hetero-list.js
+++ b/war/src/main/js/components/dropdowns/hetero-list.js
@@ -22,20 +22,20 @@ function generateHandles() {
 }
 
 function convertInputsToButtons(e) {
-    let oldInputs = e.querySelectorAll("INPUT.hetero-list-add");
-    oldInputs.forEach((oldbtn) => {
-      let btn = document.createElement("button");
-      btn.setAttribute("type", "button");
-      btn.classList.add("hetero-list-add", "jenkins-button");
-      btn.innerText = oldbtn.getAttribute("value");
-      if (oldbtn.hasAttribute("suffix")) {
-        btn.setAttribute("suffix", oldbtn.getAttribute("suffix"));
-      }
-      let chevron = createElementFromHtml(Symbols.CHEVRON_DOWN);
-      btn.appendChild(chevron);
-      oldbtn.parentNode.appendChild(btn);
-      oldbtn.remove();
-    });
+  let oldInputs = e.querySelectorAll("INPUT.hetero-list-add");
+  oldInputs.forEach((oldbtn) => {
+    let btn = document.createElement("button");
+    btn.setAttribute("type", "button");
+    btn.classList.add("hetero-list-add", "jenkins-button");
+    btn.innerText = oldbtn.getAttribute("value");
+    if (oldbtn.hasAttribute("suffix")) {
+      btn.setAttribute("suffix", oldbtn.getAttribute("suffix"));
+    }
+    let chevron = createElementFromHtml(Symbols.CHEVRON_DOWN);
+    btn.appendChild(chevron);
+    oldbtn.parentNode.appendChild(btn);
+    oldbtn.remove();
+  });
 }
 
 function generateButtons() {

--- a/war/src/main/js/components/dropdowns/hetero-list.js
+++ b/war/src/main/js/components/dropdowns/hetero-list.js
@@ -21,6 +21,23 @@ function generateHandles() {
   });
 }
 
+function convertInputsToButtons(e) {
+    let oldInputs = e.querySelectorAll("INPUT.hetero-list-add");
+    oldInputs.forEach((oldbtn) => {
+      let btn = document.createElement("button");
+      btn.setAttribute("type", "button");
+      btn.classList.add("hetero-list-add", "jenkins-button");
+      btn.innerText = oldbtn.getAttribute("value");
+      if (oldbtn.hasAttribute("suffix")) {
+        btn.setAttribute("suffix", oldbtn.getAttribute("suffix"));
+      }
+      let chevron = createElementFromHtml(Symbols.CHEVRON_DOWN);
+      btn.appendChild(chevron);
+      oldbtn.parentNode.appendChild(btn);
+      oldbtn.remove();
+    });
+}
+
 function generateButtons() {
   behaviorShim.specify(
     "DIV.hetero-list-container",
@@ -31,26 +48,8 @@ function generateButtons() {
         return;
       }
 
+      convertInputsToButtons(e);
       let btn = Array.from(e.querySelectorAll("BUTTON.hetero-list-add")).pop();
-      if (!btn) {
-        let oldbtn = Array.from(
-          e.querySelectorAll("INPUT.hetero-list-add"),
-        ).pop();
-        if (!oldbtn) {
-          return;
-        }
-        btn = document.createElement("button");
-        btn.setAttribute("type", "button");
-        btn.classList.add("hetero-list-add", "jenkins-button");
-        btn.innerText = oldbtn.getAttribute("value");
-        if (oldbtn.hasAttribute("suffix")) {
-          btn.setAttribute("suffix", oldbtn.getAttribute("suffix"));
-        }
-        let chevron = createElementFromHtml(Symbols.CHEVRON_DOWN);
-        btn.appendChild(chevron);
-        oldbtn.parentNode.appendChild(btn);
-        oldbtn.remove();
-      }
 
       let prototypes = e.lastElementChild;
       while (!prototypes.classList.contains("prototypes")) {


### PR DESCRIPTION
when a plugin defines the hetero-list elements on its own and still uses an `<input type="button">` element and an inner element is already using a hetero-list with a `<button>` element, then the old input wasn't converted to a button as the inner button was selected as the target. Avoid this by converting all inputs to buttons before actually looking up the button.

See [JENKINS-72170](https://issues.jenkins.io/browse/JENKINS-72170).


### Testing done

Manually tested as described in [JENKINS-72170](https://issues.jenkins.io/browse/JENKINS-72170) that the button is working properly with this fix

### Proposed changelog entries

- Fix multibranch Pipeline "Add source" and other uses that mix inputs and buttons (regression in 2.422).

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

