### PR TITLE
[JENKINS-71700] avoid stacktrace from artifactarchiver when no artifacts are found

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -31,7 +31,6 @@ import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.Functions;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.AbstractBuild;
@@ -272,10 +271,8 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                         if (msg != null) {
                             listener.getLogger().println(msg);
                         }
-                    } catch (FilePath.FileMaskNoMatchesFoundException e) {
-                        listener.getLogger().println(e.getMessage());
                     } catch (Exception e) {
-                        Functions.printStackTrace(e, listener.getLogger());
+                        LOG.log(Level.FINE, e, () -> "Failed to validate ant file mask.");
                     }
                     if (allowEmptyArchive) {
                         listener.getLogger().println(Messages.ArtifactArchiver_NoMatchFound(artifacts));


### PR DESCRIPTION
When the validateAntFileMask fails because there are too many files or it takes too long an exception is thrown that was intended to be catched in the ArtifactArchiver. The fix in https://github.com/jenkinsci/jenkins/pull/6475 only considered builds running on the controller, but when the build happens on an agent, this didn't work as the exception is deeply wrapped in 2 other exceptions.
As printing the exception message is of no real help, just catch all exceptions and print them to the jenkins log but not the build log. Any other message might just be misleading as one could get the impression that jenkins stopped after looking at 10000 files and only because of this no files where archived but this is not the case. At this place the ArtifactArchiver is just trying to give a hint why it didn't archive anything.


<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-71700](https://issues.jenkins.io/browse/JENKINS-71700).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Added unit test.

Manual testing
- open script console and run `hudson.FilePath.VALIDATE_ANT_FILE_MASK_BOUND=1`
- create freestyle job that writes 2 files to the workspace and add an archiveArtifact post build step that will not match any of the files

Before
Case 1: job runs on controller:
This creates the following output:
```
18:04:20 Archiving artifacts
18:04:21 no matches found within 1
18:04:21 ERROR: Step ‘Archive the artifacts’ failed: No artifacts found that match the file pattern "dist/libs/**/*.tgz". Configuration error?
```

Case 2: job runs on an agent
This prints a  stacktrace to the build log
```
18:05:09 Archiving artifacts
18:05:09 hudson.FilePath$ValidateAntFileMask$1Cancel
18:05:09 	at hudson.FilePath$ValidateAntFileMask$1.isCaseSensitive(FilePath.java:3338)
...
18:05:09 Caused: java.lang.InterruptedException: hudson.FilePath$FileMaskNoMatchesFoundException: no matches found within 1
18:05:09 	at hudson.FilePath.act(FilePath.java:1232)
...
18:05:09 ERROR: Step ‘Archive the artifacts’ failed: No artifacts found that match the file pattern "dist/libs/**/*.tgz". Configuration error?
```

After:
In both cases there is only the following
```
18:17:31 Archiving artifacts
18:17:31 ERROR: Step ‘Archive the artifacts’ failed: No artifacts found that match the file pattern "dist/libs/**/*.tgz". Configuration error?
```
A warning is logged with FINE level.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- JENKINS-71700, avoid stacktrace from artifactarchiver when no artifacts are found

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
