### PR TITLE
[JENKINS-66530] Change focus in the 'new item' page only if 'from' has a valid job name

### DIFF
--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -334,7 +334,13 @@ $.when(getItems()).done(function (data) {
         if (!getFieldValidationStatus("name")) {
           activateValidationMessage("#itemname-required", ".add-item-name");
           setTimeout(function () {
-            $('input[name="name"][type="text"]', "#createItem").focus();
+            var parentName = $('input[name="from"]', "#createItem").val();
+            $.get("job/" + parentName + "/api/json?tree=name").done(function (data) {
+              if (data.name === parentName) {
+                //if "name" is invalid, but "from" is a valid job, then switch focus to "name"
+                $('input[name="name"][type="text"]', "#createItem").focus();
+              }
+            })
           }, 400);
         } else {
           if (getFormValidationStatus()) {

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -335,12 +335,14 @@ $.when(getItems()).done(function (data) {
           activateValidationMessage("#itemname-required", ".add-item-name");
           setTimeout(function () {
             var parentName = $('input[name="from"]', "#createItem").val();
-            $.get("job/" + parentName + "/api/json?tree=name").done(function (data) {
-              if (data.name === parentName) {
-                //if "name" is invalid, but "from" is a valid job, then switch focus to "name"
-                $('input[name="name"][type="text"]', "#createItem").focus();
-              }
-            })
+            $.get("job/" + parentName + "/api/json?tree=name").done(
+              function (data) {
+                if (data.name === parentName) {
+                  //if "name" is invalid, but "from" is a valid job, then switch focus to "name"
+                  $('input[name="name"][type="text"]', "#createItem").focus();
+                }
+              },
+            );
           }, 400);
         } else {
           if (getFormValidationStatus()) {


### PR DESCRIPTION
## Change focus in the "new item" page only if 'from' has a valid job name

See [JENKINS-66530](https://issues.jenkins.io/browse/JENKINS-66530).

### Testing done

Discussion of code change and testing was done in coordination with Mark Waite, as can be seen in the comments of JENKINS-66530

### Proposed changelog entries

- Change focus in the 'new item' page only if 'from' has a valid job name.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@MarkEWaite 

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
