### PR TITLE
Add telemetry for basic Java system properties

### DIFF
--- a/core/src/main/java/jenkins/telemetry/impl/JavaSystemProperties.java
+++ b/core/src/main/java/jenkins/telemetry/impl/JavaSystemProperties.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.telemetry.impl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.TreeMap;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Collect the value of various Java system properties describing the environment.
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class JavaSystemProperties extends Telemetry {
+    private static final String[] PROPERTIES = new String[] {
+            "file.encoding",
+            "file.separator",
+            "java.vm.name",
+            "java.vm.vendor",
+            "java.vm.version",
+            "os.arch",
+            "os.name",
+            "os.version",
+            "user.language"
+    };
+
+    public Map<String, String> getProperties() {
+        Map<String, String> properties = new TreeMap<>();
+        for (String property : PROPERTIES) {
+            final String value = System.getProperty(property);
+            properties.put(property, value);
+        }
+        return properties;
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "System Properties";
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2023, 12, 17);
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2024, 4, 1);
+    }
+
+    @Override
+    public JSONObject createContent() {
+        JSONObject o = new JSONObject();
+        for (Map.Entry<String, String> entry : getProperties().entrySet()) {
+            final String value = entry.getValue();
+            o = o.element(entry.getKey(), value == null ? "(undefined)" : value);
+        }
+        o.put("components", buildComponentInformation());
+        return o;
+    }
+}

--- a/core/src/main/java/jenkins/telemetry/impl/JavaSystemProperties.java
+++ b/core/src/main/java/jenkins/telemetry/impl/JavaSystemProperties.java
@@ -49,7 +49,7 @@ public class JavaSystemProperties extends Telemetry {
             "os.arch",
             "os.name",
             "os.version",
-            "user.language"
+            "user.language",
     };
 
     public Map<String, String> getProperties() {

--- a/core/src/main/resources/hudson/model/UsageStatistics/help-usageStatisticsCollected.jelly
+++ b/core/src/main/resources/hudson/model/UsageStatistics/help-usageStatisticsCollected.jelly
@@ -48,7 +48,7 @@
                 <j:if test="${not collector.end.isBefore(now)}">
                     <dt>${collector.displayName}</dt>
                     <dd>
-                        <st:include from="${collector}" optional="true" page="description.jelly"/>
+                        <st:include it="${collector}" optional="true" page="description.jelly"/>
                         <p>
                             Start date: ${collector.start}<br/>
                             End date: ${collector.end}

--- a/core/src/main/resources/jenkins/telemetry/impl/JavaSystemProperties/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/JavaSystemProperties/description.jelly
@@ -1,0 +1,24 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <p>
+        ${%blurb}
+    </p>
+    <ul>
+        <j:forEach items="${it.properties.entrySet()}" var="e">
+            <li>
+                <tt>${e.key}</tt>
+                <j:choose>
+                    <j:when test="${e.value == null}">
+                        (current value: <em>undefined</em>)
+                    </j:when>
+                    <j:otherwise>
+                        (current value: <tt>${e.value}</tt>)
+                    </j:otherwise>
+                </j:choose>
+            </li>
+        </j:forEach>
+    </ul>
+    <p>
+        ${%blurb2}
+    </p>
+</j:jelly>

--- a/core/src/main/resources/jenkins/telemetry/impl/JavaSystemProperties/description.properties
+++ b/core/src/main/resources/jenkins/telemetry/impl/JavaSystemProperties/description.properties
@@ -1,0 +1,5 @@
+blurb = This trial collects the values of some basic Java system properties, that provide information about basic system configuration \
+  (OS, Java runtime, default language and character set). \
+  The collected system properties and their values are listed below.
+blurb2 = Additionally, this trial collects the list of installed plugins, their version, and the version of Jenkins. \
+  This data will be used to understand the environments that Jenkins is running in.


### PR DESCRIPTION
This could be useful to collect. There is some overlap with the general usage stats (so not all of this will be new), and it doesn't get agent JVM information, but still. I think this tells us more about OS and JVM than what we currently know.

### Testing done

No dedicated autotest due to the similarity with other similar telemetry implementations.

```
ExtensionList.lookupSingleton(jenkins.telemetry.impl.JavaSystemProperties).createContent()
```

Output:
> `Result: {"file.encoding":"UTF-8","file.separator":"/","java.vm.name":"OpenJDK 64-Bit Server VM","java.vm.vendor":"Eclipse Adoptium","java.vm.version":"11.0.15+10","os.arch":"aarch64","os.name":"Mac OS X","os.version":"13.6.1","user.language":"en","components":{"bouncycastle-api":"2.29","caffeine-api":"3.1.8-133.v17b_1ff2e0599","commons-lang3-api":"3.13.0-62.v7d18e55f51e2","commons-text-api":"1.10.0-78.v3e7b_ea_d5a_fe1","ionicons-api":"56.v1b_1c8c49374e","jackson2-api":"2.15.2-350.v0c2f3f8fc595","javax-activation-api":"1.2.0-6","jaxb":"2.3.9-1","jenkins-core":"2.436-SNAPSHOT","matrix-auth":"3.2.1","scm-api":"676.v886669a_199a_a_","script-security":"1275.v23895f409fb_d","snakeyaml-api":"2.2-111.vc6598e30cc65","structs":"325.vcb_307d2a_2782"}}`

On Configure System, the help shows as expected:

> <img width="981" alt="system properties trial" src="https://github.com/jenkinsci/jenkins/assets/1831569/7aa5d4ea-9c7c-4cba-b38e-52ef9cb93abf">

Ran `ExtensionList.lookupSingleton(jenkins.telemetry.Telemetry$TelemetryReporter).run()` and confirmed it shows up in Uplink.

Added a `test` property to the list to ensure it renders correctly:

> <img width="743" alt="Screenshot 2023-12-17 at 23 23 29" src="https://github.com/jenkinsci/jenkins/assets/1831569/08963e2b-2840-492a-88d8-a2151379d2d6">

> `Result: {"file.encoding":"UTF-8","file.separator":"/","java.vm.name":"OpenJDK 64-Bit Server VM","java.vm.vendor":"Eclipse Adoptium","java.vm.version":"11.0.15+10","os.arch":"aarch64","os.name":"Mac OS X","os.version":"13.6.1","test":"(undefined)","user.language":"en","components":{"bouncycastle-api":"2.29","caffeine-api":"3.1.8-133.v17b_1ff2e0599","commons-lang3-api":"3.13.0-62.v7d18e55f51e2","commons-text-api":"1.10.0-78.v3e7b_ea_d5a_fe1","ionicons-api":"56.v1b_1c8c49374e","jackson2-api":"2.15.2-350.v0c2f3f8fc595","javax-activation-api":"1.2.0-6","jaxb":"2.3.9-1","jenkins-core":"2.436-SNAPSHOT","matrix-auth":"3.2.1","scm-api":"676.v886669a_199a_a_","script-security":"1275.v23895f409fb_d","snakeyaml-api":"2.2-111.vc6598e30cc65","structs":"325.vcb_307d2a_2782"}}`

Why even test for `null`? While I expect it to always exist, https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/System.html#getProperties() doesn't list `file.encoding` as part of the default set, so I added this to be safe.

### Proposed changelog entries

- Add telemetry for basic Java system properties describing the environment

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
