### PR TITLE
Don't try to publish artifacts on RC GitHub releases

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       project-version: ${{ steps.set-version.outputs.project-version }}
       is-lts: ${{ steps.set-version.outputs.is-lts }}
+      is-rc: ${{ steps.set-version.outputs.is-rc }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11
@@ -34,16 +35,23 @@ jobs:
             is_lts=false
           fi
 
-          echo "Version is $version, is_lts: $is_lts"
+          is_rc=false
+          if [[ ${version} == *"-SNAPSHOT" ]]; then
+            is_rc=true
+          fi
+
+          echo "Version is $version, is_lts: $is_lts, is_rc: $is_rc"
 
           echo "is-lts=${is_lts}" >> $GITHUB_OUTPUT
           echo "project-version=$version" >> $GITHUB_OUTPUT
+          echo "is-rc=${is_rc}" >> $GITHUB_OUTPUT
   war:
     permissions:
       contents: write # to upload release asset (softprops/action-gh-release)
 
     runs-on: ubuntu-latest
     needs: determine-version
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
     steps:
       - name: Fetch war
         id: fetch-war
@@ -76,6 +84,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
     steps:
       - name: Fetch Deb
         id: fetch-deb
@@ -110,6 +119,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
     steps:
       - name: Fetch RPM
         id: fetch-rpm
@@ -145,6 +155,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
     steps:
       - name: Fetch MSI
         id: fetch-msi
@@ -180,6 +191,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
     steps:
       - name: Fetch suse rpm
         id: fetch-suse-rpm


### PR DESCRIPTION
This PR adds a condition to not run publication steps in the "Publish artifact" GitHub Action if the current version is a release candidate (ie ends with `-SNAPSHOT`) so the job doesn't fail, as RC versions aren't published on GitHub releases.

Related conversation during the 2.426.2 RC preparation in the #jenkinsci/release chat room: https://matrix.to/#/!JlkqzpdEnsUUuVtjgE:matrix.org/$rS0DQu7jyc6K6zo3L6c6gqeui97hZrzsWQPEkk8XfhI?via=gitter.im&via=matrix.org

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

Tested on a fork.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

No changelog entry, doesn't concern Core code.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
