### PR TITLE
[JENKINS-72371] rework node monitor configuration

### DIFF
--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -66,6 +66,21 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
     }
 
     /**
+     * Indicates if this monitor is capable to take agents offline in case it detects a problem.
+     * If true, this will enable the configuration option to ignore the monitor.
+     * Defaults to {@code true} so plugins that do not override this method behave as before.
+     * @return true if this monitor might take agents offline
+     */
+    public boolean canTakeOffline() {
+        return true;
+    }
+
+    @Override
+    public String getConfigPage() {
+        return getViewPage(clazz, "configure.jelly");
+    }
+
+    /**
      * @deprecated as of 1.522
      *      Extend from {@link AbstractAsyncNodeMonitorDescriptor}
      */

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -69,7 +69,11 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      * Indicates if this monitor is capable to take agents offline in case it detects a problem.
      * If true, this will enable the configuration option to ignore the monitor.
      * Defaults to {@code true} so plugins that do not override this method behave as before.
+     * Plugins that do implement a monitor that will not take agents offline should override this
+     * method and return false.
+     *
      * @return true if this monitor might take agents offline
+     * @since TODO
      */
     public boolean canTakeOffline() {
         return true;

--- a/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ArchitectureMonitor.java
@@ -30,10 +30,8 @@ import hudson.model.Computer;
 import hudson.remoting.Callable;
 import java.io.IOException;
 import jenkins.security.MasterToSlaveCallable;
-import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Discovers the architecture of the system to display in the agent list page.
@@ -60,8 +58,8 @@ public class ArchitectureMonitor extends NodeMonitor {
         }
 
         @Override
-        public NodeMonitor newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new ArchitectureMonitor();
+        public boolean canTakeOffline() {
+            return false;
         }
     }
 

--- a/core/src/main/java/hudson/node_monitors/ClockMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ClockMonitor.java
@@ -32,12 +32,10 @@ import hudson.model.Node;
 import hudson.remoting.Callable;
 import hudson.util.ClockDifference;
 import java.io.IOException;
-import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * {@link NodeMonitor} that checks clock of {@link Node} to
@@ -73,6 +71,11 @@ public class ClockMonitor extends NodeMonitor {
         }
 
         @Override
+        public boolean canTakeOffline() {
+            return false;
+        }
+
+        @Override
         protected Callable<ClockDifference, IOException> createCallable(Computer c) {
             Node n = c.getNode();
             if (n == null) return null;
@@ -83,11 +86,6 @@ public class ClockMonitor extends NodeMonitor {
         @Override
         public String getDisplayName() {
             return Messages.ClockMonitor_DisplayName();
-        }
-
-        @Override
-        public NodeMonitor newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new ClockMonitor();
         }
     }
 }

--- a/core/src/main/java/hudson/node_monitors/NodeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/NodeMonitor.java
@@ -37,6 +37,7 @@ import hudson.tasks.Publisher;
 import hudson.util.DescriptorList;
 import java.util.List;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -133,6 +134,7 @@ public abstract class NodeMonitor implements ExtensionPoint, Describable<NodeMon
         return ignored;
     }
 
+    @DataBoundSetter
     public void setIgnored(boolean ignored) {
         this.ignored = ignored;
     }

--- a/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/ResponseTimeMonitor.java
@@ -34,10 +34,8 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.logging.Logger;
 import jenkins.security.MasterToSlaveCallable;
-import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -102,11 +100,6 @@ public class ResponseTimeMonitor extends NodeMonitor {
         @Override
         public String getDisplayName() {
             return Messages.ResponseTimeMonitor_DisplayName();
-        }
-
-        @Override
-        public NodeMonitor newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new ResponseTimeMonitor();
         }
     }
 

--- a/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/SwapSpaceMonitor.java
@@ -33,12 +33,10 @@ import hudson.model.Computer;
 import java.io.IOException;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
-import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.jvnet.hudson.MemoryMonitor;
 import org.jvnet.hudson.MemoryUsage;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -104,6 +102,11 @@ public class SwapSpaceMonitor extends NodeMonitor {
         }
 
         @Override
+        public boolean canTakeOffline() {
+            return false;
+        }
+
+        @Override
         protected MonitorTask createCallable(Computer c) {
             return new MonitorTask();
         }
@@ -112,11 +115,6 @@ public class SwapSpaceMonitor extends NodeMonitor {
         @Override
         public String getDisplayName() {
             return Messages.SwapSpaceMonitor_DisplayName();
-        }
-
-        @Override
-        public NodeMonitor newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new SwapSpaceMonitor();
         }
     }
 

--- a/core/src/main/resources/hudson/model/ComputerSet/configure.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/configure.jelly
@@ -42,7 +42,8 @@ THE SOFTWARE.
       <f:form method="post" action="configSubmit" name="config">
         <f:descriptorList title="${%Preventive Node Monitoring}"
                           descriptors="${it.nodeMonitorDescriptors}"
-                          instances="${it.nonIgnoredMonitors}" />
+                          instances="${it.monitors}"
+                          forceRowSet="true"/>
 
         <l:hasAdministerOrManage>
           <f:bottomButtonBar>

--- a/core/src/main/resources/hudson/model/ComputerSet/configure.properties
+++ b/core/src/main/resources/hudson/model/ComputerSet/configure.properties
@@ -1,1 +1,2 @@
-description=Jenkins monitors each attached node for disk space, free temp space, free swap, clock time/sync, and response time. Nodes will be taken offline if any of these values go outside of the configured threshold.
+description=Jenkins monitors each attached node for various metrics like free disk space, free temp space, free swap, clock time/sync, response time and others provided by plugins. \
+  Some of these monitors are able to mark nodes temporarily offline, when the values go outside the configured thresholds.

--- a/core/src/main/resources/hudson/node_monitors/ArchitectureMonitor/help.html
+++ b/core/src/main/resources/hudson/node_monitors/ArchitectureMonitor/help.html
@@ -1,4 +1,4 @@
 <div>
   This monitor just shows the architecture of the agent for your information. It
-  never marks the agent offline.
+  never marks an agent offline.
 </div>

--- a/core/src/main/resources/hudson/node_monitors/ClockMonitor/help.html
+++ b/core/src/main/resources/hudson/node_monitors/ClockMonitor/help.html
@@ -3,7 +3,8 @@
   Jenkins itself is generally capable of tolerating clock differences between
   systems, version control activities and distributed file access (such as NFS,
   Windows file shares) tend to have strange problems when systems involved have
-  different clocks.<br/>
+  different clocks.
+  <br />
   It never marks an agent offline.
 
   <p>To keep clocks in sync, refer to NTP.</p>

--- a/core/src/main/resources/hudson/node_monitors/ClockMonitor/help.html
+++ b/core/src/main/resources/hudson/node_monitors/ClockMonitor/help.html
@@ -3,7 +3,8 @@
   Jenkins itself is generally capable of tolerating clock differences between
   systems, version control activities and distributed file access (such as NFS,
   Windows file shares) tend to have strange problems when systems involved have
-  different clocks.
+  different clocks.<br/>
+  It never marks an agent offline.
 
   <p>To keep clocks in sync, refer to NTP.</p>
 </div>

--- a/core/src/main/resources/hudson/node_monitors/NodeMonitor/configure.jelly
+++ b/core/src/main/resources/hudson/node_monitors/NodeMonitor/configure.jelly
@@ -1,0 +1,24 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <j:set var="help" value="${descriptor.helpFile}"/>
+  <div class="jenkins-form-label help-sibling tr">
+    ${descriptor.displayName}
+    <f:helpLink url="${help}" featureName="${descriptor.displayName}"/>
+  </div>
+  <f:helpArea />
+  <div class="optionalBlock-container jenkins-form-item">
+    <div class="form-container">
+      <j:if test="${descriptor.canTakeOffline()}">
+        <f:entry title="${%Don't mark agents temporarily offline}" field="ignored">
+          <f:checkbox checked="${instance.ignored}" />
+        </f:entry>
+      </j:if>
+      <j:if test="${!descriptor.canTakeOffline()}">
+        <f:invisibleEntry>
+          <f:checkbox name="ignored" checked="false" />
+        </f:invisibleEntry>
+      </j:if>
+      <st:include page="config.jelly" class="${descriptor.clazz}" optional="true"/>
+    </div>
+  </div>
+</j:jelly>

--- a/core/src/main/resources/hudson/node_monitors/NodeMonitor/help-ignored.html
+++ b/core/src/main/resources/hudson/node_monitors/NodeMonitor/help-ignored.html
@@ -1,0 +1,4 @@
+<div>
+    When checked the agent will <i>not</i> be marked temporarily offline in case the monitor detects a problem. But the monitor
+    will still run to collect data and the corresponding field will be highlighted in case of a problem.
+</div>

--- a/core/src/main/resources/hudson/node_monitors/NodeMonitor/help-ignored.html
+++ b/core/src/main/resources/hudson/node_monitors/NodeMonitor/help-ignored.html
@@ -1,4 +1,7 @@
 <div>
-    When checked the agent will <i>not</i> be marked temporarily offline in case the monitor detects a problem. But the monitor
-    will still run to collect data and the corresponding field will be highlighted in case of a problem.
+  When checked the agent will
+  <i>not</i>
+  be marked temporarily offline in case the monitor detects a problem. But the
+  monitor will still run to collect data and the corresponding field will be
+  highlighted in case of a problem.
 </div>

--- a/core/src/main/resources/hudson/node_monitors/ResponseTimeMonitor/help.html
+++ b/core/src/main/resources/hudson/node_monitors/ResponseTimeMonitor/help.html
@@ -1,7 +1,6 @@
 <div>
   This monitors the round trip network response time from the controller to the
-  agent, and if it goes above a threshold repeatedly, it marks the agent
-  offline.
+  agent, and if it goes above a threshold repeatedly, it disconnects the agent.
 
   <p>
     This is useful for detecting unresponsive agents, or other network problems

--- a/core/src/main/resources/hudson/node_monitors/SwapSpaceMonitor/help.html
+++ b/core/src/main/resources/hudson/node_monitors/SwapSpaceMonitor/help.html
@@ -1,10 +1,22 @@
 <div>
-  This monitors the available virtual memory (also known as <code>swap space</code>).
+  This monitors the available virtual memory (also known as
+  <code>swap space</code>
+  ).
   <p>The exact definition of swap space is platform dependent.</p>
   <ul>
-    <li>On Windows this is the available space of the page file. As Windows can automatically increase
-    the page file size, this value doesn't mean much.</li>
-    <li>On Linux this value is retrieved from <code>/proc/meminfo</code>.</li>
-    <li>For other Unix systems, the value is obtained from the <code>top</code> command.</li>
+    <li>
+      On Windows this is the available space of the page file. As Windows can
+      automatically increase the page file size, this value doesn't mean much.
+    </li>
+    <li>
+      On Linux this value is retrieved from
+      <code>/proc/meminfo</code>
+      .
+    </li>
+    <li>
+      For other Unix systems, the value is obtained from the
+      <code>top</code>
+      command.
+    </li>
   </ul>
 </div>

--- a/core/src/main/resources/hudson/node_monitors/SwapSpaceMonitor/help.html
+++ b/core/src/main/resources/hudson/node_monitors/SwapSpaceMonitor/help.html
@@ -1,0 +1,10 @@
+<div>
+  This monitors the available virtual memory (also known as <code>swap space</code>).
+  <p>The exact definition of swap space is platform dependent.</p>
+  <ul>
+    <li>On Windows this is the available space of the page file. As Windows can automatically increase
+    the page file size, this value doesn't mean much.</li>
+    <li>On Linux this value is retrieved from <code>/proc/meminfo</code>.</li>
+    <li>For other Unix systems, the value is obtained from the <code>top</code> command.</li>
+  </ul>
+</div>


### PR DESCRIPTION
This PR reworks the way node monitors are configured. It ensures that also monitors which are set to ignored, can be configured. 

Previously, there was a checkbox before each monitor, where the behaviour was not totally clear. It meant that the monitor is ignored but still collecting data and not disabled as one might think. But when the monitor was ignored any configuration was lost and default values were used. Due to this behaviour the [Versions Node Monitor plugin](https://plugins.jenkins.io/versioncolumn/) implemented its own disconnect checkbox.

Before:
<img width="361" alt="image" src="https://github.com/jenkinsci/jenkins/assets/17767050/c6eef8e3-309d-4100-a2b5-459c68ed93ec">

After:
<img width="355" alt="image" src="https://github.com/jenkinsci/jenkins/assets/17767050/ea6c1c20-5cc8-496d-9b1d-e47eea0ea069">


<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-72371](https://issues.jenkins.io/browse/JENKINS-72371).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Before:
1. Go to computer/configure
2. Set Value for Free Temp Space to 2 GiB and 3 GiB warning, apply and reload page
3. Uncheck Free Space Space (the config fields are no longer visible) apply and reload page
4. Check the file nodeMonitors.xml in JENKINS_HOME, there are the default values of 1GiB and 2 GiB warning.
5. Check Free Space Space in the UI, the config fields reappear and contain the defaults

After:
1. Go to computer/configure
2. Set Value for Free Temp Space to 2 GiB and 3 GiB warning, apply and reload page
3. Check `Don't Mark agents temporarily offline` for Free Space Space apply and reload
4. Check the file nodeMonitors.xml in JENKINS_HOME, there values of 2GiB and 3GiB warning are still there
5. The UI shows the configured values and not the defaults


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- JENKINS-72371, rework node monitor configuration

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
