### PR TITLE
Use `ABORTED` from `Run.reload`

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -364,8 +364,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      */
     public void reload() throws IOException {
         this.state = State.COMPLETED;
-        // TODO ABORTED would perhaps make more sense than FAILURE:
-        this.result = Result.FAILURE;  // defensive measure. value should be overwritten by unmarshal, but just in case the saved data is inconsistent
+        this.result = Result.ABORTED;  // defensive measure. value should be overwritten by unmarshal, but just in case the saved data is inconsistent
         getDataFile().unmarshal(this); // load the rest of the data
 
         if (state == State.COMPLETED) {


### PR DESCRIPTION
Resolving a comment I made a decade ago (!) in b55c157813c0f5dc3cb06d0503834d21115aebc9: if a non-Pipeline build is interrupted by a controller restart, `ABORTED` status (used for all sorts of sudden interruptions unrelated to the logical build steps) is more natural than `FAILURE` (a problem in a specific step preventing the build from proceeding). This is also more consistent with Pipeline builds, or `node` blocks, that fail to resume for various reasons when normally they could.

### Testing done

None; apparently this does not have test coverage? Could add some if it seems valuable.

### Proposed changelog entries

- Non-Pipeline builds interrupted by a controller restart will now be marked as aborted rather than failed.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
