### PR TITLE
[JENKINS-72370][JENKINS-11889] fix SimpleScheduledRetentionStrategy with inbound agents

### DIFF
--- a/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/SimpleScheduledRetentionStrategy.java
@@ -170,6 +170,11 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
     }
 
     @Override
+    public boolean isAcceptingTasks(SlaveComputer c) {
+        return isOnlineScheduled();
+    }
+
+    @Override
     @GuardedBy("hudson.model.Queue.lock")
     public synchronized long check(final SlaveComputer c) {
         boolean shouldBeOnline = isOnlineScheduled();
@@ -191,7 +196,6 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
                                 LOGGER.log(INFO,
                                         "Enabling new jobs for computer {0} as it has started its scheduled uptime",
                                         new Object[]{c.getName()});
-                                c.setAcceptingTasks(true);
                             }
                         } catch (InterruptedException | ExecutionException e) {
                         }
@@ -199,45 +203,44 @@ public class SimpleScheduledRetentionStrategy extends RetentionStrategy<SlaveCom
                 });
             }
         } else if (!shouldBeOnline && c.isOnline()) {
-            if (keepUpWhenActive) {
-                if (!c.isIdle() && c.isAcceptingTasks()) {
-                    c.setAcceptingTasks(false);
-                    LOGGER.log(INFO,
-                            "Disabling new jobs for computer {0} as it has finished its scheduled uptime",
+            if (c.isLaunchSupported()) {
+                if (keepUpWhenActive) {
+                    if (!c.isIdle() && c.isAcceptingTasks()) {
+                        LOGGER.log(INFO,
+                                "Disabling new jobs for computer {0} as it has finished its scheduled uptime",
+                                new Object[]{c.getName()});
+                        return 1;
+                    } else if (c.isIdle() && c.isAcceptingTasks()) {
+                        Queue.withLock(new Runnable() {
+                            @Override
+                            public void run() {
+                                if (c.isIdle()) {
+                                    LOGGER.log(INFO, "Disconnecting computer {0} as it has finished its scheduled uptime",
+                                            new Object[]{c.getName()});
+                                    c.disconnect(OfflineCause
+                                            .create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
+                                }
+                            }
+                        });
+                    } else if (c.isIdle() && !c.isAcceptingTasks()) {
+                        Queue.withLock(new Runnable() {
+                            @Override
+                            public void run() {
+                                if (c.isIdle()) {
+                                    LOGGER.log(INFO, "Disconnecting computer {0} as it has finished all jobs running when "
+                                            + "it completed its scheduled uptime", new Object[]{c.getName()});
+                                    c.disconnect(OfflineCause
+                                            .create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
+                                }
+                            }
+                        });
+                    }
+                } else {
+                    // no need to get the queue lock as the user has selected the break builds option!
+                    LOGGER.log(INFO, "Disconnecting computer {0} as it has finished its scheduled uptime",
                             new Object[]{c.getName()});
-                    return 1;
-                } else if (c.isIdle() && c.isAcceptingTasks()) {
-                    Queue.withLock(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (c.isIdle()) {
-                                LOGGER.log(INFO, "Disconnecting computer {0} as it has finished its scheduled uptime",
-                                        new Object[]{c.getName()});
-                                c.disconnect(OfflineCause
-                                        .create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
-                            } else {
-                                c.setAcceptingTasks(false);
-                            }
-                        }
-                    });
-                } else if (c.isIdle() && !c.isAcceptingTasks()) {
-                    Queue.withLock(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (c.isIdle()) {
-                                LOGGER.log(INFO, "Disconnecting computer {0} as it has finished all jobs running when "
-                                        + "it completed its scheduled uptime", new Object[]{c.getName()});
-                                c.disconnect(OfflineCause
-                                        .create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
-                            }
-                        }
-                    });
+                    c.disconnect(OfflineCause.create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
                 }
-            } else {
-                // no need to get the queue lock as the user has selected the break builds option!
-                LOGGER.log(INFO, "Disconnecting computer {0} as it has finished its scheduled uptime",
-                        new Object[]{c.getName()});
-                c.disconnect(OfflineCause.create(Messages._SimpleScheduledRetentionStrategy_FinishedUpTime()));
             }
         }
         return 1;


### PR DESCRIPTION
By implementing `isAcceptingTasks` the availability strategy ensures that no builds can start when the agent should not do anything. 
The current behaviour with an inbound agent is that controller and agent play jojo. The strategy disconnects the agent, the agents java process detects the disconnect and reconnects to the controller, with the strategy again disconnecting the agent and so on.
So the change will only disconnect the agent when the controller can itself launch the agent, this means inbound agents are not disconnected, to avoid playing jojo. The agent will just not accept new tasks for execution.

The change also avoids the problem in [JENKINS-11889] for outbound agents where the accepting tasks of an agents seems to be not reset when changing the availability strategy to always on.

See [JENKINS-72370](https://issues.jenkins.io/browse/JENKINS-72370).
See [JENKINS-11889](https://issues.jenkins.io/browse/JENKINS-11889).

### Testing done
Manual testing as described in the Jira ticket.

### Proposed changelog entries

- Fix  SimpleScheduledRetentionStrategy on inbound agents.   Allow suspended agents to again accept tasks when they are reconnected and the configured scheduling policy is enabled.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
