### PR TITLE
Reduce usage of `StringUtils`

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -245,9 +245,9 @@ public class CLI {
 
         if (auth == null && bearer == null) {
             // -auth option not set
-            if (StringUtils.isNotBlank(userIdEnv) && StringUtils.isNotBlank(tokenEnv)) {
+            if ((userIdEnv != null && !userIdEnv.isBlank()) && (tokenEnv != null && !tokenEnv.isBlank())) {
                 auth = StringUtils.defaultString(userIdEnv).concat(":").concat(StringUtils.defaultString(tokenEnv));
-            } else if (StringUtils.isNotBlank(userIdEnv) || StringUtils.isNotBlank(tokenEnv)) {
+            } else if ((userIdEnv != null && !userIdEnv.isBlank()) || (tokenEnv != null && !tokenEnv.isBlank())) {
                 printUsage(Messages.CLI_BadAuth());
                 return -1;
             } // Otherwise, none credentials were set

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -133,7 +133,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.input.CountingInputStream;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
@@ -1712,7 +1711,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     public FilePath createTempDir(final String prefix, final String suffix) throws IOException, InterruptedException {
         try {
             String[] s;
-            if (StringUtils.isBlank(suffix)) {
+            if (suffix == null || suffix.isBlank()) {
                 s = new String[]{prefix, "tmp"}; // see File.createTempFile - tmp is used if suffix is null
             } else {
                 s = new String[]{prefix, suffix};

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -968,7 +968,7 @@ public class Functions {
     public static String getFooterURL() {
         if (footerURL == null) {
             footerURL = SystemProperties.getString("hudson.footerURL");
-            if (StringUtils.isBlank(footerURL)) {
+            if (footerURL == null || footerURL.isBlank()) {
                 footerURL = "https://www.jenkins.io/";
             }
         }
@@ -2194,7 +2194,7 @@ public class Functions {
             int firstPeriod = part.indexOf(".");
             return slash > 0 && firstPeriod > 0 && slash < firstPeriod;
         }).collect(Collectors.joining(" "));
-        if (StringUtils.isBlank(views)) {
+        if (views == null || views.isBlank()) {
             // fallback to full thread name if there are no apparent views
             return threadName;
         }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -272,7 +272,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      */
     public static @NonNull PluginManager createDefault(@NonNull Jenkins jenkins) {
         String pmClassName = SystemProperties.getString(CUSTOM_PLUGIN_MANAGER);
-        if (!StringUtils.isBlank(pmClassName)) {
+        if (pmClassName != null && !pmClassName.isBlank()) {
             LOGGER.log(FINE, String.format("Use of custom plugin manager [%s] requested.", pmClassName));
             try {
                 final Class<? extends PluginManager> klass = Class.forName(pmClassName).asSubclass(PluginManager.class);
@@ -370,7 +370,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             throw new UncheckedIOException(e);
         }
         String workDir = SystemProperties.getString(PluginManager.class.getName() + ".workDir");
-        this.workDir = StringUtils.isBlank(workDir) ? null : new File(workDir);
+        this.workDir = workDir == null || workDir.isBlank() ? null : new File(workDir);
 
         strategy = createPluginStrategy();
     }
@@ -1429,7 +1429,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         for (UpdateSite site : Jenkins.get().getUpdateCenter().getSiteList()) {
             List<JSONObject> sitePlugins = site.getAvailables().stream()
                 .filter(plugin -> {
-                    if (StringUtils.isBlank(query)) {
+                    if (query == null || query.isBlank()) {
                         return true;
                     }
                     return StringUtils.containsIgnoreCase(plugin.name, query) ||
@@ -1864,9 +1864,10 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             File tmpDir = Files.createTempDirectory("uploadDir").toFile();
             ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory(DiskFileItemFactory.DEFAULT_SIZE_THRESHOLD, tmpDir));
             List<FileItem> items = upload.parseRequest(req);
-            if (StringUtils.isNotBlank(items.get(1).getString())) {
+            String string = items.get(1).getString();
+            if (string != null && !string.isBlank()) {
                 // this is a URL deployment
-                fileName = items.get(1).getString();
+                fileName = string;
                 copier = new UrlPluginCopier(fileName);
             } else {
                 // this is a file upload
@@ -1909,7 +1910,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 }
                 String deps = m.getMainAttributes().getValue("Plugin-Dependencies");
 
-                if (StringUtils.isNotBlank(deps)) {
+                if (deps != null && !deps.isBlank()) {
                     // now we get to parse it!
                     String[] plugins = deps.split(",");
                     for (String p : plugins) {
@@ -1940,7 +1941,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     @Restricted(NoExternalUse.class)
     @RequirePOST public FormValidation doCheckPluginUrl(StaplerRequest request, @QueryParameter String value) throws IOException {
-        if (StringUtils.isNotBlank(value)) {
+        if (value != null && !value.isBlank()) {
             try {
                 URL url = new URL(value);
                 if (!url.getProtocol().startsWith("http")) {

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -115,7 +115,6 @@ import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
 import jenkins.widgets.HasWidgets;
 import net.jcip.annotations.GuardedBy;
-import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.kohsuke.accmod.Restricted;
@@ -1522,7 +1521,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         }
 
         String nExecutors = req.getSubmittedForm().getString("numExecutors");
-        if (StringUtils.isBlank(nExecutors) || Integer.parseInt(nExecutors) <= 0) {
+        if (nExecutors == null || nExecutors.isBlank() || Integer.parseInt(nExecutors) <= 0) {
             throw new FormException(Messages.Slave_InvalidConfig_Executors(nodeName), "numExecutors");
         }
 

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -63,7 +63,6 @@ import jenkins.security.ResourceDomainRootAction;
 import jenkins.util.SystemProperties;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipOutputStream;
 import org.kohsuke.accmod.Restricted;
@@ -280,7 +279,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
             if (zip) {
                 rsp.setContentType("application/zip");
                 String includes, prefix;
-                if (StringUtils.isBlank(rest)) {
+                if (rest == null || rest.isBlank()) {
                     includes = "**";
                     // JENKINS-19947, JENKINS-61473: traditional behavior is to prepend the directory name
                     prefix = baseFile.getName();

--- a/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
+++ b/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
@@ -34,7 +34,6 @@ import jenkins.model.Jenkins;
 import jenkins.model.item_category.ItemCategory;
 import org.apache.commons.jelly.Script;
 import org.apache.commons.jelly.XMLOutput;
-import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.jenkins.ui.icon.IconSpec;
@@ -215,8 +214,9 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> im
     @CheckForNull
     @Deprecated
     public String getIconFilePath(String size) {
-        if (!StringUtils.isBlank(getIconFilePathPattern())) {
-            return getIconFilePathPattern().replace(":size", size);
+        String iconFilePathPattern = getIconFilePathPattern();
+        if (iconFilePathPattern != null && !iconFilePathPattern.isBlank()) {
+            return iconFilePathPattern.replace(":size", size);
         }
         return null;
     }

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -78,7 +78,6 @@ import jenkins.security.LastGrantedAuthoritiesProperty;
 import jenkins.security.UserDetailsCache;
 import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -795,7 +794,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      * @since 1.600
      */
     public static boolean isIdOrFullnameAllowed(@CheckForNull String id) {
-        if (StringUtils.isBlank(id)) {
+        if (id == null || id.isBlank()) {
             return false;
         }
         final String trimmedId = id.trim();

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -106,7 +106,6 @@ import jenkins.widgets.HasWidgets;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.kohsuke.accmod.Restricted;
@@ -1121,7 +1120,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
         int order = 0;
         String resUrl;
 
-        if (StringUtils.isNotBlank(iconStyle)) {
+        if (iconStyle != null && !iconStyle.isBlank()) {
             resUrl = req.getContextPath() + Jenkins.RESOURCE_PATH;
         } else {
             resUrl = null;
@@ -1137,7 +1136,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
             metadata.put("description", descriptor.getDescription());
             metadata.put("iconFilePathPattern", descriptor.getIconFilePathPattern());
             String iconClassName = descriptor.getIconClassName();
-            if (StringUtils.isNotBlank(iconClassName)) {
+            if (iconClassName != null && !iconClassName.isBlank()) {
                 metadata.put("iconClassName", iconClassName);
                 if (resUrl != null) {
                     Icon icon = IconSet.icons

--- a/core/src/main/java/hudson/model/ViewDescriptor.java
+++ b/core/src/main/java/hudson/model/ViewDescriptor.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Objects;
 import jenkins.model.DirectlyModifiableTopLevelItemGroup;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -141,7 +140,7 @@ public abstract class ViewDescriptor extends Descriptor<View> {
      */
     @SuppressWarnings("unused") // expose utility check method to subclasses
     protected FormValidation checkDisplayName(@NonNull View view, @CheckForNull String value) {
-        if (StringUtils.isBlank(value)) {
+        if (value == null || value.isBlank()) {
             // no custom name, no need to check
             return FormValidation.ok();
         }

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -679,7 +679,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
 
         // Return encoded value or at least "/" in the case exception occurred during encode()
         // or if the encoded content is blank value
-        return StringUtils.isBlank(returnValue) ? "/" : returnValue;
+        return returnValue == null || returnValue.isBlank() ? "/" : returnValue;
     }
 
     private static class None extends SecurityRealm {

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -418,7 +418,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
             boolean hasProjects = false;
             while (tokens.hasMoreTokens()) {
                 String projectName = tokens.nextToken().trim();
-                if (StringUtils.isNotBlank(projectName)) {
+                if (projectName != null && !projectName.isBlank()) {
                     Item item = Jenkins.get().getItem(projectName, project, Item.class);
                     if (item == null) {
                         Job<?, ?> nearest = Items.findNearest(Job.class, projectName, project.getParent());

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -76,7 +76,6 @@ import jenkins.mvn.GlobalSettingsProvider;
 import jenkins.mvn.SettingsProvider;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -331,13 +330,13 @@ public class Maven extends Builder {
 
             if (!S_PATTERN.matcher(targets).find()) { // check the given target/goals do not contain settings parameter already
                 String settingsPath = SettingsProvider.getSettingsRemotePath(getSettings(), build, listener);
-                if (StringUtils.isNotBlank(settingsPath)) {
+                if (settingsPath != null && !settingsPath.isBlank()) {
                     args.add("-s", settingsPath);
                 }
             }
             if (!GS_PATTERN.matcher(targets).find()) {
                 String settingsPath = GlobalSettingsProvider.getSettingsRemotePath(getGlobalSettings(), build, listener);
-                if (StringUtils.isNotBlank(settingsPath)) {
+                if (settingsPath != null && !settingsPath.isBlank()) {
                     args.add("-gs", settingsPath);
                 }
             }

--- a/core/src/main/java/hudson/triggers/SCMTrigger.java
+++ b/core/src/main/java/hudson/triggers/SCMTrigger.java
@@ -81,7 +81,6 @@ import jenkins.triggers.SCMTriggerItem;
 import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
 import org.apache.commons.jelly.XMLOutput;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -381,7 +380,7 @@ public class SCMTrigger extends Trigger<Item> {
         public FormValidation doCheckScmpoll_spec(@QueryParameter String value,
                                                   @QueryParameter boolean ignorePostCommitHooks,
                                                   @AncestorInPath Item item) {
-            if (StringUtils.isBlank(value)) {
+            if (value == null || value.isBlank()) {
                 if (ignorePostCommitHooks) {
                     return FormValidation.ok(Messages.SCMTrigger_no_schedules_no_hooks());
                 } else {

--- a/core/src/main/java/hudson/util/io/ZipArchiver.java
+++ b/core/src/main/java/hudson/util/io/ZipArchiver.java
@@ -36,7 +36,6 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.OpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tools.zip.Zip64Mode;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipOutputStream;
@@ -62,7 +61,7 @@ final class ZipArchiver extends Archiver {
     @Restricted(NoExternalUse.class)
     ZipArchiver(OutputStream out, String prefix, OpenOption... openOptions) {
         this.openOptions = openOptions;
-        if (StringUtils.isBlank(prefix)) {
+        if (prefix == null || prefix.isBlank()) {
             this.prefix = "";
         } else {
             this.prefix = Util.ensureEndsWith(prefix, "/");

--- a/core/src/main/java/jenkins/install/InstallState.java
+++ b/core/src/main/java/jenkins/install/InstallState.java
@@ -37,7 +37,6 @@ import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.stapler.StaplerAccessibleType;
 import jenkins.util.Timer;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Jenkins install state.
@@ -152,7 +151,8 @@ public class InstallState implements ExtensionPoint {
         public void initializeState() {
             // Skip this state if a boot script already configured the root URL
             // in case we add more fields in this page, this should be adapted
-            if (StringUtils.isNotBlank(JenkinsLocationConfiguration.getOrDie().getUrl())) {
+            String url = JenkinsLocationConfiguration.getOrDie().getUrl();
+            if (url != null && !url.isBlank()) {
                 InstallUtil.proceedToNextStateFrom(this);
             }
         }
@@ -315,7 +315,7 @@ public class InstallState implements ExtensionPoint {
     @Deprecated
     protected Object readResolve() {
         // If we get invalid state from the configuration, fallback to unknown
-        if (StringUtils.isBlank(name)) {
+        if (name == null || name.isBlank()) {
             LOGGER.log(Level.WARNING, "Read install state with blank name: ''{0}''. It will be ignored", name);
             return UNKNOWN;
         }

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -55,7 +55,6 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 import jenkins.util.xml.XMLUtils;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -214,7 +213,7 @@ public class InstallUtil {
                 String version = Files.readString(Util.fileToPath(lastExecVersionFile), Charset.defaultCharset());
                 // JENKINS-37438 blank will force the setup
                 // wizard regardless of current state of the system
-                if (StringUtils.isBlank(version)) {
+                if (version == null || version.isBlank()) {
                     return FORCE_NEW_INSTALL_VERSION.toString();
                 }
                 return version;

--- a/core/src/main/java/jenkins/model/AssetManager.java
+++ b/core/src/main/java/jenkins/model/AssetManager.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.ClassLoaderReflectionToolkit;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -76,7 +75,7 @@ public class AssetManager implements UnprotectedRootAction {
      * doesn't find it, fall back to the parent classloader.
      */
     private @CheckForNull URL findResource(@NonNull String path) throws IOException {
-        if (StringUtils.isBlank(path)) {
+        if (path == null || path.isBlank()) {
             return null;
         }
 

--- a/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
+++ b/core/src/main/java/jenkins/model/ProjectNamingStrategy.java
@@ -38,7 +38,6 @@ import java.io.Serializable;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.servlet.ServletException;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -172,7 +171,7 @@ public abstract class ProjectNamingStrategy implements Describable<ProjectNaming
 
         @Override
         public void checkName(String name) {
-            if (StringUtils.isNotBlank(namePattern) && StringUtils.isNotBlank(name)) {
+            if ((namePattern != null && !namePattern.isBlank()) && (name != null && !name.isBlank())) {
                 if (!Pattern.matches(namePattern, name)) {
                     throw new Failure(description == null || description.isEmpty() ?
                         Messages.Hudson_JobNameConventionNotApplyed(name, namePattern) :

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -57,7 +57,6 @@ import jenkins.util.SystemProperties;
 import net.jcip.annotations.Immutable;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -191,7 +190,7 @@ public class ApiTokenProperty extends UserProperty {
     }
 
     public boolean matchesPassword(String token) {
-        if (StringUtils.isBlank(token)) {
+        if (token == null || token.isBlank()) {
             return false;
         }
 
@@ -512,7 +511,7 @@ public class ApiTokenProperty extends UserProperty {
             }
 
             final String tokenName;
-            if (StringUtils.isBlank(newTokenName)) {
+            if (newTokenName == null || newTokenName.isBlank()) {
                 tokenName = Messages.Token_Created_on(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()));
             } else {
                 tokenName = newTokenName;
@@ -548,7 +547,7 @@ public class ApiTokenProperty extends UserProperty {
             }
 
             final String tokenName;
-            if (StringUtils.isBlank(newTokenName)) {
+            if (newTokenName == null || newTokenName.isBlank()) {
                 tokenName = String.format("Token created on %s", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()));
             } else {
                 tokenName = newTokenName;
@@ -575,10 +574,10 @@ public class ApiTokenProperty extends UserProperty {
             // only current user + administrator can rename token
             u.checkPermission(Jenkins.ADMINISTER);
 
-            if (StringUtils.isBlank(newName)) {
+            if (newName == null || newName.isBlank()) {
                 return HttpResponses.errorJSON("The name cannot be empty");
             }
-            if (StringUtils.isBlank(tokenUuid)) {
+            if (tokenUuid == null || tokenUuid.isBlank()) {
                 // using the web UI this should not occur
                 return HttpResponses.errorWithoutStack(400, "The tokenUuid cannot be empty");
             }
@@ -606,7 +605,7 @@ public class ApiTokenProperty extends UserProperty {
             // only current user + administrator can revoke token
             u.checkPermission(Jenkins.ADMINISTER);
 
-            if (StringUtils.isBlank(tokenUuid)) {
+            if (tokenUuid == null || tokenUuid.isBlank()) {
                 // using the web UI this should not occur
                 return HttpResponses.errorWithoutStack(400, "The tokenUuid cannot be empty");
             }
@@ -644,7 +643,7 @@ public class ApiTokenProperty extends UserProperty {
             // only current user + administrator can revoke token
             u.checkPermission(Jenkins.ADMINISTER);
 
-            if (StringUtils.isBlank(tokenUuid)) {
+            if (tokenUuid == null || tokenUuid.isBlank()) {
                 // using the web UI this should not occur
                 return HttpResponses.errorWithoutStack(400, "The tokenUuid cannot be empty");
             }

--- a/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
+++ b/core/src/main/java/jenkins/security/apitoken/ApiTokenStore.java
@@ -51,7 +51,6 @@ import java.util.stream.Collectors;
 import jenkins.security.Messages;
 import net.jcip.annotations.Immutable;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -110,7 +109,7 @@ public class ApiTokenStore {
             }
 
             String name = receivedTokenData.getString("tokenName");
-            if (StringUtils.isBlank(name)) {
+            if (name == null || name.isBlank()) {
                 LOGGER.log(Level.INFO, "Empty name received for {0}, we do not care about it", hashedToken.uuid);
                 return;
             }

--- a/core/src/main/java/jenkins/tasks/filters/impl/RetainVariablesLocalRule.java
+++ b/core/src/main/java/jenkins/tasks/filters/impl/RetainVariablesLocalRule.java
@@ -41,7 +41,6 @@ import jenkins.tasks.filters.EnvVarsFilterLocalRule;
 import jenkins.tasks.filters.EnvVarsFilterLocalRuleDescriptor;
 import jenkins.tasks.filters.EnvVarsFilterRuleContext;
 import jenkins.tasks.filters.EnvVarsFilterableBuilder;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.accmod.Restricted;
@@ -87,7 +86,7 @@ public class RetainVariablesLocalRule implements EnvVarsFilterLocalRule {
         String[] variablesArray = variablesCommaSeparated.split("\\s+");
         List<String> variables = new ArrayList<>();
         for (String nameFragment : variablesArray) {
-            if (StringUtils.isNotBlank(nameFragment)) {
+            if (nameFragment != null && !nameFragment.isBlank()) {
                 variables.add(nameFragment.toLowerCase(Locale.ENGLISH));
             }
         }

--- a/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
+++ b/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java
@@ -66,7 +66,6 @@ import java.util.logging.Logger;
 import jenkins.model.DependencyDeclarer;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -214,7 +213,7 @@ public final class ReverseBuildTrigger extends Trigger<Job> implements Dependenc
             boolean hasProjects = false;
             while (tokens.hasMoreTokens()) {
                 String projectName = tokens.nextToken().trim();
-                if (StringUtils.isNotBlank(projectName)) {
+                if (projectName != null && !projectName.isBlank()) {
                     Job item = Jenkins.get().getItem(projectName, project, Job.class);
                     if (item == null) {
                         Job nearest = Items.findNearest(Job.class, projectName, project.getParent());

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -47,7 +47,6 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import jenkins.security.MasterToSlaveCallable;
 import jenkins.util.io.OnMaster;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -102,7 +101,7 @@ public class SystemProperties {
         public void contextInitialized(ServletContextEvent event) {
             ServletContext theContext = event.getServletContext();
             handler = key -> {
-                if (StringUtils.isNotBlank(key)) {
+                if (key != null && !key.isBlank()) {
                     try {
                         return theContext.getInitParameter(key);
                     } catch (SecurityException ex) {

--- a/core/src/main/java/jenkins/util/TreeString.java
+++ b/core/src/main/java/jenkins/util/TreeString.java
@@ -32,7 +32,6 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import java.io.Serializable;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * {@link TreeString} is an alternative string representation that saves the
@@ -165,7 +164,8 @@ public final class TreeString implements Serializable {
     }
 
     public boolean isBlank() {
-        return StringUtils.isBlank(toString());
+        String string = toString();
+        return string == null || string.isBlank();
     }
 
     public static String toString(final TreeString t) {

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -62,7 +62,6 @@ import java.util.stream.Collectors;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
 import jenkins.security.MasterToSlaveCallable;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.types.AbstractFileSet;
 import org.apache.tools.ant.types.selectors.SelectorUtils;
@@ -368,7 +367,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
     public int zip(OutputStream outputStream, String includes, String excludes, boolean useDefaultExcludes,
                    String prefix, OpenOption... openOptions) throws IOException {
         String correctPrefix;
-        if (StringUtils.isBlank(prefix)) {
+        if (prefix == null || prefix.isBlank()) {
             correctPrefix = "";
         } else {
             correctPrefix = Util.ensureEndsWith(prefix, "/");

--- a/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
+++ b/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
@@ -55,19 +55,19 @@ public final class Symbol {
         String symbol = SYMBOLS
                 .computeIfAbsent(identifier, key -> new ConcurrentHashMap<>())
                 .computeIfAbsent(name, key -> loadSymbol(identifier, key));
-        if (StringUtils.isNotBlank(tooltip) && StringUtils.isBlank(htmlTooltip)) {
+        if ((tooltip != null && !tooltip.isBlank()) && (htmlTooltip == null || htmlTooltip.isBlank())) {
             symbol = symbol.replaceAll("<svg", "<svg tooltip=\"" + Functions.htmlAttributeEscape(tooltip) + "\"");
         }
-        if (StringUtils.isNotBlank(htmlTooltip)) {
+        if (htmlTooltip != null && !htmlTooltip.isBlank()) {
             symbol = symbol.replaceAll("<svg", "<svg data-html-tooltip=\"" + Functions.htmlAttributeEscape(htmlTooltip) + "\"");
         }
-        if (StringUtils.isNotBlank(id)) {
+        if (id != null && !id.isBlank()) {
             symbol = symbol.replaceAll("<svg", "<svg id=\"" + Functions.htmlAttributeEscape(id) + "\"");
         }
-        if (StringUtils.isNotBlank(classes)) {
+        if (classes != null && !classes.isBlank()) {
             symbol = symbol.replaceAll("<svg", "<svg class=\"" + Functions.htmlAttributeEscape(classes) + "\"");
         }
-        if (StringUtils.isNotBlank(title)) {
+        if (title != null && !title.isBlank()) {
             symbol = "<span class=\"jenkins-visually-hidden\">" + Util.xmlEscape(title) + "</span>" + symbol;
         }
         return symbol;

--- a/test/src/test/java/jenkins/diagnostics/RootUrlNotSetMonitorTest.java
+++ b/test/src/test/java/jenkins/diagnostics/RootUrlNotSetMonitorTest.java
@@ -25,11 +25,11 @@
 package jenkins.diagnostics;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import hudson.model.AdministrativeMonitor;
 import jenkins.model.JenkinsLocationConfiguration;
-import org.apache.commons.lang.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -45,7 +45,9 @@ public class RootUrlNotSetMonitorTest {
     public void testWithRootUrl_configured() {
         // test relies on the default JTH behavior
         JenkinsLocationConfiguration config = JenkinsLocationConfiguration.get();
-        assertTrue(StringUtils.isNotBlank(config.getUrl()));
+        String url = config.getUrl();
+        assertNotNull(url);
+        assertFalse(url.isBlank());
 
         RootUrlNotSetMonitor monitor = j.jenkins.getExtensionList(AdministrativeMonitor.class).get(RootUrlNotSetMonitor.class);
         assertFalse("Monitor must not be activated", monitor.isActivated());


### PR DESCRIPTION
Like #6270 but for `StringUtils#isBlank` and `StringUtils#isNotBlank`. Reduce usages of Commons Lang 2 in hopes that we may eventually be able to remove this outdated library from core.

### Testing done

`mvn clean verify -Dtest=jenkins.diagnostics.RootUrlNotSetMonitorTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
