### PR TITLE
Missing `VirtualFile.run` usage in `DirectoryBrowserSupport`

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -753,12 +753,14 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         private final List<List<Path>> glob;
         private final boolean containsSymLink;
         private final boolean containsTmpDir;
+
         BuildChildPathsResult(List<List<Path>> glob, boolean containsSymLink, boolean containsTmpDir) {
             this.glob = glob;
             this.containsSymLink = containsSymLink;
             this.containsTmpDir = containsTmpDir;
         }
     }
+
     private static final class BuildChildPaths extends MasterToSlaveCallable<BuildChildPathsResult, IOException> {
         private final VirtualFile cur;
         private final Locale locale;

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -327,7 +327,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                 // serve directory index
                 var result = baseFile.run(new BuildChildPaths(baseFile, req.getLocale(), getOpenOptions()));
                 glob = result.glob;
-                containsSymlink = baseFile.containsSymLinkChild(getOpenOptions());
+                containsSymlink = result.containsSymLink;
                 containsTmpDir = result.containsTmpDir;
             }
 
@@ -751,9 +751,11 @@ public final class DirectoryBrowserSupport implements HttpResponse {
     private static final class BuildChildPathsResult implements Serializable { // TODO Java 21+ record
         private static final long serialVersionUID = 1;
         private final List<List<Path>> glob;
+        private final boolean containsSymLink;
         private final boolean containsTmpDir;
-        BuildChildPathsResult(List<List<Path>> glob, boolean containsTmpDir) {
+        BuildChildPathsResult(List<List<Path>> glob, boolean containsSymLink, boolean containsTmpDir) {
             this.glob = glob;
+            this.containsSymLink = containsSymLink;
             this.containsTmpDir = containsTmpDir;
         }
     }
@@ -769,7 +771,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         }
 
         @Override public BuildChildPathsResult call() throws IOException {
-            return new BuildChildPathsResult(buildChildPaths(cur, locale), cur.containsTmpDirChild(openOptions));
+            return new BuildChildPathsResult(buildChildPaths(cur, locale), cur.containsSymLinkChild(openOptions), cur.containsTmpDirChild(openOptions));
         }
     }
     /**


### PR DESCRIPTION
I found a failing test in `artifact-manager-s3` during a routine dependency bump including a core version change, and bisected the failure to a security fix 80452662b31ac6c9f4418cffae1af6af4daf479a. This neglected to use `VirtualFile.run` to batch together file metadata operations, causing the number of S3 API calls in the test case to jump from 13 to 37. A simple reorganization of method calls restores the previous behavior so far as this test case is concerned.

### Testing done

https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/450#issuecomment-1896022561

### Proposed changelog entries

- A security fix in 2.394 caused a substantial slowdown in displaying build artifacts when using remote artifact managers such as in S3.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
