### PR TITLE
Fill in since todo

### DIFF
--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -468,7 +468,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
      * @return the singleton instance of the given type in its list.
      * @throws IllegalStateException if there are no instances
      *
-     * @since TODO
+     * @since 2.435
      */
     public static @NonNull <U> U lookupFirst(Class<U> type) {
         var all = lookup(type);

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1909,7 +1909,7 @@ public class Functions {
      * Computes the link to the console for the run for the specified executable, taking {@link ConsoleUrlProvider} into account.
      * @param executable the executable (normally a {@link Run})
      * @return the absolute URL for accessing the build console for the executable, or null if there is no build associated with the executable
-     * @since TODO
+     * @since 2.433
      */
     public static @CheckForNull String getConsoleUrl(Queue.Executable executable) {
         if (executable == null) {

--- a/core/src/main/java/hudson/model/BuildTimelineWidget.java
+++ b/core/src/main/java/hudson/model/BuildTimelineWidget.java
@@ -40,9 +40,8 @@ import org.kohsuke.stapler.StaplerRequest;
  *
  * @author Kohsuke Kawaguchi
  * @since 1.372
- * @deprecated since TODO
  */
-@Deprecated
+@Deprecated(since = "2.431")
 public class BuildTimelineWidget {
     protected final RunList<?> builds;
 

--- a/core/src/main/java/hudson/model/BuildTimelineWidget.java
+++ b/core/src/main/java/hudson/model/BuildTimelineWidget.java
@@ -40,6 +40,7 @@ import org.kohsuke.stapler.StaplerRequest;
  *
  * @author Kohsuke Kawaguchi
  * @since 1.372
+ * @deprecated since 2.431
  */
 @Deprecated(since = "2.431")
 public class BuildTimelineWidget {

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -406,7 +406,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
 
     /**
-     * @since TODO
+     * @since 2.426
      */
     @DataBoundSetter
     public void setFilterExecutors(boolean filterExecutors) {
@@ -421,7 +421,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
 
     /**
-     * @since TODO
+     * @since 2.426
      */
     @DataBoundSetter
     public void setFilterQueue(boolean filterQueue) {

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -73,7 +73,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      * method and return false.
      *
      * @return true if this monitor might take agents offline
-     * @since TODO
+     * @since 2.437
      */
     public boolean canTakeOffline() {
         return true;

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorDescriptor.java
@@ -183,11 +183,11 @@ public abstract class DiskSpaceMonitorDescriptor extends AbstractAsyncNodeMonito
         /**
          * Gets GB left.
          *
-         * @deprecated since TODO
+         * @deprecated
          *   Directly use the size field or to get a human-readable value with units use
          *   {@link Functions#humanReadableByteSize(long)}
          */
-        @Deprecated
+        @Deprecated(since = "2.434")
         public String getGbLeft() {
             long space = size;
             space /= 1024L;   // convert to KB

--- a/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorNodeProperty.java
+++ b/core/src/main/java/hudson/node_monitors/DiskSpaceMonitorNodeProperty.java
@@ -11,7 +11,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * {@link NodeProperty} that allows users to set agent specific disk space thresholds.
  *
- * @since TODO
+ * @since 2.434
  */
 public class DiskSpaceMonitorNodeProperty extends NodeProperty<Node> {
     private final String freeDiskSpaceThreshold;

--- a/core/src/main/java/jenkins/console/ConsoleUrlProvider.java
+++ b/core/src/main/java/jenkins/console/ConsoleUrlProvider.java
@@ -52,7 +52,7 @@ import org.kohsuke.stapler.Stapler;
  * Pipeline flow graph, there may be various edge cases where your visualization does not work at all, but the classic
  * console view is unaffected.
  * @see Functions#getConsoleUrl
- * @since TODO
+ * @since 2.433
  */
 public interface ConsoleUrlProvider extends Describable<ConsoleUrlProvider> {
     @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/console/ConsoleUrlProviderGlobalConfiguration.java
+++ b/core/src/main/java/jenkins/console/ConsoleUrlProviderGlobalConfiguration.java
@@ -48,7 +48,7 @@ import org.kohsuke.stapler.StaplerRequest;
 /**
  * Allows administrators to activate and sort {@link ConsoleUrlProvider} extensions to set defaults for all users.
  * @see ConsoleUrlProviderUserProperty
- * @since TODO
+ * @since 2.433
  */
 @Extension
 @Symbol("consoleUrlProvider")

--- a/core/src/main/java/jenkins/console/ConsoleUrlProviderUserProperty.java
+++ b/core/src/main/java/jenkins/console/ConsoleUrlProviderUserProperty.java
@@ -39,7 +39,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 /**
  * Allows users to activate and sort {@link ConsoleUrlProvider} extensions based on their preferences.
  * @see ConsoleUrlProviderGlobalConfiguration
- * @since TODO
+ * @since 2.433
  */
 @Restricted(NoExternalUse.class)
 public class ConsoleUrlProviderUserProperty extends UserProperty {

--- a/core/src/main/java/jenkins/console/DefaultConsoleUrlProvider.java
+++ b/core/src/main/java/jenkins/console/DefaultConsoleUrlProvider.java
@@ -36,7 +36,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * Default implementation of {@link ConsoleUrlProvider} that uses the standard Jenkins console view.
  * <p>Exists so that users have a way to override {@link ConsoleUrlProviderGlobalConfiguration} and specify the default
  * console view if desired via {@link ConsoleUrlProviderUserProperty}.
- * @since TODO
+ * @since 2.433
  */
 @Restricted(value = NoExternalUse.class)
 public class DefaultConsoleUrlProvider implements ConsoleUrlProvider {

--- a/core/src/main/java/jenkins/model/Loadable.java
+++ b/core/src/main/java/jenkins/model/Loadable.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 /**
  * Object whose state can be loaded from disk. In general, also implements {@link Saveable}.
  *
- * @since TODO
+ * @since 2.428
  */
 public interface Loadable {
 

--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -242,7 +242,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
     }
 
     /**
-     * @since TODO
+     * @since 2.436
      */
     public static final Permalink LAST_STABLE_BUILD = new PeepholePermalink() {
         @Override
@@ -262,7 +262,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
     };
 
     /**
-     * @since TODO
+     * @since 2.436
      */
     public static final Permalink LAST_SUCCESSFUL_BUILD = new PeepholePermalink() {
         @Override
@@ -283,7 +283,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
     };
 
     /**
-     * @since TODO
+     * @since 2.436
      */
     public static final Permalink LAST_FAILED_BUILD = new PeepholePermalink() {
         @Override
@@ -303,7 +303,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
     };
 
     /**
-     * @since TODO
+     * @since 2.436
      */
     public static final Permalink LAST_UNSTABLE_BUILD = new PeepholePermalink() {
         @Override
@@ -323,7 +323,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
     };
 
     /**
-     * @since TODO
+     * @since 2.436
      */
     public static final Permalink LAST_UNSUCCESSFUL_BUILD = new PeepholePermalink() {
         @Override
@@ -343,7 +343,7 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
     };
 
     /**
-     * @since TODO
+     * @since 2.436
      */
     public static final Permalink LAST_COMPLETED_BUILD = new PeepholePermalink() {
         @Override

--- a/core/src/main/java/jenkins/security/FIPS140.java
+++ b/core/src/main/java/jenkins/security/FIPS140.java
@@ -32,7 +32,7 @@ import jenkins.util.SystemProperties;
  * The environment (host, JVM and servlet container), must be suitably configured which is outside the scope of the Jenkins project.
  * @see <a href="https://csrc.nist.gov/pubs/fips/140-2/upd2/final">FIPS-140-2</a>
  * @see <a href="https://github.com/jenkinsci/jep/tree/master/jep/237#readme">JEP-237</a>
- * @since TODO
+ * @since 2.426
  */
 public class FIPS140 {
 

--- a/core/src/main/java/jenkins/util/DefaultScriptListener.java
+++ b/core/src/main/java/jenkins/util/DefaultScriptListener.java
@@ -37,7 +37,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 /**
  * Basic default implementation of {@link jenkins.util.ScriptListener} that just logs.
  *
- * @since TODO
+ * @since 2.427
  */
 @Extension
 @Restricted(NoExternalUse.class)

--- a/core/src/main/java/jenkins/util/ScriptListener.java
+++ b/core/src/main/java/jenkins/util/ScriptListener.java
@@ -49,7 +49,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * @see hudson.cli.GroovyshCommand
  * @see jenkins.util.groovy.GroovyHookScript
  *
- * @since TODO
+ * @since 2.427
  */
 public interface ScriptListener extends ExtensionPoint {
 


### PR DESCRIPTION
```
➜  jenkins git:(fill-in-todos-yup) ./update-since-todo.py
Analyzing core/src/main/java/hudson/ExtensionList.java:471
        first sha: 0f0d81b306c6452621f29bd3b0493662e12ef009
        first tag was jenkins-2.435
        Updating file in place
Analyzing core/src/main/java/hudson/Functions.java:1912
        first sha: b9b3e6bfa8495ba0ecbb7834728ab1694d8c888d
        first tag was jenkins-2.433
        Updating file in place
Analyzing core/src/main/java/hudson/model/View.java:409
        first sha: 105951c11c670fad5904a3a2d64caba7d109bd96
        first tag was jenkins-2.426
        Updating file in place
Analyzing core/src/main/java/hudson/model/View.java:424
        first sha: 105951c11c670fad5904a3a2d64caba7d109bd96
        first tag was jenkins-2.426
        Updating file in place
Analyzing core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java:76
        first sha: 7258cad41408a35590ab85ab28cad9e9ffe4aeda
        first tag was jenkins-2.437
        Updating file in place
Analyzing core/src/main/java/hudson/node_monitors/DiskSpaceMonitorNodeProperty.java:14
        first sha: aad79effa12865395403badd58cef8a56e4860c7
        first tag was jenkins-2.434
        Updating file in place
Analyzing core/src/main/java/jenkins/console/ConsoleUrlProvider.java:55
        first sha: b9b3e6bfa8495ba0ecbb7834728ab1694d8c888d
        first tag was jenkins-2.433
        Updating file in place
Analyzing core/src/main/java/jenkins/console/ConsoleUrlProviderGlobalConfiguration.java:51
        first sha: b9b3e6bfa8495ba0ecbb7834728ab1694d8c888d
        first tag was jenkins-2.433
        Updating file in place
Analyzing core/src/main/java/jenkins/console/ConsoleUrlProviderUserProperty.java:42
        first sha: b9b3e6bfa8495ba0ecbb7834728ab1694d8c888d
        first tag was jenkins-2.433
        Updating file in place
Analyzing core/src/main/java/jenkins/console/DefaultConsoleUrlProvider.java:39
        first sha: b9b3e6bfa8495ba0ecbb7834728ab1694d8c888d
        first tag was jenkins-2.433
        Updating file in place
Analyzing core/src/main/java/jenkins/model/Loadable.java:9
        first sha: 3df097f1b8f41444e5c684a9afae0695c208f8d7
        first tag was jenkins-2.428
        Updating file in place
        Updating file in place
Analyzing core/src/main/java/jenkins/model/PeepholePermalink.java:245
        first sha: f9a777bc682963de4640303b2f28ac488f9b93ef
        first tag was jenkins-2.436
        Updating file in place
Analyzing core/src/main/java/jenkins/model/PeepholePermalink.java:265
        first sha: f9a777bc682963de4640303b2f28ac488f9b93ef
        first tag was jenkins-2.436
        Updating file in place
Analyzing core/src/main/java/jenkins/model/PeepholePermalink.java:286
        first sha: f9a777bc682963de4640303b2f28ac488f9b93ef
        first tag was jenkins-2.436
        Updating file in place
Analyzing core/src/main/java/jenkins/model/PeepholePermalink.java:306
        first sha: f9a777bc682963de4640303b2f28ac488f9b93ef
        first tag was jenkins-2.436
        Updating file in place
Analyzing core/src/main/java/jenkins/model/PeepholePermalink.java:326
        first sha: f9a777bc682963de4640303b2f28ac488f9b93ef
        first tag was jenkins-2.436
        Updating file in place
Analyzing core/src/main/java/jenkins/model/PeepholePermalink.java:346
        first sha: f9a777bc682963de4640303b2f28ac488f9b93ef
        first tag was jenkins-2.436
        Updating file in place
Analyzing core/src/main/java/jenkins/security/FIPS140.java:35
        first sha: db48740dd21e55b38578c8d1a681a13eb253e176
        first tag was jenkins-2.426
        Updating file in place
Analyzing core/src/main/java/jenkins/util/DefaultScriptListener.java:40
        first sha: 270062ace3254a65fa29d37046b901d57b908fa5
        first tag was jenkins-2.427
        Updating file in place
Analyzing core/src/main/java/jenkins/util/ScriptListener.java:52
        first sha: 270062ace3254a65fa29d37046b901d57b908fa5
        first tag was jenkins-2.427
        Updating file in place
```
List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.426
  - https://github.com/jenkinsci/jenkins/commit/105951c11c670fad5904a3a2d64caba7d109bd96
  - https://github.com/jenkinsci/jenkins/commit/db48740dd21e55b38578c8d1a681a13eb253e176
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.427
  - https://github.com/jenkinsci/jenkins/commit/270062ace3254a65fa29d37046b901d57b908fa5
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.428
  - https://github.com/jenkinsci/jenkins/commit/3df097f1b8f41444e5c684a9afae0695c208f8d7
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.433
  - https://github.com/jenkinsci/jenkins/commit/b9b3e6bfa8495ba0ecbb7834728ab1694d8c888d
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.434
  - https://github.com/jenkinsci/jenkins/commit/aad79effa12865395403badd58cef8a56e4860c7
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.435
  - https://github.com/jenkinsci/jenkins/commit/0f0d81b306c6452621f29bd3b0493662e12ef009
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.436
  - https://github.com/jenkinsci/jenkins/commit/f9a777bc682963de4640303b2f28ac488f9b93ef
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.437
  - https://github.com/jenkinsci/jenkins/commit/7258cad41408a35590ab85ab28cad9e9ffe4aeda
