### PR TITLE
Simplify label to 'Jenkins user database'

### DIFF
--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -25,7 +25,7 @@ GlobalSecurityConfiguration.Description=Secure Jenkins; define who is allowed to
 HudsonPrivateSecurityRealm.WouldYouLikeToSignUp=This {0} {1} is new to Jenkins. Would you like to sign up?
 LegacyAuthorizationStrategy.DisplayName=Legacy mode
 
-HudsonPrivateSecurityRealm.DisplayName=Jenkins’ own user database
+HudsonPrivateSecurityRealm.DisplayName=Jenkins user database
 HudsonPrivateSecurityRealm.SignupWarning=With signup enabled, anyone on your network can become an authenticated user. It is recommended in this case to minimize the permissions granted to any authenticated user.
 HudsonPrivateSecurityRealm.Details.DisplayName=Password
 HudsonPrivateSecurityRealm.Details.PasswordError=\


### PR DESCRIPTION
Thoughts about this simplification in the label?

Pros:

* It's simpler
* No weird _'_ at the end of _Jenkins_ ([that can easily be missed](https://github.com/jenkins-infra/jenkins.io/pull/7166#discussion_r1517398190))

Cons:

* It could more easily be confused with _security realm_ as a term ("My Jenkins user database is LDAP").

### Testing done

<img width="824" alt="config screenshot" src="https://github.com/jenkinsci/jenkins/assets/1831569/4e05286c-3349-4163-8849-ee06311e8aa4">
<img width="553" alt="breadcrumb screenshot" src="https://github.com/jenkinsci/jenkins/assets/1831569/8739fff4-96d8-436c-9254-e084973972f1">


### Proposed changelog entries

- JENKINS-XXXXX, human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
