### PR TITLE
Cleaning up more FilePath API restrictions

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -483,7 +483,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * @return The number of files/directories archived.
      *          This is only really useful to check for a situation where nothing
      */
-    @Restricted(NoExternalUse.class)
     public int zip(OutputStream out, DirScanner scanner, String verificationRoot, String prefix, OpenOption... openOptions) throws IOException, InterruptedException {
         ArchiverFactory archiverFactory = prefix == null ? ArchiverFactory.ZIP : ArchiverFactory.createZipWithPrefix(prefix, openOptions);
         return archive(archiverFactory, out, scanner, verificationRoot, openOptions);
@@ -515,7 +514,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * @return The number of files/directories archived.
      *          This is only really useful to check for a situation where nothing
      */
-    @Restricted(NoExternalUse.class)
     public int archive(final ArchiverFactory factory, OutputStream os, final DirScanner scanner,
                        String verificationRoot, OpenOption... openOptions) throws IOException, InterruptedException {
         final OutputStream out = channel != null ? new RemoteOutputStream(os) : os;
@@ -762,7 +760,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         }
     }
 
-    @Restricted(NoExternalUse.class)
     public boolean hasSymlink(FilePath verificationRoot, OpenOption... openOptions) throws IOException, InterruptedException {
         return act(new HasSymlink(verificationRoot == null ? null : verificationRoot.remote, openOptions));
     }
@@ -783,7 +780,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         }
     }
 
-    @Restricted(NoExternalUse.class)
     public boolean containsSymlink(FilePath verificationRoot, OpenOption... openOptions) throws IOException, InterruptedException {
         return !list(new SymlinkRetainingFileFilter(verificationRoot, openOptions)).isEmpty();
     }
@@ -2057,7 +2053,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
      * @param openOptions the options to apply when opening.
      * @return Direct children of this directory.
      */
-    @Restricted(NoExternalUse.class)
     @NonNull
     public List<FilePath> list(FilePath verificationRoot, OpenOption... openOptions) throws IOException, InterruptedException {
         return list(new OptionalDiscardingFileFilter(verificationRoot, openOptions));
@@ -2222,7 +2217,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         return read(null, new OpenOption[0]);
     }
 
-    @Restricted(NoExternalUse.class)
     public InputStream read(FilePath rootPath, OpenOption... openOptions) throws IOException, InterruptedException {
         String rootPathString = rootPath == null ? null : rootPath.remote;
         if (channel == null) {
@@ -2237,7 +2231,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         return p.getIn();
     }
 
-    @Restricted(NoExternalUse.class)
     public static InputStream newInputStreamDenyingSymlinkAsNeeded(File file, String verificationRoot, OpenOption... openOptions) throws IOException {
         InputStream inputStream = null;
         try {
@@ -2254,7 +2247,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         return inputStream;
     }
 
-    @Restricted(NoExternalUse.class)
     public static InputStream openInputStream(File file, OpenOption[] openOptions) throws IOException {
         return Files.newInputStream(fileToPath(file), stripLocalOptions(openOptions));
     }
@@ -2290,7 +2282,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         }
     }
 
-    @Restricted(NoExternalUse.class)
     public static boolean isSymlink(File file, String root, OpenOption... openOptions) {
         if (isNoFollowLink(openOptions)) {
             if (Util.isSymlink(file.toPath())) {
@@ -2306,7 +2297,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         return isSymlink(visitorInfo.f, visitorInfo.verificationRoot, visitorInfo.openOptions);
     }
 
-    @Restricted(NoExternalUse.class)
     public static boolean isTmpDir(File file, String root, OpenOption... openOptions) {
         if (isIgnoreTmpDirs(openOptions)) {
             if (isTmpDir(file)) {
@@ -2318,7 +2308,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         return false;
     }
 
-    @Restricted(NoExternalUse.class)
     public static boolean isTmpDir(String filename, OpenOption... openOptions) {
         if (isIgnoreTmpDirs(openOptions)) {
             return isTmpDir(filename);
@@ -2338,12 +2327,10 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         return filename.length() > WorkspaceList.TMP_DIR_SUFFIX.length() && filename.endsWith(WorkspaceList.TMP_DIR_SUFFIX);
     }
 
-    @Restricted(NoExternalUse.class)
     public static boolean isNoFollowLink(OpenOption... openOptions) {
         return Arrays.asList(openOptions).contains(LinkOption.NOFOLLOW_LINKS);
     }
 
-    @Restricted(NoExternalUse.class)
     public static boolean isIgnoreTmpDirs(OpenOption... openOptions) {
         return Arrays.asList(openOptions).contains(DisplayOption.IGNORE_TMP_DIRS);
     }
@@ -3713,7 +3700,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     /**
      * Wraps {@link FileVisitor} to ignore symlinks.
      */
-    @Restricted(NoExternalUse.class)
     public static FileVisitor ignoringSymlinks(final FileVisitor v, String verificationRoot, OpenOption... openOptions) {
         return validatingVisitor(FilePath::isNoFollowLink,
                 visitorInfo -> !isSymlink(visitorInfo),
@@ -3723,7 +3709,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     /**
      * Wraps {@link FileVisitor} to ignore tmp directories.
      */
-    @Restricted(NoExternalUse.class)
     public static FileVisitor ignoringTmpDirs(final FileVisitor v, String verificationRoot, OpenOption... openOptions) {
         return validatingVisitor(FilePath::isIgnoreTmpDirs,
                 visitorInfo -> !isTmpDir(visitorInfo),


### PR DESCRIPTION
This is a follow up to #8913 
As these methods looks to also be leftovers from an old security release.

### Proposed changelog entries

- Developer: Grant access to more FilePath APIs.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
