### PR TITLE
`RunListener.allowLoad` + `AbstractLazyLoadRunMap.recognizeNumber`

### DIFF
--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -28,7 +28,10 @@ import static java.util.logging.Level.FINEST;
 import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.ASC;
 import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.DESC;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
+import hudson.model.listeners.RunListener;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -38,6 +41,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,6 +68,8 @@ public final class RunMap<R extends Run<?, R>> extends AbstractLazyLoadRunMap<R>
      */
     private final SortedMap<Integer, R> view = Collections.unmodifiableSortedMap(this);
 
+    private final @CheckForNull Job<?, ?> job;
+
     private Constructor<R> cons;
 
     /** Normally overwritten by {@link LazyBuildMixIn#onLoad} or {@link LazyBuildMixIn#onCreatedFromScratch}, in turn created during {@link Job#onLoad}. */
@@ -76,20 +82,38 @@ public final class RunMap<R extends Run<?, R>> extends AbstractLazyLoadRunMap<R>
 
     /**
      * @deprecated as of 1.485
-     *      Use {@link #RunMap(File, Constructor)}.
+     *      Use {@link #RunMap(Job, Constructor)}.
      */
     @Deprecated
     public RunMap() {
-        super(null); // will be set later
+        job = null;
+        initBaseDir(null); // will be set later
+    }
+
+    @Restricted(NoExternalUse.class)
+    public RunMap(@NonNull Job<?, ?> job) {
+        this.job = Objects.requireNonNull(job);
     }
 
     /**
      * @param cons
      *      Used to create new instance of {@link Run}.
+     * @since TODO
      */
-    public RunMap(File baseDir, Constructor cons) {
-        super(baseDir);
+    public RunMap(@NonNull Job<?, ?> job, Constructor cons) {
+        this.job = Objects.requireNonNull(job);
         this.cons = cons;
+        initBaseDir(job.getBuildDir());
+    }
+
+    /**
+     * @deprecated Use {@link #RunMap(Job, Constructor)}.
+     */
+    @Deprecated
+    public RunMap(File baseDir, Constructor cons) {
+        job = null;
+        this.cons = cons;
+        initBaseDir(baseDir);
     }
 
     public boolean remove(R run) {
@@ -222,6 +246,22 @@ public final class RunMap<R extends Run<?, R>> extends AbstractLazyLoadRunMap<R>
     @Override
     protected BuildReference<R> createReference(R r) {
         return r.createReference();
+    }
+
+    @Override
+    protected boolean allowLoad(int buildNumber) {
+        if (job == null) {
+            LOGGER.fine(() -> "deprecated constructor without Job used on " + dir);
+            return true;
+        }
+        for (RunListener<?> l : RunListener.all()) {
+            if (!l.allowLoad(job, buildNumber)) {
+                LOGGER.finer(() -> l + " declined to load " + buildNumber + " in " + job);
+                return false;
+            }
+        }
+        LOGGER.finest(() -> "no RunListener declined to load " + buildNumber + " in " + job + " so proceeding");
+        return true;
     }
 
     @Override

--- a/core/src/main/java/hudson/model/ViewJob.java
+++ b/core/src/main/java/hudson/model/ViewJob.java
@@ -26,6 +26,7 @@ package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Descriptor.FormException;
+import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -62,7 +63,7 @@ public abstract class ViewJob<JobT extends ViewJob<JobT, RunT>, RunT extends Run
     /**
      * All {@link Run}s. Copy-on-write semantics.
      */
-    protected transient volatile /*almost final*/ RunMap<RunT> runs = new RunMap<>(null, null);
+    protected transient volatile /*almost final*/ RunMap<RunT> runs = new RunMap<>((File) null, null);
 
     private transient volatile boolean notLoaded = true;
 

--- a/core/src/main/java/hudson/model/listeners/RunListener.java
+++ b/core/src/main/java/hudson/model/listeners/RunListener.java
@@ -35,6 +35,7 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Environment;
+import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.Run;
 import hudson.model.Run.RunnerAbortedException;
@@ -46,8 +47,11 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import jenkins.model.lazy.AbstractLazyLoadRunMap;
 import jenkins.util.Listeners;
 import org.jvnet.tiger_types.Types;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 
 /**
  * Receives notifications about builds.
@@ -170,6 +174,18 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
      *      from breaking all the builds.
      */
     public void onDeleted(R r) {}
+
+    /**
+     * Allows listeners to veto build loading.
+     * @param job the job from which a build might be loaded
+     * @param buildNumber the proposed build number
+     * @return false to veto build loading
+     * @see AbstractLazyLoadRunMap#recognizeNumber
+     */
+    @Restricted(Beta.class)
+    public boolean allowLoad(@NonNull Job<?, ?> job, int buildNumber) {
+        return true;
+    }
 
     /**
      * Registers this object as an active listener so that it can start getting

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -31,6 +31,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.RunMap;
+import hudson.model.listeners.RunListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.AbstractCollection;
@@ -54,6 +55,7 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import jenkins.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
@@ -290,8 +292,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
     protected File dir;
 
     @Restricted(NoExternalUse.class) // subclassing other than by RunMap does not guarantee compatibility
-    protected AbstractLazyLoadRunMap(File dir) {
-        initBaseDir(dir);
+    protected AbstractLazyLoadRunMap() {
     }
 
     @Restricted(NoExternalUse.class)
@@ -348,13 +349,47 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
                 continue;
             }
             try {
-                list.add(Integer.parseInt(s));
+                int buildNumber = Integer.parseInt(s);
+                if (allowLoad(buildNumber)) {
+                    list.add(buildNumber);
+                } else {
+                    LOGGER.fine(() -> "declining to consider " + buildNumber + " in " + dir);
+                }
             } catch (NumberFormatException e) {
                 // matched BUILD_NUMBER but not an int?
             }
         }
         list.sort();
         numberOnDisk = list;
+    }
+
+    @Restricted(NoExternalUse.class)
+    protected boolean allowLoad(int buildNumber) {
+        return true;
+    }
+
+    /**
+     * Permits a previous blocked build number to be eligible for loading.
+     * @param buildNumber a build number
+     * @see RunListener#allowLoad
+     */
+    @Restricted(Beta.class)
+    public final void recognizeNumber(int buildNumber) {
+        if (new File(dir, Integer.toString(buildNumber)).isDirectory()) {
+            synchronized (this) {
+                SortedIntList list = new SortedIntList(numberOnDisk);
+                if (list.contains(buildNumber)) {
+                    LOGGER.fine(() -> "already knew about " + buildNumber + " in " + dir);
+                } else {
+                    list.add(buildNumber);
+                    list.sort();
+                    numberOnDisk = list;
+                    LOGGER.fine(() -> "recognizing " + buildNumber + " in " + dir);
+                }
+            }
+        } else {
+            LOGGER.fine(() -> "no such subdirectory " + buildNumber + " in " + dir);
+        }
     }
 
     @Override
@@ -540,7 +575,12 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
                     return v;
                 }
             }
-            return load(n, null);
+            if (allowLoad(n)) {
+                return load(n, null);
+            } else {
+                LOGGER.fine(() -> "declining to load " + n + " in " + dir);
+                return null;
+            }
         }
     }
 

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -66,8 +66,8 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
 
     private static final Logger LOGGER = Logger.getLogger(LazyBuildMixIn.class.getName());
 
-    @SuppressWarnings("deprecation") // [JENKINS-15156] builds accessed before onLoad or onCreatedFromScratch called
-    private @NonNull RunMap<RunT> builds = new RunMap<>();
+    // [JENKINS-15156] builds accessed before onLoad or onCreatedFromScratch called
+    private @NonNull RunMap<RunT> builds = new RunMap<>(asJob());
 
     /**
      * Initializes this mixin.
@@ -142,7 +142,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
     }
 
     private RunMap<RunT> createBuildRunMap() {
-        RunMap<RunT> r = new RunMap<>(asJob().getBuildDir(), new RunMap.Constructor<RunT>() {
+        RunMap<RunT> r = new RunMap<>(asJob(), new RunMap.Constructor<RunT>() {
             @Override
             public RunT create(File dir) throws IOException {
                 return loadBuild(dir);

--- a/core/src/test/java/jenkins/model/lazy/FakeMap.java
+++ b/core/src/test/java/jenkins/model/lazy/FakeMap.java
@@ -34,7 +34,7 @@ import java.nio.file.Files;
  */
 public class FakeMap extends AbstractLazyLoadRunMap<Build> {
     public FakeMap(File dir) {
-        super(dir);
+        initBaseDir(dir);
     }
 
     @Override


### PR DESCRIPTION
Introduces beta APIs permitting a plugin to control which builds are loaded into the controller’s memory and when. CloudBees CI uses these facilities in HA mode to block a controller process from loading selected (running) build numbers from disk, either during startup or thereafter; but then to subsequently (after completion) permit them to be loaded. While a block is in effect on a given build number, the effect is as if it does not exist, just as if the build directory were absent from `$JENKINS_HOME/jobs/xxx/builds/`.

`AbstractLazyLoadRunMap.removeValue` and `.getLoadedBuilds` are also used to unload builds; those are already public.

### Testing done

Covered by various kinds of tests in CloudBees CI. Could add tests here with a mock listener, though I do not foresee any OSS use case for this.

### Proposed changelog entries

- N/A, beta APIs only

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
