### PR TITLE
[JENKINS-72613] Introduced `ItemGroup.getItemName`

### DIFF
--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -966,7 +966,7 @@ public abstract class AbstractItem extends Actionable implements Loadable, Item,
         Items.whileUpdatingByXml(new NotReallyRoleSensitiveCallable<Void, IOException>() {
             @Override
             public Void call() throws IOException {
-                onLoad(getParent(), getRootDir().getName());
+                onLoad(getParent(), getParent().getItemName(getRootDir(), AbstractItem.this));
                 return null;
             }
         });

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -176,4 +176,17 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
     // TODO could delegate to allItems overload taking Authentication, but perhaps more useful to introduce a variant to perform preauth filtering using Predicate and check Item.READ afterwards
     // or return a Stream<Item> and provide a Predicate<Item> public static Items.readable(), and see https://stackoverflow.com/q/22694884/12916 if you are looking for just one result
 
+    /**
+     * Determines the item name based on a logic that can be overridden (e.g. by AbstractFolder).
+     *
+     * Defaults to the item root directory name.
+     *
+     * @param dir The root directory the item was loaded from.
+     * @param item the partially loaded item (take care what methods you call, the item will not have a reference to its parent).
+     *
+     * @since TODO
+     */
+    default String getItemName(File dir, T item) {
+        return dir.getName();
+    }
 }

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -373,7 +373,7 @@ public class Items {
      */
     public static Item load(ItemGroup parent, File dir) throws IOException {
         Item item = (Item) getConfigFile(dir).read();
-        item.onLoad(parent, dir.getName());
+        item.onLoad(parent, parent.getItemName(dir, item));
         return item;
     }
 


### PR DESCRIPTION
See [JENKINS-72613](https://issues.jenkins.io/browse/JENKINS-72613). Requires https://github.com/jenkinsci/cloudbees-folder-plugin/pull/367 to be effective. Original patch by @Vlatombe.

### Testing done

https://github.com/jenkinsci/workflow-multibranch-plugin/pull/292

### Proposed changelog entries

- Introduce an API to be used by the Folders plugin to fix some corner cases involving branch project reloading.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
