### PR TITLE
Allow update sites to define a custom URL for wizard plugin suggestion

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -496,7 +496,7 @@ public class UpdateSite {
     /**
      *
      * @return the URL used by {@link jenkins.install.SetupWizard} for suggested plugins to install at setup time
-     * @since 2.445 (ish)
+     * @since TODO
      */
     @Exported
     public String getSuggestedPluginsUrl() {

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -493,6 +493,17 @@ public class UpdateSite {
         return url;
     }
 
+    /**
+     *
+     * @return the URL used by {@link jenkins.install.SetupWizard} for suggested plugins to install at setup time
+     * @since 2.445 (ish)
+     */
+    @Exported
+    public String getSuggestedPluginsUrl() {
+        String updateCenterJsonUrl = getUrl();
+        return updateCenterJsonUrl.replace("/update-center.json", "/platform-plugins.json");
+    }
+
 
     /**
      * URL which exposes the metadata location in a specific update site.

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -132,6 +132,13 @@ public class SetupWizard extends PageDecorator {
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
     private static /* not final */ String ADMIN_INITIAL_API_TOKEN = SystemProperties.getString(ADMIN_INITIAL_API_TOKEN_PROPERTY_NAME);
 
+    /**
+     * At setup time, Jenkins will read a json file with suggested plugins coming from a json from {@link UpdateSite#getUrl()}
+     * and replace "/update-center.json" with the value fo this system property (default is {@code "/platform-plugins.json"}
+     */
+    private static final String SUGGESTED_PLUGINS_FILE_NAME =
+            SystemProperties.getString(SetupWizard.class.getName() + ".SUGGESTED_PLUGINS_FILE_NAME", "/platform-plugins.json");
+
     @NonNull
     @Override
     public String getDisplayName() {
@@ -554,7 +561,7 @@ public class SetupWizard extends PageDecorator {
         JSONArray initialPluginList = null;
         updateSiteList: for (UpdateSite updateSite : Jenkins.get().getUpdateCenter().getSiteList()) {
             String updateCenterJsonUrl = updateSite.getUrl();
-            String suggestedPluginUrl = updateCenterJsonUrl.replace("/update-center.json", "/platform-plugins.json");
+            String suggestedPluginUrl = updateCenterJsonUrl.replace("/update-center.json", SUGGESTED_PLUGINS_FILE_NAME);
             VersionNumber version = Jenkins.getVersion();
             if (version != null && (suggestedPluginUrl.startsWith("https://") || suggestedPluginUrl.startsWith("http://"))) {
                 // Allow remote update site to distinguish based on the current version

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -132,13 +132,6 @@ public class SetupWizard extends PageDecorator {
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
     private static /* not final */ String ADMIN_INITIAL_API_TOKEN = SystemProperties.getString(ADMIN_INITIAL_API_TOKEN_PROPERTY_NAME);
 
-    /**
-     * At setup time, Jenkins will read a json file with suggested plugins coming from a json from {@link UpdateSite#getUrl()}
-     * and replace "/update-center.json" with the value fo this system property (default is {@code "/platform-plugins.json"}
-     */
-    private static final String SUGGESTED_PLUGINS_FILE_NAME =
-            SystemProperties.getString(SetupWizard.class.getName() + ".SUGGESTED_PLUGINS_FILE_NAME", "/platform-plugins.json");
-
     @NonNull
     @Override
     public String getDisplayName() {
@@ -560,8 +553,7 @@ public class SetupWizard extends PageDecorator {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         JSONArray initialPluginList = null;
         updateSiteList: for (UpdateSite updateSite : Jenkins.get().getUpdateCenter().getSiteList()) {
-            String updateCenterJsonUrl = updateSite.getUrl();
-            String suggestedPluginUrl = updateCenterJsonUrl.replace("/update-center.json", SUGGESTED_PLUGINS_FILE_NAME);
+            String suggestedPluginUrl = updateSite.getSuggestedPluginsUrl();
             VersionNumber version = Jenkins.getVersion();
             if (version != null && (suggestedPluginUrl.startsWith("https://") || suggestedPluginUrl.startsWith("http://"))) {
                 // Allow remote update site to distinguish based on the current version


### PR DESCRIPTION
Use case: a unique distribution with two json files: 
- the usual one,
- a second one with a limited list. Some plugins maybe not be compatible with the startup mode (e.g FIPS mode)

currently the file is hardcoded and there is not extension point available with the setup wizard

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Add ability for custom update center's to override the suggested plugin list

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
