### PR TITLE
do not generate td when outside table for buildbutton

### DIFF
--- a/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
@@ -23,29 +23,32 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-      <td class="jenkins-table__cell--tight">
-          <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
-            <j:set var="id" value="${h.generateId()}"/>
-            <j:set var="href" value="${jobBaseUrl}${job.shortUrl}build?delay=0sec"/>
-            <div class="jenkins-table__cell__button-wrapper">
-              <j:choose>
-                <j:when test="${job.parameterized}">
-                  <j:set var="title" value="${%Schedule_a_task_with_parameters(h.getRelativeDisplayNameFrom(job, itemGroup),it.taskNoun(job))}"/>
-                </j:when>
-                <j:otherwise>
-                  <span class="build-button-column-icon-reference-holder" data-id="${id}" data-url="${href}" data-notification="${%Task_scheduled(it.taskNoun(job))}"/>
-                  <j:set var="title" value="${%Schedule_a_task(h.getRelativeDisplayNameFrom(job, itemGroup),it.taskNoun(job))}"/>
-                </j:otherwise>
-              </j:choose>
-              <j:set var="isQueued" value="${app.queue.contains(job)}"/>
-              <a id="${id}" tooltip="${title}" class="jenkins-table__button jenkins-!-build-color" href="${href}">
-                <span class="${isQueued ? 'pulse-animation': ''}">
-                  <l:icon src="symbol-play" />
-                </span>
-                <st:adjunct includes="hudson.views.BuildButtonColumn.icon"/>
-              </a>
-            </div>
-          </j:if>
-      </td>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
+    <x:element name="${jenkins_mobile_show?'div':'td'}">
+        <j:if test="${!jenkins_mobile_show}">
+          <x:attribute name="class">jenkins-table__cell--tight</x:attribute>
+        </j:if>
+        <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">
+          <j:set var="id" value="${h.generateId()}"/>
+          <j:set var="href" value="${jobBaseUrl}${job.shortUrl}build?delay=0sec"/>
+          <div class="jenkins-table__cell__button-wrapper">
+            <j:choose>
+              <j:when test="${job.parameterized}">
+                <j:set var="title" value="${%Schedule_a_task_with_parameters(h.getRelativeDisplayNameFrom(job, itemGroup),it.taskNoun(job))}"/>
+              </j:when>
+              <j:otherwise>
+                <span class="build-button-column-icon-reference-holder" data-id="${id}" data-url="${href}" data-notification="${%Task_scheduled(it.taskNoun(job))}"/>
+                <j:set var="title" value="${%Schedule_a_task(h.getRelativeDisplayNameFrom(job, itemGroup),it.taskNoun(job))}"/>
+              </j:otherwise>
+            </j:choose>
+            <j:set var="isQueued" value="${app.queue.contains(job)}"/>
+            <a id="${id}" tooltip="${title}" class="jenkins-table__button jenkins-!-build-color" href="${href}">
+              <span class="${isQueued ? 'pulse-animation': ''}">
+                <l:icon src="symbol-play" />
+              </span>
+              <st:adjunct includes="hudson.views.BuildButtonColumn.icon"/>
+            </a>
+          </div>
+        </j:if>
+    </x:element>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/projectView.jelly
+++ b/core/src/main/resources/lib/hudson/projectView.jelly
@@ -88,6 +88,7 @@ THE SOFTWARE.
       </div>
 
       <div class="jenkins-jobs-list jenkins-mobile-show">
+        <j:set var="jenkins_mobile_show" value="${true}"/>
         <j:forEach var="job" items="${jobs}">
           <j:set var="relativeLinkToJob" value="${h.getRelativeLinkTo(job)}"/>
           <j:set var="jobBaseUrl" value="${relativeLinkToJob.substring(0, relativeLinkToJob.length() - job.shortUrl.length())}"/>
@@ -121,7 +122,7 @@ THE SOFTWARE.
               </div>
             </a>
             <div class="jenkins-jobs-list__item__actions">
-              <st:include page="column.jelly" it="${buildButtonColumn}" optional="true" />
+              <st:include page="column.jelly" it="${buildButtonColumn}" optional="true"/>
             </div>
           </div>
         </j:forEach>


### PR DESCRIPTION
projectView renders a buildButton twice once inside a table for wide screens and once outside a table for narrow or mobile screens with one always hidden. But the buildButton always wraps everything in a `td`. When projectView is now itself wrapped somewhere in a table (was done in dashboard-view plugin) then the brwoser will move the `td` to the outer table and it gets always shown and breaks the UI.

See https://github.com/jenkinsci/dashboard-view-plugin/issues/294

### Testing done
Install dashboard-view plugin and create a view with the `Jenkins jobs list` portlet added to one of the Portlet containers.
Prior to the fix UI is broken, with fix everything looks as expected

### Proposed changelog entries

- Fix build button rendering for dashboard view plugin.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
