### PR TITLE
Use grid for node-list design in labels page

### DIFF
--- a/core/src/main/resources/hudson/model/Label/index.jelly
+++ b/core/src/main/resources/hudson/model/Label/index.jelly
@@ -42,16 +42,16 @@ THE SOFTWARE.
 
       <div>
         <h2>${%Nodes}</h2>
-        <j:forEach var="n" items="${it.sortedNodes}">
-          <j:set var="c" value="${app.getComputer(n.nodeName)}"/>
-          <j:set var="url" value="${rootURL}/${c.url}"/>
-          <nobr>
-            <a href="${url}" class="jenkins-link--with-icon"><l:icon src="${c.iconClassName}" /></a>
-            <st:nbsp/>
-            <a href="${url}" class="model-link inside">${c.displayName}</a>
-          </nobr>
-          <wbr/>
-        </j:forEach>
+        <div class="jenkins-label-list">
+          <j:forEach var="n" items="${it.sortedNodes}">
+            <j:set var="c" value="${app.getComputer(n.nodeName)}"/>
+            <j:set var="url" value="${rootURL}/${c.url}"/>
+            <a href="${url}" class="model-link jenkins-label-node">
+              <l:icon class="icon" src="${c.iconClassName}" />
+              <span class="name">${c.displayName}</span>
+            </a>
+          </j:forEach>
+        </div>
       </div>
 
       <h2>${%Projects}</h2>

--- a/war/src/main/scss/pages/_index.scss
+++ b/war/src/main/scss/pages/_index.scss
@@ -5,3 +5,4 @@
 @use "plugin-manager";
 @use "setupWizardFirstUser";
 @use "setupWizardConfigureInstance";
+@use "label";

--- a/war/src/main/scss/pages/_label.scss
+++ b/war/src/main/scss/pages/_label.scss
@@ -1,0 +1,80 @@
+@use "../abstracts/mixins";
+
+$label-grid-gap: 20px;
+$label-grid-margin-bottom: 20px;
+$label-grid-margin-left: 10px; // Inverse of inset left/right
+
+$label-grid-col-p: 1;
+$label-grid-col-t: 2;
+$label-grid-col-ds: 3;
+$label-grid-col-dm: 4;
+$label-grid-col-dl: 5;
+$label-grid-col-dxl: 6;
+
+
+.jenkins-label-list {
+  display: grid;
+  gap: $label-grid-gap;
+  margin: 0 0 $label-grid-margin-bottom $label-grid-margin-left;
+
+  @media only screen and (max-width: 640px) {
+    grid-template-columns: repeat($label-grid-col-p, minmax(auto, calc(100% / $label-grid-col-p - $label-grid-gap)));
+  }
+  @media only screen and (min-width: 641px) and (max-width: 1280px) {
+    grid-template-columns: repeat($label-grid-col-t, minmax(auto, calc(100% / $label-grid-col-t - $label-grid-gap)));
+  }
+  @media only screen and (min-width: 1281px) and (max-width: 1600px) {
+    grid-template-columns: repeat($label-grid-col-ds, minmax(auto, calc(100% / $label-grid-col-ds - $label-grid-gap)));
+  }
+  @media only screen and (min-width: 1601px) and (max-width: 1920px) {
+    grid-template-columns: repeat($label-grid-col-dm, minmax(auto, calc(100% / $label-grid-col-dm - $label-grid-gap)));
+  }
+  @media only screen and (min-width: 1921px) and (max-width: 2560px) {
+    grid-template-columns: repeat($label-grid-col-dl, minmax(auto, calc(100% / $label-grid-col-dl - $label-grid-gap)));
+  }
+  @media only screen and (min-width: 2561px) {
+    grid-template-columns: repeat($label-grid-col-dxl, minmax(auto, calc(100% / $label-grid-col-dxl - $label-grid-gap)));
+  }
+
+  .jenkins-label-node {
+    @include mixins.link;
+    display: flex;
+    align-items: center;
+    border: 0;
+    outline: 0;
+
+    .name {
+      margin-left: 5px;
+      text-overflow: ellipsis;
+      max-width: 90%;
+      overflow: hidden;
+      display: block;
+      white-space: nowrap;
+    }
+
+    &::before {
+      content: "";
+      inset: -7px -10px;
+      border-radius: 6px;
+      background-color: transparent;
+      position: absolute;
+      transform-style: var(--standard-transition);
+      pointer-events: none;
+    }
+
+    &:not(:disabled):hover::before {
+      background-color: var(--item-background--hover);
+      right: -30px !important;
+    }
+
+    .icon {
+      width: 16px;
+      height: 16px;
+      color: var(--text-color) !important;
+    }
+
+    &:hover, &:active, &:visited, &:focus, &:focus-visible, &:focus-within, &:target {
+      text-decoration: none;
+    }
+  }
+}

--- a/war/src/main/scss/pages/_label.scss
+++ b/war/src/main/scss/pages/_label.scss
@@ -11,33 +11,56 @@ $label-grid-col-dm: 4;
 $label-grid-col-dl: 5;
 $label-grid-col-dxl: 6;
 
-
 .jenkins-label-list {
   display: grid;
   gap: $label-grid-gap;
   margin: 0 0 $label-grid-margin-bottom $label-grid-margin-left;
 
-  @media only screen and (max-width: 640px) {
-    grid-template-columns: repeat($label-grid-col-p, minmax(auto, calc(100% / $label-grid-col-p - $label-grid-gap)));
+  @media only screen and (width <= 640px) {
+    grid-template-columns: repeat(
+      $label-grid-col-p,
+      minmax(auto, calc(100% / $label-grid-col-p - $label-grid-gap))
+    );
   }
-  @media only screen and (min-width: 641px) and (max-width: 1280px) {
-    grid-template-columns: repeat($label-grid-col-t, minmax(auto, calc(100% / $label-grid-col-t - $label-grid-gap)));
+
+  @media only screen and (width >= 641px) and (width <= 1280px) {
+    grid-template-columns: repeat(
+      $label-grid-col-t,
+      minmax(auto, calc(100% / $label-grid-col-t - $label-grid-gap))
+    );
   }
-  @media only screen and (min-width: 1281px) and (max-width: 1600px) {
-    grid-template-columns: repeat($label-grid-col-ds, minmax(auto, calc(100% / $label-grid-col-ds - $label-grid-gap)));
+
+  @media only screen and (width >= 1281px) and (width <= 1600px) {
+    grid-template-columns: repeat(
+      $label-grid-col-ds,
+      minmax(auto, calc(100% / $label-grid-col-ds - $label-grid-gap))
+    );
   }
-  @media only screen and (min-width: 1601px) and (max-width: 1920px) {
-    grid-template-columns: repeat($label-grid-col-dm, minmax(auto, calc(100% / $label-grid-col-dm - $label-grid-gap)));
+
+  @media only screen and (width >= 1601px) and (width <= 1920px) {
+    grid-template-columns: repeat(
+      $label-grid-col-dm,
+      minmax(auto, calc(100% / $label-grid-col-dm - $label-grid-gap))
+    );
   }
-  @media only screen and (min-width: 1921px) and (max-width: 2560px) {
-    grid-template-columns: repeat($label-grid-col-dl, minmax(auto, calc(100% / $label-grid-col-dl - $label-grid-gap)));
+
+  @media only screen and (width >= 1921px) and (width <= 2560px) {
+    grid-template-columns: repeat(
+      $label-grid-col-dl,
+      minmax(auto, calc(100% / $label-grid-col-dl - $label-grid-gap))
+    );
   }
-  @media only screen and (min-width: 2561px) {
-    grid-template-columns: repeat($label-grid-col-dxl, minmax(auto, calc(100% / $label-grid-col-dxl - $label-grid-gap)));
+
+  @media only screen and (width >= 2561px) {
+    grid-template-columns: repeat(
+      $label-grid-col-dxl,
+      minmax(auto, calc(100% / $label-grid-col-dxl - $label-grid-gap))
+    );
   }
 
   .jenkins-label-node {
     @include mixins.link;
+
     display: flex;
     align-items: center;
     border: 0;
@@ -73,7 +96,13 @@ $label-grid-col-dxl: 6;
       color: var(--text-color) !important;
     }
 
-    &:hover, &:active, &:visited, &:focus, &:focus-visible, &:focus-within, &:target {
+    &:hover,
+    &:active,
+    &:visited,
+    &:focus,
+    &:focus-visible,
+    &:focus-within,
+    &:target {
       text-decoration: none;
     }
   }


### PR DESCRIPTION
Updates the List of Nodes / Computers assigned to a label at `/jenkins/label/<label>`.
Uses a grid to properly align the nodes in all directions. Adds the default link behavior of e.g. tables to result in a more cohesive frontend experience (on hover -> background). Node-Names longer than the column width result in ellipsis.
Aligns the icon to the left of the nodes name properly vertically to the name.

### Testing done
Dynamic amount of nodes (ranging from 1/2 to 30ish) in different viewports.

![phone](https://github.com/jenkinsci/jenkins/assets/27054324/29fda5da-2ceb-454d-8065-e606ca10ecb1)
![phone – 1](https://github.com/jenkinsci/jenkins/assets/27054324/354049bf-0c99-449e-a7b6-3ccb5432c269)
![phone – 2](https://github.com/jenkinsci/jenkins/assets/27054324/35eb2859-a3d4-4e10-a71a-c62453153ea4)
![phone – 3](https://github.com/jenkinsci/jenkins/assets/27054324/f578c7df-b26c-4943-b29a-a2e4d047c9d6)

After - on hover:
![hover](https://github.com/jenkinsci/jenkins/assets/27054324/92159059-33d5-480b-b9ba-40297ccd954d)

Ellipsis on text overflow:
![ellipsis](https://github.com/jenkinsci/jenkins/assets/27054324/4054266d-7bb4-4e7c-b701-d039136431ea)


### Proposed changelog entries
N/A

### Proposed upgrade guidelines
N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers
N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
