### PR TITLE
More helpful error message for `ExtensionList.lookupSingleton`

### DIFF
--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -450,7 +450,10 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
      */
     public static @NonNull <U> U lookupSingleton(Class<U> type) {
         ExtensionList<U> all = lookup(type);
-        if (all.size() != 1) {
+        if (Main.isUnitTest && all.isEmpty()) {
+            throw new IllegalStateException("Found no instances of " + type.getName() +
+                " registered (possible annotation processor issue); try using `mvn clean test -Dtest=…` rather than an IDE test runner");
+        } else if (all.size() != 1) {
             throw new IllegalStateException("Expected 1 instance of " + type.getName() + " but got " + all.size());
         }
         return all.get(0);


### PR DESCRIPTION
A periodic issue, most recently noticed going over something with @julieheard: if you run `JenkinsRule` tests using a special test runner from an IDE which does not autodiscover annotation processors, things will be badly broken, and a typical symptom is this otherwise fairly opaque error. If in doubt, use Maven to run tests (and invoke the `clean` phase to be sure).

### Testing done

None, my IDE runs Maven (well, `mvnd`) to begin with! **Edit**: https://github.com/jenkinsci/jenkins/pull/8646#issuecomment-1781448588

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
