### PR TITLE
Hide build history page navigation controls if there's no additional pages

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -63,18 +63,20 @@ THE SOFTWARE.
 
   <j:set var="page" value="${it.historyPageFilter}" />
   <div id="buildHistoryPage" page-ajax="${it.baseUrl}/buildHistory/ajax" page-entry-newest="${page.newestOnPage}" page-entry-oldest="${page.oldestOnPage}" page-has-up="${page.hasUpPage}" page-has-down="${page.hasDownPage}">
-    <div id="buildHistoryPageNav">
-      <div class="buildHistoryPageNav__item buildHistoryPageNav__item--page-one pageOne" title="Page 1 (Newest/Latest Builds)">
-        <div class="buildHistoryPageNav__item-page-one-top"></div>
-        <l:svgIcon href="${resURL}/images/svgs/go-up.svg#arrow" viewBox="0 0 16 16" />
+    <j:if test="${page.hasUpPage or page.hasDownPage}">
+      <div id="buildHistoryPageNav">
+        <div class="buildHistoryPageNav__item buildHistoryPageNav__item--page-one pageOne" title="Page 1 (Newest/Latest Builds)">
+          <div class="buildHistoryPageNav__item-page-one-top"></div>
+          <l:svgIcon href="${resURL}/images/svgs/go-up.svg#arrow" viewBox="0 0 16 16" />
+        </div>
+        <div class="buildHistoryPageNav__item pageUp" title="Newer Builds">
+          <l:svgIcon href="${resURL}/images/svgs/go-up.svg#arrow" viewBox="0 0 16 16" />
+        </div>
+        <div class="buildHistoryPageNav__item pageDown" title="Older Builds">
+          <l:svgIcon href="${resURL}/images/svgs/go-down.svg#arrow" viewBox="0 0 16 16" />
+        </div>
       </div>
-      <div class="buildHistoryPageNav__item pageUp" title="Newer Builds">
-        <l:svgIcon href="${resURL}/images/svgs/go-up.svg#arrow" viewBox="0 0 16 16" />
-      </div>
-      <div class="buildHistoryPageNav__item pageDown" title="Older Builds">
-        <l:svgIcon href="${resURL}/images/svgs/go-down.svg#arrow" viewBox="0 0 16 16" />
-      </div>
-    </div>
+    </j:if>
 
     <l:pane width="3" title="${h.runScript(paneTitle)}" footer="${h.runScript(paneFooter)}" id="buildHistory" class="jenkins-pane stripped">
       <tr class="build-search-row">

--- a/war/src/main/js/filter-build-history.js
+++ b/war/src/main/js/filter-build-history.js
@@ -16,9 +16,9 @@ const noBuildsBanner = document.getElementById("no-builds");
 const sidePanel = document.getElementById("side-panel");
 const buildHistoryPageNav = document.getElementById("buildHistoryPageNav");
 
-const pageOne = buildHistoryPageNav.querySelector(".pageOne");
-const pageUp = buildHistoryPageNav.querySelector(".pageUp");
-const pageDown = buildHistoryPageNav.querySelector(".pageDown");
+const pageOne = buildHistoryPageNav?.querySelector(".pageOne");
+const pageUp = buildHistoryPageNav?.querySelector(".pageUp");
+const pageDown = buildHistoryPageNav?.querySelector(".pageDown");
 
 const leftRightPadding = 4;
 const updateBuildsRefreshInterval = 5000;
@@ -159,8 +159,8 @@ function updatePageParams(dataTable) {
   );
 }
 function togglePageUpDown() {
-  buildHistoryPageNav.classList.remove("hasUpPage");
-  buildHistoryPageNav.classList.remove("hasDownPage");
+  buildHistoryPageNav?.classList.remove("hasUpPage");
+  buildHistoryPageNav?.classList.remove("hasDownPage");
   if (hasPageUp()) {
     buildHistoryPageNav.classList.add("hasUpPage");
   }
@@ -559,25 +559,25 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Show/hide the nav as the mouse moves into the sidepanel and build history.
   sidePanel.addEventListener("mouseover", function () {
-    buildHistoryPageNav.classList.add("mouseOverSidePanel");
+    buildHistoryPageNav?.classList.add("mouseOverSidePanel");
   });
   sidePanel.addEventListener("mouseout", function () {
-    buildHistoryPageNav.classList.remove("mouseOverSidePanel");
+    buildHistoryPageNav?.classList.remove("mouseOverSidePanel");
   });
   buildHistoryContainer.addEventListener("mouseover", function () {
-    buildHistoryPageNav.classList.add("mouseOverSidePanelBuildHistory");
+    buildHistoryPageNav?.classList.add("mouseOverSidePanelBuildHistory");
   });
   buildHistoryContainer.addEventListener("mouseout", function () {
-    buildHistoryPageNav.classList.remove("mouseOverSidePanelBuildHistory");
+    buildHistoryPageNav?.classList.remove("mouseOverSidePanelBuildHistory");
   });
 
-  pageOne.addEventListener("click", function () {
+  pageOne?.addEventListener("click", function () {
     loadPage();
   });
-  pageUp.addEventListener("click", function () {
+  pageUp?.addEventListener("click", function () {
     loadPage({ "newer-than": getNewestEntryId() });
   });
-  pageDown.addEventListener("click", function () {
+  pageDown?.addEventListener("click", function () {
     if (hasPageDown()) {
       cancelRefreshTimeout();
       loadPage({ "older-than": getOldestEntryId() });


### PR DESCRIPTION
Currently we show these little navigation controls regardless of if there's additional pages the user can navigate to - 

![image](https://github.com/jenkinsci/jenkins/assets/43062514/7eb588a6-e8ed-413d-815b-fc4553bd444d)

These offer no use if there aren't additional pages and don't provide suitable feedback to the user that they won't do anything, or worst case, they'll hide the users existing builds. This PR hides the controls if there's no additional pages for the user to navigate to.

### Testing done

* Controls are hidden if there are no additional pages to navigate to
* Controls are visible if there are additional pages to navigate to

### Proposed changelog entries

- Hide build history page navigation controls if there are no additional pages.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
