### PR TITLE
Set current object to be the administrative monitor itself when loading its description view

### DIFF
--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
@@ -46,7 +46,7 @@ f.section(title: _("Administrative monitors configuration")) {
                 }
                 div(class: "tr") {
                     div(class: "jenkins-checkbox__description") {
-                        st.include(from: am, page: "description", optional: true)
+                        st.include(from: am, it: am, page: "description", optional: true)
                     }
                 }
             }

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
@@ -46,7 +46,7 @@ f.section(title: _("Administrative monitors configuration")) {
                 }
                 div(class: "tr") {
                     div(class: "jenkins-checkbox__description") {
-                        st.include(from: am, it: am, page: "description", optional: true)
+                        st.include(it: am, page: "description", optional: true)
                     }
                 }
             }


### PR DESCRIPTION
This allows to reference a method from the administrative monitor instance.

All instances of administrative monitor I could find use boilerplate `${%blurb}` with a corresponding resource bundle so this won't have any impact to them, while allowing more flexible ways of providing descriptions.

### Testing done

Exercised by various administrative monitors in CloudBees CI, limiting the number of files to create to add a new administrative monitor.


### Proposed changelog entries

- Provide current administrative monitor as context object when loading its description.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
