### PR TITLE
Log `Error`s from `SlaveComputer._connect`

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -308,7 +308,7 @@ public class SlaveComputer extends Computer {
                     e.addSuppressed(threadInfo);
                     Functions.printStackTrace(e, taskListener.error(Messages.ComputerLauncher_abortedLaunch()));
                     throw e;
-                } catch (RuntimeException e) {
+                } catch (RuntimeException | Error e) {
                     e.addSuppressed(threadInfo);
                     Functions.printStackTrace(e, taskListener.error(Messages.ComputerLauncher_unexpectedError()));
                     throw e;


### PR DESCRIPTION
When an (outbound) agent fails to launch, we expect any errors to be printed to the agent log. This is done by `_connect`, since (unlike the case in #7284) this returns a `Future` and a caller of `Computer.connect` may or may wait for it (`get`; most do not). While this checked for a variety of checked and unchecked exceptions, it failed to account for `Error`s.

### Testing done

Discovered while investigating a (proprietary) test flake. Without the patch, when launching fails (randomly), nothing appears in the log; in fact `slave.log` is not created at all. With the patch, the agent log shows the error, in this case

```
ERROR: Unexpected error in launching an agent. This is probably a bug in Jenkins
java.lang.ClassNotFoundException: org.bouncycastle.crypto.prng.RandomGenerator
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at jenkins.util.URLClassLoader2.findClass(URLClassLoader2.java:35)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
Also:   java.lang.Throwable: launched here
	at hudson.slaves.SlaveComputer._connect(SlaveComputer.java:286)
	at hudson.model.Computer.connect(Computer.java:448)
	at …
Caused: java.lang.NoClassDefFoundError: org/bouncycastle/crypto/prng/RandomGenerator
	at org.apache.sshd.common.util.security.bouncycastle.BouncyCastleRandomFactory.create(BouncyCastleRandomFactory.java:43)
	at org.apache.sshd.common.util.security.bouncycastle.BouncyCastleRandomFactory.create(BouncyCastleRandomFactory.java:28)
	at org.apache.sshd.common.random.SingletonRandomFactory.<init>(SingletonRandomFactory.java:38)
	at org.apache.sshd.common.BaseBuilder.fillWithDefaultValues(BaseBuilder.java:166)
	at org.apache.sshd.client.ClientBuilder.fillWithDefaultValues(ClientBuilder.java:110)
	at org.apache.sshd.client.ClientBuilder.fillWithDefaultValues(ClientBuilder.java:54)
	at org.apache.sshd.common.BaseBuilder.build(BaseBuilder.java:273)
	at org.apache.sshd.client.ClientBuilder.build(ClientBuilder.java:161)
	at com.cloudbees.jenkins.plugins.sshslaves.PluginImpl.sshClient(PluginImpl.java:23)
	at com.cloudbees.jenkins.plugins.sshslaves.SSHLauncher.openConnection(SSHLauncher.java:326)
	at com.cloudbees.jenkins.plugins.sshslaves.SSHLauncher.launch(SSHLauncher.java:153)
	at hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:297)
	at …
```

(Never mind the root cause for purposes of this PR.)

### Proposed changelog entries

- More consistently report errors launching outbound agents.

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
