### PR TITLE
[JENKINS-72540] FilePath.copyRecursiveTo() copying now also if local and remote have incompatible character sets at binary level

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -87,6 +87,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.CopyOption;
 import java.nio.file.FileSystemException;
 import java.nio.file.FileSystems;
@@ -2848,8 +2849,8 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             // local -> remote copy
             final Pipe pipe = Pipe.createLocalToRemote();
 
-            Future<Void> future = target.actAsync(new ReadFromTar(target, pipe, description, compression));
-            Future<Integer> future2 = actAsync(new WriteToTar(scanner, pipe, compression));
+            Future<Void> future = target.actAsync(new ReadFromTar(target, pipe, description, compression, StandardCharsets.UTF_8));
+            Future<Integer> future2 = actAsync(new WriteToTar(scanner, pipe, compression, StandardCharsets.UTF_8));
             try {
                 // JENKINS-9540 in case the reading side failed, report that error first
                 future.get();
@@ -2861,9 +2862,9 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             // remote -> local copy
             final Pipe pipe = Pipe.createRemoteToLocal();
 
-            Future<Integer> future = actAsync(new CopyRecursiveRemoteToLocal(pipe, scanner, compression));
+            Future<Integer> future = actAsync(new CopyRecursiveRemoteToLocal(pipe, scanner, compression, StandardCharsets.UTF_8));
             try {
-                readFromTar(remote + '/' + description, new File(target.remote), compression.extract(pipe.getIn()));
+                readFromTar(remote + '/' + description, new File(target.remote), compression.extract(pipe.getIn()), StandardCharsets.UTF_8);
             } catch (IOException e) { // BuildException or IOException
                 try {
                     future.get(3, TimeUnit.SECONDS);
@@ -2976,12 +2977,14 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         private final String description;
         private final TarCompression compression;
         private final FilePath target;
+        private final String filenamesEncoding;
 
-        ReadFromTar(FilePath target, Pipe pipe, String description, @NonNull TarCompression compression) {
+        ReadFromTar(FilePath target, Pipe pipe, String description, @NonNull TarCompression compression, Charset filenamesEncoding) {
             this.target = target;
             this.pipe = pipe;
             this.description = description;
             this.compression = compression;
+            this.filenamesEncoding = filenamesEncoding.name();
         }
 
         private static final long serialVersionUID = 1L;
@@ -2989,7 +2992,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
             try (InputStream in = pipe.getIn()) {
-                readFromTar(target.remote + '/' + description, f, compression.extract(in));
+                readFromTar(target.remote + '/' + description, f, compression.extract(in), Charset.forName(filenamesEncoding));
                 return null;
             }
         }
@@ -2999,18 +3002,20 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         private final DirScanner scanner;
         private final Pipe pipe;
         private final TarCompression compression;
+        private final String filenamesEncoding;
 
-        WriteToTar(DirScanner scanner, Pipe pipe, @NonNull TarCompression compression) {
+        WriteToTar(DirScanner scanner, Pipe pipe, @NonNull TarCompression compression, Charset filenamesEncoding) {
             this.scanner = scanner;
             this.pipe = pipe;
             this.compression = compression;
+            this.filenamesEncoding = filenamesEncoding.name();
         }
 
         private static final long serialVersionUID = 1L;
 
         @Override
         public Integer invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-            return writeToTar(f, scanner, compression.compress(pipe.getOut()));
+            return writeToTar(f, scanner, compression.compress(pipe.getOut()), Charset.forName(filenamesEncoding));
         }
     }
 
@@ -3019,17 +3024,19 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         private final Pipe pipe;
         private final DirScanner scanner;
         private final TarCompression compression;
+        private final String filenamesEncoding;
 
-        CopyRecursiveRemoteToLocal(Pipe pipe, DirScanner scanner, @NonNull TarCompression compression) {
+        CopyRecursiveRemoteToLocal(Pipe pipe, DirScanner scanner, @NonNull TarCompression compression, Charset filenamesEncoding) {
             this.pipe = pipe;
             this.scanner = scanner;
             this.compression = compression;
+            this.filenamesEncoding = filenamesEncoding.name();
         }
 
         @Override
         public Integer invoke(File f, VirtualChannel channel) throws IOException {
             try (OutputStream out = pipe.getOut()) {
-                return writeToTar(f, scanner, compression.compress(out));
+                return writeToTar(f, scanner, compression.compress(out), Charset.forName(filenamesEncoding));
             }
         }
     }
@@ -3061,22 +3068,26 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * @return
      *      number of files/directories that are written.
      */
-    private static Integer writeToTar(File baseDir, DirScanner scanner, OutputStream out) throws IOException {
-        Archiver tw = ArchiverFactory.TAR.create(out);
+    private static Integer writeToTar(File baseDir, DirScanner scanner, OutputStream out, Charset filenamesEncoding) throws IOException {
+        Archiver tw = ArchiverFactory.TAR.create(out, filenamesEncoding);
         try (tw) {
             scanner.scan(baseDir, tw);
         }
         return tw.countEntries();
     }
 
+    private static void readFromTar(String name, File baseDir, InputStream in) throws IOException {
+        readFromTar(name, baseDir, in, Charset.defaultCharset());
+    }
+
     /**
      * Reads from a tar stream and stores obtained files to the base dir.
      * Supports large files > 10 GB since 1.627 when this was migrated to use commons-compress.
      */
-    private static void readFromTar(String name, File baseDir, InputStream in) throws IOException {
+    private static void readFromTar(String name, File baseDir, InputStream in, Charset filenamesEncoding) throws IOException {
 
         // TarInputStream t = new TarInputStream(in);
-        try (TarArchiveInputStream t = new TarArchiveInputStream(in)) {
+        try (TarArchiveInputStream t = new TarArchiveInputStream(in, filenamesEncoding.name())) {
             TarArchiveEntry te;
             while ((te = t.getNextTarEntry()) != null) {
                 File f = new File(baseDir, te.getName());

--- a/core/src/main/java/hudson/util/io/ArchiverFactory.java
+++ b/core/src/main/java/hudson/util/io/ArchiverFactory.java
@@ -30,6 +30,7 @@ import hudson.FilePath.TarCompression;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.nio.charset.Charset;
 import java.nio.file.OpenOption;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -43,9 +44,21 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public abstract class ArchiverFactory implements Serializable {
     /**
      * Creates an archiver on top of the given stream.
+     * File names in the archive are encoded with default character set.
      */
     @NonNull
-    public abstract Archiver create(OutputStream out) throws IOException;
+    public Archiver create(OutputStream out) throws IOException {
+        return create(out, Charset.defaultCharset());
+    }
+
+    /**
+     * Creates an archiver on top of the given stream.
+     *
+     * @param filenamesEncoding the encoding to be used in the archive for file names
+     * @since TODO
+     */
+    @NonNull
+    public abstract Archiver create(OutputStream out, Charset filenamesEncoding) throws IOException;
 
     /**
      * Uncompressed tar format.
@@ -85,8 +98,8 @@ public abstract class ArchiverFactory implements Serializable {
 
         @NonNull
         @Override
-        public Archiver create(OutputStream out) throws IOException {
-            return new TarArchiver(method.compress(out));
+        public Archiver create(OutputStream out, Charset filenamesEncoding) throws IOException {
+            return new TarArchiver(method.compress(out), filenamesEncoding);
         }
 
         private static final long serialVersionUID = 1L;
@@ -108,8 +121,8 @@ public abstract class ArchiverFactory implements Serializable {
 
         @NonNull
         @Override
-        public Archiver create(OutputStream out) {
-            return new ZipArchiver(out, prefix, openOptions);
+        public Archiver create(OutputStream out, Charset filenamesEncoding) {
+            return new ZipArchiver(out, prefix, filenamesEncoding, openOptions);
         }
 
         private static final long serialVersionUID = 1L;

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -49,8 +50,8 @@ final class TarArchiver extends Archiver {
     private final byte[] buf = new byte[8192];
     private final TarArchiveOutputStream tar;
 
-    TarArchiver(OutputStream out) {
-        tar = new TarArchiveOutputStream(out);
+    TarArchiver(OutputStream out, Charset filenamesEncoding) {
+        tar = new TarArchiveOutputStream(out, filenamesEncoding.name());
         tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_STAR);
         tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
     }

--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.OpenOption;
@@ -55,12 +56,12 @@ final class ZipArchiver extends Archiver {
     private final String prefix;
 
     ZipArchiver(OutputStream out) {
-        this(out, "");
+        this(out, "", Charset.defaultCharset());
     }
 
     // Restriction added for clarity, it's a package class, you should not use it outside of Jenkins core
     @Restricted(NoExternalUse.class)
-    ZipArchiver(OutputStream out, String prefix, OpenOption... openOptions) {
+    ZipArchiver(OutputStream out, String prefix, Charset filenamesEncoding, OpenOption... openOptions) {
         this.openOptions = openOptions;
         if (StringUtils.isBlank(prefix)) {
             this.prefix = "";
@@ -69,7 +70,7 @@ final class ZipArchiver extends Archiver {
         }
 
         zip = new ZipOutputStream(out);
-        zip.setEncoding(System.getProperty("file.encoding"));
+        zip.setEncoding(filenamesEncoding.name());
         zip.setUseZip64(Zip64Mode.AsNeeded);
     }
 


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-72540](https://issues.jenkins.io/browse/JENKINS-72540).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

- The pipeline-maven-plugin's 'Generated Artifacts Publisher' that had been originally failing (see [JENKINS-72540](https://issues.jenkins.io/browse/JENKINS-72540)) had been re-run successfully on an z/OS agent with default character set CP1047.
- existing integration test on a linux machine
- no automated test provided as reproducing the issue requires a remote with default character set CP1047

### Proposed changelog entries

- Allow recursive remote file copy even if local and remote nodes have incompatible character sets at binary level, e.g. ISO-8859-1 and CP1047.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
