### PR TITLE
Use Collection.isEmpty() to test if collections are empty

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -345,21 +345,21 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             String token = tokens.get(i);
             if (token.equals(".")) {
                 tokens.remove(i);
-                if (tokens.size() > 0)
+                if (!tokens.isEmpty())
                     tokens.remove(i > 0 ? i - 1 : i);
             } else if (token.equals("..")) {
                 if (i == 0) {
                     // If absolute path, just remove: /../something
                     // If relative path, not collapsible so leave as-is
                     tokens.remove(0);
-                    if (tokens.size() > 0) token += tokens.remove(0);
+                    if (!tokens.isEmpty()) token += tokens.remove(0);
                     if (!isAbsolute) buf.append(token);
                 } else {
                     // Normalize: remove something/.. plus separator before/after
                     i -= 2;
                     for (int j = 0; j < 3; j++) tokens.remove(i);
                     if (i > 0) tokens.remove(i - 1);
-                    else if (tokens.size() > 0) tokens.remove(0);
+                    else if (!tokens.isEmpty()) tokens.remove(0);
                 }
             } else
                 i += 2;

--- a/core/src/main/java/hudson/cli/DisablePluginCommand.java
+++ b/core/src/main/java/hudson/cli/DisablePluginCommand.java
@@ -147,7 +147,7 @@ public class DisablePluginCommand extends CLICommand {
         }
 
         printIndented(indent, Messages.DisablePluginCommand_StatusMessage(oneResult.getPlugin(), oneResult.getStatus(), oneResult.getMessage()));
-        if (oneResult.getDependentsDisableStatus().size() > 0) {
+        if (!oneResult.getDependentsDisableStatus().isEmpty()) {
             indent += INDENT_SPACE;
             for (PluginWrapper.PluginDisableResult oneDependentResult : oneResult.getDependentsDisableStatus()) {
                 printResult(oneDependentResult, indent);
@@ -182,7 +182,7 @@ public class DisablePluginCommand extends CLICommand {
             return true;
         }
 
-        if (oneResult.getDependentsDisableStatus().size() > 0) {
+        if (!oneResult.getDependentsDisableStatus().isEmpty()) {
             for (PluginWrapper.PluginDisableResult oneDependentResult : oneResult.getDependentsDisableStatus()) {
                 if (restartIfNecessary(oneDependentResult)) {
                     return true;

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -1572,7 +1572,7 @@ public class UpdateSite {
          */
         @Restricted(DoNotUse.class)
         public boolean hasWarnings() {
-            return getWarnings().size() > 0;
+            return !getWarnings().isEmpty();
         }
 
         /**

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -483,7 +483,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
     private static class DoVetoersExist extends SlaveToMasterCallable<Boolean, IOException> {
         @Override
         public Boolean call() throws IOException {
-            return ProcessKillingVeto.all().size() > 0;
+            return !ProcessKillingVeto.all().isEmpty();
         }
     }
 

--- a/core/src/main/java/jenkins/security/stapler/DoActionFilter.java
+++ b/core/src/main/java/jenkins/security/stapler/DoActionFilter.java
@@ -65,7 +65,7 @@ public class DoActionFilter implements FunctionList.Filter {
 
         // check whitelist
         ExtensionList<RoutingDecisionProvider> whitelistProviders = ExtensionList.lookup(RoutingDecisionProvider.class);
-        if (whitelistProviders.size() > 0) {
+        if (!whitelistProviders.isEmpty()) {
             for (RoutingDecisionProvider provider : whitelistProviders) {
                 RoutingDecisionProvider.Decision methodDecision = provider.decide(signature);
                 if (methodDecision == RoutingDecisionProvider.Decision.ACCEPTED) {

--- a/core/src/main/java/jenkins/security/stapler/TypedFilter.java
+++ b/core/src/main/java/jenkins/security/stapler/TypedFilter.java
@@ -147,7 +147,7 @@ public class TypedFilter implements FieldRef.Filter, FunctionList.Filter {
 
         // check whitelist
         ExtensionList<RoutingDecisionProvider> decisionProviders = ExtensionList.lookup(RoutingDecisionProvider.class);
-        if (decisionProviders.size() > 0) {
+        if (!decisionProviders.isEmpty()) {
             for (RoutingDecisionProvider provider : decisionProviders) {
                 RoutingDecisionProvider.Decision fieldDecision = provider.decide(signature);
                 if (fieldDecision == RoutingDecisionProvider.Decision.ACCEPTED) {
@@ -204,7 +204,7 @@ public class TypedFilter implements FieldRef.Filter, FunctionList.Filter {
 
         // check whitelist
         ExtensionList<RoutingDecisionProvider> decision = ExtensionList.lookup(RoutingDecisionProvider.class);
-        if (decision.size() > 0) {
+        if (!decision.isEmpty()) {
             for (RoutingDecisionProvider provider : decision) {
                 RoutingDecisionProvider.Decision methodDecision = provider.decide(signature);
                 if (methodDecision == RoutingDecisionProvider.Decision.ACCEPTED) {

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -264,7 +264,7 @@ public class HistoryPageFilter<T> {
     private void addRun(Run run) {
         HistoryPageEntry<Run> entry = new HistoryPageEntry<>(run);
         // Assert that runs have been added in descending order
-        if (runs.size() > 0) {
+        if (!runs.isEmpty()) {
             if (entry.getEntryId() > runs.get(runs.size() - 1).getEntryId()) {
                 throw new IllegalStateException("Runs were out of order");
             }


### PR DESCRIPTION

The aim of this RP is to remove violations of the Sonar rule S1155 'Collection.isEmpty()' should be used to test for emptiness.

When you call isEmpty(), it clearly communicates the code’s intention, which is to check if the collection is empty. Using size() == 0 for this purpose is less direct and makes the code slightly more complex.

These changes have been made automatically by our "Indepth" java code remediation solution, which aims to improve code quality. You can also use it periodically to remove issues that have appeared in the source code. Use of this solution is free for all open source projects. You can find all the documentation and the download link on the site https://www.indepth.fr


