### PR TITLE
Follow-up fixes to `Nodes` refactoring

### DIFF
--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -1751,7 +1751,7 @@ public class Queue extends ResourceController implements Saveable {
             Label lbl = p.getAssignedLabel();
 
             Computer masterComputer = h.toComputer();
-            if (lbl != null && lbl.equals(h.getSelfLabel())) {
+            if (lbl != null && lbl.equals(h.getSelfLabel()) && masterComputer != null) {
                 // the flyweight task is bound to the master
                 if (h.canTake(p) == null) {
                     return createFlyWeightTaskRunnable(p, masterComputer);
@@ -1760,7 +1760,7 @@ public class Queue extends ResourceController implements Saveable {
                 }
             }
 
-            if (lbl == null && h.canTake(p) == null && masterComputer.isOnline() && masterComputer.isAcceptingTasks()) {
+            if (lbl == null && h.canTake(p) == null && masterComputer != null && masterComputer.isOnline() && masterComputer.isAcceptingTasks()) {
                 // The flyweight task is not tied to a specific label, so execute on master if possible.
                 // This will ensure that actual agent disconnects do not impact flyweight tasks randomly assigned to them.
                 return createFlyWeightTaskRunnable(p, masterComputer);
@@ -1794,7 +1794,7 @@ public class Queue extends ResourceController implements Saveable {
         return null;
     }
 
-    private Runnable createFlyWeightTaskRunnable(final BuildableItem p, final Computer c) {
+    private Runnable createFlyWeightTaskRunnable(final BuildableItem p, final @NonNull Computer c) {
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.log(Level.FINEST, "Creating flyweight task {0} for computer {1}",
                     new Object[]{p.task.getFullDisplayName(), c.getName()});

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -332,9 +332,6 @@ public class Nodes implements PersistenceRoot {
      */
     public void load() throws IOException {
         final File nodesDir = getRootDir();
-        if (!nodesDir.exists()) {
-            return;
-        }
         final File[] subdirs = nodesDir.listFiles(File::isDirectory);
         final Map<String, Node> newNodes = new TreeMap<>();
         if (subdirs != null) {


### PR DESCRIPTION
Follows up #8979. I found a test regression in a CloudBees CI plugin triggered by this change, after removing a defensive null check not present in #8979. After some investigation I found that #8979 caused `MasterComputer` to be created a bit later during Jenkins startup: rather than inside `Nodes.load` as before

```
jenkins.model.Jenkins$MasterComputer.<init>(Jenkins.java:5346)
hudson.model.Hudson$MasterComputer.<init>(Hudson.java:330)
jenkins.model.Jenkins.createComputer(Jenkins.java:3367)
hudson.model.AbstractCIBase.lambda$createNewComputerForNode$0(AbstractCIBase.java:173)
java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
hudson.model.AbstractCIBase.createNewComputerForNode(AbstractCIBase.java:171)
hudson.model.AbstractCIBase.updateComputer(AbstractCIBase.java:153)
hudson.model.AbstractCIBase$1.run(AbstractCIBase.java:252)
hudson.model.Queue._withLock(Queue.java:1410)
hudson.model.Queue.withLock(Queue.java:1284)
hudson.model.AbstractCIBase.updateComputerList(AbstractCIBase.java:238)
jenkins.model.Jenkins.updateComputerList(Jenkins.java:1705)
jenkins.model.Nodes$6.run(Nodes.java:351)
hudson.model.Queue._withLock(Queue.java:1410)
hudson.model.Queue.withLock(Queue.java:1284)
jenkins.model.Nodes.load(Nodes.java:346)
jenkins.model.Jenkins$12.run(Jenkins.java:3499)
```

it was being created during an explicit call to `Jenkins.updateComputerList` in the startup sequence

```
jenkins.model.Jenkins$MasterComputer.<init>(Jenkins.java:5366)
hudson.model.Hudson$MasterComputer.<init>(Hudson.java:330)
jenkins.model.Jenkins.createComputer(Jenkins.java:3387)
hudson.model.AbstractCIBase.lambda$createNewComputerForNode$0(AbstractCIBase.java:173)
java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
hudson.model.AbstractCIBase.createNewComputerForNode(AbstractCIBase.java:171)
hudson.model.AbstractCIBase.updateComputer(AbstractCIBase.java:153)
hudson.model.AbstractCIBase$1.run(AbstractCIBase.java:252)
hudson.model.Queue._withLock(Queue.java:1409)
hudson.model.Queue.withLock(Queue.java:1283)
hudson.model.AbstractCIBase.updateComputerList(AbstractCIBase.java:238)
jenkins.model.Jenkins.updateComputerList(Jenkins.java:1710)
jenkins.model.Jenkins.<init>(Jenkins.java:1029)
```

The reason was an attempted optimization to skip loading when the `nodes` directory did not exist, which would be true if no agent had ever been created (the case in the plugin test), even though `listFiles` was already being checked for null; the optimization wound up also skipping the early call to `Jenkins.updateComputerList`, which was unintentional.

That would probably not have mattered were it not for two other factors: an NPE in `Queue.createFlyWeightTaskRunnable` which failed to check¹ for a null return value from `Jenkins.toComputer()` and thus broke resumed Pipeline build handling; and a mistake in the proprietary plugin which wound up attempting to load running Pipeline builds earlier than they normally would have been loaded by `FlowExecutionList.resume`.

I also noticed that the new `ScheduleMaintenanceAfterSavingNode` calls `Queue.scheduleMaintenance` even when `Jenkins.save` (not `Slave.save`) is called, which might be wasteful, though it does not seem to have contributed to the test failure. Perhaps it is correct, in case `Jenkins.numExecutors` is adjusted?

### Testing done

Removal of early exit in `Nodes.load` fixes a functional test in a CloudBees CI plugin. Extra null check also did. Fixing timing in the plugin also did.

¹Note that SpotBugs does not find this even after deleting https://github.com/jenkinsci/jenkins/blob/ec5c07252a24578f4ee04a0142de89e9a9e892bc/core/src/spotbugs/excludesFilter.xml#L273-L274

### Proposed changelog entries

- N/A, no known user impact

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
