### PR TITLE
[JENKINS-64816] prepare for support of node monitors by JCasC

### DIFF
--- a/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -40,6 +41,11 @@ import org.kohsuke.stapler.StaplerRequest;
  * @author Kohsuke Kawaguchi
  */
 public class ArchitectureMonitor extends NodeMonitor {
+
+    @DataBoundConstructor
+    public ArchitectureMonitor() {
+    }
+
     @Extension @Symbol("architecture")
     public static final class DescriptorImpl extends AbstractAsyncNodeMonitorDescriptor<String> {
         @Override

--- a/core/src/main/java/hudson/node_monitors/ClockMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ClockMonitor.java
@@ -36,6 +36,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -46,6 +47,11 @@ import org.kohsuke.stapler.StaplerRequest;
  * @since 1.123
  */
 public class ClockMonitor extends NodeMonitor {
+
+    @DataBoundConstructor
+    public ClockMonitor() {
+    }
+
     public ClockDifference getDifferenceFor(Computer c) {
         return DESCRIPTOR.get(c);
     }

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -92,8 +92,11 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
         }
     }
 
-    @Extension
+    /**
+     * @deprecated since TODO
+     */
+    @Deprecated
     public static DiskSpaceMonitorDescriptor install() {
-        return DESCRIPTOR;
+        return (DiskSpaceMonitorDescriptor) Jenkins.get().getDescriptor(DiskSpaceMonitor.class);
     }
 }

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -63,6 +63,7 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
         return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
     }
 
+    @SuppressFBWarnings(value = "MS_PKGPROTECT", justification = "for backward compatibility")
     public static /*almost final*/ DiskSpaceMonitorDescriptor DESCRIPTOR;
 
     @Extension @Symbol("diskSpace")
@@ -89,7 +90,7 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
 
             return p.asCallableWith(new GetUsableSpace());
         }
-    };
+    }
 
     @Extension
     public static DiskSpaceMonitorDescriptor install() {

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -91,12 +91,4 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
             return p.asCallableWith(new GetUsableSpace());
         }
     }
-
-    /**
-     * @deprecated since TODO
-     */
-    @Deprecated
-    public static DiskSpaceMonitorDescriptor install() {
-        return (DiskSpaceMonitorDescriptor) Jenkins.get().getDescriptor(DiskSpaceMonitor.class);
-    }
 }

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitor.java
@@ -25,6 +25,7 @@
 package hudson.node_monitors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;
@@ -34,6 +35,7 @@ import hudson.remoting.Callable;
 import java.io.IOException;
 import java.text.ParseException;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -61,7 +63,16 @@ public class DiskSpaceMonitor extends AbstractDiskSpaceMonitor {
         return Jenkins.get().hasPermission(Jenkins.ADMINISTER) ? super.getColumnCaption() : null;
     }
 
-    public static final DiskSpaceMonitorDescriptor DESCRIPTOR = new DiskSpaceMonitorDescriptor() {
+    public static /*almost final*/ DiskSpaceMonitorDescriptor DESCRIPTOR;
+
+    @Extension @Symbol("diskSpace")
+    public static class DescriptorImpl extends DiskSpaceMonitorDescriptor {
+
+        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "for backward compatibility")
+        public DescriptorImpl() {
+            DESCRIPTOR = this;
+        }
+
         @NonNull
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/hudson/node_monitors/NodeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/NodeMonitor.java
@@ -61,6 +61,9 @@ import org.kohsuke.stapler.export.ExportedBean;
  * <p>
  * {@link NodeMonitor}s are persisted via XStream.
  *
+ * <h2>CasC</h2>
+ * To be able to configure {@link NodeMonitor}s via JCasC, they should have a {@link org.kohsuke.stapler.DataBoundConstructor}
+ *
  * @author Kohsuke Kawaguchi
  * @since 1.123
  */

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -25,6 +25,7 @@
 package hudson.node_monitors;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.remoting.Callable;
@@ -34,6 +35,8 @@ import java.util.Map;
 import java.util.logging.Logger;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -44,8 +47,20 @@ import org.kohsuke.stapler.export.ExportedBean;
  * @author Kohsuke Kawaguchi
  */
 public class ResponseTimeMonitor extends NodeMonitor {
+
+    @DataBoundConstructor
+    public ResponseTimeMonitor() {
+    }
+
+    public static /*almost final*/ AbstractNodeMonitorDescriptor<Data> DESCRIPTOR;
     @Extension
-    public static final AbstractNodeMonitorDescriptor<Data> DESCRIPTOR = new AbstractAsyncNodeMonitorDescriptor<>() {
+    @Symbol("responseTime")
+    public static class DescriptorImpl extends AbstractAsyncNodeMonitorDescriptor<Data> {
+
+        @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "for backward compatibility")
+        public DescriptorImpl() {
+            DESCRIPTOR = this;
+        }
 
         @Override
         protected Callable<Data, IOException> createCallable(Computer c) {

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -52,7 +52,9 @@ public class ResponseTimeMonitor extends NodeMonitor {
     public ResponseTimeMonitor() {
     }
 
+    @SuppressFBWarnings(value = "MS_PKGPROTECT", justification = "for backward compatibility")
     public static /*almost final*/ AbstractNodeMonitorDescriptor<Data> DESCRIPTOR;
+
     @Extension
     @Symbol("responseTime")
     public static class DescriptorImpl extends AbstractAsyncNodeMonitorDescriptor<Data> {
@@ -106,7 +108,7 @@ public class ResponseTimeMonitor extends NodeMonitor {
         public NodeMonitor newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             return new ResponseTimeMonitor();
         }
-    };
+    }
 
     private static final class Step1 extends MasterToSlaveCallable<Data, IOException> {
         private Data cur;

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -37,6 +37,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.jvnet.hudson.MemoryMonitor;
 import org.jvnet.hudson.MemoryUsage;
+import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -48,6 +49,11 @@ import org.kohsuke.stapler.export.ExportedBean;
  * @since 1.233
  */
 public class SwapSpaceMonitor extends NodeMonitor {
+
+    @DataBoundConstructor
+    public SwapSpaceMonitor() {
+    }
+
     /**
      * Returns the HTML representation of the space.
      */

--- a/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/TemporarySpaceMonitor.java
@@ -101,14 +101,6 @@ public class TemporarySpaceMonitor extends AbstractDiskSpaceMonitor {
         }
     }
 
-    /**
-     * @deprecated as of 2.0
-     */
-    @Deprecated
-    public static DiskSpaceMonitorDescriptor install() {
-        return (DiskSpaceMonitorDescriptor) Jenkins.get().getDescriptor(TemporarySpaceMonitor.class);
-    }
-
     protected static final class GetTempSpace extends MasterToSlaveFileCallable<DiskSpace> {
         @Override
         public DiskSpace invoke(File f, VirtualChannel channel) throws IOException {


### PR DESCRIPTION
In order that configuration as code plugin can properly support node monitors we need to add databound constructors.

See [JENKINS-64816](https://issues.jenkins.io/browse/JENKINS-64816).

### Testing done
No functional changes, verified in the context of https://github.com/jenkinsci/configuration-as-code-plugin/pull/2392 that with this change the node monitors can then be configured via CasC

### Proposed changelog entries

- Prepare node monitors to work with configuration as code.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
