### PR TITLE
`AbstractPasswordBasedSecurityRealm.authenticateByPassword`

### DIFF
--- a/core/src/main/java/hudson/security/AbstractPasswordBasedSecurityRealm.java
+++ b/core/src/main/java/hudson/security/AbstractPasswordBasedSecurityRealm.java
@@ -4,6 +4,8 @@ import hudson.Util;
 import jenkins.model.Jenkins;
 import jenkins.security.ImpersonatingUserDetailsService2;
 import jenkins.security.SecurityListener;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.springframework.security.authentication.AnonymousAuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
@@ -78,6 +80,15 @@ public abstract class AbstractPasswordBasedSecurityRealm extends SecurityRealm {
         } else {
             throw new AbstractMethodError("Implement authenticate2");
         }
+    }
+
+    /**
+     * A public alias of @{link {@link #authenticate2(String, String)}.
+     * @since TODO
+     */
+    @Restricted(Beta.class)
+    public final UserDetails authenticateByPassword(String username, String password) throws AuthenticationException {
+        return authenticate2(username, password);
     }
 
     /**


### PR DESCRIPTION
CloudBees CI includes a single sign-on system from a controller to an “operations center”. For the most part this just involves the usual SSO redirect dance. However there is also an implementation of `createSecurityComponents` allowing password authentication in case someone wants to use the REST or CLI with a password rather than an API token. While this is generally a bad idea, it would be supported without SSO so we needed some way to check the password on the operations center side. Due to the `protected` access here that was not possible without an extra API.

### Testing done

Covered by a functional test in CloudBees CI. Not much to test here.

### Proposed changelog entries

- N/A, beta anyway

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
