### PR TITLE
[JENKINS-72679] Allow button clicks after an administrative monitor popup is closed

### DIFF
--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
@@ -48,16 +48,46 @@
   display: block;
   background-color: var(--background);
   box-shadow: var(--dropdown-box-shadow);
-  transition: var(--standard-transition);
   border-radius: 15px;
   opacity: 0;
-  transform: translateY(-10px) scale(0.975);
-  z-index: 1000;
+  animation: hide-am-list 300ms ease-in 1 normal;
+  z-index: 0;
 }
+
 .am-container.visible div.am-list {
   opacity: 1;
-  transform: scale(1);
+  animation: show-am-list 300ms ease-in 1 normal forwards;
+  z-index: 1000;
 }
+
+@keyframes show-am-list {
+  from {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px) scale(0.975);
+  }
+  to {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+  }
+}
+
+@keyframes hide-am-list {
+  from {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+    z-index: 1000;
+  }
+  to {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px) scale(0.975);
+    z-index: 1000;
+  }
+}
+
 .am-container .am-message {
   display: block;
   line-height: 1.4em;


### PR DESCRIPTION
The div of the admin monitor pop-up is set to opacity 0 but keeps z-index 1000 when closed. This makes the buttons, that are behind the popup when shown unusable.
This change uses an animation that ensures the z-index is 0 after hiding the popup and buttons are still usable

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

Before:
<video src="https://github.com/jenkinsci/jenkins/assets/17767050/e50e7e82-2815-45da-ac45-378e423174ba"/>

After:
<video src="https://github.com/jenkinsci/jenkins/assets/17767050/66cf9b6f-766a-4bbe-9bc3-b4a4efef5882"/>

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Manually testing

### Proposed changelog entries

- Allow button clicks after closing an administrative monitor popup.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
