### PR TITLE
[JENKINS-72711] Restore progress animation in build history and buildtime trend views

### DIFF
--- a/core/src/main/resources/hudson/model/Job/buildTimeTrend.jelly
+++ b/core/src/main/resources/hudson/model/Job/buildTimeTrend.jelly
@@ -38,6 +38,13 @@ THE SOFTWARE.
         <l:icon src="symbol-status-nobuilt" id="nobuilt" />
         <l:icon src="symbol-status-aborted" id="aborted" />
         <l:icon src="symbol-status-disabled" id="disabled" />
+
+        <l:icon src="symbol-status-blue-anime" id="blue-anime" />
+        <l:icon src="symbol-status-yellow-anime" id="yellow-anime" />
+        <l:icon src="symbol-status-red-anime" id="red-anime" />
+        <l:icon src="symbol-status-nobuilt-anime" id="nobuilt-anime" />
+        <l:icon src="symbol-status-aborted-anime" id="aborted-anime" />
+        <l:icon src="symbol-status-disabled-anime" id="disabled-anime" />
       </template>
       <h1>${%Build Time Trend}</h1>
           <div align="center">

--- a/core/src/main/resources/hudson/model/Job/buildTimeTrend_resources.js
+++ b/core/src/main/resources/hudson/model/Job/buildTimeTrend_resources.js
@@ -69,7 +69,6 @@ window.buildTimeTrend_displayBuilds = function (data) {
  */
 function generateSVGIcon(iconName) {
   const icons = document.querySelector("#jenkins-build-status-icons");
-  iconName = iconName.replace("-anime", "");
 
   return icons.content.querySelector(`#${iconName}`).cloneNode(true);
 }

--- a/core/src/main/resources/lib/hudson/buildListTable.jelly
+++ b/core/src/main/resources/lib/hudson/buildListTable.jelly
@@ -37,6 +37,12 @@ THE SOFTWARE.
     <l:icon src="symbol-status-nobuilt" id="nobuilt" />
     <l:icon src="symbol-status-aborted" id="aborted" />
     <l:icon src="symbol-status-disabled" id="disabled" />
+    <l:icon src="symbol-status-blue-anime" id="blue-anime" />
+    <l:icon src="symbol-status-yellow-anime" id="yellow-anime" />
+    <l:icon src="symbol-status-red-anime" id="red-anime" />
+    <l:icon src="symbol-status-nobuilt-anime" id="nobuilt-anime" />
+    <l:icon src="symbol-status-aborted-anime" id="aborted-anime" />
+    <l:icon src="symbol-status-disabled-anime" id="disabled-anime" />
     <l:icon src="symbol-terminal" id="console" />
   </template>
 


### PR DESCRIPTION
… time trend views

See [JENKINS-72711](https://issues.jenkins.io/browse/JENKINS-72711).

Amends #8705

### Testing done

Looked at the affected pages while builds were running while the previous build was: green, red, aborted, notbuilt, canceled.

Confirmed no other views include the responsible JS file (and would need these definitions).

### Proposed changelog entries

- Restore progress animation in build history and build time trend views (regression in 2.434).

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
