### PR TITLE
[JENKINS-72222] Fix inconsistent wording between login page and security configuration

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -431,7 +431,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     private volatile SecurityRealm securityRealm = SecurityRealm.NO_AUTHENTICATION;
 
     /**
-     * Disables the keep me signed in option in the standard login screen.
+     * Disables the "Keep me signed in" option in the standard login screen.
      *
      * @since 1.534
      */

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -431,7 +431,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     private volatile SecurityRealm securityRealm = SecurityRealm.NO_AUTHENTICATION;
 
     /**
-     * Disables the remember me on this computer option in the standard login screen.
+     * Disables the keep me signed in option in the standard login screen.
      *
      * @since 1.534
      */

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/help-disableRememberMe.html
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/help-disableRememberMe.html
@@ -1,4 +1,4 @@
 <div>
-  Select this option to remove the “Remember me on this computer” checkbox from
-  the login screen.
+  Select this option to remove the “Keep me signed in” checkbox from the login
+  screen.
 </div>

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.properties
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.properties
@@ -1,4 +1,4 @@
-Disable\ remember\ me=Disable "Keep me signed in"
+Disable\ remember\ me=Disable “Keep me signed in”
 slaveAgentPortEnforced=enforced to {0,number,#} on startup through system property.
 slaveAgentPortEnforcedRandom=enforced to random port on startup through system property.
 slaveAgentPortEnforcedDisabled=disabled on startup through system property.

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.properties
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.properties
@@ -1,3 +1,4 @@
+Disable\ remember\ me=Disable "Keep me signed in"
 slaveAgentPortEnforced=enforced to {0,number,#} on startup through system property.
 slaveAgentPortEnforcedRandom=enforced to random port on startup through system property.
 slaveAgentPortEnforcedDisabled=disabled on startup through system property.

--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index_tr.properties
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index_tr.properties
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Enable\ security=Güvenliği devreye al
+Disable\ remember\ me=Beni hatırla özelliğini devre dışı bırak
 Markup\ Formatter=
 Access\ Control=Erişim Kontrolü
 Security\ Realm=Güvenlik Alanı


### PR DESCRIPTION
The option in the login page was reworded as "**Keep me signed in**" in the past however the wording in the security configuration was never updated. This PR only changes the help text and the Javadoc to refer to the correct option. 

I'm marking this PR as draft but I believe it's complete. I just want to make sure this is the best way to address the inconsistency. 

See [JENKINS-72222](https://issues.jenkins.io/browse/JENKINS-72222).

### Testing done

<img width="608" alt="Screen Shot 2023-10-22 at 22 39 14" src="https://github.com/jenkinsci/jenkins/assets/881222/f38265e0-3635-40ae-9421-ff6e770fd601">
<img width="608" alt="Screen Shot 2023-10-22 at 22 38 40" src="https://github.com/jenkinsci/jenkins/assets/881222/8d43a888-e8d6-4de9-9e46-8bac8820ce9a">

### Proposed changelog entries

- JENKINS-72222, refer to the correct option in the help text

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
