### PR TITLE
[JENKINS-72443] Do not show copy option without visible items

### DIFF
--- a/core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/core/src/main/resources/hudson/model/View/newJob.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
 
             <div id="items" class="categories flat" role="radiogroup" aria-labelledby="Items" data-valid="false" />
 
-            <j:if test="${!empty(app.itemMap)}">
+            <j:if test="${!empty(app.items)}">
               <div class="item-copy">
                 <p class="description">${%CopyOption.description}</p>
                 <div class="add-item-copy">

--- a/test/src/test/java/jenkins/model/NewJobCopyFromTest.java
+++ b/test/src/test/java/jenkins/model/NewJobCopyFromTest.java
@@ -1,0 +1,32 @@
+package jenkins.model;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import hudson.model.Item;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.xml.sax.SAXException;
+
+public class NewJobCopyFromTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void checkLabel() throws IOException, SAXException {
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            // no items - validate assertion
+            assertThat(wc.goTo("newJob").getElementById("from"), is(nullValue()));
+
+            // actual test
+            j.createFreeStyleProject();
+            j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+            j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Item.CREATE, Jenkins.READ).everywhere().toEveryone());
+            assertThat(wc.goTo("newJob").getElementById("from"), is(nullValue()));
+        }
+    }
+}


### PR DESCRIPTION
See [JENKINS-72443](https://issues.jenkins.io/browse/JENKINS-72443).

### Testing done

Went to `/newJob` with a user that has only Overall/Read and Item/Create and confirmed the copy option isn't shown even if there are jobs. It was before.

### Proposed changelog entries

- Do not show option to copy items when there are no items visible

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
