### PR TITLE
Backporting for 2.426.1

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -196,7 +196,7 @@ public abstract class Slave extends Node implements Serializable {
         this.numExecutors = numExecutors;
         this.mode = mode;
         this.remoteFS = Util.fixNull(remoteFS).trim();
-        this.labelAtomSet = Collections.unmodifiableSet(Label.parse(labelString));
+        _setLabelString(labelString);
         this.launcher = launcher;
         this.retentionStrategy = retentionStrategy;
         getAssignedLabels();    // compute labels now

--- a/core/src/main/java/jenkins/agents/CloudSet.java
+++ b/core/src/main/java/jenkins/agents/CloudSet.java
@@ -39,6 +39,11 @@ import hudson.util.FormValidation;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletException;
@@ -246,6 +251,25 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
         }
         // take the user back to the cloud list top page
         rsp.sendRedirect2(".");
+    }
+
+    @POST
+    public void doReorder(StaplerRequest req, StaplerResponse rsp) throws IOException {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        var names = req.getParameterValues("name");
+        if (names == null) {
+            throw new Failure("No cloud names given");
+        }
+        var namesList = Arrays.asList(names);
+        var clouds = new ArrayList<>(Jenkins.get().clouds);
+        Collections.sort(clouds, Comparator.comparingInt(c -> getIndexOf(namesList, c)));
+        Jenkins.get().clouds.replaceBy(clouds);
+        rsp.sendRedirect2(".");
+    }
+
+    private static int getIndexOf(List<String> namesList, Cloud cloud) {
+        var i = namesList.indexOf(cloud.name);
+        return i == -1 ? Integer.MAX_VALUE : i;
     }
 
     @Extension

--- a/core/src/main/java/jenkins/telemetry/impl/Uptime.java
+++ b/core/src/main/java/jenkins/telemetry/impl/Uptime.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.telemetry.impl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.time.LocalDate;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Records approximations of when Jenkins was started and the current time, to allow for computation of uptime.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class Uptime extends Telemetry {
+    private static final long START = System.nanoTime();
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Uptime";
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2023, 10, 20);
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2024, 1, 20);
+    }
+
+    @Override
+    public JSONObject createContent() {
+        return new JSONObject().element("start", START).element("now", System.nanoTime()).element("components", buildComponentInformation());
+    }
+}

--- a/core/src/main/resources/hudson/model/BooleanParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/BooleanParameterValue/value.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <j:set var="escapeEntryTitleAndDescription" value="false"/>
-    <f:entry>
-        <f:checkbox title="${h.escape(it.name)}" description="${it.formattedDescription}" name="value" checked="${it.value}" readonly="true" />
+    <f:entry description="${it.formattedDescription}">
+        <f:checkbox title="${h.escape(it.name)}" name="value" checked="${it.value}" readonly="true" />
     </f:entry>
 </j:jelly>

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -26,8 +26,14 @@ THE SOFTWARE.
   Entrance to the configuration page
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout title="${it.displayName}" type="one-column">
+    <l:isAdmin>
+      <l:header>
+        <script src="${resURL}/jsbundles/pages/cloud-set.js" type="text/javascript" />
+        <link rel="stylesheet" href="${resURL}/jsbundles/pages/cloud-set.css" type="text/css" />
+      </l:header>
+    </l:isAdmin>
     <l:main-panel>
       <j:choose>
         <j:when test="${it.cloudAvailable and it.hasClouds()}">
@@ -39,36 +45,46 @@ THE SOFTWARE.
               </a>
             </l:isAdmin>
           </l:app-bar>
-          <table id="clouds" class="jenkins-table sortable">
-            <thead>
-              <tr>
-                <th class="jenkins-table__cell--tight"/>
-                <th initialSortDir="down">${%Name}</th>
-                <th class="jenkins-table__cell--tight"/>
-              </tr>
-            </thead>
-            <tbody>
-              <j:forEach var="cloud" items="${it.clouds}">
-                <tr id="cloud_${cloud.name}">
-                  <td data="${cloud.icon}" class="jenkins-table__cell--tight jenkins-table__icon">
-                    <div class="jenkins-table__cell__button-wrapper">
-                      <l:icon src="${cloud.iconClassName}" tooltip="${cloud.iconAltText}"/>
-                    </div>
-                  </td>
-                  <td>
-                    <a href="${it.getCloudUrl(request,app,cloud)}" class="jenkins-table__link model-link inside">${cloud.name}</a>
-                  </td>
-                  <td class="jenkins-table__cell--tight">
-                    <div class="jenkins-table__cell__button-wrapper">
-                      <a href="${it.getCloudUrl(request,app,cloud)}configure" class="jenkins-table__button">
-                        <l:icon src="symbol-settings"/>
-                      </a>
-                    </div>
-                  </td>
+          <p class="description">${%description}</p>
+          <f:form method="post" name="config" action="reorder">
+            <table id="clouds" class="jenkins-table">
+              <thead>
+                <tr>
+                  <th tooltip="${%Drag and drop cells to reorder}">${%Order}</th>
+                  <th>${%Name}</th>
+                  <th/>
                 </tr>
-              </j:forEach>
-            </tbody>
-          </table>
+              </thead>
+              <tbody class="with-drag-drop">
+                <j:forEach var="cloud" items="${it.clouds}">
+                  <tr class="repeated-chunk" id="cloud_${cloud.name}">
+                    <td data="${cloud.icon}" class="jenkins-table__cell--tight jenkins-table__icon">
+                      <div class="jenkins-table__cell__button-wrapper dd-handle">
+                        <l:icon src="${cloud.iconClassName}" tooltip="${cloud.iconAltText}"/>
+                      </div>
+                    </td>
+                    <td>
+                      <input type="hidden" name="name" value="${cloud.name}" />
+                      <a href="${it.getCloudUrl(request,app,cloud)}" class="jenkins-table__link model-link inside">${cloud.name}</a>
+                    </td>
+                    <td class="jenkins-table__cell--tight">
+                      <div class="jenkins-table__cell__button-wrapper">
+                        <a href="${it.getCloudUrl(request,app,cloud)}configure" class="jenkins-table__button">
+                          <l:icon src="symbol-settings"/>
+                        </a>
+                      </div>
+                    </td>
+                  </tr>
+                </j:forEach>
+              </tbody>
+            </table>
+            <l:isAdmin>
+              <f:bottomButtonBar>
+                <f:submit id="saveButton" value="${%Save}" clazz="jenkins-hidden" />
+              </f:bottomButtonBar>
+            </l:isAdmin>
+          </f:form>
+          <st:adjunct includes="lib.form.confirm" />
         </j:when>
         <j:otherwise>
           <div class="empty-state-block">

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.properties
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.properties
@@ -3,3 +3,4 @@ noCloudAvailable=There are no clouds currently setup, create one or install a pl
 noCloudPlugin=There are no cloud implementations for dynamically allocated agents installed.
 newCloud=New cloud
 installCloudPlugin=Install a plugin
+description=During node provisioning, clouds are tried in the order they appear in this table.

--- a/core/src/main/resources/jenkins/telemetry/impl/Uptime/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/Uptime/description.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    This trial collects two timestamps:
+    <ul>
+        <li><a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/System.html#nanoTime()"><code>System#nanoTime</code></a> when the trial was initialized (corresponds roughly to when Jenkins was started)</li>
+        <li><a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/System.html#nanoTime()"><code>System#nanoTime</code></a> when the trial data was collected (i.e., when it was prepared just before submission)</li>
+    </ul>
+
+    Additionally this trial collects the list of installed plugins, their version, and the version of Jenkins.
+    This data will help understand unexpected submission frequency of other trials' data.
+</j:jelly>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.29</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>6.13</winstone.version>
+    <winstone.version>6.14</winstone.version>
   </properties>
 
   <!--

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3148.v532a_7e715ee3</remoting.version>
+    <remoting.version>3160.vd76b_9ddd10cc</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -636,7 +636,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>10.0.16</version>
+        <version>10.0.17</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)

--- a/war/src/main/js/components/dropdowns/hetero-list.js
+++ b/war/src/main/js/components/dropdowns/hetero-list.js
@@ -21,6 +21,23 @@ function generateHandles() {
   });
 }
 
+function convertInputsToButtons(e) {
+  let oldInputs = e.querySelectorAll("INPUT.hetero-list-add");
+  oldInputs.forEach((oldbtn) => {
+    let btn = document.createElement("button");
+    btn.setAttribute("type", "button");
+    btn.classList.add("hetero-list-add", "jenkins-button");
+    btn.innerText = oldbtn.getAttribute("value");
+    if (oldbtn.hasAttribute("suffix")) {
+      btn.setAttribute("suffix", oldbtn.getAttribute("suffix"));
+    }
+    let chevron = createElementFromHtml(Symbols.CHEVRON_DOWN);
+    btn.appendChild(chevron);
+    oldbtn.parentNode.appendChild(btn);
+    oldbtn.remove();
+  });
+}
+
 function generateButtons() {
   behaviorShim.specify(
     "DIV.hetero-list-container",
@@ -31,26 +48,8 @@ function generateButtons() {
         return;
       }
 
+      convertInputsToButtons(e);
       let btn = Array.from(e.querySelectorAll("BUTTON.hetero-list-add")).pop();
-      if (!btn) {
-        let oldbtn = Array.from(
-          e.querySelectorAll("INPUT.hetero-list-add"),
-        ).pop();
-        if (!oldbtn) {
-          return;
-        }
-        btn = document.createElement("button");
-        btn.setAttribute("type", "button");
-        btn.classList.add("hetero-list-add", "jenkins-button");
-        btn.innerText = oldbtn.getAttribute("value");
-        if (oldbtn.hasAttribute("suffix")) {
-          btn.setAttribute("suffix", oldbtn.getAttribute("suffix"));
-        }
-        let chevron = createElementFromHtml(Symbols.CHEVRON_DOWN);
-        btn.appendChild(chevron);
-        oldbtn.parentNode.appendChild(btn);
-        oldbtn.remove();
-      }
 
       let prototypes = e.lastElementChild;
       while (!prototypes.classList.contains("prototypes")) {

--- a/war/src/main/js/pages/cloud-set/index.js
+++ b/war/src/main/js/pages/cloud-set/index.js
@@ -1,0 +1,9 @@
+import { registerSortableTableDragDrop } from "@/sortable-drag-drop";
+
+document.addEventListener("DOMContentLoaded", function () {
+  document.querySelectorAll("tbody").forEach((table) =>
+    registerSortableTableDragDrop(table, function () {
+      document.getElementById("saveButton").classList.remove("jenkins-hidden");
+    }),
+  );
+});

--- a/war/src/main/js/pages/cloud-set/index.scss
+++ b/war/src/main/js/pages/cloud-set/index.scss
@@ -1,0 +1,3 @@
+.dd-handle {
+  cursor: move;
+}

--- a/war/src/main/js/sortable-drag-drop.js
+++ b/war/src/main/js/sortable-drag-drop.js
@@ -36,6 +36,22 @@ function registerSortableDragDrop(e) {
   });
 }
 
+export function registerSortableTableDragDrop(e, onChangeFunction) {
+  if (!e || !e.classList.contains("with-drag-drop")) {
+    return false;
+  }
+
+  Sortable.create(e, {
+    handle: ".dd-handle",
+    items: "tr",
+    onChange: function (event) {
+      if (onChangeFunction) {
+        onChangeFunction(event);
+      }
+    },
+  });
+}
+
 /*
  * Expose the function to register drag & drop components to the window objects
  * so that other widgets can use it (repeatable, hetero-list)

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -639,17 +639,7 @@ function updateValidationArea(validationArea, content) {
     // Only change content if different, causes an unnecessary animation otherwise
     if (validationArea.innerHTML !== content) {
       validationArea.innerHTML = content;
-      validationArea.style.height =
-        validationArea.children[0].offsetHeight + "px";
-
-      // Only include the notice in the validation-error-area, move all other elements out
-      if (validationArea.children.length > 1) {
-        Array.from(validationArea.children)
-          .slice(1)
-          .forEach((element) => {
-            validationArea.after(element);
-          });
-      }
+      validationArea.style.height = "auto";
 
       Behaviour.applySubtree(validationArea);
       // For errors with additional details, apply the subtree to the expandable details pane

--- a/war/webpack.config.js
+++ b/war/webpack.config.js
@@ -28,6 +28,10 @@ module.exports = (env, argv) => ({
       ),
     ],
     app: [path.join(__dirname, "src/main/js/app.js")],
+    "pages/cloud-set": [
+      path.join(__dirname, "src/main/js/pages/cloud-set/index.js"),
+      path.join(__dirname, "src/main/js/pages/cloud-set/index.scss"),
+    ],
     "pages/manage-jenkins": [
       path.join(__dirname, "src/main/js/pages/manage-jenkins"),
     ],


### PR DESCRIPTION
## Backporting for LTS 2.426.1

Latest core version: [Jenkins 2.429](https://www.jenkins.io/changelog/#v2.429)

### Fixed

<pre>
JENKINS-72248           Minor                   2.428
        Backport uptime telemetry
        https://issues.jenkins.io/browse/JENKINS-72248

JENKINS-72189           Major                   2.430
        Drag&Drop for repeatables not working for existing entries (regression in 2.335)
        regression
        https://issues.jenkins.io/browse/JENKINS-72189

JENKINS-72179           Minor                   2.429
        Parameters view of builds does not show descriptions of checkbox parameters (regression in 2.179)
        regression
        https://issues.jenkins.io/browse/JENKINS-72179

JENKINS-72170           Major                   2.428
        Cannot add additional branch sources in multibranch pipeline after 2.422
        regression
        https://issues.jenkins.io/browse/JENKINS-72170

JENKINS-72163           Major                   3160.vd76b_9ddd10cc
        Retry on initial connection failure occurs in one entrypoint but not the other
        https://issues.jenkins.io/browse/JENKINS-72163

JENKINS-72156           Minor                   2.428, 2.414.3
        Include Jetty 10.0.17 in a Jenkins release
        https://issues.jenkins.io/browse/JENKINS-72156

JENKINS-72020           Minor                   2.428
        Unable to reorder clouds anymore via UI
        https://issues.jenkins.io/browse/JENKINS-72020

JENKINS-71937           Major                   2.427
        Jenkins 2.421 breaks vSphere Cloud agent labels
        regression
        https://issues.jenkins.io/browse/JENKINS-71937

JENKINS-71252           Critical                2.427
        Form validation is never displayed for fields initially hidden under Advanced section (regression in 2.355)
        regression
        https://issues.jenkins.io/browse/JENKINS-71252

JENKINS-70793           Minor                   2.427
        Form validation does not clear previous errors (regression in 2.355)
        regression
        https://issues.jenkins.io/browse/JENKINS-70793

JENKINS-65368           Major                   3159.vb_8c0ef2b_55a_f as included in 2.428
        Remoting agent.jar does not work behind proxy
        https://issues.jenkins.io/browse/JENKINS-65368
</pre>

The developer mailing list has the [backporting announcement](https://groups.google.com/g/jenkinsci-dev/c/d9Qr08oFstQ/m/-d8IzXwUNgAJ).  The [2.426.1 release checklist](https://github.com/jenkins-infra/release/issues/464) has more information as well.

Several candidates are not included in this pull request, but the authors of those candidates have been asked if those changes should be included in the 2.426.1 LTS backports.  Those include:

* Fix drag and drop for repeatables - [JENKINS-72189](https://issues.jenkins.io/browse/JENKINS-72189) & [JENKINS-71089](https://issues.jenkins.io/browse/JENKINS-71089)

### Testing done

Ran the generated war file interactively with Java 11, Java 17, and Java 21 and confirmed that it was well behaved with a few minutes of interactive testing.

Ran tests successfully with `mvn clean verify` on Linux.

### Proposed changelog entries

N/A - changelog will be created by the documentation team.

### Proposed upgrade guidelines

N/A - no items in this pull request that need an entry in the upgrade guide

### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@NotMyFault

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
