### PR TITLE
Add an 'Appearance' category to the wizard

### DIFF
--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -95,6 +95,14 @@
     ]
   },
   {
+    "category": "Appearance",
+    "plugins": [
+      { "name": "dark-theme", "suggested": true },
+      { "name": "simple-theme-plugin" },
+      { "name": "login-theme" }
+    ]
+  },
+  {
     "category": "Languages",
     "plugins": [{ "name": "locale" }, { "name": "localization-zh-cn" }]
   }

--- a/core/src/main/resources/jenkins/install/platform-plugins.json
+++ b/core/src/main/resources/jenkins/install/platform-plugins.json
@@ -96,11 +96,7 @@
   },
   {
     "category": "Appearance",
-    "plugins": [
-      { "name": "dark-theme", "suggested": true },
-      { "name": "simple-theme-plugin" },
-      { "name": "login-theme" }
-    ]
+    "plugins": [{ "name": "dark-theme", "suggested": true }]
   },
   {
     "category": "Languages",


### PR DESCRIPTION
The change proposed adds an "Appearance" category to the setup wizard's plugin category, listing a few active developed plugins changing the look and feel of Jenkins.

The dark theme plugin is selected as default, given it adds a significant value to Jenkins' appearance and integrates smooth by respecting the users' browser and OS theme if configured, no longer hurting your eyes when working in the late hours ;)

### Testing done

The new category appears in the sidebar of the setup wizard, and the dark theme plugin is selected as intended.

![Screenshot 2024-01-03 at 11 08 27](https://github.com/jenkinsci/jenkins/assets/13383509/94eb14bd-62d5-4782-944b-3a1248f61a70)

### Proposed changelog entries

- Add an 'Appearance' category to the setup wizard.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
