### PR TITLE
Remove direct use of Commons Collections from core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -157,10 +157,6 @@ THE SOFTWARE.
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -153,6 +153,7 @@ THE SOFTWARE.
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
+      <!-- Jenkins core does not use this directly, but it remains a transitive dependency through BeanUtils, Jelly, and JSON-lib, and plugins rely on core providing it. -->
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
     </dependency>

--- a/core/src/main/java/hudson/util/LRUStringConverter.java
+++ b/core/src/main/java/hudson/util/LRUStringConverter.java
@@ -2,8 +2,8 @@ package hudson.util;
 
 import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import org.apache.commons.collections.map.LRUMap;
 
 public class LRUStringConverter extends AbstractSingleValueConverter {
 
@@ -18,7 +18,12 @@ public class LRUStringConverter extends AbstractSingleValueConverter {
     }
 
     public LRUStringConverter(int size) {
-        cache = Collections.synchronizedMap(new LRUMap(size));
+        cache = Collections.synchronizedMap(new LinkedHashMap<>(size, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+                return size() > size;
+            }
+        });
     }
 
     @Override

--- a/core/src/main/java/hudson/util/LRUStringConverter.java
+++ b/core/src/main/java/hudson/util/LRUStringConverter.java
@@ -2,8 +2,8 @@ package hudson.util;
 
 import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import org.apache.commons.collections.map.LRUMap;
 
 public class LRUStringConverter extends AbstractSingleValueConverter {
 
@@ -17,8 +17,16 @@ public class LRUStringConverter extends AbstractSingleValueConverter {
         this(1000);
     }
 
-    public LRUStringConverter(int size) {
-        cache = Collections.synchronizedMap(new LRUMap(size));
+    public LRUStringConverter(int maxSize) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("Maximum size must be greater than 0");
+        }
+        cache = Collections.synchronizedMap(new LinkedHashMap<>(maxSize, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+                return size() > maxSize;
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

Remove direct use of Apache Commons Collections from Jenkins core as preparation for a future day when it can be removed as a transitive dependency of Jenkins core.

Apache Commons Collections is currently a transitive dependency of Apache Commons BeanUtils.  It must remain in Jenkins core until the Apache Commons BeanUtils dependency is removed.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

Automated testing exercises the changed lines as shown by the coverage report.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
