### PR TITLE
Further reduce usages of `StringUtils`

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -82,7 +82,6 @@ import jenkins.util.io.OnMaster;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.jvnet.tiger_types.Types;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -425,7 +424,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
      * sets that as the 'fillUrl' attribute.
      */
     public void calcFillSettings(String field, Map<String, Object> attributes) {
-        String capitalizedFieldName = StringUtils.capitalize(field);
+        String capitalizedFieldName = field == null || field.isEmpty() ? field : Character.toTitleCase(field.charAt(0)) + field.substring(1);
         String methodName = "doFill" + capitalizedFieldName + "Items";
         Method method = ReflectionUtils.getPublicMethodNamed(getClass(), methodName);
         if (method == null)
@@ -467,7 +466,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
      * Computes the auto-completion setting
      */
     public void calcAutoCompleteSettings(String field, Map<String, Object> attributes) {
-        String capitalizedFieldName = StringUtils.capitalize(field);
+        String capitalizedFieldName = field == null || field.isEmpty() ? field : Character.toTitleCase(field.charAt(0)) + field.substring(1);
         String methodName = "doAutoComplete" + capitalizedFieldName;
         Method method = ReflectionUtils.getPublicMethodNamed(getClass(), methodName);
         if (method == null)

--- a/core/src/main/java/hudson/util/FormValidation.java
+++ b/core/src/main/java/hudson/util/FormValidation.java
@@ -61,7 +61,6 @@ import java.util.stream.Stream;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
@@ -638,7 +637,7 @@ public abstract class FormValidation extends IOException implements HttpResponse
 
         public CheckMethod(Descriptor descriptor, String fieldName) {
             this.descriptor = descriptor;
-            this.capitalizedFieldName = StringUtils.capitalize(fieldName);
+            this.capitalizedFieldName = fieldName == null || fieldName.isEmpty() ? fieldName : Character.toTitleCase(fieldName.charAt(0)) + fieldName.substring(1);
 
             method = ReflectionUtils.getPublicMethodNamed(descriptor.getClass(), "doCheck" + capitalizedFieldName);
             if (method != null) {

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -21,11 +21,11 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import jenkins.model.Jenkins;
 import jenkins.util.URLClassLoader2;
-import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -151,7 +151,7 @@ public class PluginWrapperTest {
         private ClassLoader cl = null;
 
         private PluginWrapperBuilder(String name) {
-            this.name = name;
+            this.name = Objects.requireNonNull(name);
         }
 
         public PluginWrapperBuilder version(String version) {
@@ -192,7 +192,7 @@ public class PluginWrapperTest {
             Manifest manifest = new Manifest();
             Attributes attributes = manifest.getMainAttributes();
             attributes.putValue("Short-Name", name);
-            attributes.putValue("Long-Name", StringUtils.capitalize(name));
+            attributes.putValue("Long-Name", Character.toTitleCase(name.charAt(0)) + name.substring(1));
             attributes.putValue("Jenkins-Version", requiredCoreVersion);
             attributes.putValue("Plugin-Version", version);
             return new PluginWrapper(

--- a/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
@@ -41,7 +41,7 @@ import hudson.Functions;
 import hudson.PluginWrapper;
 import java.io.IOException;
 import java.util.function.BiPredicate;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Rule;

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -56,7 +56,7 @@ import jenkins.security.ApiTokenProperty;
 import jenkins.security.SecurityListener;
 import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.seed.UserSeedProperty;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matcher;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.HttpMethod;

--- a/test/src/test/java/jenkins/diagnostics/RootUrlNotSetMonitorTest.java
+++ b/test/src/test/java/jenkins/diagnostics/RootUrlNotSetMonitorTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 
 import hudson.model.AdministrativeMonitor;
 import jenkins.model.JenkinsLocationConfiguration;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;

--- a/test/src/test/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitorTest.java
+++ b/test/src/test/java/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitorTest.java
@@ -34,7 +34,7 @@ import hudson.model.AdministrativeMonitor;
 import hudson.model.User;
 import java.io.IOException;
 import jenkins.security.ApiTokenProperty;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matchers;
 import org.htmlunit.Page;
 import org.htmlunit.html.DomNodeList;

--- a/test/src/test/java/org/kohsuke/stapler/BindTest.java
+++ b/test/src/test/java/org/kohsuke/stapler/BindTest.java
@@ -12,7 +12,7 @@ import hudson.model.InvisibleAction;
 import hudson.model.RootAction;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.htmlunit.Page;
 import org.htmlunit.ScriptException;
 import org.htmlunit.html.HtmlPage;


### PR DESCRIPTION
Like https://github.com/jenkinsci/jenkins/pull/6270 but for `StringUtils#capitalize` and `StringUtils#uncapitalize`. Reduce usages of Commons Lang 2 in hopes that we may eventually be able to remove this outdated library from core.

- In `core/src/main/` I rewrote this to use standard Java Platform functionality. Note the use of `toTitleCase` rather than `toUpperCase` to preserve existing behavior with e.g. [U+01C8](https://www.fileformat.info/info/unicode/char/01c8/index.htm). I chose to be as defensive as possible with the input to maintain existing behavior.
- In `core/src/test/` we could depend on Commons Lang 3 but it seemed overkill to pull in a new dependency just for this one case, so I treated this the same as `core/src/main/`. Here the code could be simpler because in a test we don't have to be as defensive about the input.
- In `test/src/test/` we already pull in Commons Lang 3 so I just switched to that.

### Testing done

`mvn clean verify -Dtest=hudson.PluginWrapperTest,hudson.cli.DisablePluginCommandTest,hudson.security.HudsonPrivateSecurityRealmTest,jenkins.security.apitoken.LegacyApiTokenAdministrativeMonitorTest,org.kohsuke.stapler.BindTest,hudson.util.FormValidationTest,hudson.model.DescriptorTest,jenkins.diagnostics.RootUrlNotSetMonitorTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
