### PR TITLE
Added validation of FIPS password length

### DIFF
--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -452,6 +452,11 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
             si.errors.put("password1", Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordRequired());
         }
 
+        if (FIPS140.useCompliantAlgorithms()) {
+            if (si.password1.length() < 14) {
+                si.errors.put("password1", Messages.HudsonPrivateSecurityRealm_CreateAccount_FIPS_PasswordLengthInvalid());
+            }
+        }
         if (si.fullname == null || si.fullname.isEmpty()) {
             si.fullname = si.username;
         }

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -114,6 +114,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  * @author Kohsuke Kawaguchi
  */
 public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRealm implements ModelObject, AccessControlled {
+    private static final int FIPS_PASSWORD_LENGTH = 14;
     private static /* not final */ String ID_REGEX = System.getProperty(HudsonPrivateSecurityRealm.class.getName() + ".ID_REGEX");
 
     /**
@@ -453,7 +454,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         }
 
         if (FIPS140.useCompliantAlgorithms()) {
-            if (si.password1.length() < 14) {
+            if (si.password1.length() < FIPS_PASSWORD_LENGTH) {
                 si.errors.put("password1", Messages.HudsonPrivateSecurityRealm_CreateAccount_FIPS_PasswordLengthInvalid());
             }
         }

--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -36,6 +36,7 @@ HudsonPrivateSecurityRealm.ManageUserLinks.Description=Create/delete/modify user
 
 HudsonPrivateSecurityRealm.CreateAccount.TextNotMatchWordInImage=Text didn''t match the word shown in the image
 HudsonPrivateSecurityRealm.CreateAccount.PasswordNotMatch=Password didn''t match
+HudsonPrivateSecurityRealm.CreateAccount.FIPS.PasswordLengthInvalid=Password should be atleast 112 bits(14 Characters in FIPS mode)
 HudsonPrivateSecurityRealm.CreateAccount.PasswordRequired=Password is required
 HudsonPrivateSecurityRealm.CreateAccount.UserNameRequired=User name is required
 HudsonPrivateSecurityRealm.CreateAccount.UserNameInvalidCharacters=User name must only contain alphanumeric characters, underscore and dash

--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -36,7 +36,7 @@ HudsonPrivateSecurityRealm.ManageUserLinks.Description=Create/delete/modify user
 
 HudsonPrivateSecurityRealm.CreateAccount.TextNotMatchWordInImage=Text didn''t match the word shown in the image
 HudsonPrivateSecurityRealm.CreateAccount.PasswordNotMatch=Password didn''t match
-HudsonPrivateSecurityRealm.CreateAccount.FIPS.PasswordLengthInvalid=Password should be atleast 112 bits(14 Characters in FIPS mode)
+HudsonPrivateSecurityRealm.CreateAccount.FIPS.PasswordLengthInvalid=Password must be at least 14 characters long
 HudsonPrivateSecurityRealm.CreateAccount.PasswordRequired=Password is required
 HudsonPrivateSecurityRealm.CreateAccount.UserNameRequired=User name is required
 HudsonPrivateSecurityRealm.CreateAccount.UserNameInvalidCharacters=User name must only contain alphanumeric characters, underscore and dash


### PR DESCRIPTION
See [JENKINS-72332](https://issues.jenkins.io/browse/JENKINS-72332).

### Testing done


FIPS Enabled Jenkins requires password to be 112 bits(14 chars) minimum. While creating a User, when the password is short, it was showing error in console and navigating to error page. Now a validation has been added to check the password length.

The error couldnt be caught since its unchecked exception and its been caused in the line of code where framework's encode method is called.this doesnt allow adding a new exception apart from the one defined in the interface.

Testing has been done in FIPS enabled Docker container.

### Proposed changelog entries

- Fips mode now requires a minimum of 14 characters for a password.


### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```


