### PR TITLE
Basic `ProxyConfigurationManagerTest`

### DIFF
--- a/test/src/test/java/hudson/ProxyConfigurationManagerTest.java
+++ b/test/src/test/java/hudson/ProxyConfigurationManagerTest.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+public class ProxyConfigurationManagerTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @LocalData
+    @Test public void serialForm() throws Exception {
+        /* Set up this way:
+        r.jenkins.proxy = new ProxyConfiguration("proxy.mycorp", 80);
+        r.jenkins.proxy.save();
+        */
+        ProxyConfiguration pc = r.jenkins.proxy;
+        assertNotNull(pc);
+        assertEquals("proxy.mycorp", pc.name);
+    }
+
+}

--- a/test/src/test/resources/hudson/ProxyConfigurationManagerTest/proxy.xml
+++ b/test/src/test/resources/hudson/ProxyConfigurationManagerTest/proxy.xml
@@ -1,0 +1,5 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<proxy>
+  <name>proxy.mycorp</name>
+  <port>80</port>
+</proxy>


### PR DESCRIPTION
Came across #8693 and noticed that the XML serial form of `ProxyConfiguration` was not tested. This is not trivial as can be seen from https://github.com/jenkinsci/jenkins/blob/8b949243a92cc0ff89742be6b509920db0e0a456/core/src/main/java/hudson/ProxyConfiguration.java#L296-L306 https://github.com/jenkinsci/jenkins/blob/8b949243a92cc0ff89742be6b509920db0e0a456/core/src/main/java/hudson/ProxyConfiguration.java#L506-L512

(There is also a getter & setter in `Jenkins` from #3935 which is tested downstream in `configuration-as-code-plugin`: `ProxyConfiguratorTest`.)

### Testing done

Test passes locally.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
