### PR TITLE
readonly mode for f:select

### DIFF
--- a/core/src/main/resources/lib/form/select.jelly
+++ b/core/src/main/resources/lib/form/select.jelly
@@ -63,7 +63,7 @@ THE SOFTWARE.
 
   ${descriptor.calcFillSettings(field,attrs)} <!-- this figures out the 'fillUrl' and 'fillDependsOn' attribute -->
   <j:set var="value" value="${attrs.value ?: instance[attrs.field] ?: attrs.default}" />
-  <div class="jenkins-select">
+  <div class="jenkins-select" data-readonly="${readOnlyMode}">
     <m:select xmlns:m="jelly:hudson.util.jelly.MorphTagLibrary"
               class="jenkins-select__input ${attrs.checkUrl!=null?'validated':''} select ${attrs.clazz}"
               name="${attrs.name ?: '_.'+attrs.field}"

--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -132,7 +132,10 @@ Behaviour.specify("SELECT.select", "select", 1000, function (e) {
   // handle readonly mode, the actually selected option is only filled asynchronously so we have
   // to wait until the data is filled by registering to the filled event.
   let parentDiv = e.closest(".jenkins-select");
-  if (parentDiv.dataset.readonly === "true" && !parentDiv.hasAttribute("data-listener-added")) {
+  if (
+    parentDiv.dataset.readonly === "true" &&
+    !parentDiv.hasAttribute("data-listener-added")
+  ) {
     // need to avoid duplicate eventListeners so mark that we already added it
     parentDiv.setAttribute("data-listener-added", "true");
     function handleFilled(event) {

--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -129,6 +129,30 @@ Behaviour.specify("SELECT.select", "select", 1000, function (e) {
     }
   }
 
+  // handle readonly mode, the actually selected option is only filled asynchronously so we have
+  // to wait until the data is filled by registering to the filled event.
+  let parentDiv = e.closest(".jenkins-select");
+  if (parentDiv.dataset.readonly === "true" && !parentDiv.hasAttribute("data-listener-added")) {
+    // need to avoid duplicate eventListeners so mark that we already added it
+    parentDiv.setAttribute("data-listener-added", "true");
+    function handleFilled(event) {
+      // ignore events for other elements
+      if (event.detail === e) {
+        let pre = document.createElement("pre");
+        if (e.selectedIndex != -1) {
+          pre.innerText = e.options[e.selectedIndex].text;
+        } else {
+          pre.innerText = "N/A";
+        }
+        e.remove();
+        pre.classList.add("jenkins-readonly");
+        parentDiv.classList.remove("jenkins-select");
+        parentDiv.appendChild(pre);
+      }
+    }
+    parentDiv.addEventListener("filled", handleFilled);
+  }
+
   // controls that this SELECT box depends on
   refillOnChange(e, function (params) {
     var value = e.value;

--- a/core/src/main/resources/lib/form/select/select.js
+++ b/core/src/main/resources/lib/form/select/select.js
@@ -129,30 +129,32 @@ Behaviour.specify("SELECT.select", "select", 1000, function (e) {
     }
   }
 
+  let parentDiv = e.closest(".jenkins-select");
+
+  function handleFilled(event) {
+    // ignore events for other elements
+    if (event.detail === e) {
+      let pre = document.createElement("pre");
+      if (e.selectedIndex != -1) {
+        pre.innerText = e.options[e.selectedIndex].text;
+      } else {
+        pre.innerText = "N/A";
+      }
+      e.remove();
+      pre.classList.add("jenkins-readonly");
+      parentDiv.classList.remove("jenkins-select");
+      parentDiv.appendChild(pre);
+    }
+  }
+
   // handle readonly mode, the actually selected option is only filled asynchronously so we have
   // to wait until the data is filled by registering to the filled event.
-  let parentDiv = e.closest(".jenkins-select");
   if (
     parentDiv.dataset.readonly === "true" &&
     !parentDiv.hasAttribute("data-listener-added")
   ) {
     // need to avoid duplicate eventListeners so mark that we already added it
     parentDiv.setAttribute("data-listener-added", "true");
-    function handleFilled(event) {
-      // ignore events for other elements
-      if (event.detail === e) {
-        let pre = document.createElement("pre");
-        if (e.selectedIndex != -1) {
-          pre.innerText = e.options[e.selectedIndex].text;
-        } else {
-          pre.innerText = "N/A";
-        }
-        e.remove();
-        pre.classList.add("jenkins-readonly");
-        parentDiv.classList.remove("jenkins-select");
-        parentDiv.appendChild(pre);
-      }
-    }
     parentDiv.addEventListener("filled", handleFilled);
   }
 

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -612,9 +612,10 @@ function geval(script) {
 // eslint-disable-next-line no-unused-vars
 function fireEvent(element, event) {
   return !element.dispatchEvent(
-    new Event(event, {
+    new CustomEvent(event, {
       bubbles: true,
       cancelable: true,
+      detail: element,
     }),
   );
 }


### PR DESCRIPTION
when enabling readonly mode with the extended read permissions plugin the places where an f:select is used are not made readonly. The dropdowns are still working

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

Before:
![image](https://github.com/jenkinsci/jenkins/assets/17767050/c78caa4d-a4e6-4de2-bddd-f2a59e20b7e4)
![image](https://github.com/jenkinsci/jenkins/assets/17767050/dd7c0c27-488b-4a88-a651-b5bcf4d58ebb)

After:
![image](https://github.com/jenkinsci/jenkins/assets/17767050/d9ca7627-267f-4277-a747-7b32de7be35f)

An alternative would be to just set the disabled flag on the select via javascript. Unfortunately the morphtag doesn't allow to set the disabled with a null value, the `disabled` attribute would still be rendered which is enough to disable the select.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Manually tested

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- readonly mode for f:select

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
