### PR TITLE
Create new index page for heap dump creation

### DIFF
--- a/core/src/main/java/hudson/util/RemotingDiagnostics.java
+++ b/core/src/main/java/hudson/util/RemotingDiagnostics.java
@@ -31,6 +31,7 @@ import groovy.lang.GroovyShell;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Util;
+import hudson.model.ModelObject;
 import hudson.model.User;
 import hudson.remoting.AsyncFutureImpl;
 import hudson.remoting.DelegatingCallable;
@@ -56,9 +57,12 @@ import jenkins.security.MasterToSlaveCallable;
 import jenkins.util.ScriptListener;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
  * Various remoting operations related to diagnostics.
@@ -196,7 +200,7 @@ public final class RemotingDiagnostics {
      * Heap dump, exposable to URL via Stapler.
      *
      */
-    public static class HeapDump {
+    public static class HeapDump implements ModelObject {
         private final AccessControlled owner;
         private final VirtualChannel channel;
 
@@ -205,14 +209,8 @@ public final class RemotingDiagnostics {
             this.channel = channel;
         }
 
-        /**
-         * Obtains the heap dump.
-         */
-        public void doIndex(StaplerResponse rsp) throws IOException {
-            rsp.sendRedirect("heapdump.hprof");
-        }
-
         @WebMethod(name = "heapdump.hprof")
+        @RequirePOST
         public void doHeapDump(StaplerRequest req, StaplerResponse rsp) throws IOException, InterruptedException {
             owner.checkPermission(Jenkins.ADMINISTER);
             rsp.setContentType("application/octet-stream");
@@ -225,8 +223,21 @@ public final class RemotingDiagnostics {
             }
         }
 
+        @Restricted(DoNotUse.class)
+        public AccessControlled getContext() {
+            if (owner instanceof ModelObject) {
+                return owner;
+            }
+            return Jenkins.get();
+        }
+
         public FilePath obtain() throws IOException, InterruptedException {
             return RemotingDiagnostics.getHeapDump(channel);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.HeapDump_DisplayName();
         }
     }
 }

--- a/core/src/main/resources/hudson/util/Messages.properties
+++ b/core/src/main/resources/hudson/util/Messages.properties
@@ -30,6 +30,8 @@ FormValidation.ValidateRequired=Required
 FormValidation.Error.Details=(show details)
 HttpResponses.Saved=Saved
 
+HeapDump.DisplayName = Heap Dump
+
 Retrier.Attempt=Attempt #{0} to do the action {1}
 Retrier.AttemptFailed=The attempt #{0} to do the action {1} failed
 Retrier.Sleeping=Sleeping for {0} milliseconds before a new attempt for the action {1}

--- a/core/src/main/resources/hudson/util/RemotingDiagnostics/HeapDump/index.jelly
+++ b/core/src/main/resources/hudson/util/RemotingDiagnostics/HeapDump/index.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <l:layout permission="${app.ADMINISTER}">
+        <st:include page="sidepanel.jelly" it="${it.context}"/>
+        <l:main-panel>
+            <l:app-bar title="${%title(it.context.displayName)}"/>
+            <p class="jenkins-description">
+                ${%blurb}
+            </p>
+            <form action="heapdump.hprof" method="post">
+                <input type="submit" class="jenkins-button" value="${%Download}"/>
+            </form>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/core/src/main/resources/hudson/util/RemotingDiagnostics/HeapDump/index.properties
+++ b/core/src/main/resources/hudson/util/RemotingDiagnostics/HeapDump/index.properties
@@ -1,0 +1,3 @@
+blurb = Download a heap dump to help diagnose problems. \
+  Heap dump creation is only supported on Java runtimes based on OpenJDK/HotSpot.
+title = Download Heap Dump for {0}


### PR DESCRIPTION
> <img width="1200" alt="Screenshot" src="https://github.com/jenkinsci/jenkins/assets/1831569/e6caa660-e200-400f-8c3a-4de1b3122ba9">

Two small improvements to `/heapDump`:

* Create a page explaining the heap dump download a bit and a known limitation.
* Require POST to download `heapDump.hprof`. Not addressing a security issue, just seems nicer.

This does not address the following remaining issues (which can be done later):

* Discoverability (e.g. linking from `/systemInfo` and corresponding agent pages, or directly integrating it there)
* Determine beforehand whether it would succeed, and only offer download option if it is.

### Testing done

1. Navigated to `/heapDump` and clicked the button. Download started.
2. Navigated to `/computer/a1/heapDump` of a connected agent, and clicked the button. Download started.
3. Navigated to `/heapDump/heapDump.hprof` (from `@RequirePOST`)and clicked the button. Download started.
3. Navigated to `/computer/a1/heapDump/heapDump.hprof` (from `@RequirePOST`)and clicked the button. Download started.

### Proposed changelog entries

- Create an index page for heap dump creation.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
