### PR TITLE
Remove usages of `ArrayUtils`

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -124,7 +124,6 @@ import jenkins.util.io.OnMaster;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.jelly.XMLOutput;
-import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
@@ -2151,8 +2150,11 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     private String convertBytesToString(List<Byte> bytes) {
         Collections.reverse(bytes);
-        Byte[] byteArray = bytes.toArray(new Byte[0]);
-        return new String(ArrayUtils.toPrimitive(byteArray), getCharset());
+        byte[] byteArray = new byte[bytes.size()];
+        for (int i = 0; i < byteArray.length; i++) {
+            byteArray[i] = bytes.get(i);
+        }
+        return new String(byteArray, getCharset());
     }
 
     public void doBuildStatus(StaplerRequest req, StaplerResponse rsp) throws IOException {

--- a/core/src/main/java/hudson/util/MultipartFormDataParser.java
+++ b/core/src/main/java/hudson/util/MultipartFormDataParser.java
@@ -38,7 +38,6 @@ import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -150,7 +149,11 @@ public class MultipartFormDataParser implements AutoCloseable {
             return false;
         }
 
-        String[] parts = contentType.split(";");
-        return ArrayUtils.contains(parts, "multipart/form-data");
+        for (String part : contentType.split(";")) {
+            if ("multipart/form-data".equals(part)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/main/java/hudson/util/Protector.java
+++ b/core/src/main/java/hudson/util/Protector.java
@@ -35,7 +35,6 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
-import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -62,8 +61,10 @@ public class Protector {
             Cipher cipher = Secret.getCipher(ALGORITHM_MODE);
             cipher.init(Cipher.ENCRYPT_MODE, KEY, new IvParameterSpec(iv));
             final byte[] encrypted = cipher.doFinal((secret + MAGIC).getBytes(StandardCharsets.UTF_8));
-            final byte[] value = ArrayUtils.addAll(iv, encrypted);
-            return new String(Base64.getEncoder().encode(value), StandardCharsets.UTF_8);
+            byte[] result = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, result, 0, iv.length);
+            System.arraycopy(encrypted, 0, result, iv.length, encrypted.length);
+            return new String(Base64.getEncoder().encode(result), StandardCharsets.UTF_8);
         } catch (GeneralSecurityException e) {
             throw new Error(e); // impossible
         }

--- a/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
@@ -51,7 +51,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
-import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
@@ -290,8 +289,11 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
         private String encode() {
             String value = timestamp.toEpochMilli() + ":" + username.length() + ":" + username + ":" + path;
             byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
-            byte[] byteValue = ArrayUtils.addAll(KEY.mac(valueBytes), valueBytes);
-            return Base64.getUrlEncoder().encodeToString(byteValue);
+            byte[] macBytes = KEY.mac(valueBytes);
+            byte[] result = new byte[macBytes.length + valueBytes.length];
+            System.arraycopy(macBytes, 0, result, 0, macBytes.length);
+            System.arraycopy(valueBytes, 0, result, macBytes.length, valueBytes.length);
+            return Base64.getUrlEncoder().encodeToString(result);
         }
 
         private static Token decode(String value) {


### PR DESCRIPTION
Like https://github.com/jenkinsci/jenkins/pull/6270 but for `ArrayUtils`. Reduce usages of Commons Lang 2 in hopes that we may eventually be able to remove this outdated library from core.

### Testing done

`mvn clean verify -Dtest=jenkins.diagnostics.RootUrlNotSetMonitorTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
