### PR TITLE
Bump `tibdex/github-app-token` from 1 to 2 (try 2)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -48,9 +48,11 @@ jobs:
         id: generate-token
         with:
           app_id: ${{ secrets.JENKINS_CHANGELOG_UPDATER_APP_ID }}
+          installation_retrieval_mode: repository
+          installation_retrieval_payload: jenkins-infra/jenkins.io
           private_key: ${{ secrets.JENKINS_CHANGELOG_UPDATER_PRIVATE_KEY }}
           repositories: >-
-            ["jenkins-infra/jenkins.io"]
+            ["jenkins.io"]
       - name: Check out
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Apparently the example in the `README` was incorrect: https://github.com/tibdex/github-app-token/issues/105

### Testing done

Will monitor build after merged.