### PR TITLE
[JEP-237] Do not support shortening of HMAC code on FIPS mode

### DIFF
--- a/core/src/main/java/jenkins/security/HMACConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/HMACConfidentialKey.java
@@ -98,6 +98,11 @@ public class HMACConfidentialKey extends ConfidentialKey {
     }
 
     private byte[] chop(byte[] mac) {
+        //don't shorten the mac code on FIPS mode
+        //if length supplied is less than original mac code length on FIPS, throw exception
+        if (FIPS140.useCompliantAlgorithms() && length < mac.length) {
+            throw new IllegalArgumentException("Supplied length can't be less than " + mac.length + " on FIPS mode");
+        }
         if (mac.length <= length)  return mac; // already too short
 
         byte[] b = new byte[length];

--- a/core/src/test/java/jenkins/security/HMACConfidentialKeyTest.java
+++ b/core/src/test/java/jenkins/security/HMACConfidentialKeyTest.java
@@ -1,5 +1,7 @@
 package jenkins.security;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -42,6 +44,7 @@ public class HMACConfidentialKeyTest {
     public void testTruncatedMacOnNonFips() {
         HMACConfidentialKey key1 = new HMACConfidentialKey("test", 16);
         String str = key1.mac("Hello World");
-        assertTrue(str, str.matches("[0-9A-Fa-f]{32}"));
+        String pattern = "[0-9A-Fa-f]{32}";
+        assertThat(str, matchesPattern(pattern));
     }
 }

--- a/core/src/test/java/jenkins/security/HMACConfidentialKeyTest.java
+++ b/core/src/test/java/jenkins/security/HMACConfidentialKeyTest.java
@@ -1,8 +1,10 @@
 package jenkins.security;
 
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Set;
 import java.util.TreeSet;
@@ -38,4 +40,39 @@ public class HMACConfidentialKeyTest {
         }
     }
 
+
+    @Test
+    public void testMacWithShortenedCodeOnFips() {
+        System.setProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+        HMACConfidentialKey key1 = new HMACConfidentialKey("test", 16);
+        try {
+            String str = key1.mac("Hello World");
+        } catch (IllegalArgumentException exception) {
+            assertEquals("Supplied length can't be less than 32 on FIPS mode", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void testMacWithShortenedCodeOnNonFips() {
+        System.setProperty("jenkins.security.FIPS140.COMPLIANCE", "false");
+        HMACConfidentialKey key1 = new HMACConfidentialKey("test", 16);
+        try {
+            String str = key1.mac("Hello World");
+            assertTrue(str, str.matches("[0-9A-Fa-f]{32}"));
+        } catch (IllegalArgumentException exception) {
+            fail("Found IllegalArgumentException");
+        }
+    }
+
+    @Test
+    public void testCompleteMaCodeOnNonFips() {
+        System.setProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+        HMACConfidentialKey key1 = new HMACConfidentialKey("test", 32);
+        try {
+            String str = key1.mac("Hello World");
+            assertTrue(str, str.matches("[0-9A-Fa-f]{64}"));
+        } catch (IllegalArgumentException exception) {
+            fail("Found IllegalArgumentException");
+        }
+    }
 }

--- a/core/src/test/java/jenkins/security/HMACConfidentialKeyTest.java
+++ b/core/src/test/java/jenkins/security/HMACConfidentialKeyTest.java
@@ -1,10 +1,8 @@
 package jenkins.security;
 
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Set;
 import java.util.TreeSet;
@@ -40,39 +38,10 @@ public class HMACConfidentialKeyTest {
         }
     }
 
-
     @Test
-    public void testMacWithShortenedCodeOnFips() {
-        System.setProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+    public void testTruncatedMacOnNonFips() {
         HMACConfidentialKey key1 = new HMACConfidentialKey("test", 16);
-        try {
-            String str = key1.mac("Hello World");
-        } catch (IllegalArgumentException exception) {
-            assertEquals("Supplied length can't be less than 32 on FIPS mode", exception.getMessage());
-        }
-    }
-
-    @Test
-    public void testMacWithShortenedCodeOnNonFips() {
-        System.setProperty("jenkins.security.FIPS140.COMPLIANCE", "false");
-        HMACConfidentialKey key1 = new HMACConfidentialKey("test", 16);
-        try {
-            String str = key1.mac("Hello World");
-            assertTrue(str, str.matches("[0-9A-Fa-f]{32}"));
-        } catch (IllegalArgumentException exception) {
-            fail("Found IllegalArgumentException");
-        }
-    }
-
-    @Test
-    public void testCompleteMaCodeOnNonFips() {
-        System.setProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
-        HMACConfidentialKey key1 = new HMACConfidentialKey("test", 32);
-        try {
-            String str = key1.mac("Hello World");
-            assertTrue(str, str.matches("[0-9A-Fa-f]{64}"));
-        } catch (IllegalArgumentException exception) {
-            fail("Found IllegalArgumentException");
-        }
+        String str = key1.mac("Hello World");
+        assertTrue(str, str.matches("[0-9A-Fa-f]{32}"));
     }
 }

--- a/test/src/test/java/hudson/security/HMACConfidentialKeyFIPSTest.java
+++ b/test/src/test/java/hudson/security/HMACConfidentialKeyFIPSTest.java
@@ -1,6 +1,7 @@
 package hudson.security;
 
-
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.Assert.assertThrows;
 
 import org.junit.ClassRule;
@@ -11,7 +12,6 @@ import org.jvnet.hudson.test.FlagRule;
 import jenkins.security.HMACConfidentialKey;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class HMACConfidentialKeyFIPSTest {
    @ClassRule
@@ -26,9 +26,10 @@ public class HMACConfidentialKeyFIPSTest {
     }
 
     @Test
-    public void testCompleteMacOnNonFips() {
+    public void testCompleteMacOnFips() {
         HMACConfidentialKey key1 = new HMACConfidentialKey("test", 32);
         String str = key1.mac("Hello World");
-        assertTrue(str, str.matches("[0-9A-Fa-f]{64}"));
+        String pattern = "[0-9A-Fa-f]{64}";
+        assertThat(str, matchesPattern(pattern));
     }
 }

--- a/test/src/test/java/hudson/security/HMACConfidentialKeyFIPSTest.java
+++ b/test/src/test/java/hudson/security/HMACConfidentialKeyFIPSTest.java
@@ -2,16 +2,14 @@ package hudson.security;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import jenkins.security.HMACConfidentialKey;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.jvnet.hudson.test.FlagRule;
-
-import jenkins.security.HMACConfidentialKey;
-
-import static org.junit.Assert.assertEquals;
 
 public class HMACConfidentialKeyFIPSTest {
    @ClassRule

--- a/test/src/test/java/hudson/security/HMACConfidentialKeyFIPSTest.java
+++ b/test/src/test/java/hudson/security/HMACConfidentialKeyFIPSTest.java
@@ -22,7 +22,7 @@ public class HMACConfidentialKeyFIPSTest {
     public void testTruncatedMacOnFips() {
         HMACConfidentialKey key1 = new HMACConfidentialKey("test", 16);
         IllegalArgumentException  iae = assertThrows(IllegalArgumentException.class, () -> key1.mac("Hello World"));
-        assertEquals("Supplied length can't be less than 32 on FIPS mode", iae .getMessage());
+        assertEquals("Supplied length can't be less than 32 on FIPS mode", iae.getMessage());
     }
 
     @Test

--- a/test/src/test/java/hudson/security/HMACConfidentialKeyFIPSTest.java
+++ b/test/src/test/java/hudson/security/HMACConfidentialKeyFIPSTest.java
@@ -1,0 +1,34 @@
+package hudson.security;
+
+
+import static org.junit.Assert.assertThrows;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.jvnet.hudson.test.FlagRule;
+
+import jenkins.security.HMACConfidentialKey;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HMACConfidentialKeyFIPSTest {
+   @ClassRule
+   // do not use the FIPS140 class here as that initializes the field before we set the property!
+   public static TestRule flagRule = FlagRule.systemProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+
+    @Test
+    public void testTruncatedMacOnFips() {
+        HMACConfidentialKey key1 = new HMACConfidentialKey("test", 16);
+        IllegalArgumentException  iae = assertThrows(IllegalArgumentException.class, () -> key1.mac("Hello World"));
+        assertEquals("Supplied length can't be less than 32 on FIPS mode", iae .getMessage());
+    }
+
+    @Test
+    public void testCompleteMacOnNonFips() {
+        HMACConfidentialKey key1 = new HMACConfidentialKey("test", 32);
+        String str = key1.mac("Hello World");
+        assertTrue(str, str.matches("[0-9A-Fa-f]{64}"));
+    }
+}


### PR DESCRIPTION
HMACConfidentialKey supports an option to return trimmed HMAC code. Usage of trimmed code can cause issues when used from security context. This change is to throw an exception when callers try to get trimmed HMAC code on FIPS mode and also
this change assumes that Legacy Token is disabled on FIPS mode. There is a plan to remove support for Legacy Token and enhancement [JENKINS-71573](https://issues.jenkins.io/browse/JENKINS-71573) exists for same. Hence, Legacy Token flag  needs to be disabled on FIPS mode for this change to work successfully.

Verified across all the plugins and found there are no plugins which are using the truncated HMAC code.
The only impact is on Legacy Token in Jenkins Core

See [JEP-237](https://github.com/jenkinsci/jep/blob/master/jep/237/README.adoc).


### Testing done
Verified exception is thrown when HMAC Key is being created with length less than original length of HAMC code on FIPS mode
Verified trimmed code is returned when HMAC Key is being created with length less than 32 on non FIPS mode

### Proposed changelog entries

Prevent trimming HMAC codes (using `HAMCConfidentialKey`) when running in FIPS mode only.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jtnord 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
