### PR TITLE
Use spotbugs 4.8.2 with more exclusions

### DIFF
--- a/core/src/spotbugs/excludesFilter.xml
+++ b/core/src/spotbugs/excludesFilter.xml
@@ -53,6 +53,125 @@
     <Bug pattern="SF_SWITCH_NO_DEFAULT"/>
     <Class name="hudson.scheduler.CrontabParser"/>
   </Match>
+  <Match>
+    <!-- Preserve API compatibility -->
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.PluginManager"/>
+    <Field name="pluginUploaded"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.ProxyConfiguration"/>
+    <Field name="noProxyHost"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.cli.CLICommand"/>
+    <Or>
+      <Field name="locale"/>
+      <Field name="stderr"/>
+      <Field name="stdin"/>
+      <Field name="stdout"/>
+    </Or>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.cli.CopyJobCommand"/>
+    <Field name="dst"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.cli.CreateJobCommand"/>
+    <Field name="name"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.cli.SetBuildDescriptionCommand"/>
+    <Field name="description"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.cli.SetBuildDisplayNameCommand"/>
+    <Field name="displayName"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.model.Job"/>
+    <Field name="runIdMigrator"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.model.StringParameterValue"/>
+    <Field name="value"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.security.Permission"/>
+    <Field name="enabled"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.tasks.Maven"/>
+    <Field name="usePrivateRepository"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.util.Graph"/>
+    <Field name="defaultScale"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.widgets.HistoryWidget"/>
+    <Field name="baseList"/>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="jenkins.model.Jenkins"/>
+    <Or>
+      <Field name="tcpSlaveAgentListener"/>
+      <Field name="proxy"/>
+      <Field name="VERSION"/>
+      <Field name="CHANGELOG_URL"/>
+      <Field name="VERSION_HASH"/>
+      <Field name="SESSION_HASH"/>
+      <Field name="RESOURCE_PATH"/>
+      <Field name="VIEW_RESOURCE_PATH"/>
+    </Or>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="jenkins.widgets.HistoryPageFilter"/>
+    <Or>
+      <Field name="hasDownPage"/>
+      <Field name="hasUpPage"/>
+      <Field name="newestOnPage"/>
+      <Field name="nextBuildNumber"/>
+      <Field name="oldestOnPage"/>
+    </Or>
+  </Match>
+  <Match>
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="hudson.slaves.JNLPLauncher"/>
+    <Field name="tunnel"/>
+  </Match>
+  <Match>
+    <!-- Reserved for future use -->
+    <Bug pattern="SS_SHOULD_BE_STATIC"/>
+    <Class name="hudson.model.User"/>
+    <Field name="version"/>
+  </Match>
+  <Match>
+    <!-- Reserved for future use -->
+    <Bug pattern="SS_SHOULD_BE_STATIC"/>
+    <Class name="hudson.model.UserIdMapper"/>
+    <Field name="version"/>
+  </Match>
+  <Match>
+    <!-- Reserved for future use -->
+    <Bug pattern="SS_SHOULD_BE_STATIC"/>
+    <Class name="hudson.util.Graph"/>
+    <Field name="defaultScale"/>
+  </Match>
   <!--
     Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
     on this section, pick an exclusion to triage, then:
@@ -376,5 +495,9 @@
         </Or>
       </And>
     </Or>
+  </Match>
+  <Match>
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC"/>
+    <Class name="jenkins.security.stapler.StaplerDispatchValidator$ValidatorCache$Validator"/>
   </Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,11 @@ THE SOFTWARE.
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
 
+    <!-- TODO: Remove when parent pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/pom/pull/510 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.omitVisitors>FindReturnRef,ConstructorThrow</spotbugs.omitVisitors>
     <spotbugs.threshold>Medium</spotbugs.threshold>
 
     <access-modifier.version>1.33</access-modifier.version>


### PR DESCRIPTION
## Use spotbugs plugin 4.8.2.0 with additional suppressions

The [parent pom spotbugs pull request](https://github.com/jenkinsci/pom/pull/510) needs this change along with the changes in other repositories that use the Jenkins parent pom.

https://github.com/jenkinsci/pom/pull/501#pullrequestreview-1718536231 recommends that the new spotbugs issues be either suppressed or resolved in the upstream release of spotbugs.  This change suppresses the new warning for primitive fields that are publicly visible and the new warning for a few cases where a field could be made static.

This change skips the warnings related to CT_CONSTRUCTOR_THROWS because they are not relevant to Jenkins.  https://github.com/jenkinsci/plugin-pom/pull/869#issuecomment-1860918407 provides more details along with the discussion at https://github.com/spotbugs/spotbugs/issues/2695

The changes to pom.xml are flagged so that they can be removed when the other repositories that consume the parent pom have been verified that they will be able to use spotbugs plugin 4.8.2.0 without additional noise.

Additional pull requests that have been merged include:

* [x] https://github.com/jenkinsci/lib-file-leak-detector/pull/164
* [x] https://github.com/jenkinsci/remoting/pull/708
* [x] https://github.com/jenkinsci/stapler/pull/507

The additional repositories that have been reviewed and confirmed they are ready for the parent pom update to use spotbugs 4.8.2 include:

* [x] https://github.com/jenkinsci/acceptance-test-harness
* [x] https://github.com/jenkinsci/bom
* [x] https://github.com/jenkinsci/bridge-method-injector
* [x] https://github.com/jenkinsci/extensibility-api
* [x] https://github.com/jenkinsci/extras-memory-monitor
* [x] https://github.com/jenkinsci/jellydoc-maven-plugin
* [x] https://github.com/jenkinsci/jelly
* [x] https://github.com/jenkinsci/jenkins-test-harness-htmlunit
* [x] https://github.com/jenkinsci/jenkins-test-harness
* [x] https://github.com/jenkinsci/lib-access-modifier
* [x] https://github.com/jenkinsci/lib-annotation-indexer
* [x] https://github.com/jenkinsci/lib-crypto-util
* [x] https://github.com/jenkinsci/lib-mock-javamail
* [x] https://github.com/jenkinsci/lib-process-utils
* [x] https://github.com/jenkinsci/lib-support-log-formatter
* [x] https://github.com/jenkinsci/lib-symbol-annotation
* [x] https://github.com/jenkinsci/lib-task-reactor
* [x] https://github.com/jenkinsci/lib-test-annotations
* [x] https://github.com/jenkinsci/lib-version-number
* [x] https://github.com/jenkinsci/maven-hpi-plugin
* [x] https://github.com/jenkinsci/plugin-compat-tester
* [x] https://github.com/jenkinsci/plugin-installation-manager-tool
* [x] https://github.com/jenkinsci/stapler-maven-plugin
* [x] https://github.com/jenkinsci/trilead-ssh2
* [x] https://github.com/jenkinsci/winp
* [x] https://github.com/jenkinsci/winstone

### Testing done

Confirmed that automated tests pass on my Linux computer with Java 21.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
