### PR TITLE
[JENKINS-71025] Remove inline JS from configure-common

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1941,6 +1941,11 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
         }
 
         @Restricted(DoNotUse.class)
+        public FormValidation doCheckDisplayNameOrNull(@AncestorInPath AbstractProject project, @QueryParameter String value) {
+            return Jenkins.get().doCheckDisplayName(value, project.getName());
+        }
+
+        @Restricted(DoNotUse.class)
         public FormValidation doCheckAssignedLabelString(@AncestorInPath AbstractProject<?, ?> project,
                                                          @QueryParameter String value) {
           // Provide a legacy interface in case plugins are not going through p:config-assignedLabel

--- a/core/src/main/resources/hudson/model/AbstractProject/configure-common.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/configure-common.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     <!-- if there's only one JDK configured, always use that. -->
     <f:entry title="JDK"
              description="${%JDK to be used for this project}">
-      <select class="jenkins-input validated" name="jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
+      <select class="jenkins-input validated" name="jdk" checkUrl="${rootURL}/defaultJDKCheck" checkDependsOn="">
         <j:getStatic var="DEFAULT_NAME" className="hudson.model.JDK" field="DEFAULT_NAME"/>
         <option>${DEFAULT_NAME}</option>
         <j:forEach var="inst" items="${jdks}">

--- a/core/src/main/resources/hudson/model/AbstractProject/configure-common.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/configure-common.jelly
@@ -54,7 +54,7 @@ THE SOFTWARE.
     <p:config-blockWhenDownstreamBuilding />
     <st:include page="configure-advanced.jelly" optional="true" />
     <f:entry title="${%Display Name}" field="displayNameOrNull">
-      <f:textbox checkUrl="'${rootURL}/checkDisplayName?displayName='+encodeURIComponent(this.value)+'&amp;jobName='+encodeURIComponent('${h.jsStringEscape(it.name)}')"/>
+      <f:textbox/>
     </f:entry>
     <f:optionalBlock name="keepDependencies" checked="${it.keepDependencies}" title="${%Keep the build logs of dependencies}" help="/help/tasks/fingerprint/keepDependencies.html"/>
   </f:advanced>


### PR DESCRIPTION
replaces #6861

See [JENKINS-71025](https://issues.jenkins.io/browse/JENKINS-71025).


### Testing done
Create a first item (type doesn't matter could even be a folder) with name `item1` and set a displayname for it to `mydisplayname`
Create a freestyle job with name `freestyle`. 
In Configure under advanced, change the displayname first to `item1`, when leaving the input field it should show warning that `item1`  is already used as name of another job
Now change the displayname to `mydisplayname`, when leaving the input field it should show a warning that `mydisplayname` is already in use by another job


### Proposed changelog entries

- Remove inline JavaScript from configure-common.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
