### PR TITLE
Further reduce usages of `StringUtils`

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -61,7 +61,6 @@ import java.util.logging.Logger;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
-import org.apache.commons.lang.StringUtils;
 import org.glassfish.tyrus.client.ClientManager;
 import org.glassfish.tyrus.client.ClientProperties;
 import org.glassfish.tyrus.client.SslEngineConfigurator;
@@ -246,7 +245,7 @@ public class CLI {
         if (auth == null && bearer == null) {
             // -auth option not set
             if ((userIdEnv != null && !userIdEnv.isBlank()) && (tokenEnv != null && !tokenEnv.isBlank())) {
-                auth = StringUtils.defaultString(userIdEnv).concat(":").concat(StringUtils.defaultString(tokenEnv));
+                auth = userIdEnv.concat(":").concat(tokenEnv);
             } else if ((userIdEnv != null && !userIdEnv.isBlank()) || (tokenEnv != null && !tokenEnv.isBlank())) {
                 printUsage(Messages.CLI_BadAuth());
                 return -1;

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -163,7 +163,6 @@ import org.apache.commons.jelly.Script;
 import org.apache.commons.jelly.XMLOutput;
 import org.apache.commons.jexl.parser.ASTSizeFunction;
 import org.apache.commons.jexl.util.Introspector;
-import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.jvnet.tiger_types.Types;
@@ -2415,7 +2414,7 @@ public class Functions {
     }
 
     private static @NonNull String filterIconNameClasses(@NonNull String classNames) {
-        return Arrays.stream(StringUtils.split(classNames, ' '))
+        return Arrays.stream(classNames.split(" "))
             .filter(className -> className.startsWith("icon-"))
             .collect(Collectors.joining(" "));
     }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -145,7 +145,6 @@ import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.LogFactory;
 import org.jenkinsci.Symbol;
 import org.jvnet.hudson.reactor.Executable;
@@ -1472,7 +1471,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     jsonObject.put("title", plugin.title);
                     jsonObject.put("displayName", plugin.getDisplayName());
                     if (plugin.wiki == null || !(plugin.wiki.startsWith("https://") || plugin.wiki.startsWith("http://"))) {
-                        jsonObject.put("wiki", StringUtils.EMPTY);
+                        jsonObject.put("wiki", "");
                     } else {
                         jsonObject.put("wiki", plugin.wiki);
                     }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1442,7 +1442,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                         plugin.getCategoriesStream()
                             .map(UpdateCenter::getCategoryDisplayName)
                             .anyMatch(category -> category != null && category.toLowerCase().contains(query.toLowerCase())) ||
-                        (plugin.hasWarnings() && query.equalsIgnoreCase("warning:"));
+                        plugin.hasWarnings() && query.equalsIgnoreCase("warning:");
                 })
                 .limit(Math.max(limit - plugins.size(), 1))
                 .sorted((o1, o2) -> {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1436,14 +1436,14 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     if (query == null || query.isBlank()) {
                         return true;
                     }
-                    return StringUtils.containsIgnoreCase(plugin.name, query) ||
-                        StringUtils.containsIgnoreCase(plugin.title, query) ||
-                        StringUtils.containsIgnoreCase(plugin.excerpt, query) ||
+                    return (plugin.name != null && plugin.name.toLowerCase().contains(query.toLowerCase())) ||
+                        (plugin.title != null && plugin.title.toLowerCase().contains(query.toLowerCase())) ||
+                        (plugin.excerpt != null && plugin.excerpt.toLowerCase().contains(query.toLowerCase())) ||
                         plugin.hasCategory(query) ||
                         plugin.getCategoriesStream()
                             .map(UpdateCenter::getCategoryDisplayName)
-                            .anyMatch(category -> StringUtils.containsIgnoreCase(category, query)) ||
-                        plugin.hasWarnings() && query.equalsIgnoreCase("warning:");
+                            .anyMatch(category -> category != null && category.toLowerCase().contains(query.toLowerCase())) ||
+                        (plugin.hasWarnings() && query.equalsIgnoreCase("warning:"));
                 })
                 .limit(Math.max(limit - plugins.size(), 1))
                 .sorted((o1, o2) -> {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -73,7 +73,6 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.DetachedPluginsUtil;
 import jenkins.security.UpdateSiteWarningsMonitor;
 import jenkins.util.URLClassLoader2;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.LogFactory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -497,7 +496,12 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
 
     @Override
     public String getDisplayName() {
-        return StringUtils.removeStart(getLongName(), "Jenkins ");
+        String displayName = getLongName();
+        String removePrefix = "Jenkins ";
+        if (displayName != null && displayName.startsWith(removePrefix)) {
+            return displayName.substring(removePrefix.length());
+        }
+        return displayName;
     }
 
     public Api getApi() {

--- a/core/src/main/java/hudson/cli/CLIAction.java
+++ b/core/src/main/java/hudson/cli/CLIAction.java
@@ -52,7 +52,6 @@ import jenkins.util.FullDuplexHttpService;
 import jenkins.util.SystemProperties;
 import jenkins.websocket.WebSocketSession;
 import jenkins.websocket.WebSockets;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -128,7 +127,17 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
         }
         if (ALLOW_WEBSOCKET == null) {
             final String actualOrigin = req.getHeader("Origin");
-            final String expectedOrigin = StringUtils.removeEnd(StringUtils.removeEnd(Jenkins.get().getRootUrlFromRequest(), "/"), req.getContextPath());
+
+            String o = Jenkins.get().getRootUrlFromRequest();
+            String removeSuffix1 = "/";
+            if (o.endsWith(removeSuffix1)) {
+                o = o.substring(0, o.length() - removeSuffix1.length());
+            }
+            String removeSuffix2 = req.getContextPath();
+            if (o.endsWith(removeSuffix2)) {
+                o = o.substring(0, o.length() - removeSuffix2.length());
+            }
+            final String expectedOrigin = o;
 
             if (actualOrigin == null || !actualOrigin.equals(expectedOrigin)) {
                 LOGGER.log(Level.FINE, () -> "Rejecting origin: " + actualOrigin + "; expected was from request: " + expectedOrigin);

--- a/core/src/main/java/hudson/model/AutoCompletionCandidates.java
+++ b/core/src/main/java/hudson/model/AutoCompletionCandidates.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.List;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -173,6 +172,6 @@ public class AutoCompletionCandidates implements HttpResponse {
     }
 
     private static boolean startsWithImpl(String str, String prefix, boolean ignoreCase) {
-        return ignoreCase ? StringUtils.startsWithIgnoreCase(str, prefix) : str.startsWith(prefix);
+        return ignoreCase ? str.toLowerCase().startsWith(prefix.toLowerCase()) : str.startsWith(prefix);
     }
 }

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -67,7 +67,6 @@ import jenkins.fingerprints.FingerprintStorage;
 import jenkins.model.FingerprintFacet;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientFingerprintFacetFactory;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.springframework.security.access.AccessDeniedException;
@@ -681,7 +680,7 @@ public class Fingerprint implements ModelObject, Saveable {
             }
 
             String[] items = Util.tokenize(list, ",");
-            if (items.length > 1 && items.length <= StringUtils.countMatches(list, ",")) {
+            if (items.length > 1 && items.length <= list.chars().filter(c -> c == ',').count()) {
                 if (!skipError) {
                     throw new IllegalArgumentException(
                             String.format("Unable to parse '%s', expected correct notation M,N or M-N", list));
@@ -704,7 +703,7 @@ public class Fingerprint implements ModelObject, Saveable {
                     }
 
                     if (s.contains("-")) {
-                        if (StringUtils.countMatches(s, "-") > 1) {
+                        if (s.chars().filter(c -> c == '-').count() > 1) {
                             if (!skipError) {
                                 throw new IllegalArgumentException(String.format(
                                         "Unable to parse '%s', expected correct notation M,N or M-N", list));

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -63,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -392,7 +393,7 @@ public abstract class Slave extends Node implements Serializable {
             // if computer is null then channel is null and thus we were going to return null anyway
             return null;
         } else {
-            return createPath(computer.getAbsoluteRemoteFs() == null ? remoteFS : computer.getAbsoluteRemoteFs());
+            return createPath(Objects.toString(computer.getAbsoluteRemoteFs(), remoteFS));
         }
     }
 

--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -73,7 +73,6 @@ import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import jenkins.slaves.WorkspaceLocator;
 import jenkins.util.SystemProperties;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -393,7 +392,7 @@ public abstract class Slave extends Node implements Serializable {
             // if computer is null then channel is null and thus we were going to return null anyway
             return null;
         } else {
-            return createPath(StringUtils.defaultString(computer.getAbsoluteRemoteFs(), remoteFS));
+            return createPath(computer.getAbsoluteRemoteFs() == null ? remoteFS : computer.getAbsoluteRemoteFs());
         }
     }
 

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -83,7 +83,6 @@ import jenkins.util.SystemProperties;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -1299,7 +1298,11 @@ public class UpdateSite {
                 displayName = title;
             else
                 displayName = name;
-            return StringUtils.removeStart(displayName, "Jenkins ");
+            String removePrefix = "Jenkins ";
+            if (displayName != null && displayName.startsWith(removePrefix)) {
+                return displayName.substring(removePrefix.length());
+            }
+            return displayName;
         }
 
         /**

--- a/core/src/main/java/hudson/search/FixedSet.java
+++ b/core/src/main/java/hudson/search/FixedSet.java
@@ -27,7 +27,6 @@ package hudson.search;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Set of {@link SearchItem}s that are statically known upfront.
@@ -62,7 +61,7 @@ public class FixedSet implements SearchIndex {
         boolean caseInsensitive = UserSearchProperty.isCaseInsensitive();
         for (SearchItem i : items) {
             String name = i.getSearchName();
-            if (name != null && (name.contains(token) || (caseInsensitive && StringUtils.containsIgnoreCase(name, token)))) {
+            if (name != null && (name.contains(token) || (caseInsensitive && name.toLowerCase().contains(token.toLowerCase())))) {
                 result.add(i);
             }
         }

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -56,7 +56,6 @@ import jenkins.security.AuthenticationSuccessHandler;
 import jenkins.security.BasicHeaderProcessor;
 import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -672,7 +671,10 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
 
         // If deduced entry point isn't deduced yet or the content is a blank value
         // use the root web point "/" as a fallback
-        from = StringUtils.defaultIfBlank(from, "/").trim();
+        if (from == null || from.isBlank()) {
+            from = "/";
+        }
+        from = from.trim();
 
         // Encode the return value
         String returnValue = URLEncoder.encode(from, StandardCharsets.UTF_8);

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -39,7 +39,6 @@ import jenkins.model.identity.InstanceIdentityProvider;
 import jenkins.slaves.RemotingWorkDirSettings;
 import jenkins.util.SystemProperties;
 import jenkins.websocket.WebSockets;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -230,7 +229,7 @@ public class JNLPLauncher extends ComputerLauncher {
      * spaces and therefore with double quotes and backticks.
      */
     private static String escapeUnix(String input) {
-        if (StringUtils.isAlphanumeric(input)) {
+        if (input != null && !input.isEmpty() && input.chars().allMatch(Character::isLetterOrDigit)) {
             return input;
         }
         Escaper escaper =
@@ -243,7 +242,7 @@ public class JNLPLauncher extends ComputerLauncher {
      * spaces and therefore with double quotes.
      */
     private static String escapeWindows(String input) {
-        if (StringUtils.isAlphanumeric(input)) {
+        if (input != null && !input.isEmpty() && input.chars().allMatch(Character::isLetterOrDigit)) {
             return input;
         }
         Escaper escaper = Escapers.builder().addEscape('"', "\\\"").build();

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -228,8 +228,8 @@ public class JNLPLauncher extends ComputerLauncher {
      * {@link Jenkins#checkGoodName(String)} saves us from most troublesome characters, but we still have to deal with
      * spaces and therefore with double quotes and backticks.
      */
-    private static String escapeUnix(String input) {
-        if (input != null && !input.isEmpty() && input.chars().allMatch(Character::isLetterOrDigit)) {
+    private static String escapeUnix(@NonNull String input) {
+        if (!input.isEmpty() && input.chars().allMatch(Character::isLetterOrDigit)) {
             return input;
         }
         Escaper escaper =
@@ -241,8 +241,8 @@ public class JNLPLauncher extends ComputerLauncher {
      * {@link Jenkins#checkGoodName(String)} saves us from most troublesome characters, but we still have to deal with
      * spaces and therefore with double quotes.
      */
-    private static String escapeWindows(String input) {
-        if (input != null && !input.isEmpty() && input.chars().allMatch(Character::isLetterOrDigit)) {
+    private static String escapeWindows(@NonNull String input) {
+        if (!input.isEmpty() && input.chars().allMatch(Character::isLetterOrDigit)) {
             return input;
         }
         Escaper escaper = Escapers.builder().addEscape('"', "\\\"").build();

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -68,7 +68,6 @@ import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.ReverseBuildTrigger;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -114,7 +113,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
 
     @DataBoundConstructor
     public BuildTrigger(String childProjects, String threshold) {
-        this(childProjects, Result.fromString(StringUtils.defaultString(threshold, Result.SUCCESS.toString())));
+        this(childProjects, Result.fromString(threshold == null ? Result.SUCCESS.toString() : threshold));
     }
 
     public BuildTrigger(String childProjects, Result threshold) {

--- a/core/src/main/java/hudson/tasks/BuildTrigger.java
+++ b/core/src/main/java/hudson/tasks/BuildTrigger.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -113,7 +114,7 @@ public class BuildTrigger extends Recorder implements DependencyDeclarer {
 
     @DataBoundConstructor
     public BuildTrigger(String childProjects, String threshold) {
-        this(childProjects, Result.fromString(threshold == null ? Result.SUCCESS.toString() : threshold));
+        this(childProjects, Result.fromString(Objects.toString(threshold, Result.SUCCESS.toString())));
     }
 
     public BuildTrigger(String childProjects, Result threshold) {

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -1,7 +1,5 @@
 package jenkins.install;
 
-import static org.apache.commons.lang.StringUtils.defaultIfBlank;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -486,7 +484,11 @@ public class SetupWizard extends PageDecorator {
         File state = getUpdateStateFile();
         if (state.exists()) {
             try {
-                from = new VersionNumber(defaultIfBlank(Files.readString(Util.fileToPath(state), StandardCharsets.UTF_8), "1.0").trim());
+                String version = Files.readString(Util.fileToPath(state), StandardCharsets.UTF_8);
+                if (version == null || version.isBlank()) {
+                    version = "1.0";
+                }
+                from = new VersionNumber(version.trim());
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "Cannot read the current version file", ex);
                 return null;

--- a/core/src/main/java/jenkins/security/BasicHeaderProcessor.java
+++ b/core/src/main/java/jenkins/security/BasicHeaderProcessor.java
@@ -18,7 +18,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -65,7 +64,7 @@ public class BasicHeaderProcessor implements Filter {
         HttpServletResponse rsp = (HttpServletResponse) response;
         String authorization = req.getHeader("Authorization");
 
-        if (StringUtils.startsWithIgnoreCase(authorization, "Basic ")) {
+        if (authorization != null && authorization.toLowerCase().startsWith("Basic ".toLowerCase())) {
             // authenticate the user
             String uidpassword = Scrambler.descramble(authorization.substring(6));
             int idx = uidpassword.indexOf(':');

--- a/core/src/main/java/org/jenkins/ui/icon/Icon.java
+++ b/core/src/main/java/org/jenkins/ui/icon/Icon.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.jelly.JellyContext;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -238,7 +237,7 @@ public class Icon {
         if (string == null) {
             return null;
         }
-        if (StringUtils.endsWithAny(string, SUPPORTED_FORMATS)) {
+        if (Arrays.stream(SUPPORTED_FORMATS).anyMatch(string::endsWith)) {
             string = string.substring(0, string.length() - 4);
         }
         return string.replace('_', '-');

--- a/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
+++ b/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
@@ -15,7 +15,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Helper class to load symbols from Jenkins core or plugins.
@@ -50,7 +49,7 @@ public final class Symbol {
         String pluginName = request.getPluginName();
         String id = request.getId();
 
-        String identifier = StringUtils.defaultIfBlank(pluginName, "core");
+        String identifier = (pluginName == null || pluginName.isBlank()) ? "core" : pluginName;
 
         String symbol = SYMBOLS
                 .computeIfAbsent(identifier, key -> new ConcurrentHashMap<>())


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

like #6270 



<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- JENKINS-XXXXX, human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
