### PR TITLE
Fix UI for plugin manager's Advanced settings with SystemRead

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -67,16 +67,18 @@ THE SOFTWARE.
                 <h2 class="jenkins-section__title">${%Update Site}</h2>
                 <f:form method="post" action="siteConfigure" name="siteConfigure">
                     <f:entry title="${%URL}">
-                        <j:if test="${app.updateCenter.ID_DEFAULT.equals(app.updateCenter.PREDEFINED_UPDATE_SITE_ID)}">
-                          <a id="reset-to-default" href="#">${%Reset to default}</a>
-                        </j:if>
+                        <l:isAdmin>
+                            <j:if test="${app.updateCenter.ID_DEFAULT.equals(app.updateCenter.PREDEFINED_UPDATE_SITE_ID)}">
+                                <a id="reset-to-default" href="#">${%Reset to default}</a>
+                            </j:if>
+                        </l:isAdmin>
                         <f:textbox name="site"
                                    id="update-site-url"
                                    value="${app.updateCenter.getSite(app.updateCenter.ID_DEFAULT).url}"
                                    checkUrl="checkUpdateSiteUrl" checkDependsOn=""/>
                     </f:entry>
-                    <st:adjunct includes="hudson.PluginManager._updateSite"/>
                     <l:isAdmin>
+                        <st:adjunct includes="hudson.PluginManager._updateSite"/>
                         <f:block>
                             <f:submit/>
                         </f:block>


### PR DESCRIPTION
Noticed while playing with SystemRead: #6886 did not take into account users with Overall/SystemRead permission and the changed UI shown to them.

### Testing done

Navigate to `/pluginManager/advanced` with SystemRead permission and confirm no link shows, no JS error.

> <img width="1043" alt="Screenshot 2024-02-07 at 21 44 54" src="https://github.com/jenkinsci/jenkins/assets/1831569/4e3c18fb-3fbe-4067-9ecf-9d631b2c1493">

<details>
<summary>Before</summary>

> <img width="1113" alt="Screenshot 2024-02-07 at 21 50 25" src="https://github.com/jenkinsci/jenkins/assets/1831569/d5041dd0-425a-473d-80ea-f613236c2e1d">

</details>

### Proposed changelog entries

too minor 

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
