### PR TITLE
`QueueIdStrategy`

### DIFF
--- a/core/src/main/java/jenkins/model/queue/QueueIdStrategy.java
+++ b/core/src/main/java/jenkins/model/queue/QueueIdStrategy.java
@@ -1,0 +1,86 @@
+package jenkins.model.queue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Action;
+import hudson.model.Queue;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+/**
+ * Pluggable strategy to generate queue item IDs as well as persist an optional opaque state whenever the queue is persisted.
+ */
+@Restricted(Beta.class)
+public abstract class QueueIdStrategy implements ExtensionPoint {
+    private static final QueueIdStrategy DEFAULT = new DefaultStrategy();
+
+    public static QueueIdStrategy get() {
+        var strategies = ExtensionList.lookup(QueueIdStrategy.class);
+        if (strategies.isEmpty()) {
+            return DEFAULT;
+        }
+        return strategies.get(0);
+    }
+
+    /**
+     * Persist the state of this strategy.
+     */
+    public void persist(@NonNull Queue.State queueState) {}
+
+    /**
+     * Loads the state of this strategy from a persisted queue state.
+     */
+    public void load(@NonNull Queue.State queueState) {}
+
+    /**
+     * Generates a new ID for the given project and actions.
+     * @param project The task to be queued.
+     * @param actions The actions linked the task.
+     * @return a new queue ID.
+     */
+    public abstract long generateIdFor(@NonNull Queue.Task project, @NonNull List<Action> actions);
+
+    /**
+     * Default implementation if no extension is found. Simply uses a counter.
+     */
+    public static final class DefaultStrategy extends QueueIdStrategy {
+        private static final AtomicLong COUNTER = new AtomicLong(0);
+
+        @Override
+        public long generateIdFor(Queue.Task project, List<Action> actions) {
+            return COUNTER.incrementAndGet();
+        }
+
+        @Override
+        public void persist(Queue.State queueState) {
+            queueState.properties.put(getClass().getName(), COUNTER.get());
+        }
+
+        @Override
+        public void load(Queue.State queueState) {
+            var prop = queueState.properties.get(getClass().getName());
+            if (prop instanceof Long) {
+                COUNTER.set((Long) prop);
+            } else {
+                queueState.items.stream()
+                        .filter(Queue.Item.class::isInstance)
+                        .map(Queue.Item.class::cast)
+                        .max(Comparator.comparing(Queue.Item::getId))
+                        .ifPresentOrElse(
+                                maxItem -> COUNTER.set(maxItem.getId()),
+                                () -> COUNTER.set(0)
+                        );
+            }
+        }
+
+        @Restricted(DoNotUse.class) // testing only
+        public static long getCurrentCounterValue() {
+            return COUNTER.get();
+        }
+    }
+}

--- a/core/src/test/java/hudson/model/QueueTest.java
+++ b/core/src/test/java/hudson/model/QueueTest.java
@@ -36,9 +36,9 @@ public class QueueTest {
     public void cancelItemOnaValidItemShouldReturnA204() throws IOException, ServletException {
         when(task.hasAbortPermission()).thenReturn(true);
         Queue queue = new Queue(LoadBalancer.CONSISTENT_HASH);
-        queue.schedule(task, 6000);
+        long id = queue.schedule(task, 6000).getId();
 
-        HttpResponse httpResponse = queue.doCancelItem(Queue.WaitingItem.getCurrentCounterValue());
+        HttpResponse httpResponse = queue.doCancelItem(id);
         httpResponse.generateResponse(null, resp, null);
 
         verify(resp).setStatus(HttpServletResponse.SC_NO_CONTENT);
@@ -48,9 +48,9 @@ public class QueueTest {
     @Test
     public void cancelItemOnANonExistingItemShouldReturnA404()  throws IOException, ServletException {
         Queue queue = new Queue(LoadBalancer.CONSISTENT_HASH);
-        queue.schedule(task, 6000);
+        long id = queue.schedule(task, 6000).getId();
 
-        HttpResponse httpResponse = queue.doCancelItem(Queue.WaitingItem.getCurrentCounterValue() + 1);
+        HttpResponse httpResponse = queue.doCancelItem(id + 1);
         httpResponse.generateResponse(null, resp, null);
 
         verify(resp).setStatus(HttpServletResponse.SC_NOT_FOUND);
@@ -61,9 +61,9 @@ public class QueueTest {
     public void cancelItemOnANonCancellableItemShouldReturnA422()  throws IOException, ServletException {
         when(task.hasAbortPermission()).thenReturn(false);
         Queue queue = new Queue(LoadBalancer.CONSISTENT_HASH);
-        queue.schedule(task, 6000);
+        long id = queue.schedule(task, 6000).getId();
 
-        HttpResponse httpResponse = queue.doCancelItem(Queue.WaitingItem.getCurrentCounterValue());
+        HttpResponse httpResponse = queue.doCancelItem(id);
         httpResponse.generateResponse(null, resp, null);
 
         verify(resp).setStatus(422);

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -108,6 +108,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import jenkins.model.BlockedBecauseOfBuildInProgress;
 import jenkins.model.Jenkins;
+import jenkins.model.queue.QueueIdStrategy;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import org.acegisecurity.acls.sid.PrincipalSid;
 import org.apache.commons.fileupload.FileUploadException;
@@ -200,7 +201,7 @@ public class QueueTest {
 
         // The current counter should be the id from the item brought back
         // from the persisted queue.xml.
-        assertEquals(3, Queue.WaitingItem.getCurrentCounterValue());
+        assertEquals(3, QueueIdStrategy.DefaultStrategy.getCurrentCounterValue());
 
         // Clear the queue
         assertTrue(r.jenkins.getQueue().cancel(r.jenkins.getItemByFullName("test", FreeStyleProject.class)));
@@ -213,7 +214,7 @@ public class QueueTest {
         Queue q = r.jenkins.getQueue();
 
         resetQueueState();
-        assertEquals(0, Queue.WaitingItem.getCurrentCounterValue());
+        assertEquals(0, QueueIdStrategy.DefaultStrategy.getCurrentCounterValue());
 
         // prevent execution to push stuff into the queue
         r.jenkins.setNumExecutors(0);
@@ -234,7 +235,7 @@ public class QueueTest {
         assertEquals(0, q.getItems().length);
 
         // The counter state should be maintained.
-        assertEquals(1, Queue.WaitingItem.getCurrentCounterValue());
+        assertEquals(1, QueueIdStrategy.DefaultStrategy.getCurrentCounterValue());
     }
 
     /**

--- a/test/src/test/java/jenkins/model/ParameterizedJobMixInTest.java
+++ b/test/src/test/java/jenkins/model/ParameterizedJobMixInTest.java
@@ -25,6 +25,7 @@
 package jenkins.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
@@ -90,11 +91,12 @@ public class ParameterizedJobMixInTest {
         webClient.getPage(webClient.addCrumb(new WebRequest(new URL(j.getURL(), project.getUrl() + "build"), HttpMethod.POST)));
         long triggerTime = System.currentTimeMillis();
 
-        Queue.Item item = Jenkins.get().getQueue().getItem(1);
-        assertThat(item, instanceOf(Queue.WaitingItem.class));
-        assertThat(item.task, instanceOf(FreeStyleProject.class));
+        Queue.Item[] items = Jenkins.get().getQueue().getItems();
+        assertThat(items, arrayWithSize(1));
+        assertThat(items[0], instanceOf(Queue.WaitingItem.class));
+        assertThat(items[0].task, instanceOf(FreeStyleProject.class));
 
-        Queue.WaitingItem waitingItem = (Queue.WaitingItem) item;
+        Queue.WaitingItem waitingItem = (Queue.WaitingItem) items[0];
         Assert.assertTrue(waitingItem.timestamp.getTimeInMillis() - triggerTime > 45000);
 
         Jenkins.get().getQueue().doCancelItem(1);


### PR DESCRIPTION
Permits the generation of queue ids to be replaced. By default, Jenkins numbers queue items sequentially. This however requires maintaining a global counter. In CloudBees CI in HA mode this is simplified to just generate a random (nonnegative) `long`, which is unlikely to result in collisions among the 2⁶³ possibilities (especially as `LeftItem`s are only retained for 5m).

Jenkins _could_ also switch to the same randomized behavior unconditionally, though it causes issues for external software (for example using the REST API and a database) expecting numbers below 2³¹ which had never been adapted to https://github.com/jenkinsci/jenkins/pull/1566 simply because in practice the ids are usually not that big.

### Testing done

Implementation in CloudBees CI is tested in a number of ways.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
