### PR TITLE
`Job.fastUpdateNextBuildNumber`

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -115,6 +115,7 @@ import org.jfree.data.category.CategoryDataset;
 import org.jfree.ui.RectangleInsets;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.args4j.Argument;
@@ -424,6 +425,16 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             this.nextBuildNumber = next;
             saveNextBuildNumber();
         }
+    }
+
+    /**
+     * Unconditionally sets the value of {@link #getNextBuildNumber}.
+     * Unlike {@link #updateNextBuildNumber} this does not save the number on disk,
+     * and does not check {@link #getLastBuild}.
+     */
+    @Restricted(Beta.class)
+    public void fastUpdateNextBuildNumber(int nextBuildNumber) {
+        this.nextBuildNumber = nextBuildNumber;
     }
 
     /**


### PR DESCRIPTION
Introduces a minimal beta API that has been used successfully in CloudBees CI to reload a `Job.nextBuildNumber` from disk. The existing `updateNextBuildNumber` is not well suited to this purpose because it forces loading of the last build and also saves the value back to disk, noticeably increasing disk I/O when called frequently on a slower filesystem.

### Testing done

Integration tests exist in CloudBees CI.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
