### PR TITLE
Increase MavenTest#sensitiveParameters() timeout to 500s

### DIFF
--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -191,7 +191,7 @@ public class MavenTest {
         assertNotNull(isp.installers.get(MavenInstaller.class));
     }
 
-    @Test @WithTimeout(300) public void sensitiveParameters() throws Exception {
+    @Test @WithTimeout(500) public void sensitiveParameters() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         ParametersDefinitionProperty pdb = new ParametersDefinitionProperty(
                 new StringParameterDefinition("string", "defaultValue", "string description"),


### PR DESCRIPTION
Build [5736](https://ci.jenkins.io/job/Core/job/jenkins/job/master/5736/consoleText) of the master branch reports a duration of 350s (!!!) it takes to complete `MavenTest#sensitiveParameters()`.
This PR is a follow-up of https://github.com/jenkinsci/jenkins/pull/8837 working towards https://github.com/jenkins-infra/helpdesk/issues/3890