### PR TITLE
[JENKINS-70684] Deprecate standalone use of `hudson.Main`

### DIFF
--- a/core/src/main/java/hudson/Main.java
+++ b/core/src/main/java/hudson/Main.java
@@ -57,7 +57,11 @@ import jenkins.util.SystemProperties;
  */
 public class Main {
 
-    /** @see #remotePost */
+    /**
+     * @see #remotePost
+     * @deprecated Scheduled for removal in mid 2024.
+     * */
+    @Deprecated
     public static void main(String[] args) {
         try {
             System.exit(run(args));
@@ -67,8 +71,16 @@ public class Main {
         }
     }
 
-    /** @see #remotePost */
+    /**
+     * @see #remotePost
+     * @deprecated Scheduled for removal in mid 2024.
+     * */
+    @Deprecated
     public static int run(String[] args) throws Exception {
+        System.err.println("Running `java -jar jenkins-core.jar …` has been deprecated and will be removed in a future release.");
+        System.err.println("Use `java -jar jenkins-cli.jar set-external-build-result …` instead.");
+        System.err.println("See JENKINS-70684 for more information.");
+
         String home = getHudsonHome();
         if (home == null) {
             System.err.println("JENKINS_HOME is not set.");
@@ -91,7 +103,9 @@ public class Main {
     /**
      * Run command and send result to {@code ExternalJob} in the {@code external-monitor-job} plugin.
      * Obsoleted by {@code SetExternalBuildResultCommand} but kept here for compatibility.
+     * @deprecated Scheduled for removal in mid 2024.
      */
+    @Deprecated
     public static int remotePost(String[] args) throws Exception {
         String projectName = args[0];
 
@@ -233,6 +247,8 @@ public class Main {
 
     /**
      * Time out for socket connection to Hudson.
+     * @deprecated Scheduled for removal in mid 2024.
      */
+    @Deprecated
     public static final int TIMEOUT = SystemProperties.getInteger(Main.class.getName() + ".timeout", 15000);
 }


### PR DESCRIPTION
See [JENKINS-70684](https://issues.jenkins.io/browse/JENKINS-70684).

Thoughts about this as a first step?

### Testing done

None yet, so far asking about the general direction.

### Proposed changelog entries

- Deprecate use of `jenkins-core.jar` for External Monitor Job Type Plugin.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
