### PR TITLE
`WebSockets.upgradeResponse`

### DIFF
--- a/core/src/main/java/jenkins/websocket/WebSockets.java
+++ b/core/src/main/java/jenkins/websocket/WebSockets.java
@@ -31,10 +31,13 @@ import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Support for serving WebSocket responses.
@@ -62,65 +65,74 @@ public class WebSockets {
     // TODO ability to handle subprotocols?
 
     public static HttpResponse upgrade(WebSocketSession session) {
+        return (req, rsp, node) -> upgradeResponse(session, req, rsp);
+    }
+
+    /**
+     * Variant of {@link #upgrade} that does not presume a {@link StaplerRequest}.
+     * @since TODO
+     */
+    public static void upgradeResponse(WebSocketSession session, HttpServletRequest req, HttpServletResponse rsp) throws IOException, ServletException {
         if (provider == null) {
-            throw HttpResponses.notFound();
+            rsp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
         }
-        return (req, rsp, node) -> {
-            try {
-                session.handler = provider.handle(req, rsp, new Provider.Listener() {
-                    private Object providerSession;
+        try {
+            session.handler = provider.handle(req, rsp, new Provider.Listener() {
+                private Object providerSession;
 
-                    @Override
-                    public void onWebSocketConnect(Object providerSession) {
-                        this.providerSession = providerSession;
-                        session.startPings();
-                        session.opened();
-                    }
+                @Override
+                public void onWebSocketConnect(Object providerSession) {
+                    this.providerSession = providerSession;
+                    session.startPings();
+                    session.opened();
+                }
 
-                    @Override
-                    public Object getProviderSession() {
-                        return providerSession;
-                    }
+                @Override
+                public Object getProviderSession() {
+                    return providerSession;
+                }
 
-                    @Override
-                    public void onWebSocketClose(int statusCode, String reason) {
-                        session.stopPings();
-                        session.closed(statusCode, reason);
-                    }
+                @Override
+                public void onWebSocketClose(int statusCode, String reason) {
+                    session.stopPings();
+                    session.closed(statusCode, reason);
+                }
 
-                    @Override
-                    public void onWebSocketError(Throwable cause) {
-                        if (cause instanceof ClosedChannelException) {
-                            onWebSocketClose(0, cause.toString());
-                        } else {
-                            session.error(cause);
-                        }
+                @Override
+                public void onWebSocketError(Throwable cause) {
+                    if (cause instanceof ClosedChannelException) {
+                        onWebSocketClose(0, cause.toString());
+                    } else {
+                        session.error(cause);
                     }
+                }
 
-                    @Override
-                    public void onWebSocketBinary(byte[] payload, int offset, int length) {
-                        try {
-                            session.binary(payload, offset, length);
-                        } catch (IOException x) {
-                            session.error(x);
-                        }
+                @Override
+                public void onWebSocketBinary(byte[] payload, int offset, int length) {
+                    try {
+                        session.binary(payload, offset, length);
+                    } catch (IOException x) {
+                        session.error(x);
                     }
+                }
 
-                    @Override
-                    public void onWebSocketText(String message) {
-                        try {
-                            session.text(message);
-                        } catch (IOException x) {
-                            session.error(x);
-                        }
+                @Override
+                public void onWebSocketText(String message) {
+                    try {
+                        session.text(message);
+                    } catch (IOException x) {
+                        session.error(x);
                     }
-                });
-            } catch (Exception x) {
-                LOGGER.log(Level.WARNING, null, x);
-                throw HttpResponses.error(x);
-            }
+                }
+            });
             // OK, unless handler is null in which case we expect an error was already sent.
-        };
+        } catch (IOException | ServletException x) {
+            throw x;
+        } catch (Exception x) {
+            LOGGER.log(Level.WARNING, null, x);
+            rsp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
     }
 
     public static boolean isSupported() {


### PR DESCRIPTION
Allows `WebSockets` to be used in contexts in which only a `HttpServletRequest`/ `HttpServletResponse` is available, and not a `StaplerRequest` / `StaplerResponse`, as for example from a `HttpServletFilter`. The Stapler-extended interfaces were not really necessary here.

### Testing done

Has functional test coverage in CloudBees CI, where there is a use case for doing this.

### Proposed changelog entries

- N/A (developer-only change, in API which was already marked beta)

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
