### PR TITLE
Remove last usages of .bigtable

### DIFF
--- a/core/src/main/resources/hudson/triggers/SCMTrigger/DescriptorImpl/index.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/DescriptorImpl/index.jelly
@@ -46,21 +46,25 @@ THE SOFTWARE.
           <p>
             ${%The following polling activities are currently in progress:}
           </p>
-          <table id="threads" class="sortable pane bigtable">
-            <tr>
-              <th initialSortDir="down">${%Project}</th>
-              <th>${%Running for}</th>
-            </tr>
-            <j:forEach var="r" items="${it.runners}">
+          <table id="threads" class="jenkins-table sortable">
+            <thead>
               <tr>
-                <td>
-                  <a href="${rootURL}/${r.target.asItem().url}scmPollLog/">${r.target.asItem().fullDisplayName}</a>
-                </td>
-                <td>
-                  ${r.duration}
-                </td>
+                <th initialSortDir="down">${%Project}</th>
+                <th>${%Running for}</th>
               </tr>
-            </j:forEach>
+            </thead>
+            <tbody>
+              <j:forEach var="r" items="${it.runners}">
+                <tr>
+                  <td>
+                    <a href="${rootURL}/${r.target.asItem().url}scmPollLog/">${r.target.asItem().fullDisplayName}</a>
+                  </td>
+                  <td>
+                    ${r.duration}
+                  </td>
+                </tr>
+              </j:forEach>
+            </tbody>
           </table>
         </j:otherwise>
       </j:choose>

--- a/core/src/main/resources/jenkins/diagnosis/HsErrPidList/index.jelly
+++ b/core/src/main/resources/jenkins/diagnosis/HsErrPidList/index.jelly
@@ -31,32 +31,36 @@ THE SOFTWARE.
 
       <p>${%blurb}</p>
 
-      <table class="bigtable sortable pane">
-        <tr>
-          <th>${%Name}</th>
-          <th>${%Date}</th>
-          <th/>
-        </tr>
-        <j:forEach var="f" items="${it.files}" varStatus="idx">
+      <table class="jenkins-table sortable">
+        <thead>
           <tr>
-            <td style="padding-right:3em">
-              <l:icon class="icon-clipboard icon-lg" style="margin-right:1em"/>
-              <a href="files/${idx.index}/download/${f.name}">
-                ${f.path}
-              </a>
-            </td>
-            <td data="${f.lastModified}">
-              <i:formatDate value="${f.lastModifiedDate}" type="both" dateStyle="medium" timeStyle="medium"/>
-              <st:nbsp />
-              (${%ago(f.timeSpanString)})
-            </td>
-            <td>
-              <form method="post" action="files/${idx.index}/delete" name="${idx}">
-                <f:submit value="${%Delete}"/>
-              </form>
-            </td>
+            <th>${%Name}</th>
+            <th>${%Date}</th>
+            <th/>
           </tr>
-        </j:forEach>
+        </thead>
+        <tbody>
+          <j:forEach var="f" items="${it.files}" varStatus="idx">
+            <tr>
+              <td style="padding-right:3em">
+                <l:icon class="icon-clipboard icon-lg" style="margin-right:1em"/>
+                <a href="files/${idx.index}/download/${f.name}">
+                  ${f.path}
+                </a>
+              </td>
+              <td data="${f.lastModified}">
+                <i:formatDate value="${f.lastModifiedDate}" type="both" dateStyle="medium" timeStyle="medium"/>
+                <st:nbsp />
+                (${%ago(f.timeSpanString)})
+              </td>
+              <td>
+                <form method="post" action="files/${idx.index}/delete" name="${idx}">
+                  <f:submit value="${%Delete}"/>
+                </form>
+              </td>
+            </tr>
+          </j:forEach>
+        </tbody>
       </table>
     </l:main-panel>
   </l:layout>


### PR DESCRIPTION
Removes the last usages of `.bigtable` from Jenkins, replaced with `.jenkins-table` https://weekly.ci.jenkins.io/design-library/Table/

Whitespace ignoring diff: https://github.com/jenkinsci/jenkins/pull/8797/files?w=1

**Before**
<img width="799" alt="Screenshot 2023-12-20 at 21 13 25" src="https://github.com/jenkinsci/jenkins/assets/43062514/70e28084-017a-41e7-bc87-a5c357c00e2a">

**After**
<img width="746" alt="Screenshot 2023-12-20 at 21 12 19" src="https://github.com/jenkinsci/jenkins/assets/43062514/47f0b567-f810-4c24-95c5-8140c3b9d197">

Unsure of how to access the `Java VM Crash Reports` page but considering its simplicity I'm confident it'll appear as expected.

### Testing done

* Tables use the new Jenkins table design

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
