### PR TITLE
Print deprecation warning when using `-jnlpUrl`

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -877,6 +877,12 @@ public class SlaveComputer extends Computer {
 
     @WebMethod(name = "jenkins-agent.jnlp")
     public HttpResponse doJenkinsAgentJnlp(StaplerRequest req, StaplerResponse res) {
+        LOGGER.log(
+                Level.WARNING,
+                "Agent \"" + getName()
+                        + "\" is connecting with the \"-jnlpUrl\" argument, which is deprecated."
+                        + " Use \"-url\" and \"-name\" instead, potentially also passing in"
+                        + " \"-webSocket\", \"-tunnel\", and/or work directory options as needed.");
         return new EncryptedSlaveAgentJnlpFile(this, "jenkins-agent.jnlp.jelly", getName(), CONNECT);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3192.v713e3b_039fb_e</remoting.version>
+    <remoting.version>3198.v03a_401881f3e</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
 


### PR DESCRIPTION
Upgrade to the latest release of Remoting, which prints this warning on the client side, and also add a similar warning on the server side as well to maximize the chances that the warning is actually seen by an administrator.

### Testing done

Connected with `-jnlpUrl` and verified that the warning was printed on both the server and client side. Connected with `-url` and `-name` and verified that the warning was no longer printed on either the server or client side.

### Proposed changelog entries

- The `-jnlpUrl ${JENKINS_URL}/computer/${AGENT_NAME}/jenkins-agent.jnlp` argument to the agent JAR has been deprecated; use `-url ${JENKINS_URL}` and `-name ${AGENT_NAME}` instead, potentially also passing in `-webSocket`, `-tunnel`, and/or work directory options as needed.

### Proposed upgrade guidelines

- The `-jnlpUrl ${JENKINS_URL}/computer/${AGENT_NAME}/jenkins-agent.jnlp` argument to the agent JAR has been deprecated; use `-url ${JENKINS_URL}` and `-name ${AGENT_NAME}` instead, potentially also passing in `-webSocket`, `-tunnel`, and/or work directory options as needed. Official Docker images already use the new calling convention.

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
