### PR TITLE
Pull up `AbstractFolder.delete` logic into `AbstractItem`

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -730,7 +730,9 @@ public abstract class AbstractItem extends Actionable implements Loadable, Item,
                     Item item = Tasks.getItemOf(i.task);
                     while (item != null) {
                         if (item == this) {
-                            queue.cancel(i);
+                            if (!queue.cancel(i)) {
+                                LOGGER.warning(() -> "failed to cancel " + i);
+                            }
                             break;
                         }
                         if (item.getParent() instanceof Item) {


### PR DESCRIPTION
Refactoring of #2789 since https://github.com/jenkinsci/cloudbees-folder-plugin/pull/95 copied a bunch of complex code. As seen in https://github.com/jenkinsci/cloudbees-folder-plugin/commit/cdf73702a8bef58b5c2cef1d05e3b4ce823b6494 this complicates maintenance. Started to clean up in https://github.com/jenkinsci/cloudbees-folder-plugin/pull/353 + https://github.com/jenkinsci/cloudbees-folder-plugin/pull/355 but to really remove the duplication it is simplest to just handle child deletion directly in `AbstractItem`.

Should have no behavioral effect for now since `AbstractFolder` overrides this, and the added block only pays attention to `TopLevelItem`, so should not affect `MavenModuleSet` or `MatrixProject`. https://github.com/jenkinsci/cloudbees-folder-plugin/pull/356 completes the cleanup.

### Testing done

`JobTest.interruptOnDelete` should check that non-folders are unaffected. Added a downstream test for what it is worth: https://github.com/jenkinsci/cloudbees-folder-plugin/pull/356#discussion_r1372410882

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
