### PR TITLE
Fixing `NotSerializableException: org.acegisecurity.context.SecurityContext$1`

### DIFF
--- a/core/src/test/java/org/acegisecurity/context/SecurityContextTest.java
+++ b/core/src/test/java/org/acegisecurity/context/SecurityContextTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.acegisecurity.context;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("deprecation")
+public class SecurityContextTest {
+
+    @Test
+    public void serializabilityFromSpring() throws Exception {
+        org.springframework.security.core.context.SecurityContext spring1 = new org.springframework.security.core.context.SecurityContextImpl();
+        spring1.setAuthentication(new org.springframework.security.authentication.UsernamePasswordAuthenticationToken("user", null));
+        SecurityContext acegi1 = SecurityContext.fromSpring(spring1);
+        SecurityContext acegi2 = serDeser(SecurityContext.class, acegi1);
+        org.springframework.security.core.context.SecurityContext spring2 = acegi2.toSpring();
+        assertThat(spring2.getAuthentication().getPrincipal(), is("user"));
+    }
+
+    @Test
+    public void serializabilityToSpring() throws Exception {
+        SecurityContext acegi1 = new SecurityContextImpl();
+        acegi1.setAuthentication(new UsernamePasswordAuthenticationToken("user", null));
+        org.springframework.security.core.context.SecurityContext spring1 = acegi1.toSpring();
+        org.springframework.security.core.context.SecurityContext spring2 = serDeser(org.springframework.security.core.context.SecurityContext.class, spring1);
+        SecurityContext acegi2 = SecurityContext.fromSpring(spring2);
+        assertThat(acegi2.getAuthentication().getPrincipal(), is("user"));
+    }
+
+    private static <T> T serDeser(Class<T> type, T object) throws Exception {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(object);
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray()); ObjectInputStream ois = new ObjectInputStream(bais)) {
+                return type.cast(ois.readObject());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
While testing some CloudBees CI code in a non-production context involving serialized web sessions, I noticed an error

```
java.io.NotSerializableException: org.acegisecurity.context.SecurityContext$1
```

Looking into #4848 I noticed that I had forgotten `implements Serializable` in a spot:

```console
$ javap -classpath ~/.m2/repository/org/acegisecurity/acegi-security/1.0.7/acegi-security-1.0.7.jar org.acegisecurity.context.SecurityContext
Compiled from "SecurityContext.java"
public interface org.acegisecurity.context.SecurityContext extends java.io.Serializable {
  public abstract org.acegisecurity.Authentication getAuthentication();
  public abstract void setAuthentication(org.acegisecurity.Authentication);
}
```

### Testing done

Test without patch:

```
java.io.NotSerializableException: org.acegisecurity.context.SecurityContext$1
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1175)
	at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:345)
	at org.acegisecurity.context.SecurityContextTest.serDeser(SecurityContextTest.java:61)
	at org.acegisecurity.context.SecurityContextTest.serializabilityFromSpring(SecurityContextTest.java:44)
java.io.NotSerializableException: org.acegisecurity.context.SecurityContextImpl
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1175)
	at java.base/java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1543)
	at java.base/java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1500)
	at java.base/java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1423)
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1169)
	at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:345)
	at org.acegisecurity.context.SecurityContextTest.serDeser(SecurityContextTest.java:61)
	at org.acegisecurity.context.SecurityContextTest.serializabilityToSpring(SecurityContextTest.java:54)
```

### Proposed changelog entries

- N/A, not known to affect production code

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
