### PR TITLE
EOL `Global-Mask-Classes`

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -86,11 +86,6 @@ public class ClassicPluginStrategy implements PluginStrategy {
 
     private final PluginManager pluginManager;
 
-    /**
-     * All the plugins eventually delegate this classloader to load core, servlet APIs, and SE runtime.
-     */
-    private final MaskingClassLoader coreClassLoader = new MaskingClassLoader(getClass().getClassLoader());
-
     public ClassicPluginStrategy(PluginManager pluginManager) {
         this.pluginManager = pluginManager;
     }
@@ -235,16 +230,8 @@ public class ClassicPluginStrategy implements PluginStrategy {
 
         fix(atts, optionalDependencies);
 
-        // Register global classpath mask. This is useful for hiding JavaEE APIs that you might see from the container,
-        // such as database plugin for JPA support. The Mask-Classes attribute is insufficient because those classes
-        // also need to be masked by all the other plugins that depend on the database plugin.
-        String masked = atts.getValue("Global-Mask-Classes");
-        if (masked != null) {
-            for (String pkg : masked.trim().split("[ \t\r\n]+"))
-                coreClassLoader.add(pkg);
-        }
-
-        ClassLoader dependencyLoader = new DependencyClassLoader(coreClassLoader, archive, Util.join(dependencies, optionalDependencies), pluginManager);
+        ClassLoader dependencyLoader = new DependencyClassLoader(
+                getClass().getClassLoader(), archive, Util.join(dependencies, optionalDependencies), pluginManager);
         dependencyLoader = getBaseClassLoader(atts, dependencyLoader);
 
         return new PluginWrapper(pluginManager, archive, manifest, baseResourceURL,

--- a/core/src/main/java/hudson/util/MaskingClassLoader.java
+++ b/core/src/main/java/hudson/util/MaskingClassLoader.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 /**
  * {@link ClassLoader} that masks a specified set of classes
@@ -46,9 +46,9 @@ public class MaskingClassLoader extends ClassLoader {
     /**
      * Prefix of the packages that should be hidden.
      */
-    private final List<String> masksClasses = new CopyOnWriteArrayList<>();
+    private final List<String> masksClasses;
 
-    private final List<String> masksResources = new CopyOnWriteArrayList<>();
+    private final List<String> masksResources;
 
     static {
         registerAsParallelCapable();
@@ -60,14 +60,13 @@ public class MaskingClassLoader extends ClassLoader {
 
     public MaskingClassLoader(ClassLoader parent, Collection<String> masks) {
         super(parent);
-        this.masksClasses.addAll(masks);
+        this.masksClasses = List.copyOf(masks);
 
         /*
          * The name of a resource is a '/'-separated path name
          */
-        for (String mask : masks) {
-            masksResources.add(mask.replace('.', '/'));
-        }
+        this.masksResources =
+                masks.stream().map(mask -> mask.replace('.', '/')).collect(Collectors.toUnmodifiableList());
     }
 
     @Override
@@ -92,13 +91,6 @@ public class MaskingClassLoader extends ClassLoader {
         if (isMasked(name)) return Collections.emptyEnumeration();
 
         return super.getResources(name);
-    }
-
-    public void add(String prefix) {
-        masksClasses.add(prefix);
-        if (prefix != null) {
-            masksResources.add(prefix.replace('.', '/'));
-        }
     }
 
     private boolean isMasked(String name) {


### PR DESCRIPTION
Reverts commit a9fc20d5b1882f8e29b91dc67379badbac106df6. I discovered this unmitigated complexity while reading this code recently. I do not know if it was ever used, but it is completely unused today: I checked both Jenkins and CloudBees sources and nothing came up. I cannot imagine any good reason to use this "feature." Better to rip it out now while we still can before someone decides to start using it in the future and then we are obligated to support this unusual use case. The code comment mentions something about database plugins, but I checked them and none of them are using this feature, nor is anything else in the Jenkins ecosystem using it today.

As a bonus, ripping out this feature allows us to simplify the implementation of `MaskingClassLoader` to use immutable data structures, making it easier to reason about the concurrency implications of that class.

If accepted, I will also file subsequent PRs to purge any references to this "feature" from the HPI plugin and documentation.

### Testing done

Started up Jenkins with `java -jar jenkins.war` with the `jakarta-mail-api` plugin installed, which exercises the (non-global) `Mask-Classes` code path and therefore the changed constructor. No errors.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
