### PR TITLE
[JENKINS-72469] Avoid repeated tool downloads from misconfigured HTTP servers

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1037,7 +1037,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             }
 
             if (this.exists()) {
-                if (resultEtag != null && !resultEtag.isEmpty() && etag != null && !etag.isEmpty() && resultEtag.contains(etag)) {
+                if (resultEtag != null && !resultEtag.isEmpty() && etag != null && !etag.isEmpty() && resultEtag.equals(etag)) {
                     return false;   // already up to date
                 }
                 if (lastModified != 0 && sourceTimestamp == lastModified)

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -28,6 +28,7 @@ package hudson;
 
 import static hudson.Util.fileToPath;
 import static hudson.Util.fixEmpty;
+import static hudson.Util.fixEmptyAndTrim;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.jcraft.jzlib.GZIPInputStream;
@@ -984,14 +985,16 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         try {
             FilePath timestamp = this.child(".timestamp");
             long lastModified = timestamp.lastModified();
-            String etag = timestamp.exists() ? timestamp.readToString().replace("\"", "") : null;
+            // https://httpwg.org/specs/rfc9110.html#field.etag is the ETag specification
+            // Read previously stored ETag if timestamp is available
+            String etag = timestamp.exists() ? fixEmptyAndTrim(timestamp.readToString()) : null;
             URLConnection con;
             try {
                 con = ProxyConfiguration.open(archive);
                 if (lastModified != 0) {
                     con.setIfModifiedSince(lastModified);
                 }
-                if (etag != null && !etag.isEmpty()) {
+                if (etag != null) {
                     con.setRequestProperty("If-None-Match", etag);
                 }
                 con.connect();
@@ -1020,7 +1023,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                         return false;
                     }
                 }
-                if (lastModified != 0 || (etag != null && !etag.isEmpty())) {
+                if (lastModified != 0 || etag != null) {
                     if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
                         return false;
                     } else if (responseCode != HttpURLConnection.HTTP_OK) {
@@ -1031,13 +1034,10 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             }
 
             long sourceTimestamp = con.getLastModified();
-            String resultEtag = con.getHeaderField("ETag");
-            if (resultEtag != null && !resultEtag.isEmpty()) {
-                resultEtag = resultEtag.replace("\"", "");
-            }
+            String resultEtag = fixEmptyAndTrim(con.getHeaderField("ETag"));
 
             if (this.exists()) {
-                if (resultEtag != null && !resultEtag.isEmpty() && etag != null && !etag.isEmpty() && resultEtag.equals(etag)) {
+                if (equalETags(etag, resultEtag)) {
                     return false;   // already up to date
                 }
                 if (lastModified != 0 && sourceTimestamp == lastModified)
@@ -1053,7 +1053,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                 // First try to download from the agent machine.
                 try {
                     act(new Unpack(archive));
-                    if (resultEtag != null && !resultEtag.isEmpty() && !resultEtag.equals(etag)) {
+                    if (resultEtag != null && !equalETags(etag, resultEtag)) {
                         /* Store the ETag value in the timestamp file for later use */
                         timestamp.write(resultEtag, "UTF-8");
                     }
@@ -1076,7 +1076,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                 throw new IOException(String.format("Failed to unpack %s (%d bytes read of total %d)",
                         archive, cis.getByteCount(), con.getContentLength()), e);
             }
-            if (resultEtag != null && !resultEtag.isEmpty() && !resultEtag.equals(etag)) {
+            if (resultEtag != null && !equalETags(etag, resultEtag)) {
                 /* Store the ETag value in the timestamp file for later use */
                 timestamp.write(resultEtag, "UTF-8");
             }
@@ -1085,6 +1085,25 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         } catch (IOException e) {
             throw new IOException("Failed to install " + archive + " to " + remote, e);
         }
+    }
+
+    /* Return true if etag1 equals etag2 as defined by the etag specification
+       https://httpwg.org/specs/rfc9110.html#field.etag
+     */
+    private boolean equalETags(String etag1, String etag2) {
+        if (etag1 == null || etag2 == null) {
+            return false;
+        }
+        if (etag1.equals(etag2)) {
+            return true;
+        }
+        /* Weak tags are identified by leading characters "W/" as a marker */
+        /* Weak tag marker must not be considered in tag comparison.
+           This implements the weak comparison in the specification at
+           https://httpwg.org/specs/rfc9110.html#field.etag */
+        String opaqueTag1 = etag1.startsWith("W/") ? etag1.substring(2) : etag1;
+        String opaqueTag2 = etag2.startsWith("W/") ? etag2.substring(2) : etag2;
+        return opaqueTag1.equals(opaqueTag2);
     }
 
     // this reads from arbitrary URL

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -673,7 +673,7 @@ public class FilePathTest {
     @Issue("JENKINS-72469")
     @Test public void installIfNecessaryWithoutLastModifiedStrongValidator() throws Exception {
         String validator = "\"An-ETag-strong-validator\"";
-        installIfNecessaryWithoutLastModified(validator, validator);
+        installIfNecessaryWithoutLastModified(validator);
     }
 
     @Issue("JENKINS-72469")
@@ -681,13 +681,13 @@ public class FilePathTest {
         // This ETag is a violation of the spec at https://httpwg.org/specs/rfc9110.html#field.etag
         // However, better safe to handle without quotes as well, just in case
         String validator = "An-ETag-strong-validator-without-quotes";
-        installIfNecessaryWithoutLastModified(validator, validator);
+        installIfNecessaryWithoutLastModified(validator);
     }
 
     @Issue("JENKINS-72469")
     @Test public void installIfNecessaryWithoutLastModifiedWeakValidator() throws Exception {
         String validator = "W/\"An-ETag-weak-validator\"";
-        installIfNecessaryWithoutLastModified(validator, validator);
+        installIfNecessaryWithoutLastModified(validator);
     }
 
     @Issue("JENKINS-72469")
@@ -695,6 +695,10 @@ public class FilePathTest {
         String validator = "\"An-ETag-validator\"";
         String alternateValidator = "W/" + validator;
         installIfNecessaryWithoutLastModified(validator, alternateValidator);
+    }
+
+    private void installIfNecessaryWithoutLastModified(String validator) throws Exception {
+        installIfNecessaryWithoutLastModified(validator, validator);
     }
 
     private void installIfNecessaryWithoutLastModified(String validator, String alternateValidator) throws Exception {

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -672,29 +672,36 @@ public class FilePathTest {
 
     @Issue("JENKINS-72469")
     @Test public void installIfNecessaryWithoutLastModifiedStrongValidator() throws Exception {
-        String validator = "\"An-ETag-strong-validator\"";
-        installIfNecessaryWithoutLastModified(validator);
+        String strongValidator = "\"An-ETag-strong-validator\"";
+        installIfNecessaryWithoutLastModified(strongValidator);
     }
 
     @Issue("JENKINS-72469")
     @Test public void installIfNecessaryWithoutLastModifiedStrongValidatorNoQuotes() throws Exception {
         // This ETag is a violation of the spec at https://httpwg.org/specs/rfc9110.html#field.etag
         // However, better safe to handle without quotes as well, just in case
-        String validator = "An-ETag-strong-validator-without-quotes";
-        installIfNecessaryWithoutLastModified(validator);
+        String strongValidator = "An-ETag-strong-validator-without-quotes";
+        installIfNecessaryWithoutLastModified(strongValidator);
     }
 
     @Issue("JENKINS-72469")
     @Test public void installIfNecessaryWithoutLastModifiedWeakValidator() throws Exception {
-        String validator = "W/\"An-ETag-weak-validator\"";
-        installIfNecessaryWithoutLastModified(validator);
+        String weakValidator = "W/\"An-ETag-weak-validator\"";
+        installIfNecessaryWithoutLastModified(weakValidator);
+    }
+
+    @Issue("JENKINS-72469")
+    @Test public void installIfNecessaryWithoutLastModifiedStrongAndWeakValidators() throws Exception {
+        String strongValidator = "\"An-ETag-validator\"";
+        String weakValidator = "W/" + strongValidator;
+        installIfNecessaryWithoutLastModified(strongValidator, weakValidator);
     }
 
     @Issue("JENKINS-72469")
     @Test public void installIfNecessaryWithoutLastModifiedWeakAndStrongValidators() throws Exception {
-        String validator = "\"An-ETag-validator\"";
-        String alternateValidator = "W/" + validator;
-        installIfNecessaryWithoutLastModified(validator, alternateValidator);
+        String weakValidator = "W/" + strongValidator;
+        String strongValidator = "\"An-ETag-validator\"";
+        installIfNecessaryWithoutLastModified(weakValidator, strongValidator);
     }
 
     private void installIfNecessaryWithoutLastModified(String validator) throws Exception {

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -699,8 +699,8 @@ public class FilePathTest {
 
     @Issue("JENKINS-72469")
     @Test public void installIfNecessaryWithoutLastModifiedWeakAndStrongValidators() throws Exception {
-        String weakValidator = "W/" + strongValidator;
         String strongValidator = "\"An-ETag-validator\"";
+        String weakValidator = "W/" + strongValidator;
         installIfNecessaryWithoutLastModified(weakValidator, strongValidator);
     }
 

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -671,12 +671,28 @@ public class FilePathTest {
     }
 
     @Issue("JENKINS-72469")
-    @Test public void installIfNecessaryWithoutLastModified() throws Exception {
+    @Test public void installIfNecessaryWithoutLastModifiedStrongValidator() throws Exception {
+        installIfNecessaryWithoutLastModified("\"An-ETag-strong-validator\"");
+    }
+
+    @Issue("JENKINS-72469")
+    @Test public void installIfNecessaryWithoutLastModifiedStrongValidatorNoQuotes() throws Exception {
+        // This ETag is a violation of the spec at https://httpwg.org/specs/rfc9110.html#field.etag
+        // However, better safe to handle without quotes as well, just in case
+        installIfNecessaryWithoutLastModified("An-ETag-strong-validator-without-quotes");
+    }
+
+    @Issue("JENKINS-72469")
+    @Test public void installIfNecessaryWithoutLastModifiedWeakValidator() throws Exception {
+        installIfNecessaryWithoutLastModified("W/\"An-ETag-weak-validator\"");
+    }
+
+    private void installIfNecessaryWithoutLastModified(String validator) throws Exception {
         final HttpURLConnection con = mock(HttpURLConnection.class);
         // getLastModified == 0 when last-modified header is not returned
         when(con.getLastModified()).thenReturn(0L);
         // An Etag is provided by Azul CDN without last-modified header
-        when(con.getHeaderField("ETag")).thenReturn("An-opaque-ETag-string");
+        when(con.getHeaderField("ETag")).thenReturn(validator);
         when(con.getInputStream()).thenReturn(someZippedContent());
 
         final URL url = someUrlToZipFile(con);


### PR DESCRIPTION
## [JENKINS-72469] Avoid repeated tool downloads from misconfigured HTTP servers

The Azul Systems content delivery network stopped providing the last-modified header in their URL responses.  They only provide the ETag header.

Add ETag support (based on the [ETag specification](https://httpwg.org/specs/rfc9110.html#field.etag)) to the Jenkins FilePath URL download method so that if ETag is provided, we use the ETag value.  If last-modified is provided and matches, we continue to honor it as well.

[JENKINS-72469](https://issues.jenkins.io/browse/JENKINS-72469) has more details.

The [community post](https://community.jenkins.io/t/job-stuck-on-unpacking-global-jdk-tool/11272) also includes more details.

### Testing done

* Automated test added to FilePathTest for code changes on the controller.  The automated test confirms that even without a last-modified value, the later downloads are skipped if a matching ETag is received.  The automated test also confirms that download is skipped if OK is received with a matching ETag.  No automated test was added to confirm download on the agent because that path is not tested by any of the other test automation of this class.
* Interactive test with the Azul Systems JDK installer on the controller.  I created a tool installer for the Azul JDK.  I verified that before this change it was downloaded each time the job was run.  I verified that after the change it was downloaded only once.  
* Interactive test with the Azul Systems JDK installer on an agent.  I created a tool installer for the Azul JDK.  I verified that before this change it was downloaded each time the job was run.  I verified that after the change it was downloaded only once.
* Interactive test on the controller with a file download from an NGINX web server confirmed that the tool is downloaded once and then later runs of the job did not download the file again.

### Proposed changelog entries

- Avoid repeated tool downloads from misconfigured HTTP servers.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
