### PR TITLE
Improve crash consistency on Linux

### DIFF
--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -240,7 +240,6 @@ public class AtomicFileWriter extends Writer {
             }
         }
 
-
         /*
          * From fsync(2) on Linux:
          *

--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -26,11 +26,13 @@ package hudson.util;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Functions;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.ref.Cleaner;
+import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -61,6 +63,9 @@ public class AtomicFileWriter extends Writer {
 
     private static /* final */ boolean DISABLE_FORCED_FLUSH = SystemProperties.getBoolean(
             AtomicFileWriter.class.getName() + ".DISABLE_FORCED_FLUSH");
+
+    private static /* final */ boolean REQUIRES_DIR_FSYNC = SystemProperties.getBoolean(
+            AtomicFileWriter.class.getName() + ".REQUIRES_DIR_FSYNC", true);
 
     static {
         if (DISABLE_FORCED_FLUSH) {
@@ -232,6 +237,12 @@ public class AtomicFileWriter extends Writer {
                 }
 
                 throw replaceFailed;
+            }
+        }
+
+        if (!DISABLE_FORCED_FLUSH && REQUIRES_DIR_FSYNC && !Functions.isWindows()) {
+            try (FileChannel parentChannel = FileChannel.open(destPath.getParent())) {
+                parentChannel.force(true);
             }
         }
     }

--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -65,7 +65,7 @@ public class AtomicFileWriter extends Writer {
             AtomicFileWriter.class.getName() + ".DISABLE_FORCED_FLUSH");
 
     private static /* final */ boolean REQUIRES_DIR_FSYNC = SystemProperties.getBoolean(
-            AtomicFileWriter.class.getName() + ".REQUIRES_DIR_FSYNC", true);
+            AtomicFileWriter.class.getName() + ".REQUIRES_DIR_FSYNC", !Functions.isWindows());
 
     static {
         if (DISABLE_FORCED_FLUSH) {
@@ -240,7 +240,7 @@ public class AtomicFileWriter extends Writer {
             }
         }
 
-        if (!DISABLE_FORCED_FLUSH && REQUIRES_DIR_FSYNC && !Functions.isWindows()) {
+        if (!DISABLE_FORCED_FLUSH && REQUIRES_DIR_FSYNC) {
             try (FileChannel parentChannel = FileChannel.open(destPath.getParent())) {
                 parentChannel.force(true);
             }

--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -240,6 +240,13 @@ public class AtomicFileWriter extends Writer {
             }
         }
 
+
+        /*
+         * From fsync(2) on Linux:
+         *
+         *     Calling fsync() does not necessarily ensure that the entry in the directory containing the file has also
+         *     reached disk. For that an explicit fsync() on a file descriptor for the directory is also needed.
+         */
         if (!DISABLE_FORCED_FLUSH && REQUIRES_DIR_FSYNC) {
             try (FileChannel parentChannel = FileChannel.open(destPath.getParent())) {
                 parentChannel.force(true);

--- a/core/src/main/java/hudson/util/FileChannelWriter.java
+++ b/core/src/main/java/hudson/util/FileChannelWriter.java
@@ -1,6 +1,5 @@
 package hudson.util;
 
-import hudson.Functions;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
@@ -12,7 +11,6 @@ import java.nio.charset.Charset;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.util.logging.Logger;
-import jenkins.util.SystemProperties;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -31,15 +29,10 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 public class FileChannelWriter extends Writer implements Channel {
 
-    private static final boolean REQUIRES_DIR_FSYNC =
-            SystemProperties.getBoolean(FileChannelWriter.class.getName() + ".requiresDirFsync", true);
-
     private static final Logger LOGGER = Logger.getLogger(FileChannelWriter.class.getName());
 
     private final Charset charset;
     private final FileChannel channel;
-
-    private final Path parent;
 
     /**
      * {@link FileChannel#force(boolean)} is a <strong>very</strong> costly operation. This flag has been introduced mostly to
@@ -71,7 +64,6 @@ public class FileChannelWriter extends Writer implements Channel {
         this.forceOnFlush = forceOnFlush;
         this.forceOnClose = forceOnClose;
         channel = FileChannel.open(filePath, options);
-        parent = filePath.getParent();
     }
 
     @Override
@@ -86,11 +78,6 @@ public class FileChannelWriter extends Writer implements Channel {
         if (forceOnFlush) {
             LOGGER.finest("Flush is forced");
             channel.force(true);
-            if (REQUIRES_DIR_FSYNC && !Functions.isWindows()) {
-                try (FileChannel parentChannel = FileChannel.open(parent)) {
-                    parentChannel.force(true);
-                }
-            }
         } else {
             LOGGER.finest("Force disabled on flush(), no-op");
         }
@@ -106,11 +93,6 @@ public class FileChannelWriter extends Writer implements Channel {
         if (channel.isOpen()) {
             if (forceOnClose) {
                 channel.force(true);
-                if (REQUIRES_DIR_FSYNC && !Functions.isWindows()) {
-                    try (FileChannel parentChannel = FileChannel.open(parent)) {
-                        parentChannel.force(true);
-                    }
-                }
             }
             channel.close();
         }


### PR DESCRIPTION
### Problem

See [this talk](https://www.deconstructconf.com/2019/dan-luu-files) ([transcript](https://danluu.com/deconstruct-files/)):

> People seem to think that this is safe because the POSIX spec says that `rename` is atomic, but that only means `rename` is atomic with respect to normal operation, that doesn't mean it's atomic on crash.

### Solution

While the optimal solution would involve implementing an undo log / rollback journal as described in the talk or in [SQLite](https://www.sqlite.org/atomiccommit.html), this would be a drastic redesign of this core subsystem.

Rather, without breaking compatibility or changing the existing design we can `fsync` the parent directory after `fsync`ing the new file. This ensures the parent directory's inode is flushed to disk with the new directory entry for the new file. This reduces the impact of a crash. Currently, we `fsync` the new file itself, but the directory entry in the parent directory is not necessarily persisted to disk until some arbitrary amount of time passes, and if we crash during this window then we could (in some filesystem/mount option combinations) get the old version of the file when we come back up, though we may have taken other actions in the meantime that assume the new file has been persisted, thus leading to inconsistent state. This PR `fsync`s the parent directory right away, reducing the window of time where a crash could have negative consequences to the period of time between the `fsync` of the file and the `fsync` of its parent directory, which is now a much smaller and bounded amount of time.

This is also the approach taken by default in Sendmail on Linux in https://github.com/Distrotech/sendmail/blob/547129475fc1db35ae9b893a4782884c68b182fb/sendmail/deliver.c#L933-L986 whose `README` contains the following:

```
REQUIRES_DIR_FSYNC      Turn on support for file systems that require to
                call fsync() for a directory if the meta-data in it has
                been changed.  This should be turned on at least for older
                versions of ReiserFS; it is enabled by default for Linux.
                According to some information this flag is not needed
                anymore for kernel 2.4.16 and newer.  We would appreciate
                feedback about the semantics of the various file systems
                available for Linux.
```

This correctly notes that this second `fsync` isn't required in all combinations of filesystems and mount options but that it is (or was) required in some of them, and to be safe from a data correctness perspective it is enabled by default. In this PR we do the same in Jenkins. In general, filesystem behavior in this regard is poorly documented and changes frequently over time, so it is best to take the safest approach by default and only allow users to pick a more dangerous approach if they are confident their filesystem configuration can tolerate it.

More to the point, the author of `ext3` explicitly states the need to `fsync` the parent directory on Linux in [this post](https://thunk.org/tytso/blog/2009/03/15/dont-fear-the-fsync/):

> The squence above exactly provides desired “atomicity without durability”.   It doesn’t guarantee which version of the file will appear in the event of an unexpected crash; if the application needs a guarantee that the new version of the file will be present after a crash, it’s necessary to fsync the containing directory.

The performance impact should be negligible for local disk users. Users of pathologically slow NFS servers might have a problem, in which case an escape hatch has been added to restore the old behavior at the price of decreased crash consistency. If accepted, I will update [this page](https://www.jenkins.io/doc/book/managing/system-properties/) of the documentation.

### Testing done

Confirmed after this PR with `bpftrace`'s `syncsnoop` and `opensnoop` that the parent directory was being `fsync`ed as expected. Confirmed that the old behavior was restored when setting the escape hatch to false.

### Proposed changelog entries

- Reduce the window of time during which a crash may lead to inconsistent state on Linux.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
