### PR TITLE
Use truly large fictional core versions in tests

### DIFF
--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -794,7 +794,7 @@ public class PluginManagerTest {
             PluginManagerUtil.getCheckForUpdatesButton(p).click();
             HtmlPage available = wc.goTo("pluginManager/available");
             assertTrue(available.querySelector(".alert-danger")
-                    .getTextContent().contains("This plugin is built for Jenkins 2.999"));
+                    .getTextContent().contains("This plugin is built for Jenkins 9999999"));
             wc.waitForBackgroundJavaScript(100);
 
             HtmlAnchor anchor = available.querySelector(".jenkins-table__link");

--- a/test/src/test/java/jenkins/install/InstallUtilTest.java
+++ b/test/src/test/java/jenkins/install/InstallUtilTest.java
@@ -112,7 +112,7 @@ public class InstallUtilTest {
         Assert.assertEquals(InstallState.UPGRADE, InstallUtil.getNextInstallState(InstallState.UNKNOWN));
 
         // Fudge things yet again, changing the stored version to something very very new, faking a downgrade...
-        InstallUtil.saveLastExecVersion("1000.0");
+        InstallUtil.saveLastExecVersion("1000000.0");
         Assert.assertEquals(InstallState.DOWNGRADE, InstallUtil.getNextInstallState(InstallState.UNKNOWN));
     }
 

--- a/test/src/test/resources/plugins/security3037-update-center.json
+++ b/test/src/test/resources/plugins/security3037-update-center.json
@@ -50,7 +50,7 @@ updateCenter.post(
       "previousTimestamp": "2022-05-24T12:27:03.00Z<img src=x onerror=alert(1)>",
       "previousVersion": "<img src=x onerror=alert(1)>581.v0c46fa_697ffd",
       "releaseTimestamp": "2022-06-29T21:02:16.00Z<img src=x onerror=alert(1)>",
-      "requiredCore": "2.999<img src=x onerror=alert(1)>",
+      "requiredCore": "9999999<img src=x onerror=alert(1)>",
       "scm": "https://github.com/jenkinsci/workflow-aggregator-plugin<img src=x onerror=alert(1)>",
       "sha1": "6iNlKTnXvr4W+9Svwy1+ctyqgvo=<img src=x onerror=alert(1)>",
       "sha256": "P0SFgnqOBFZjxkdKORiQUbrhdlfW5YU7tOpe85bfGWE=<img src=x onerror=alert(1)>",


### PR DESCRIPTION
At one point I was playing with use of Jenkins core in a monorepo with some plugins using CD-like versioning for rapid prototyping and discovered that a couple tests failed because they assumed that the _current_ Jenkins version is of the form `2.xxx`. Such an assumption is unnecessary; for purposes of tests which deliberately simulate some future version, you may as well use an obviously large version number.

### Testing done

Have not checked recently, but at the time these patches fixed those tests.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
