### PR TITLE
[JENKINS-72252] Warn 12 months and 3 months before end of Java support

### DIFF
--- a/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
@@ -115,7 +115,7 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
 
     @Override
     public boolean isActivated() {
-        return !disabled && getDeprecationPeriod().toTotalMonths() < 18;
+        return !disabled && getDeprecationPeriod().toTotalMonths() < 12;
     }
 
     @Override
@@ -156,7 +156,7 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
 
     @NonNull
     private static Severity getSeverity() {
-        return getDeprecationPeriod().toTotalMonths() < 9 ? Severity.DANGER : Severity.WARNING;
+        return getDeprecationPeriod().toTotalMonths() < 3 ? Severity.DANGER : Severity.WARNING;
     }
 
     /**


### PR DESCRIPTION
## [JENKINS-72252] Warn 12 months and 3 months before end of Java support
 
Daniel Beck described his recommendation to alert users at 12 months and at 3 months prior to the end of support of a Java version.

He wrote:

> The second warning in particular needs to strike a balance between being shown late enough so it's actually relevant for whoever hasn't acted yet, while being shown early enough that slightly more elaborate environments (difficult to schedule maintenance windows) are informed in time. 3 months aligns rather nicely with the LTS schedule where we kinda expect folks to do that anyway.
>
> 18/9, or even 12/6 errs too far on the side of those for whom this is extreme effort (and who dismissed the first message more appropriate for their environment!), while showing everyone else completely irrelevant notices they won't care about for many months to come.

https://github.com/jenkinsci/jep/pull/400#discussion_r1371510566 provides more details.

The Java 8 to Java 11 transition saw a significant change in adoption of Java 11 once the admin monitor was visible to users.  That was shown slightly over 12 months before the release that required Java 11.  This change continues that pattern of 12 months warning before end of support.

https://github.com/jenkinsci/jep/pull/400#discussion_r1375623888 has this graph that shows the adoption curves for Java 8, Java 11, and Java 17.

![java-8-to-java-11-admin-monitor](https://github.com/jenkinsci/jenkins/assets/156685/08fb9e2b-4589-43dc-a9ee-1f9f979e3493)


### Testing done

Ran with Java 11 and confirmed that the admin monitor is displayed.

Ran with Java 17 and confirmed that the admin monitor is not displayed.

### Proposed changelog entries

- Warn users at 12 months prior to end of Java support and again at 3 months prior to end of Java support.

### Proposed upgrade guidelines

N/A

### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@daniel-beck, @jtnord, @basil

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
