### PR TITLE
Remove duplicated words in Javadoc comments

### DIFF
--- a/core/src/main/java/jenkins/slaves/RemotingWorkDirSettings.java
+++ b/core/src/main/java/jenkins/slaves/RemotingWorkDirSettings.java
@@ -102,7 +102,7 @@ public class RemotingWorkDirSettings implements Describable<RemotingWorkDirSetti
     /**
      * Check if startup should fail if the workdir is missing.
      *
-     * @return {@code true} if Remoting should fail if the the work directory is missing instead of creating it
+     * @return {@code true} if Remoting should fail if the work directory is missing instead of creating it
      */
     public boolean isFailIfWorkDirIsMissing() {
         return failIfWorkDirIsMissing;

--- a/war/src/main/webapp/scripts/yui/dragdrop/dragdrop-debug.js
+++ b/war/src/main/webapp/scripts/yui/dragdrop/dragdrop-debug.js
@@ -245,7 +245,7 @@ YAHOO.util.DragDropMgr = function() {
         locked: false,
 
         /**
-         * Provides additional information about the the current set of
+         * Provides additional information about the current set of
          * interactions.  Can be accessed from the event handlers. It
          * contains the following properties:
          *

--- a/war/src/main/webapp/scripts/yui/editor/editor-debug.js
+++ b/war/src/main/webapp/scripts/yui/editor/editor-debug.js
@@ -955,7 +955,7 @@ var Dom = YAHOO.util.Dom,
 
             /**
             * @attribute collapse
-            * @description Boolean indicating if the the titlebar should have a collapse button.
+            * @description Boolean indicating if the titlebar should have a collapse button.
             * The collapse button will not remove the toolbar, it will minimize it to the titlebar
             * @default false
             * @type Boolean

--- a/war/src/main/webapp/scripts/yui/editor/simpleeditor-debug.js
+++ b/war/src/main/webapp/scripts/yui/editor/simpleeditor-debug.js
@@ -955,7 +955,7 @@ var Dom = YAHOO.util.Dom,
 
             /**
             * @attribute collapse
-            * @description Boolean indicating if the the titlebar should have a collapse button.
+            * @description Boolean indicating if the titlebar should have a collapse button.
             * The collapse button will not remove the toolbar, it will minimize it to the titlebar
             * @default false
             * @type Boolean

--- a/war/src/main/webapp/scripts/yui/menu/menu-debug.js
+++ b/war/src/main/webapp/scripts/yui/menu/menu-debug.js
@@ -2365,7 +2365,7 @@ _subscribeToItemEvents: function (p_oItem) {
 
 /**
 * @method _onVisibleChange
-* @description Change event handler for the the menu's "visible" configuration
+* @description Change event handler for the menu's "visible" configuration
 * property.
 * @private
 * @param {String} p_sType String representing the name of the event that 
@@ -4818,7 +4818,7 @@ _setScrollHeight: function (p_nScrollHeight) {
     
 
             /*
-                Only clear the the "width" configuration property if it was set the 
+                Only clear the "width" configuration property if it was set the 
                 "_setScrollHeight" method and wasn't changed by some other means after it was set.
             */	
     

--- a/war/src/main/webapp/scripts/yui/yahoo/yahoo-debug.js
+++ b/war/src/main/webapp/scripts/yui/yahoo/yahoo-debug.js
@@ -129,7 +129,7 @@ YAHOO.namespace = function() {
  * @param  {HTML}  cat  The log category for the message.  Default
  *                        categories are "info", "warn", "error", time".
  *                        Custom categories can be used as well. (opt)
- * @param  {HTML}  src  The source of the the message (opt)
+ * @param  {HTML}  src  The source of the message (opt)
  * @return {Boolean}      True if the log operation was successful.
  */
 YAHOO.log = function(msg, cat, src) {


### PR DESCRIPTION
Remove duplicated words in Javadoc comments.

### Testing done

Tested by the javadoc compiler.  No other testing

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
