### PR TITLE
[JENKINS-65911] Correct JNA method signature for `fcntl(2)`

### DIFF
--- a/core/src/main/java/hudson/util/jna/GNUCLibrary.java
+++ b/core/src/main/java/hudson/util/jna/GNUCLibrary.java
@@ -77,7 +77,7 @@ public interface GNUCLibrary extends Library {
 
     int fcntl(int fd, int command);
 
-    int fcntl(int fd, int command, int flags);
+    int fcntl(int fd, int command, Object... flags);
 
     // obtained from Linux. Needs to be checked if these values are portable.
     int F_GETFD = 1;

--- a/core/src/test/java/hudson/util/jna/GNUCLibraryTest.java
+++ b/core/src/test/java/hudson/util/jna/GNUCLibraryTest.java
@@ -1,0 +1,103 @@
+package hudson.util.jna;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import com.sun.jna.Native;
+import hudson.Functions;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+
+public class GNUCLibraryTest {
+
+    private static final int EBADF = 9;
+    private static final int O_CREAT = "Linux".equals(System.getProperty("os.name")) ? 64 : 512;
+    private static final int O_RDWR = 2;
+
+    @Test
+    public void openTest() throws IOException {
+        assumeTrue(Functions.isGlibcSupported());
+
+        int fd = GNUCLibrary.LIBC.open("/dev/null", 0);
+        assertNotEquals(-1, fd);
+
+        int result = GNUCLibrary.LIBC.close(fd);
+        assertEquals(0, result);
+
+        result = GNUCLibrary.LIBC.close(fd);
+        assertEquals(-1, result);
+        assertEquals(EBADF, Native.getLastError());
+
+        Path tmpFile = Files.createTempFile("openTest", null);
+        Files.delete(tmpFile);
+        assertFalse(Files.exists(tmpFile));
+        try {
+            fd = GNUCLibrary.LIBC.open(tmpFile.toString(), O_CREAT | O_RDWR);
+            assertTrue(Files.exists(tmpFile));
+
+            result = GNUCLibrary.LIBC.close(fd);
+            assertEquals(0, result);
+        } finally {
+            Files.deleteIfExists(tmpFile);
+        }
+    }
+
+    @Test
+    public void closeTest() {
+        assumeTrue(Functions.isGlibcSupported());
+
+        int fd = GNUCLibrary.LIBC.open("/dev/null", 0);
+        assertNotEquals(-1, fd);
+
+        int result = GNUCLibrary.LIBC.close(fd);
+        assertEquals(0, result);
+
+        result = GNUCLibrary.LIBC.close(fd);
+        assertEquals(-1, result);
+        assertEquals(EBADF, Native.getLastError());
+    }
+
+    @Test
+    public void fcntlTest() {
+        assumeTrue(Functions.isGlibcSupported());
+
+        int fd = GNUCLibrary.LIBC.open("/dev/null", 0);
+        assertNotEquals(-1, fd);
+        try {
+            int flags = GNUCLibrary.LIBC.fcntl(fd, GNUCLibrary.F_GETFD);
+            assertEquals(0, flags);
+            int result =
+                    GNUCLibrary.LIBC.fcntl(fd, GNUCLibrary.F_SETFD, flags | GNUCLibrary.FD_CLOEXEC);
+            assertEquals(0, result);
+            result = GNUCLibrary.LIBC.fcntl(fd, GNUCLibrary.F_GETFD);
+            assertEquals(GNUCLibrary.FD_CLOEXEC, result);
+        } finally {
+            GNUCLibrary.LIBC.close(fd);
+        }
+    }
+
+    @Test
+    public void renameTest() throws IOException {
+        assumeTrue(Functions.isGlibcSupported());
+
+        Path oldFile = Files.createTempFile("renameTest", null);
+        Path newFile = Files.createTempFile("renameTest", null);
+        Files.delete(newFile);
+        assertTrue(Files.exists(oldFile));
+        assertFalse(Files.exists(newFile));
+        try {
+            GNUCLibrary.LIBC.rename(oldFile.toString(), newFile.toString());
+
+            assertFalse(Files.exists(oldFile));
+            assertTrue(Files.exists(newFile));
+        } finally {
+            Files.deleteIfExists(oldFile);
+            Files.deleteIfExists(newFile);
+        }
+    }
+}


### PR DESCRIPTION
While looking at JENKINS-72833 I remembered my old friend [JENKINS-65911](https://issues.jenkins.io/browse/JENKINS-65911). While I could no longer reproduce the problem on my macOS system, I was able to reproduce incorrect `fcntl` results in a new unit test when running on macOS (but not Linux). The problem seems to be, as I wrote back in 2021, an incorrect JNA signature. `fcntl` is a variadic function. While I couldn't find much documentation about this, I tried using Java varargs and hoping JNA would deal with this correctly, and it did. My unit test started passing on macOS and there were no regressions running the test on Linux. Just to be sure, I stepped through the restart sequence outside of systemd in a debugger and verified in a separate terminal running `strace` that the system calls on Linux were unchanged. While I was here I also wrote some other tests to increase coverage for this file.

### Testing done

Before this PR, new unit test failed on macOS and passed on Linux. After this PR, passes on both platforms.

Also stepped through the restart sequence outside of `systemd` on Linux and verified correct system call input and output in `strace`.

### Proposed changelog entries

- Fix a crash when restarting Jenkins on macOS.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
