### PR TITLE
`Lifecycle.supportsDynamicLoad`

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -41,6 +41,7 @@ import hudson.PluginWrapper.Dependency;
 import hudson.init.InitMilestone;
 import hudson.init.InitStrategy;
 import hudson.init.InitializerFinder;
+import hudson.lifecycle.Lifecycle;
 import hudson.model.AbstractItem;
 import hudson.model.AbstractModelObject;
 import hudson.model.AdministrativeMonitor;
@@ -923,6 +924,9 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                 } else {
                     throw new RestartRequiredException(Messages._PluginManager_PluginIsAlreadyInstalled_RestartRequired(sn));
                 }
+            }
+            if (!Lifecycle.get().supportsDynamicLoad()) {
+                throw new RestartRequiredException(Messages._PluginManager_LifecycleDoesNotSupportDynamicLoad_RestartRequired());
             }
             if (p == null) {
                 p = strategy.createPluginWrapper(arc);

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionPoint;
 import hudson.Functions;
+import hudson.PluginManager;
 import hudson.Util;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -39,10 +40,12 @@ import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.RestartRequiredException;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
@@ -308,6 +311,17 @@ public abstract class Lifecycle implements ExtensionPoint {
      */
     public void onStatusUpdate(String status) {
         LOGGER.log(Level.INFO, status);
+    }
+
+    /**
+     * Whether {@link PluginManager#dynamicLoad(File)} should be supported at all.
+     * If not, {@link RestartRequiredException} will always be thrown.
+     * @return true by default
+     * @since TODO
+     */
+    @Restricted(Beta.class)
+    public boolean supportsDynamicLoad() {
+        return true;
     }
 
     @Restricted(NoExternalUse.class)

--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -37,6 +37,7 @@ FilePath.validateRelativePath.notDirectory=‘{0}’ is not a directory
 FilePath.validateRelativePath.noSuchFile=No such file: ‘{0}’
 FilePath.validateRelativePath.noSuchDirectory=No such directory: ‘{0}’
 
+PluginManager.LifecycleDoesNotSupportDynamicLoad.RestartRequired=This Jenkins lifecycle does not support dynamic loading of plugins. Jenkins needs to be restarted for the update to take effect.
 PluginManager.PluginDoesntSupportDynamicLoad.RestartRequired={0} plugin doesn’t support dynamic loading. Jenkins needs to be restarted for the update to take effect.
 PluginManager.PluginIsAlreadyInstalled.RestartRequired={0} plugin is already installed. Jenkins needs to be restarted for the update to take effect.
 Util.millisecond={0} ms


### PR DESCRIPTION
In CloudBees CI running in high availability mode we run a custom lifecycle (#8589) which is not compatible with the option to dynamically install a plugin. While an individual plugin can be marked on the update center as requiring a controller restart to install, this was not available generically for _any_ plugin. `Lifecycle` seems like the right place for it since it already defined when and how to restart.

### Testing done

Interactively tested inside CloudBees CI by overriding this method.

### Proposed changelog entries

- N/A, beta-only API

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
