### PR TITLE
Restore JCasC compatibility for `JNLPLauncher.tunnel`

### DIFF
--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -55,9 +55,9 @@ import org.kohsuke.stapler.DataBoundSetter;
 */
 public class JNLPLauncher extends ComputerLauncher {
     /**
-     * Deprecated (only used with deprecated {@code -jnlpUrl} mode), but cannot mark it as such without breaking CasC.
+     * @deprecated see {@link #setTunnel}
      */
-    @DataBoundSetter
+    @Deprecated
     @CheckForNull
     public String tunnel;
 
@@ -160,6 +160,19 @@ public class JNLPLauncher extends ComputerLauncher {
     @DataBoundSetter
     public void setWebSocket(boolean webSocket) {
         this.webSocket = webSocket;
+    }
+
+    @Deprecated
+    public String getTunnel() {
+        return tunnel;
+    }
+
+    /**
+     * Deprecated (only used with deprecated {@code -jnlpUrl} mode), but cannot mark it as such without breaking CasC.
+     */
+    @DataBoundSetter
+    public void setTunnel(String tunnel) {
+        this.tunnel = tunnel;
     }
 
     @Override

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -53,11 +53,11 @@ import org.kohsuke.stapler.DataBoundSetter;
  * @author Stephen Connolly
  * @author Kohsuke Kawaguchi
 */
+@SuppressWarnings("deprecation") // see comments about CasC
 public class JNLPLauncher extends ComputerLauncher {
     /**
-     * @deprecated see {@link #setTunnel}
+     * Deprecated (only used with deprecated {@code -jnlpUrl} mode), but cannot mark it as such without breaking CasC.
      */
-    @Deprecated
     @CheckForNull
     public String tunnel;
 
@@ -67,11 +67,9 @@ public class JNLPLauncher extends ComputerLauncher {
     @Deprecated
     public final transient String vmargs = null;
 
-    @Deprecated
     @NonNull
     private RemotingWorkDirSettings workDirSettings = RemotingWorkDirSettings.getEnabledDefaults();
 
-    @Deprecated
     private boolean webSocket;
 
     /**
@@ -131,7 +129,9 @@ public class JNLPLauncher extends ComputerLauncher {
         return this;
     }
 
-    @Deprecated
+    /**
+     * Deprecated (only used with deprecated {@code -jnlpUrl} mode), but cannot mark it as such without breaking CasC.
+     */
     public RemotingWorkDirSettings getWorkDirSettings() {
         return workDirSettings;
     }
@@ -149,7 +149,9 @@ public class JNLPLauncher extends ComputerLauncher {
         return false;
     }
 
-    @Deprecated
+    /**
+     * Deprecated (only used with deprecated {@code -jnlpUrl} mode), but cannot mark it as such without breaking CasC.
+     */
     public boolean isWebSocket() {
         return webSocket;
     }
@@ -162,7 +164,9 @@ public class JNLPLauncher extends ComputerLauncher {
         this.webSocket = webSocket;
     }
 
-    @Deprecated
+    /**
+     * Deprecated (only used with deprecated {@code -jnlpUrl} mode), but cannot mark it as such without breaking CasC.
+     */
     public String getTunnel() {
         return tunnel;
     }


### PR DESCRIPTION
#8762 seems to have broken JCasC compatibility for agent definitions using `tunnel`, which is probably unusual but happened to be used by an integration test in CloudBees CI.

I suspect the reason is that `DataBoundConfigurator` is buggy and does not support `@DataBoundSetter` on fields, which despite the name is supported by Jenkins core: it never actually looks for this annotation, and perhaps just assumes that getter/setter pairs not covered by the `@DataBoundConstructor` are properties.

### Testing done

https://github.com/jenkinsci/configuration-as-code-plugin/pull/2441

Removal of `@Deprecated` seems to only be necessary for compatibility with CloudBees CI, which has its own CasC reflection code not based on JCasC and which appears to check for the `@Deprecated` annotation on fields rather than on setters. (For @cloudbees only: verified running selected tests in the `com.cloudbees.casc.server.items` package.)

### Proposed changelog entries

- The `tunnel` property on an `inbound` agent was inadvertently broken for JCasC usage in 2.437. It remains deprecated and usages should be deleted (regression in 2.437).

### Proposed upgrade guidelines

N/A

### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
