### PR TITLE
Upgrade bundled plugins

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -282,77 +282,77 @@ THE SOFTWARE.
                   <!-- dependency of checks-api, junit, and mailer -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>display-url-api</artifactId>
-                  <version>2.3.7</version>
+                  <version>2.200.vb_9327d658781</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 1.493 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>mailer</artifactId>
-                  <version>457.v3f72cb_e015e5</version>
+                  <version>463.vedf8358e006b_</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 1.535 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>matrix-auth</artifactId>
-                  <version>3.1.8</version>
+                  <version>3.2.1</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 1.553 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>antisamy-markup-formatter</artifactId>
-                  <version>159.v25b_c67cd35fb_</version>
+                  <version>162.v0e6ec0fcfcf6</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 1.561 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>matrix-project</artifactId>
-                  <version>789.v57a_725b_63c79</version>
+                  <version>818.v7eb_e657db_924</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of command-launcher, junit, matrix-project, and workflow-support -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>script-security</artifactId>
-                  <version>1251.vfe552ed55f8d</version>
+                  <version>1294.v99333c047434</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 1.577 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>junit</artifactId>
-                  <version>1207.va_09d5100410f</version>
+                  <version>1240.vf9529b_881428</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit, plugin-util-api, and workflow-support -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-api</artifactId>
-                  <version>1213.v646def1087f9</version>
+                  <version>1283.v99c10937efcb_</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of checks-api, echarts-api, font-awesome-api, and junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>plugin-util-api</artifactId>
-                  <version>3.3.0</version>
+                  <version>3.6.0</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of echarts-api and junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>bootstrap5-api</artifactId>
-                  <version>5.3.0-1</version>
+                  <version>5.3.2-2</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>checks-api</artifactId>
-                  <version>2.0.0</version>
+                  <version>2.0.2</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -360,7 +360,7 @@ THE SOFTWARE.
                   <!-- dependency of checks-api and plugin-util-api -->
                   <groupId>org.jenkins-ci.plugins.workflow</groupId>
                   <artifactId>workflow-support</artifactId>
-                  <version>839.v35e2736cfd5c</version>
+                  <version>865.v43e78cc44e0d</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -368,14 +368,14 @@ THE SOFTWARE.
                   <!-- dependency of junit and echarts-api -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>jackson2-api</artifactId>
-                  <version>2.15.2-350.v0c2f3f8fc595</version>
+                  <version>2.15.3-372.v309620682326</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>echarts-api</artifactId>
-                  <version>5.4.0-5</version>
+                  <version>5.4.3-1</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -391,7 +391,7 @@ THE SOFTWARE.
                   <!-- dependency of script-security and workflow-support -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>caffeine-api</artifactId>
-                  <version>3.1.6-115.vb_8b_b_328e59d8</version>
+                  <version>3.1.8-133.v17b_1ff2e0599</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -399,15 +399,15 @@ THE SOFTWARE.
                   <!-- dependency of echarts-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>jquery3-api</artifactId>
-                  <version>3.7.0-1</version>
+                  <version>3.7.1-1</version>
                   <type>hpi</type>
                 </artifactItem>
 
                 <artifactItem>
-                  <!-- dependency of bootstrap5-api -->
+                  <!-- former dependency of bootstrap5-api (see JENKINS-71666) -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>popper2-api</artifactId>
-                  <version>2.11.6-2</version>
+                  <version>2.11.6-4</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -415,7 +415,7 @@ THE SOFTWARE.
                   <!-- dependency of bootstrap5-api and echarts-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>font-awesome-api</artifactId>
-                  <version>6.4.0-1</version>
+                  <version>6.4.2-1</version>
                   <type>hpi</type>
                 </artifactItem>
 
@@ -430,49 +430,49 @@ THE SOFTWARE.
                   <!-- dependency of workflow-api and workflow-support -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>scm-api</artifactId>
-                  <version>672.v64378a_b_20c60</version>
+                  <version>683.vb_16722fb_b_80b_</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of scm-api and workflow-step-api -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>structs</artifactId>
-                  <version>324.va_f5d6774f3a_d</version>
+                  <version>325.vcb_307d2a_2782</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 2.16 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>bouncycastle-api</artifactId>
-                  <version>2.28</version>
+                  <version>2.29</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 2.86 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>command-launcher</artifactId>
-                  <version>100.v2f6722292ee8</version>
+                  <version>107.v773860566e2e</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 2.112 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>jdk-tool</artifactId>
-                  <version>66.vd8fa_64ee91b_d</version>
+                  <version>73.vddf737284550</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 2.163 -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>jaxb</artifactId>
-                  <version>2.3.8-1</version>
+                  <version>2.3.9-1</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- detached after 2.281 -->
                   <groupId>org.jenkins-ci.modules</groupId>
                   <artifactId>sshd</artifactId>
-                  <version>3.303.vefc7119b_ec23</version>
+                  <version>3.312.v1c601b_c83b_0e</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -500,32 +500,32 @@ THE SOFTWARE.
                   <!-- detached after 2.356 -->
                   <groupId>org.jenkins-ci.modules</groupId>
                   <artifactId>instance-identity</artifactId>
-                  <version>173.va_37c494ec4e5</version>
+                  <version>185.v303dc7c645f9</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of jdk-tool -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>apache-httpcomponents-client-4-api</artifactId>
-                  <version>4.5.14-150.v7a_b_9d17134a_5</version>
+                  <version>4.5.14-208.v438351942757</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of bootstrap5-api, checks-api, commons-text-api, echarts-api, font-awesome-api, jquery3-api, and plugin-util-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>commons-lang3-api</artifactId>
-                  <version>3.12.0-36.vd97de6465d5b_</version>
+                  <version>3.13.0-62.v7d18e55f51e2</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of bootstrap5-api, checks-api, echarts-api, font-awesome-api, jquery3-api, and plugin-util-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>commons-text-api</artifactId>
-                  <version>1.10.0-36.vc008c8fcda_7b_</version>
+                  <version>1.11.0-94.v3e1f4a_926e49</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
-                  <!-- dependency of junit -->
+                  <!-- dependency of junit and matrix-auth -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>ionicons-api</artifactId>
                   <version>56.v1b_1c8c49374e</version>
@@ -549,14 +549,14 @@ THE SOFTWARE.
                   <!-- dependency of mina-sshd-api-core and sshd -->
                   <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
                   <artifactId>mina-sshd-api-common</artifactId>
-                  <version>2.10.0-69.v28e3e36d18eb_</version>
+                  <version>2.11.0-86.v836f585d47fa_</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
                   <!-- dependency of sshd -->
                   <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
                   <artifactId>mina-sshd-api-core</artifactId>
-                  <version>2.10.0-69.v28e3e36d18eb_</version>
+                  <version>2.11.0-86.v836f585d47fa_</version>
                   <type>hpi</type>
                 </artifactItem>
               </artifactItems>


### PR DESCRIPTION
Our usual policy is not to update bundled plugins without a specific reason, such as a security fix. In this case the specific reason is the same as that of #8134, #7341, #7324, and #7175: to mitigate the impact of [JENKINS-69361](https://issues.jenkins.io/browse/JENKINS-69361).

### Testing done

Ran `mvn clean verify -Dtest=jenkins.install.LoadDetachedPluginsTest,jenkins.model.StartupTest` (including un-ignored `LoadDetachedPluginsTest#noUpdateSiteWarnings`) locally.

### Proposed changelog entries

Update several bundled plugins to the latest versions.

### Proposed upgrade guidelines

N/A

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
