### PR TITLE
Backporting for 2.426.1 - part 2

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -383,7 +383,7 @@ THE SOFTWARE.
                   <!-- dependency of jackson2-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>snakeyaml-api</artifactId>
-                  <version>1.33-95.va_b_a_e3e47b_fa_4</version>
+                  <version>2.2-111.vc6598e30cc65</version>
                   <type>hpi</type>
                 </artifactItem>
 


### PR DESCRIPTION
## Backporting for LTS 2.426.1 - part 2

Latest core version: [Jenkins 2.431](https://www.jenkins.io/changelog/#v2.431)

### Fixed

<pre>
JENKINS-70994           Minor                   2.431
        Update snakeyaml plugin to 2.0 to silence security scanners
        https://issues.jenkins.io/browse/JENKINS-70994
</pre>

Adds the Snakeyaml API plugin 2.2-111.x backport to Jenkins 2.426.1 in order to silence security scanners.  The Snakeyaml API plugin 2.2-111.x plugin has been available for two months and is actively used on ci.jenkins.io and many other Jenkins installations.  Refer to [pull request conversation](https://github.com/jenkinsci/jenkins/pull/8681#issuecomment-1802878182) for more details.

### Testing done

Ran tests successfully with `mvn clean verify` on Linux.

Will test in my environment when an incremental build is available.

Will announce a new release candidate when this is merged to the stable-2.426 branch.

### Proposed changelog entries

N/A - changelog will be created by the documentation team using information from [JENKINS-70994](https://issues.jenkins.io/browse/JENKINS-70994).

### Proposed upgrade guidelines

N/A - no items in this pull request that need an entry in the upgrade guide

### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
