### PR TITLE
Backporting for 2.426.2

### DIFF
--- a/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
@@ -115,7 +115,7 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
 
     @Override
     public boolean isActivated() {
-        return !disabled && getDeprecationPeriod().toTotalMonths() < 18;
+        return !disabled && getDeprecationPeriod().toTotalMonths() < 12;
     }
 
     @Override
@@ -156,7 +156,7 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
 
     @NonNull
     private static Severity getSeverity() {
-        return getDeprecationPeriod().toTotalMonths() < 9 ? Severity.DANGER : Severity.WARNING;
+        return getDeprecationPeriod().toTotalMonths() < 3 ? Severity.DANGER : Severity.WARNING;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.29</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>6.14</winstone.version>
+    <winstone.version>6.16</winstone.version>
   </properties>
 
   <!--

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -636,7 +636,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>10.0.17</version>
+        <version>10.0.18</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
## Backporting for 2.426.2

[JENKINS-72266](https://issues.jenkins.io/browse/JENKINS-72266) Upgrade Winstone from 6.14 to 6.16 (upgrade Jetty from 10.0.17 to 10.0.18)

A work in progress until the matching commit d3295776738cb4675161e71c992777b4605991e8 has been delivered in 2.431.

**Not a backport for 2.426.1**

### Fixed

<pre>
JENKINS-72266           Minor                   2.431
        Upgrade Winstone from 6.14 to 6.16 (upgrade Jetty from 10.0.17 to 10.0.18)
        https://issues.jenkins.io/browse/JENKINS-72266

JENKINS-72252           Minor                   2.431
        Warn administrators of Java end of support 12 months and 3 months prior
        https://issues.jenkins.io/browse/JENKINS-72252
</pre>

### Testing done

`mvn clean verify` ran successfully.  Pull request tested on the master branch by @basil where he described the testing done as:

> Built Jenkins core with these changes, started Winstone with HTTP 2 enabled and a self-signed TLS certificate, and verified that I could load the page in Firefox.

### Proposed changelog entries

- Upgrade Winstone from 6.14 to 6.16 (upgrade Jetty from 10.0.17 to 10.0.18).

### Proposed upgrade guidelines

N/A

### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
