### PR TITLE
Add `ExtensionList.lookupFirst` convenience method.

### DIFF
--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -460,6 +460,31 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
     }
 
     /**
+     * Convenience method allowing lookup of the instance of a given type with the highest ordinal.
+     * Equivalent to {@code ExtensionList.lookup(Class).get(0)} if there is at least one instance,
+     * and throws an {@code IllegalStateException} otherwise if no instance could be found.
+     *
+     * @param type The type to look up.
+     * @return the singleton instance of the given type in its list.
+     * @throws IllegalStateException if there are no instances, or more than one
+     *
+     * @since TODO
+     */
+    public static @NonNull <U> U lookupFirst(Class<U> type) {
+        var all = lookup(type);
+        if (!all.isEmpty()) {
+            return all.get(0);
+        } else {
+            if (Main.isUnitTest) {
+                throw new IllegalStateException("Found no instances of " + type.getName() +
+                        " registered (possible annotation processor issue); try using `mvn clean test -Dtest=…` rather than an IDE test runner");
+            } else {
+                throw new IllegalStateException("Found no instances of " + type.getName() + " registered");
+            }
+        }
+    }
+
+    /**
      * Places to store static-scope legacy instances.
      */
     @SuppressWarnings("rawtypes")

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -461,12 +461,12 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
 
     /**
      * Convenience method allowing lookup of the instance of a given type with the highest ordinal.
-     * Equivalent to {@code ExtensionList.lookup(Class).get(0)} if there is at least one instance,
-     * and throws an {@code IllegalStateException} otherwise if no instance could be found.
+     * Equivalent to {@code ExtensionList.lookup(type).get(0)} if there is at least one instance,
+     * and throws an {@link IllegalStateException} otherwise if no instance could be found.
      *
      * @param type The type to look up.
      * @return the singleton instance of the given type in its list.
-     * @throws IllegalStateException if there are no instances, or more than one
+     * @throws IllegalStateException if there are no instances
      *
      * @since TODO
      */

--- a/test/src/test/java/lib/form/OptionTest.java
+++ b/test/src/test/java/lib/form/OptionTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import hudson.ExtensionList;
 import hudson.model.RootAction;
 import org.htmlunit.html.DomElement;
 import org.htmlunit.html.DomNodeList;
@@ -216,7 +217,7 @@ public class OptionTest {
                             String bodyContainsExpected, String valueContainsExpected,
                             boolean checkExactCharacters,
                             boolean withValueTrue, boolean withValueFalse) throws Exception {
-        UsingJellyView view = j.jenkins.getExtensionList(UsingJellyView.class).get(0);
+        UsingJellyView view = ExtensionList.lookupFirst(UsingJellyView.class);
         view.setMode(mode);
         view.setInjection(msgToInject);
 
@@ -242,7 +243,7 @@ public class OptionTest {
                              String bodyContainsExpected, String valueContainsExpected,
                              boolean checkExactCharacters,
                              boolean withValueTrue, boolean withValueFalse) throws Exception {
-        UsingGroovyView view = j.jenkins.getExtensionList(UsingGroovyView.class).get(0);
+        UsingGroovyView view = ExtensionList.lookupFirst(UsingGroovyView.class);
         view.setMode(mode);
         view.setInjection(msgToInject);
 


### PR DESCRIPTION
When introducing an extension point that is meant to allow overriding a default behaviour with another implementation, generally the caller only cares about looking up only one implementation, the one with the highest ordinal.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- developer: A new convenience method `ExtensionList.lookupFirst` allows to retrieve the first implementation of an extension point

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
