### PR TITLE
[JENKINS-72181] Restore flushed output for 'groovy' CLI command

### DIFF
--- a/core/src/main/java/hudson/cli/GroovyCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyCommand.java
@@ -68,7 +68,7 @@ public class GroovyCommand extends CLICommand {
         final String scriptListenerCorrelationId = String.valueOf(System.identityHashCode(this));
 
         Binding binding = new Binding();
-        binding.setProperty("out", new ScriptListener.ListenerWriter(new PrintWriter(new OutputStreamWriter(stdout, getClientCharset()), true), GroovyCommand.class, null, scriptListenerCorrelationId, User.current()));
+        binding.setProperty("out", new PrintWriter(new ScriptListener.ListenerWriter(new OutputStreamWriter(stdout, getClientCharset()), GroovyCommand.class, null, scriptListenerCorrelationId, User.current()), true));
         binding.setProperty("stdin", stdin);
         binding.setProperty("stdout", stdout);
         binding.setProperty("stderr", stderr);

--- a/test/src/test/java/jenkins/model/ScriptListenerTest.java
+++ b/test/src/test/java/jenkins/model/ScriptListenerTest.java
@@ -79,7 +79,9 @@ public class ScriptListenerTest {
         logging.record(DefaultScriptListener.class.getName(), Level.FINEST).capture(100);
 
         InputStream scriptStream = new ByteArrayInputStream(script.getBytes());
-        new CLICommandInvoker(j, "groovy").withArgs("=").withStdin(scriptStream).invoke();
+        final CLICommandInvoker.Result result = new CLICommandInvoker(j, "groovy").withArgs("=").withStdin(scriptStream).invoke();
+        final String stdout = result.stdout();
+        assertThat(stdout, containsString("hello from groovy CLI"));
 
         { // DefaultScriptListener
             final List<String> messages = logging.getMessages();


### PR DESCRIPTION
See [JENKINS-72181](https://issues.jenkins.io/browse/JENKINS-72181). Amends #7056.

I accidentally wrapped the `PrintWriter` in the logging `ScriptListener.ListenerWriter` that only implements the basic `#write(…)` and doesn't automatically flush. This switches the order around, so the autoflush in `PrintWriter#newLine` happens as before.

### Testing done

```
$ echo 'println "Hello"'  | java -jar jenkins-cli.jar -s http://localhost:8080/jenkins/ groovy =
Hello
```

The added test passes with change in `core/src/main/` and fails without.

### Proposed changelog entries

- Restore printing output from `println` and similar methods for the 'groovy' CLI command. (regression in 2.427)

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
```
<!-- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer. -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
