### PR TITLE
Ssh Command modified in PrivateKeyProvider.java File in CLI module

### DIFF
--- a/cli/src/test/java/hudson/cli/PrivateKeyProviderTest.java
+++ b/cli/src/test/java/hudson/cli/PrivateKeyProviderTest.java
@@ -42,7 +42,7 @@ public class PrivateKeyProviderTest {
     }
 
     /**
-    key command: ssh-keygen -f dsa-password -t dsa -b 1024 -m PEM -p password
+    key command: ssh-keygen -f dsa-password -t dsa -b 1024 -m PEM -P password
     */
     @Test
     public void loadKeyDSAPassword() throws IOException, GeneralSecurityException {
@@ -61,7 +61,7 @@ public class PrivateKeyProviderTest {
     }
 
     /**
-    key command: ssh-keygen -f rsa-password -t rsa -b 1024 -m PEM -p password
+    key command: ssh-keygen -f rsa-password -t rsa -b 1024 -m PEM -P password
     */
     @Test
     public void loadKeyRSAPassword() throws IOException, GeneralSecurityException {
@@ -80,7 +80,7 @@ public class PrivateKeyProviderTest {
     }
 
     /**
-     key command: ssh-keygen -f openssh-unsupported -t rsa -b 1024 -m PKCS8 -p password
+     key command: ssh-keygen -f openssh-unsupported -t rsa -b 1024 -m PKCS8 -P password
      */
     @Test
     public void loadKeyOpenSSHPKCS8() throws IOException, GeneralSecurityException {


### PR DESCRIPTION
The SSH Command availble in PrivateKeyProviderTest.java not working as expected . It was generating TO MANY ARGUMENTS exception .  By making the -p to -P working fine.