### PR TITLE
[JENKINS-72796] stable context classloader for Computer.threadPoolForRemoting

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -63,6 +63,7 @@ import hudson.slaves.OfflineCause.ByCLI;
 import hudson.slaves.RetentionStrategy;
 import hudson.slaves.WorkspaceList;
 import hudson.triggers.SafeTimerTask;
+import hudson.util.ClassLoaderSanityThreadFactory;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.EditDistance;
 import hudson.util.ExceptionCatchingThreadFactory;
@@ -1381,7 +1382,9 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
                 Executors.newCachedThreadPool(
                     new ExceptionCatchingThreadFactory(
                         new NamingThreadFactory(
-                            new DaemonThreadFactory(), "Computer.threadPoolForRemoting")))), ACL.SYSTEM2));
+                            new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()),
+                            "Computer.threadPoolForRemoting")))),
+            ACL.SYSTEM2));
 
 //
 //

--- a/core/src/test/java/hudson/model/ComputerTest.java
+++ b/core/src/test/java/hudson/model/ComputerTest.java
@@ -8,9 +8,11 @@ import static org.junit.Assert.assertTrue;
 import hudson.FilePath;
 import hudson.security.ACL;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import jenkins.model.Jenkins;
+import jenkins.util.SetContextClassLoader;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.springframework.security.core.Authentication;
@@ -44,5 +46,43 @@ public class ComputerTest {
     public void testThreadPoolForRemotingActsAsSystemUser() throws InterruptedException, ExecutionException {
         Future<Authentication> job = Computer.threadPoolForRemoting.submit(Jenkins::getAuthentication2);
         assertThat(job.get(), is(ACL.SYSTEM2));
+    }
+
+    @Issue("JENKINS-72796")
+    @Test
+    public void testThreadPoolForRemotingContextClassLoaderIsSet() throws Exception {
+        // as the threadpool is cached, any other tests here pollute this test so we need enough threads to
+        // avoid any cached.
+        final int numThreads = 5;
+
+        // simulate the first call to Computer.threadPoolForRemoting with a non default classloader
+        try (var ignored = new SetContextClassLoader(new ClassLoader() {})) {
+            obtainAndCheckThreadsContextClassloaderAreCorrect(numThreads);
+        }
+        // now repeat this as the checking that the pollution of the context classloader is handled
+        obtainAndCheckThreadsContextClassloaderAreCorrect(numThreads);
+    }
+
+    private static void obtainAndCheckThreadsContextClassloaderAreCorrect(int numThreads) throws Exception {
+        ArrayList<Future<ClassLoader>> classloaderFuturesList = new ArrayList<>();
+        // block all calls to getContextClassloader() so we create more threads.
+        synchronized (WaitAndGetContextClassLoader.class) {
+            for (int i = 0; i < numThreads; i++) {
+                classloaderFuturesList.add(Computer.threadPoolForRemoting.submit(WaitAndGetContextClassLoader::getContextClassloader));
+            }
+        }
+        for (Future<ClassLoader> fc : classloaderFuturesList) {
+            assertThat(fc.get(), is(Jenkins.class.getClassLoader()));
+        }
+    }
+
+    private static class WaitAndGetContextClassLoader{
+
+        public static synchronized ClassLoader getContextClassloader() throws InterruptedException {
+            ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+            // intentionally pollute the Threads context classloader
+            Thread.currentThread().setContextClassLoader(new ClassLoader() {});
+            return ccl;
+        }
     }
 }

--- a/core/src/test/java/hudson/model/ComputerTest.java
+++ b/core/src/test/java/hudson/model/ComputerTest.java
@@ -76,7 +76,7 @@ public class ComputerTest {
         }
     }
 
-    private static class WaitAndGetContextClassLoader{
+    private static class WaitAndGetContextClassLoader {
 
         public static synchronized ClassLoader getContextClassloader() throws InterruptedException {
             ClassLoader ccl = Thread.currentThread().getContextClassLoader();


### PR DESCRIPTION
Whilst the threadpool used reset the context classloader at the end of any task, it did not ensure that the initial classloader used was anything sepcific, rather it would use whatever the calling threads contextClassLoader was.

This is now fixed as we use the Jenkins WebApp classloader (same as the Timer) which is used by (A)PeriodicTasks.

Whilst we should really not have a context classloader (aka null) and this should be set where needed by code, almost everywhere in Jenkins the context classloader is already the webapp classloader, and so setting this to be different depending on how things where called would seemingly be a little scary.  Arguably this and other context classloaders should be all set to null and any code that wants different should be changed, but this is a larger piece of work that would have potential impact on an unknown number of plugins in the ecosystem, so this fix uses what was set > 90% of the time.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-72796](https://issues.jenkins.io/browse/JENKINS-72796).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Ensure threads in the `Computer.threadPoolForRemoting`executor service always have the Jenkins webapp `ClassLoader` set as the context `ClassLoader` to prevent random class loading issues when code is running in this `ExecutorService`.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
