### PR TITLE
Class loading deadlock between `PermalinkProjectAction.Permalink` & `PeepholePermalink`

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1062,16 +1062,13 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         return Math.round((double) totalDuration / builds.size());
     }
 
-    static {
-        PeepholePermalink.initialized();
-    }
-
     /**
      * Gets all the {@link Permalink}s defined for this job.
      *
      * @return never null
      */
     public PermalinkList getPermalinks() {
+        PeepholePermalink.initialized();
         // TODO: shall we cache this?
         PermalinkList permalinks = new PermalinkList(Permalink.BUILTIN);
         for (PermalinkProjectAction ppa : getActions(PermalinkProjectAction.class)) {

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -92,6 +92,7 @@ import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.model.ModelObjectWithChildren;
+import jenkins.model.PeepholePermalink;
 import jenkins.model.ProjectNamingStrategy;
 import jenkins.model.RunIdMigrator;
 import jenkins.model.lazy.LazyBuildMixIn;
@@ -941,7 +942,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported
     @QuickSilver
     public RunT getLastSuccessfulBuild() {
-        return (RunT) Permalink.LAST_SUCCESSFUL_BUILD.resolve(this);
+        return (RunT) PeepholePermalink.LAST_SUCCESSFUL_BUILD.resolve(this);
     }
 
     /**
@@ -951,7 +952,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported
     @QuickSilver
     public RunT getLastUnsuccessfulBuild() {
-        return (RunT) Permalink.LAST_UNSUCCESSFUL_BUILD.resolve(this);
+        return (RunT) PeepholePermalink.LAST_UNSUCCESSFUL_BUILD.resolve(this);
     }
 
     /**
@@ -961,7 +962,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported
     @QuickSilver
     public RunT getLastUnstableBuild() {
-        return (RunT) Permalink.LAST_UNSTABLE_BUILD.resolve(this);
+        return (RunT) PeepholePermalink.LAST_UNSTABLE_BUILD.resolve(this);
     }
 
     /**
@@ -971,7 +972,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported
     @QuickSilver
     public RunT getLastStableBuild() {
-        return (RunT) Permalink.LAST_STABLE_BUILD.resolve(this);
+        return (RunT) PeepholePermalink.LAST_STABLE_BUILD.resolve(this);
     }
 
     /**
@@ -980,7 +981,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported
     @QuickSilver
     public RunT getLastFailedBuild() {
-        return (RunT) Permalink.LAST_FAILED_BUILD.resolve(this);
+        return (RunT) PeepholePermalink.LAST_FAILED_BUILD.resolve(this);
     }
 
     /**
@@ -989,7 +990,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Exported
     @QuickSilver
     public RunT getLastCompletedBuild() {
-        return (RunT) Permalink.LAST_COMPLETED_BUILD.resolve(this);
+        return (RunT) PeepholePermalink.LAST_COMPLETED_BUILD.resolve(this);
     }
 
     /**
@@ -1059,6 +1060,10 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         if (totalDuration == 0) return -1;
 
         return Math.round((double) totalDuration / builds.size());
+    }
+
+    static {
+        PeepholePermalink.initialized();
     }
 
     /**

--- a/core/src/main/java/hudson/model/PermalinkProjectAction.java
+++ b/core/src/main/java/hudson/model/PermalinkProjectAction.java
@@ -25,7 +25,6 @@
 package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import jenkins.model.PeepholePermalink;
@@ -111,114 +110,33 @@ public interface PermalinkProjectAction extends Action {
                 return job.getLastBuild();
             }
         };
-        public static final Permalink LAST_STABLE_BUILD = new PeepholePermalink() {
-            @Override
-            public String getDisplayName() {
-                return Messages.Permalink_LastStableBuild();
-            }
 
-            @Override
-            public String getId() {
-                return "lastStableBuild";
-            }
+        /** @deprecated use {@link PeepholePermalink#LAST_STABLE_BUILD} */
+        @Deprecated
+        public static Permalink LAST_STABLE_BUILD;
 
-            @Override
-            public boolean apply(Run<?, ?> run) {
-                return !run.isBuilding() && run.getResult() == Result.SUCCESS;
-            }
-        };
-        public static final Permalink LAST_SUCCESSFUL_BUILD = new PeepholePermalink() {
-            @Override
-            public String getDisplayName() {
-                return Messages.Permalink_LastSuccessfulBuild();
-            }
+        /** @deprecated use {@link PeepholePermalink#LAST_SUCCESSFUL_BUILD} */
+        @Deprecated
+        public static Permalink LAST_SUCCESSFUL_BUILD;
 
-            @Override
-            public String getId() {
-                return "lastSuccessfulBuild";
-            }
+        /** @deprecated use {@link PeepholePermalink#LAST_FAILED_BUILD} */
+        @Deprecated
+        public static Permalink LAST_FAILED_BUILD;
 
-            @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "TODO needs triage")
-            @Override
-            public boolean apply(Run<?, ?> run) {
-                return !run.isBuilding() && run.getResult().isBetterOrEqualTo(Result.UNSTABLE);
-            }
-        };
-        public static final Permalink LAST_FAILED_BUILD = new PeepholePermalink() {
-            @Override
-            public String getDisplayName() {
-                return Messages.Permalink_LastFailedBuild();
-            }
+        /** @deprecated use {@link PeepholePermalink#LAST_UNSTABLE_BUILD} */
+        @Deprecated
+        public static Permalink LAST_UNSTABLE_BUILD;
 
-            @Override
-            public String getId() {
-                return "lastFailedBuild";
-            }
+        /** @deprecated use {@link PeepholePermalink#LAST_UNSUCCESSFUL_BUILD} */
+        @Deprecated
+        public static Permalink LAST_UNSUCCESSFUL_BUILD;
 
-            @Override
-            public boolean apply(Run<?, ?> run) {
-                return !run.isBuilding() && run.getResult() == Result.FAILURE;
-            }
-        };
-
-        public static final Permalink LAST_UNSTABLE_BUILD = new PeepholePermalink() {
-            @Override
-            public String getDisplayName() {
-                return Messages.Permalink_LastUnstableBuild();
-            }
-
-            @Override
-            public String getId() {
-                return "lastUnstableBuild";
-            }
-
-            @Override
-            public boolean apply(Run<?, ?> run) {
-                return !run.isBuilding() && run.getResult() == Result.UNSTABLE;
-            }
-        };
-
-        public static final Permalink LAST_UNSUCCESSFUL_BUILD = new PeepholePermalink() {
-            @Override
-            public String getDisplayName() {
-                return Messages.Permalink_LastUnsuccessfulBuild();
-            }
-
-            @Override
-            public String getId() {
-                return "lastUnsuccessfulBuild";
-            }
-
-            @Override
-            public boolean apply(Run<?, ?> run) {
-                return !run.isBuilding() && run.getResult() != Result.SUCCESS;
-            }
-        };
-        public static final Permalink LAST_COMPLETED_BUILD = new PeepholePermalink() {
-            @Override
-            public String getDisplayName() {
-                return Messages.Permalink_LastCompletedBuild();
-            }
-
-            @Override
-            public String getId() {
-                return "lastCompletedBuild";
-            }
-
-            @Override
-            public boolean apply(Run<?, ?> run) {
-                return !run.isBuilding();
-            }
-        };
+        /** @deprecated use {@link PeepholePermalink#LAST_COMPLETED_BUILD} */
+        @Deprecated
+        public static Permalink LAST_COMPLETED_BUILD;
 
         static {
             BUILTIN.add(LAST_BUILD);
-            BUILTIN.add(LAST_STABLE_BUILD);
-            BUILTIN.add(LAST_SUCCESSFUL_BUILD);
-            BUILTIN.add(LAST_FAILED_BUILD);
-            BUILTIN.add(LAST_UNSTABLE_BUILD);
-            BUILTIN.add(LAST_UNSUCCESSFUL_BUILD);
-            BUILTIN.add(LAST_COMPLETED_BUILD);
         }
     }
 }

--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -2,10 +2,12 @@ package jenkins.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Job;
 import hudson.model.PermalinkProjectAction.Permalink;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
@@ -21,6 +23,8 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Convenient base implementation for {@link Permalink}s that satisfy
@@ -236,6 +240,145 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
             }
         }
     }
+
+    /**
+     * @since TODO
+     */
+    public static final Permalink LAST_STABLE_BUILD = new PeepholePermalink() {
+        @Override
+        public String getDisplayName() {
+            return hudson.model.Messages.Permalink_LastStableBuild();
+        }
+
+        @Override
+        public String getId() {
+            return "lastStableBuild";
+        }
+
+        @Override
+        public boolean apply(Run<?, ?> run) {
+            return !run.isBuilding() && run.getResult() == Result.SUCCESS;
+        }
+    };
+
+    /**
+     * @since TODO
+     */
+    public static final Permalink LAST_SUCCESSFUL_BUILD = new PeepholePermalink() {
+        @Override
+        public String getDisplayName() {
+            return hudson.model.Messages.Permalink_LastSuccessfulBuild();
+        }
+
+        @Override
+        public String getId() {
+            return "lastSuccessfulBuild";
+        }
+
+        @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "TODO needs triage")
+        @Override
+        public boolean apply(Run<?, ?> run) {
+            return !run.isBuilding() && run.getResult().isBetterOrEqualTo(Result.UNSTABLE);
+        }
+    };
+
+    /**
+     * @since TODO
+     */
+    public static final Permalink LAST_FAILED_BUILD = new PeepholePermalink() {
+        @Override
+        public String getDisplayName() {
+            return hudson.model.Messages.Permalink_LastFailedBuild();
+        }
+
+        @Override
+        public String getId() {
+            return "lastFailedBuild";
+        }
+
+        @Override
+        public boolean apply(Run<?, ?> run) {
+            return !run.isBuilding() && run.getResult() == Result.FAILURE;
+        }
+    };
+
+    /**
+     * @since TODO
+     */
+    public static final Permalink LAST_UNSTABLE_BUILD = new PeepholePermalink() {
+        @Override
+        public String getDisplayName() {
+            return hudson.model.Messages.Permalink_LastUnstableBuild();
+        }
+
+        @Override
+        public String getId() {
+            return "lastUnstableBuild";
+        }
+
+        @Override
+        public boolean apply(Run<?, ?> run) {
+            return !run.isBuilding() && run.getResult() == Result.UNSTABLE;
+        }
+    };
+
+    /**
+     * @since TODO
+     */
+    public static final Permalink LAST_UNSUCCESSFUL_BUILD = new PeepholePermalink() {
+        @Override
+        public String getDisplayName() {
+            return hudson.model.Messages.Permalink_LastUnsuccessfulBuild();
+        }
+
+        @Override
+        public String getId() {
+            return "lastUnsuccessfulBuild";
+        }
+
+        @Override
+        public boolean apply(Run<?, ?> run) {
+            return !run.isBuilding() && run.getResult() != Result.SUCCESS;
+        }
+    };
+
+    /**
+     * @since TODO
+     */
+    public static final Permalink LAST_COMPLETED_BUILD = new PeepholePermalink() {
+        @Override
+        public String getDisplayName() {
+            return hudson.model.Messages.Permalink_LastCompletedBuild();
+        }
+
+        @Override
+        public String getId() {
+            return "lastCompletedBuild";
+        }
+
+        @Override
+        public boolean apply(Run<?, ?> run) {
+            return !run.isBuilding();
+        }
+    };
+
+    static {
+        BUILTIN.add(LAST_STABLE_BUILD);
+        BUILTIN.add(LAST_SUCCESSFUL_BUILD);
+        BUILTIN.add(LAST_FAILED_BUILD);
+        BUILTIN.add(LAST_UNSTABLE_BUILD);
+        BUILTIN.add(LAST_UNSUCCESSFUL_BUILD);
+        BUILTIN.add(LAST_COMPLETED_BUILD);
+        Permalink.LAST_STABLE_BUILD = LAST_STABLE_BUILD;
+        Permalink.LAST_SUCCESSFUL_BUILD = LAST_SUCCESSFUL_BUILD;
+        Permalink.LAST_FAILED_BUILD = LAST_FAILED_BUILD;
+        Permalink.LAST_UNSTABLE_BUILD = LAST_UNSTABLE_BUILD;
+        Permalink.LAST_UNSUCCESSFUL_BUILD = LAST_UNSUCCESSFUL_BUILD;
+        Permalink.LAST_COMPLETED_BUILD = LAST_COMPLETED_BUILD;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static void initialized() {}
 
     private static final int RESOLVES_TO_NONE = -1;
 

--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -135,7 +135,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
         return b;
     }
 
-    private static @NonNull Map<String, Integer> cacheFor(@NonNull File buildDir) {
+    static @NonNull Map<String, Integer> cacheFor(@NonNull File buildDir) {
         synchronized (caches) {
             Map<String, Integer> cache = caches.get(buildDir);
             if (cache == null) {

--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -135,7 +135,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
         return b;
     }
 
-    static @NonNull Map<String, Integer> cacheFor(@NonNull File buildDir) {
+    private static @NonNull Map<String, Integer> cacheFor(@NonNull File buildDir) {
         synchronized (caches) {
             Map<String, Integer> cache = caches.get(buildDir);
             if (cache == null) {

--- a/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model;
+
+import hudson.model.PermalinkProjectAction;
+import java.io.File;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import org.junit.Test;
+
+public final class PeepholePermalinkTest {
+
+    @Test
+    public void classLoadingDeadlock() throws Exception {
+        Thread t = new Thread(() -> {
+            assertThat("successfully loaded LAST_STABLE_BUILD", PermalinkProjectAction.Permalink.LAST_STABLE_BUILD.getId(), is("lastStableBuild"));
+        });
+        t.start();
+        PeepholePermalink.cacheFor(new File("."));
+        t.join();
+    }
+
+}

--- a/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -25,11 +25,11 @@
 package jenkins.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import hudson.model.PermalinkProjectAction;
 import hudson.model.Run;
 import java.util.stream.Collectors;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import org.junit.Test;
 
 public final class PeepholePermalinkTest {

--- a/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import hudson.model.PermalinkProjectAction;
-import java.io.File;
+import hudson.model.Run;
 import org.junit.Test;
 
 public final class PeepholePermalinkTest {
@@ -39,7 +39,22 @@ public final class PeepholePermalinkTest {
             assertThat("successfully loaded LAST_STABLE_BUILD", PermalinkProjectAction.Permalink.LAST_STABLE_BUILD.getId(), is("lastStableBuild"));
         });
         t.start();
-        PeepholePermalink.cacheFor(new File("."));
+        new PeepholePermalink() {
+            @Override
+            public boolean apply(Run<?, ?> run) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String getDisplayName() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String getId() {
+                throw new UnsupportedOperationException();
+            }
+        };
         t.join();
     }
 

--- a/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -24,10 +24,11 @@
 
 package jenkins.model;
 
-import hudson.model.PermalinkProjectAction;
-import java.io.File;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+
+import hudson.model.PermalinkProjectAction;
+import java.io.File;
 import org.junit.Test;
 
 public final class PeepholePermalinkTest {

--- a/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -33,8 +33,10 @@ import org.junit.Test;
 
 public final class PeepholePermalinkTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void classLoadingDeadlock() throws Exception {
+        PeepholePermalink.initialized();
         Thread t = new Thread(() -> {
             assertThat("successfully loaded LAST_STABLE_BUILD", PermalinkProjectAction.Permalink.LAST_STABLE_BUILD.getId(), is("lastStableBuild"));
         });

--- a/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -25,20 +25,22 @@
 package jenkins.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import hudson.model.PermalinkProjectAction;
 import hudson.model.Run;
+import java.util.stream.Collectors;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import org.junit.Test;
 
 public final class PeepholePermalinkTest {
 
-    @SuppressWarnings("deprecation")
     @Test
     public void classLoadingDeadlock() throws Exception {
         PeepholePermalink.initialized();
         Thread t = new Thread(() -> {
-            assertThat("successfully loaded LAST_STABLE_BUILD", PermalinkProjectAction.Permalink.LAST_STABLE_BUILD.getId(), is("lastStableBuild"));
+            assertThat("successfully loaded permalinks",
+                PermalinkProjectAction.Permalink.BUILTIN.stream().map(p -> p.getId()).collect(Collectors.toSet()),
+                containsInAnyOrder("lastBuild", "lastStableBuild", "lastSuccessfulBuild", "lastFailedBuild", "lastUnstableBuild", "lastUnsuccessfulBuild", "lastCompletedBuild"));
         });
         t.start();
         new PeepholePermalink() {


### PR DESCRIPTION
A functional test in CloudBees CI was observed to hang occasionally. Inspecting the thread dump revealed an apparent class loading deadlock. It is unknown whether this would affect production scenarios.

Fundamentally the problem is the use of `static final` fields for non-constant expressions. It would be incompatible to just delete these fields, unfortunately; plugins using them include for example
* `build-symlink`
* `build-alias-setter`
* `copyartifact`
* `run-selector`
* `infradna-backup` (CloudBees CI)

As noted [here](https://stackoverflow.com/a/60053646/12916) it is not always clear how to solve these problems compatibly.

### Testing done

Test usually deadlocks. Thread dump after https://github.com/jenkinsci/jenkins/pull/8736/commits/7dee8b28f121f3e5178dabbc8866acc3b06634b8

```
"main" #1 prio=5 os_prio=0 cpu=350.37ms elapsed=13.59s tid=0x00007f9848016000 nid=0x958f in Object.wait()  [0x00007f984f0b3000]
   java.lang.Thread.State: RUNNABLE
	at jenkins.model.PeepholePermalinkTest.classLoadingDeadlock(PeepholePermalinkTest.java:42)
	at …

"Thread-1" #16 prio=5 os_prio=0 cpu=0.99ms elapsed=13.17s tid=0x00007f9848b62800 nid=0x95ab in Object.wait()  [0x00007f981c8f4000]
   java.lang.Thread.State: RUNNABLE
	at hudson.model.PermalinkProjectAction$Permalink.<clinit>(PermalinkProjectAction.java:114)
	at jenkins.model.PeepholePermalinkTest.lambda$classLoadingDeadlock$0(PeepholePermalinkTest.java:39)
	at jenkins.model.PeepholePermalinkTest$$Lambda$328/0x000000084010d040.run(Unknown Source)
	at java.lang.Thread.run(java.base@11.0.20.1/Thread.java:829)
```

### Proposed changelog entries

- Preventing a deadlock that can occur when loading `PermalinkProjectAction.Permalink`.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
