### PR TITLE
[JENKINS-72799] Apply `SlaveComputer.decorate` also to `openLogFile`

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -386,7 +386,7 @@ public class SlaveComputer extends Computer {
     public OutputStream openLogFile() {
         try {
             log.rewind();
-            return log;
+            return decorate(log);
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Failed to create log file " + getLogFile(), e);
             return OutputStream.nullOutputStream();


### PR DESCRIPTION
See [JENKINS-72799](https://issues.jenkins.io/browse/JENKINS-72799). Otherwise the decoration is applied to `SlaveComputer.taskListener`, used for many purposes, but not log messages printed from `DefaultJnlpSlaveReceiver` on inbound agents.

Amending 4c4367113fff8fd9388ac3659504177aedd32f33 and ultimately 0ddb0c5cca757a4a34e0c162bbca6504f5cec25f.

### Testing done

Integration test in https://github.com/jenkinsci/support-core-plugin/pull/517: [`SlaveLaunchLogsTest.onlineInboundAgent`](https://github.com/jenkinsci/support-core-plugin/pull/517/checks?check_run_id=22193032096).

### Proposed changelog entries

- Customization of agent log files did not work for inbound agents.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
