### PR TITLE
Do not offer impossible Cloud options to users with SystemRead

### DIFF
--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -93,33 +93,42 @@ THE SOFTWARE.
             <section class="empty-state-section">
               <j:choose>
                 <j:when test="${it.cloudAvailable}">
-                  <p>${%noCloudAvailable}</p>
+                  <j:choose>
+                    <j:when test="${h.hasPermission(app.ADMINISTER)}">
+                      <p>${%noCloudAvailableCTA}</p>
+                    </j:when>
+                    <j:otherwise>
+                      <p>${%noCloudAvailable}</p>
+                    </j:otherwise>
+                  </j:choose>
                 </j:when>
                 <j:otherwise>
                   <p>${%noCloudPlugin}</p>
                 </j:otherwise>
               </j:choose>
               <ul class="empty-state-section-list">
-                <j:if test="${it.cloudAvailable}">
+                <l:isAdmin>
+                  <j:if test="${it.cloudAvailable}">
+                    <li class="content-block">
+                      <a href="new"
+                         class="content-block__link">
+                        <span>${%newCloud}</span>
+                        <span class="trailing-icon">
+                          <l:icon src="symbol-add"/>
+                        </span>
+                      </a>
+                    </li>
+                  </j:if>
                   <li class="content-block">
-                    <a href="new"
+                    <a href="${rootURL}/manage/pluginManager/available?filter=${it.cloudUpdateCenterCategoryLabel}"
                        class="content-block__link">
-                      <span>${%newCloud}</span>
+                      <span>${%installCloudPlugin}</span>
                       <span class="trailing-icon">
-                        <l:icon src="symbol-add"/>
+                        <l:icon src="symbol-plugins" />
                       </span>
                     </a>
                   </li>
-                </j:if>
-                <li class="content-block">
-                  <a href="${rootURL}/manage/pluginManager/available?filter=${it.cloudUpdateCenterCategoryLabel}"
-                     class="content-block__link">
-                    <span>${%installCloudPlugin}</span>
-                    <span class="trailing-icon">
-                      <l:icon src="symbol-plugins" />
-                    </span>
-                  </a>
-                </li>
+                </l:isAdmin>
                 <li class="content-block">
                   <a href="https://www.jenkins.io/redirect/distributed-builds"
                      class="content-block__link"

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.properties
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.properties
@@ -1,5 +1,6 @@
 learnMoreDistributedBuilds=Learn more about distributed builds
-noCloudAvailable=There are no clouds currently setup, create one or install a plugin for more cloud options.
+noCloudAvailableCTA=There are no clouds currently set up. Create one, or install a plugin for more cloud options.
+noCloudAvailable=There are no clouds currently set up.
 noCloudPlugin=There is no plugin installed that supports clouds.
 newCloud=New cloud
 installCloudPlugin=Install a plugin

--- a/core/src/main/resources/jenkins/agents/CloudSet/index_fr.properties
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index_fr.properties
@@ -1,5 +1,5 @@
 learnMoreDistributedBuilds=En apprendre plus à propos des builds distribués
-noCloudAvailable=Aucune configuration de cloud, créez-en une ou installez un plugin pour plus d''options de cloud.
+noCloudAvailableCTA=Aucune configuration de cloud, créez-en une ou installez un plugin pour plus d''options de cloud.
 noCloudPlugin=Aucun plugin installé supportant les clouds.
 newCloud=Nouveau cloud
 installCloudPlugin=Installer un plugin

--- a/core/src/main/resources/jenkins/agents/CloudSet/index_tr.properties
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index_tr.properties
@@ -1,6 +1,6 @@
 Clouds=Bulutlar
 learnMoreDistributedBuilds=Dağıtık yapılandırmalar hakkında daha fazla bilgi edinin
-noCloudAvailable=Şu anda kurulu bulut yok, bir tane oluşturun veya daha fazla bulut seçeneği için bir eklenti yükleyin.
+noCloudAvailableCTA=Şu anda kurulu bulut yok, bir tane oluşturun veya daha fazla bulut seçeneği için bir eklenti yükleyin.
 noCloudPlugin=İsteğe bağlı olarak ajan hazırlamak için kullanılmak üzere herhangi bir bulut yüklü değil.
 newCloud=Yeni bulut
 installCloudPlugin=Bir eklenti yükleyin


### PR DESCRIPTION
SystemRead users cannot set up clouds, or install plugins, so do not suggest these options.

## Before

> <img width="774" alt="Screenshot 2024-02-07 at 21 47 10" src="https://github.com/jenkinsci/jenkins/assets/1831569/fa4b46e0-f941-4a1e-bfaa-667795012010">

> <img width="745" alt="Screenshot 2024-02-07 at 21 45 31" src="https://github.com/jenkinsci/jenkins/assets/1831569/fe484d90-26c8-4961-b042-4ce0613738ea">

## After

> <img width="716" alt="Screenshot 2024-02-07 at 21 45 22" src="https://github.com/jenkinsci/jenkins/assets/1831569/a29d9c9f-f0d4-49b1-93d1-c0fec495ae52">

> <img width="779" alt="Screenshot 2024-02-07 at 21 47 03" src="https://github.com/jenkinsci/jenkins/assets/1831569/4e424d4a-cf93-4ec4-87bd-bb7ef9b13a64">


### Testing done

Went to the page on the screenshots with Administer or SystemRead.

### Proposed changelog entries

too minor

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
