### PR TITLE
Avoid scrollbar in dropdown popups (page footer, log recorder)

### DIFF
--- a/core/src/main/resources/lib/layout/overflowButton.jelly
+++ b/core/src/main/resources/lib/layout/overflowButton.jelly
@@ -64,6 +64,8 @@ THE SOFTWARE.
     ${attrs.text}
   </button>
   <template>
-    <d:invokeBody />
+    <div class="jenkins-dropdown">
+      <d:invokeBody />
+    </div>
   </template>
 </j:jelly>


### PR DESCRIPTION
Adds a wrapping `<div>` to have consistent paddingwith other dropdowns (e.g. the ones in sidebar) -- that avoids extra scrollbar  when a separator is present. The diff makes more sense [without whitespace changes](https://github.com/jenkinsci/jenkins/pull/8704/files?w=1).

<details><summary>Before:</summary>

![image](https://github.com/jenkinsci/jenkins/assets/1105305/68b996a9-fe61-4b06-868b-47edc317e7a7)
![image](https://github.com/jenkinsci/jenkins/assets/1105305/8280af8d-d25d-4a8b-9cad-666e28c4681b)
![image](https://github.com/jenkinsci/jenkins/assets/1105305/4e755db0-759e-40a8-9cd1-a2b357d5a911)

</details>

<details><summary>After:</summary>

![image](https://github.com/jenkinsci/jenkins/assets/1105305/74af03aa-b523-4e22-ac46-ea561d54e470)
![image](https://github.com/jenkinsci/jenkins/assets/1105305/dc64beda-cebd-4a83-89b0-55bba9d91e01)
![image](https://github.com/jenkinsci/jenkins/assets/1105305/b2bb8af4-739b-4195-9ac7-95d89ec663a2)

</details>

Footer popup introduced in this PR: https://github.com/jenkinsci/jenkins/pull/7989

### Testing done

Screenshot above.

### Proposed changelog entries

Avoid scrollbar in the version popup (page footer)

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] Explanation as to why this change has no tests: visual improvement only
```

### Desired reviewers

@janfaracik 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
