### PR TITLE
[JENKINS-72196] avoid wrong styling when deleting the first of 2 shell steps

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1214,6 +1214,13 @@ function rowvgStartEachRow(recursive, f) {
 }
 
 (function () {
+  // This moves all link elements to the head
+  // fixes JENKINS-72196 when a link is inside a div of a repeatable and the
+  // div is deleted then the styling is lost for divs afterwards.
+  Behaviour.specify("body link", "move-css-to-head", -9999, function (link) {
+    document.head.appendChild(link);
+  });
+
   var p = 20;
   Behaviour.specify("TABLE.sortable", "table-sortable", ++p, function (e) {
     // sortable table


### PR DESCRIPTION
fixes JENKINS-72196 when in a form there are repeatables that both contain a codemirror config via a textarea. When deleting the first of those it can happen that the link elements importing the css for codemirror are defined in a div that gets deleted. This effectively removes the css from the DOM tree, so that other textareas afterwards that also require the codemirror css are no longer styled properly.

The Behaviour uses a high negative value for the priority so that the move of the link elements is applied before any other behaviour jumps in, e.g. hetero-list and repeatable add the elements to the dom via jelly of all things can that can be added and later remove them from the dom and keep them in memory so they can be injected when clicking the add button.

See [JENKINS-72196](https://issues.jenkins.io/browse/JENKINS-72196).

Without fix:
<img width="507" alt="image" src="https://github.com/jenkinsci/jenkins/assets/17767050/b9039753-31b7-488b-8a2e-563da950baac">

With fix:
<img width="498" alt="image" src="https://github.com/jenkinsci/jenkins/assets/17767050/393c1b25-8de8-423e-8c74-d191b0ecb1d0">


### Testing done

Manual testing as described in the Jira ticket.

No automated testing because automation of this area is expensive and provides little value.  Bug has existed and been unreported for many years.

### Proposed changelog entries

- Avoid incorrect styling when deleting the first of two shell steps in a job definition.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
