### PR TITLE
[JENKINS-72833] Do not attempt to self-`exec` on systems without `libc`

### DIFF
--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -120,13 +120,13 @@ public abstract class Lifecycle implements ExtensionPoint {
                     // if run on Unix, we can do restart
                     try {
                         instance = new UnixLifecycle();
-                    } catch (final IOException e) {
-                        LOGGER.log(Level.WARNING, "Failed to install embedded lifecycle implementation", e);
+                    } catch (final Throwable t) {
+                        LOGGER.log(Level.WARNING, "Failed to install embedded lifecycle implementation", t);
                         instance = new Lifecycle() {
                             @Override
                             public void verifyRestartable() throws RestartNotSupportedException {
                                 throw new RestartNotSupportedException(
-                                        "Failed to install embedded lifecycle implementation, so cannot restart: " + e, e);
+                                        "Failed to install embedded lifecycle implementation, so cannot restart: " + t, t);
                             }
                         };
                     }

--- a/core/src/main/java/jenkins/util/JavaVMArguments.java
+++ b/core/src/main/java/jenkins/util/JavaVMArguments.java
@@ -1,6 +1,6 @@
 package jenkins.util;
 
-import com.google.common.primitives.Ints;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
 import hudson.util.ProcessTree;
 import java.lang.management.ManagementFactory;
@@ -20,6 +20,7 @@ public class JavaVMArguments {
     /**
      * Gets the process argument list of the current process.
      */
+    @NonNull
     public static List<String> current() {
         ProcessHandle.Info info = ProcessHandle.current().info();
         if (info.command().isPresent() && info.arguments().isPresent()) {
@@ -30,7 +31,7 @@ public class JavaVMArguments {
             return args;
         } else if (Functions.isGlibcSupported()) {
             // Native approach
-            int pid = Ints.checkedCast(ProcessHandle.current().pid());
+            int pid = Math.toIntExact(ProcessHandle.current().pid());
             ProcessTree.OSProcess process = ProcessTree.get().get(pid);
             if (process != null) {
                 List<String> args = process.getArguments();


### PR DESCRIPTION
See [JENKINS-72833](https://issues.jenkins.io/browse/JENKINS-72833). We were attempting to use `UnixLifecycle` on a system not supported by JNA.

While I was here I also did some other cleanup of this class.

### Testing done

Tested `/safeRestart` on Linux both inside and outside `systemd`.

### Proposed changelog entries

- Do not attempt to self-restart on operating systems where this is not supported.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
