### PR TITLE
Fix issue S1130 Exceptions in 'throws' clauses should not be superfluous

### DIFF
--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -282,8 +282,8 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     @Override
     public String nextToken()
-        throws NoSuchElementException
-    {
+    
+   {
         if (!hasMoreTokens() || _token == null)
             throw new NoSuchElementException();
         String t = _token.toString();
@@ -295,8 +295,8 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     @Override
     public String nextToken(String delim)
-        throws NoSuchElementException
-    {
+    
+   {
         _delim = delim;
         _i = _lastStart;
         _token.setLength(0);
@@ -314,8 +314,8 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     @Override
     public Object nextElement()
-        throws NoSuchElementException
-    {
+    
+   {
         return nextToken();
     }
 

--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -282,8 +282,7 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     @Override
     public String nextToken()
-    
-   {
+    {
         if (!hasMoreTokens() || _token == null)
             throw new NoSuchElementException();
         String t = _token.toString();
@@ -295,8 +294,7 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     @Override
     public String nextToken(String delim)
-    
-   {
+    {
         _delim = delim;
         _i = _lastStart;
         _token.setLength(0);
@@ -314,8 +312,7 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     @Override
     public Object nextElement()
-    
-   {
+    {
         return nextToken();
     }
 

--- a/core/src/main/java/hudson/ExtensionList.java
+++ b/core/src/main/java/hudson/ExtensionList.java
@@ -158,7 +158,7 @@ public class ExtensionList<T> extends AbstractList<T> implements OnMaster {
      *
      * Meant to simplify call inside @Extension annotated class to retrieve their own instance.
      */
-    public @NonNull <U extends T> U getInstance(@NonNull Class<U> type) throws IllegalStateException {
+    public @NonNull <U extends T> U getInstance(@NonNull Class<U> type) {
         for (T ext : this)
             if (ext.getClass() == type)
                 return type.cast(ext);

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1349,7 +1349,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         }
 
         @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
+        public void checkRoles(RoleChecker checker) {
             task.checkRoles(checker);
         }
 
@@ -3620,7 +3620,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
          * Role check comes from {@link FileCallable}s.
          */
         @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
+        public void checkRoles(RoleChecker checker) {
             callable.checkRoles(checker);
         }
 

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -612,7 +612,7 @@ public class Functions {
     private static final Pattern ICON_SIZE = Pattern.compile("\\d+x\\d+");
 
     @Restricted(NoExternalUse.class)
-    public static String validateIconSize(String iconSize) throws SecurityException {
+    public static String validateIconSize(String iconSize) {
         if (!ICON_SIZE.matcher(iconSize).matches()) {
             throw new SecurityException("invalid iconSize");
         }

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1160,7 +1160,7 @@ public abstract class Launcher {
             }
 
             @Override
-            public Void call() throws RuntimeException {
+            public Void call() {
                 try {
                     ProcessTree.get().killAll(modelEnvVars);
                 } catch (InterruptedException e) {

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -89,7 +89,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
      *              It should never happen since the monitor is located in the core.
      */
     @NonNull
-    static OldDataMonitor get(Jenkins j) throws IllegalStateException {
+    static OldDataMonitor get(Jenkins j) {
         return ExtensionList.lookupSingleton(OldDataMonitor.class);
     }
 

--- a/core/src/main/java/hudson/logging/WeakLogHandler.java
+++ b/core/src/main/java/hudson/logging/WeakLogHandler.java
@@ -63,7 +63,7 @@ public final class WeakLogHandler extends Handler {
     }
 
     @Override
-    public void close() throws SecurityException {
+    public void close() {
         Handler t = resolve();
         if (t != null)
             t.close();
@@ -77,7 +77,7 @@ public final class WeakLogHandler extends Handler {
     }
 
     @Override
-    public void setFormatter(Formatter newFormatter) throws SecurityException {
+    public void setFormatter(Formatter newFormatter) {
         super.setFormatter(newFormatter);
         Handler t = resolve();
         if (t != null)
@@ -85,7 +85,7 @@ public final class WeakLogHandler extends Handler {
     }
 
     @Override
-    public void setEncoding(String encoding) throws SecurityException, UnsupportedEncodingException {
+    public void setEncoding(String encoding) throws UnsupportedEncodingException {
         super.setEncoding(encoding);
         Handler t = resolve();
         if (t != null)
@@ -93,7 +93,7 @@ public final class WeakLogHandler extends Handler {
     }
 
     @Override
-    public void setFilter(Filter newFilter) throws SecurityException {
+    public void setFilter(Filter newFilter) {
         super.setFilter(newFilter);
         Handler t = resolve();
         if (t != null)
@@ -109,7 +109,7 @@ public final class WeakLogHandler extends Handler {
     }
 
     @Override
-    public void setLevel(Level newLevel) throws SecurityException {
+    public void setLevel(Level newLevel) {
         super.setLevel(newLevel);
         Handler t = resolve();
         if (t != null)

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -416,7 +416,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P, R>, R extends A
          * @return Returns the current {@link Node}
          * @throws IllegalStateException if that cannot be determined
          */
-        protected final @NonNull Node getCurrentNode() throws IllegalStateException {
+        protected final @NonNull Node getCurrentNode() {
             Executor exec = Executor.currentExecutor();
             if (exec == null) {
                 throw new IllegalStateException("not being called from an executor thread");

--- a/core/src/main/java/hudson/model/DirectlyModifiableView.java
+++ b/core/src/main/java/hudson/model/DirectlyModifiableView.java
@@ -47,7 +47,7 @@ public interface DirectlyModifiableView {
      * @throws IOException Removal failed.
      * @throws IllegalArgumentException View rejected to remove an item.
      */
-    boolean remove(@NonNull TopLevelItem item) throws IOException, IllegalArgumentException;
+    boolean remove(@NonNull TopLevelItem item) throws IOException;
 
     /**
      * Add item to this view.
@@ -55,7 +55,7 @@ public interface DirectlyModifiableView {
      * @throws IOException Adding failed.
      * @throws IllegalArgumentException View rejected to add an item.
      */
-    void add(@NonNull TopLevelItem item) throws IOException, IllegalArgumentException;
+    void add(@NonNull TopLevelItem item) throws IOException;
 
     /**
      * Handle addJobToView web method.

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -561,7 +561,7 @@ public class Items {
      * @throws IllegalArgumentException if the move would really be a rename, or the destination cannot accept the item, or the destination already has an item of that name
      * @since 1.548
      */
-    public static <I extends AbstractItem & TopLevelItem> I move(I item, DirectlyModifiableTopLevelItemGroup destination) throws IOException, IllegalArgumentException {
+    public static <I extends AbstractItem & TopLevelItem> I move(I item, DirectlyModifiableTopLevelItemGroup destination) throws IOException {
         DirectlyModifiableTopLevelItemGroup oldParent = (DirectlyModifiableTopLevelItemGroup) item.getParent();
         if (oldParent == destination) {
             throw new IllegalArgumentException();

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -2117,7 +2117,7 @@ public class Queue extends ResourceController implements Saveable {
          * Called by {@link Executor} to perform the task.
          * @throws AsynchronousExecution if you would like to continue without consuming a thread
          */
-        @Override void run() throws AsynchronousExecution;
+        @Override void run();
 
         /**
          * Estimate of how long will it take to execute this executable.
@@ -3069,7 +3069,7 @@ public class Queue extends ResourceController implements Saveable {
         }
 
         @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
+        public void checkRoles(RoleChecker checker) {
             delegate.checkRoles(checker);
         }
     }

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -442,7 +442,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      * Only used for a legitimate user we have no idea about. We give it only minimum access
      */
     private static class LegitimateButUnknownUserDetails extends org.springframework.security.core.userdetails.User {
-        private LegitimateButUnknownUserDetails(String username) throws IllegalArgumentException {
+        private LegitimateButUnknownUserDetails(String username) {
             super(
                     username, "",
                     true, true, true, true,

--- a/core/src/main/java/hudson/model/listeners/RunListener.java
+++ b/core/src/main/java/hudson/model/listeners/RunListener.java
@@ -161,7 +161,7 @@ public abstract class RunListener<R extends Run> implements ExtensionPoint {
      *      to suppress a stack trace by the receiver.
      * @since 1.410
      */
-    public Environment setUpEnvironment(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, RunnerAbortedException {
+    public Environment setUpEnvironment(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         return new Environment() {};
     }
 

--- a/core/src/main/java/hudson/model/queue/Executables.java
+++ b/core/src/main/java/hudson/model/queue/Executables.java
@@ -43,7 +43,7 @@ public class Executables {
      * @return Discovered subtask
      */
     public static @NonNull SubTask getParentOf(@NonNull Executable e)
-            throws Error, RuntimeException {
+            throws Error {
         try {
             return e.getParent();
         } catch (AbstractMethodError ignored) { // will fallback to a private implementation

--- a/core/src/main/java/hudson/model/queue/MappingWorksheet.java
+++ b/core/src/main/java/hudson/model/queue/MappingWorksheet.java
@@ -396,6 +396,6 @@ public class MappingWorksheet {
 
         public abstract boolean isAvailable();
 
-        protected abstract void set(WorkUnit p) throws UnsupportedOperationException;
+        protected abstract void set(WorkUnit p);
     }
 }

--- a/core/src/main/java/hudson/security/ContainerAuthentication.java
+++ b/core/src/main/java/hudson/security/ContainerAuthentication.java
@@ -99,7 +99,7 @@ public final class ContainerAuthentication implements Authentication {
     }
 
     @Override
-    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+    public void setAuthenticated(boolean isAuthenticated) {
         // noop
     }
 

--- a/core/src/main/java/hudson/security/Permission.java
+++ b/core/src/main/java/hudson/security/Permission.java
@@ -139,7 +139,7 @@ public final class Permission {
      */
     public Permission(@NonNull PermissionGroup group, @NonNull String name,
             @CheckForNull Localizable description, @CheckForNull Permission impliedBy, boolean enable,
-            @NonNull PermissionScope[] scopes) throws IllegalStateException {
+            @NonNull PermissionScope[] scopes) {
         if (!JSONUtils.isJavaIdentifier(name))
             throw new IllegalArgumentException(name + " is not a Java identifier");
         this.owner = group.owner;

--- a/core/src/main/java/hudson/security/PermissionGroup.java
+++ b/core/src/main/java/hudson/security/PermissionGroup.java
@@ -60,7 +60,7 @@ public final class PermissionGroup implements Iterable<Permission>, Comparable<P
      * @param title sets {@link #title}
      * @throws IllegalStateException if this group was already registered
      */
-    public PermissionGroup(@NonNull Class owner, Localizable title) throws IllegalStateException {
+    public PermissionGroup(@NonNull Class owner, Localizable title) {
         this(title.toString(Locale.ENGLISH), owner, title);
     }
 
@@ -71,7 +71,7 @@ public final class PermissionGroup implements Iterable<Permission>, Comparable<P
      * @throws IllegalStateException if this group was already registered
      * @since 2.127
      */
-    public PermissionGroup(String id, @NonNull Class owner, Localizable title) throws IllegalStateException {
+    public PermissionGroup(String id, @NonNull Class owner, Localizable title) {
         this.owner = owner;
         this.title = title;
         this.id = id;

--- a/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
+++ b/core/src/main/java/hudson/slaves/ConnectionActivityMonitor.java
@@ -109,7 +109,7 @@ public class ConnectionActivityMonitor extends AsyncPeriodicWork {
 
     private static final class PingCommand extends SlaveToMasterCallable<Void, RuntimeException> {
         @Override
-        public Void call() throws RuntimeException {
+        public Void call() {
             return null;
         }
 

--- a/core/src/main/java/hudson/tasks/BuildWrapper.java
+++ b/core/src/main/java/hudson/tasks/BuildWrapper.java
@@ -206,7 +206,7 @@ public abstract class BuildWrapper extends AbstractDescribableImpl<BuildWrapper>
      * @since 1.280
      * @see LauncherDecorator
      */
-    public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, RunnerAbortedException {
+    public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         return launcher;
     }
 
@@ -233,7 +233,7 @@ public abstract class BuildWrapper extends AbstractDescribableImpl<BuildWrapper>
      * @since 1.374
      * @see ConsoleLogFilter
      */
-    public OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException, RunnerAbortedException {
+    public OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException {
         return logger;
     }
 

--- a/core/src/main/java/hudson/util/CompoundEnumeration.java
+++ b/core/src/main/java/hudson/util/CompoundEnumeration.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 
 /**
  * {@link Enumeration} that aggregates multiple {@link Enumeration}s.

--- a/core/src/main/java/hudson/util/CompoundEnumeration.java
+++ b/core/src/main/java/hudson/util/CompoundEnumeration.java
@@ -38,7 +38,7 @@ public class CompoundEnumeration<T> implements Enumeration<T> {
     }
 
     @Override
-    public T nextElement() throws NoSuchElementException {
+    public T nextElement() {
         return cur.nextElement();
     }
 }

--- a/core/src/main/java/hudson/util/RemotingDiagnostics.java
+++ b/core/src/main/java/hudson/util/RemotingDiagnostics.java
@@ -143,7 +143,7 @@ public final class RemotingDiagnostics {
 
         @Override
         @SuppressFBWarnings(value = "GROOVY_SHELL", justification = "script console is a feature, not a bug")
-        public String call() throws RuntimeException {
+        public String call() {
             // if we run locally, cl!=null. Otherwise the delegating classloader will be available as context classloader.
             if (cl == null)       cl = Thread.currentThread().getContextClassLoader();
             CompilerConfiguration cc = new CompilerConfiguration();

--- a/core/src/main/java/hudson/util/RingBufferLogHandler.java
+++ b/core/src/main/java/hudson/util/RingBufferLogHandler.java
@@ -121,5 +121,5 @@ public class RingBufferLogHandler extends Handler {
     public void flush() {}
 
     @Override
-    public void close() throws SecurityException {}
+    public void close() {}
 }

--- a/core/src/main/java/jenkins/MasterToSlaveFileCallable.java
+++ b/core/src/main/java/jenkins/MasterToSlaveFileCallable.java
@@ -18,7 +18,7 @@ import org.jenkinsci.remoting.RoleChecker;
  */
 public abstract class MasterToSlaveFileCallable<T> implements FileCallable<T> {
     @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
+    public void checkRoles(RoleChecker checker) {
         checker.check(this, Roles.SLAVE);
     }
 

--- a/core/src/main/java/jenkins/SlaveToMasterFileCallable.java
+++ b/core/src/main/java/jenkins/SlaveToMasterFileCallable.java
@@ -26,7 +26,7 @@ public abstract class SlaveToMasterFileCallable<T> implements FileCallable<T> {
     public static final Logger LOGGER = Logger.getLogger(SlaveToMasterFileCallable.class.getName());
 
     @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
+    public void checkRoles(RoleChecker checker) {
         warnOnController();
         checker.check(this, Roles.MASTER);
     }

--- a/core/src/main/java/jenkins/model/DirectlyModifiableTopLevelItemGroup.java
+++ b/core/src/main/java/jenkins/model/DirectlyModifiableTopLevelItemGroup.java
@@ -53,7 +53,7 @@ public interface DirectlyModifiableTopLevelItemGroup extends ModifiableTopLevelI
      * @throws IOException if adding fails
      * @throws IllegalArgumentException if {@link #canAdd} is false, or an item with this name already exists, or this item is as yet unnamed
      */
-    <I extends TopLevelItem> I add(I item, String name) throws IOException, IllegalArgumentException;
+    <I extends TopLevelItem> I add(I item, String name) throws IOException;
 
     /**
      * Removes an item from this group.
@@ -62,6 +62,6 @@ public interface DirectlyModifiableTopLevelItemGroup extends ModifiableTopLevelI
      * @throws IOException if removing fails
      * @throws IllegalArgumentException if this was not part of the group to begin with
      */
-    void remove(TopLevelItem item) throws IOException, IllegalArgumentException;
+    void remove(TopLevelItem item) throws IOException;
 
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -818,7 +818,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 2.98
      */
     @NonNull
-    public static Jenkins get() throws IllegalStateException {
+    public static Jenkins get() {
         Jenkins instance = getInstanceOrNull();
         if (instance == null) {
             throw new IllegalStateException("Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.");
@@ -832,7 +832,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @Deprecated
     @NonNull
-    public static Jenkins getActiveInstance() throws IllegalStateException {
+    public static Jenkins getActiveInstance() {
         return get();
     }
 
@@ -2514,7 +2514,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @since 1.66
      * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/Hyperlinks+in+HTML">Hyperlinks in HTML</a>
      */
-    public @Nullable String getRootUrl() throws IllegalStateException {
+    public @Nullable String getRootUrl() {
         final JenkinsLocationConfiguration config = JenkinsLocationConfiguration.get();
         String url = config.getUrl();
         if (url != null) {
@@ -3042,7 +3042,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * @throws IOException Failed to save the configuration
      * @throws IllegalArgumentException Negative value has been passed
      */
-    public void setNumExecutors(/* @javax.annotation.Nonnegative*/ int n) throws IOException, IllegalArgumentException {
+    public void setNumExecutors(/* @javax.annotation.Nonnegative*/ int n) throws IOException {
         if (n < 0) {
             throw new IllegalArgumentException("Incorrect field \"# of executors\": " + n + ". It should be a non-negative number.");
         }
@@ -3282,7 +3282,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return true;
     }
 
-    @Override public synchronized <I extends TopLevelItem> I add(I item, String name) throws IOException, IllegalArgumentException {
+    @Override public synchronized <I extends TopLevelItem> I add(I item, String name) throws IOException {
         if (items.containsKey(name)) {
             throw new IllegalArgumentException("already an item '" + name + "'");
         }
@@ -3290,7 +3290,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         return item;
     }
 
-    @Override public void remove(TopLevelItem item) throws IOException, IllegalArgumentException {
+    @Override public void remove(TopLevelItem item) throws IOException {
         items.remove(item.getName());
     }
 

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -592,7 +592,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
         return numberOnDisk.max();
     }
 
-    protected final synchronized void proposeNewNumber(int number) throws IllegalStateException {
+    protected final synchronized void proposeNewNumber(int number) {
         if (number <= maxNumberOnDisk()) {
             throw new IllegalStateException("JENKINS-27530: cannot create a build with number " + number + " since that (or higher) is already in use among " + numberOnDisk);
         }

--- a/core/src/main/java/jenkins/security/MasterToSlaveCallable.java
+++ b/core/src/main/java/jenkins/security/MasterToSlaveCallable.java
@@ -19,7 +19,7 @@ public abstract class MasterToSlaveCallable<V, T extends Throwable> implements C
     private static final long serialVersionUID = 1L;
 
     @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
+    public void checkRoles(RoleChecker checker) {
         checker.check(this, Roles.SLAVE);
     }
 }

--- a/core/src/main/java/jenkins/security/NotReallyRoleSensitiveCallable.java
+++ b/core/src/main/java/jenkins/security/NotReallyRoleSensitiveCallable.java
@@ -12,7 +12,7 @@ import org.jenkinsci.remoting.RoleChecker;
  */
 public abstract class NotReallyRoleSensitiveCallable<V, T extends Throwable> implements Callable<V, T> {
     @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
+    public void checkRoles(RoleChecker checker) {
         // not meant to be used where this matters
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/jenkins/security/SlaveToMasterCallable.java
+++ b/core/src/main/java/jenkins/security/SlaveToMasterCallable.java
@@ -11,7 +11,7 @@ import org.jenkinsci.remoting.RoleChecker;
  */
 public abstract class SlaveToMasterCallable<V, T extends Throwable> implements Callable<V, T> {
     @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
+    public void checkRoles(RoleChecker checker) {
         checker.check(this, Roles.MASTER);
     }
 

--- a/core/src/main/java/jenkins/security/s2m/CallableDirectionChecker.java
+++ b/core/src/main/java/jenkins/security/s2m/CallableDirectionChecker.java
@@ -39,7 +39,7 @@ public class CallableDirectionChecker extends RoleChecker {
     public static boolean BYPASS = SystemProperties.getBoolean(BYPASS_PROP);
 
     @Override
-    public void check(RoleSensitive subject, @NonNull Collection<Role> expected) throws SecurityException {
+    public void check(RoleSensitive subject, @NonNull Collection<Role> expected) {
         final String name = subject.getClass().getName();
 
         if (expected.contains(Roles.MASTER)) {

--- a/core/src/main/java/jenkins/tasks/SimpleBuildWrapper.java
+++ b/core/src/main/java/jenkins/tasks/SimpleBuildWrapper.java
@@ -339,7 +339,7 @@ public abstract class SimpleBuildWrapper extends BuildWrapper {
         return null;
     }
 
-    @Override public final OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException, Run.RunnerAbortedException {
+    @Override public final OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException {
         ConsoleLogFilter filter = createLoggerDecorator(build);
         return filter != null ? filter.decorateLogger(build, logger) : logger;
     }
@@ -349,7 +349,7 @@ public abstract class SimpleBuildWrapper extends BuildWrapper {
      * <p>{@inheritDoc}
      * @since 1.608
      */
-    @Override public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
+    @Override public Launcher decorateLauncher(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
         return super.decorateLauncher(build, launcher, listener);
         // TODO reasonable to decorate Launcher within a dynamic scope, but this signature does not mix well with Context pattern.
         // Called from AbstractBuildExecution.createLauncher; how do we track what is decorating what?

--- a/core/src/main/java/jenkins/util/ResourceBundleUtil.java
+++ b/core/src/main/java/jenkins/util/ResourceBundleUtil.java
@@ -54,7 +54,7 @@ public final class ResourceBundleUtil {
      * @return The bundle JSON.
      * @throws MissingResourceException Missing resource bundle.
      */
-    public static @NonNull JSONObject getBundle(@NonNull String baseName) throws MissingResourceException {
+    public static @NonNull JSONObject getBundle(@NonNull String baseName) {
         return getBundle(baseName, Locale.getDefault());
     }
 
@@ -65,7 +65,7 @@ public final class ResourceBundleUtil {
      * @return The bundle JSON.
      * @throws MissingResourceException Missing resource bundle.
      */
-    public static @NonNull JSONObject getBundle(@NonNull String baseName, @NonNull Locale locale) throws MissingResourceException {
+    public static @NonNull JSONObject getBundle(@NonNull String baseName, @NonNull Locale locale) {
         var bundleKey = baseName + ":" + locale;
         var bundleJSON = bundles.get(bundleKey);
 

--- a/core/src/main/java/jenkins/util/SystemProperties.java
+++ b/core/src/main/java/jenkins/util/SystemProperties.java
@@ -153,7 +153,7 @@ public class SystemProperties {
             }
 
             @Override
-            public Void call() throws RuntimeException {
+            public Void call() {
                 handler = new CopiedHandler(snapshot);
                 return null;
             }

--- a/core/src/main/java/jenkins/util/io/PathRemover.java
+++ b/core/src/main/java/jenkins/util/io/PathRemover.java
@@ -100,7 +100,7 @@ public class PathRemover {
     @Restricted(NoExternalUse.class)
     @FunctionalInterface
     public interface PathChecker {
-        void check(@NonNull Path path) throws SecurityException;
+        void check(@NonNull Path path);
 
         PathChecker ALLOW_ALL = path -> {};
     }

--- a/core/src/main/java/org/acegisecurity/Authentication.java
+++ b/core/src/main/java/org/acegisecurity/Authentication.java
@@ -49,7 +49,7 @@ public interface Authentication extends Principal, Serializable {
 
     boolean isAuthenticated();
 
-    void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException;
+    void setAuthenticated(boolean isAuthenticated);
 
     static @NonNull Authentication fromSpring(@NonNull org.springframework.security.core.Authentication a) {
         Objects.requireNonNull(a);
@@ -90,7 +90,7 @@ public interface Authentication extends Principal, Serializable {
                 }
 
                 @Override
-                public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+                public void setAuthenticated(boolean isAuthenticated) {
                     a.setAuthenticated(isAuthenticated);
                 }
 

--- a/core/src/main/java/org/acegisecurity/AuthenticationSpringImpl.java
+++ b/core/src/main/java/org/acegisecurity/AuthenticationSpringImpl.java
@@ -62,7 +62,7 @@ final class AuthenticationSpringImpl implements org.springframework.security.cor
     }
 
     @Override
-    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+    public void setAuthenticated(boolean isAuthenticated) {
         delegate.setAuthenticated(isAuthenticated);
     }
 

--- a/core/src/main/java/org/acegisecurity/providers/UsernamePasswordAuthenticationToken.java
+++ b/core/src/main/java/org/acegisecurity/providers/UsernamePasswordAuthenticationToken.java
@@ -82,7 +82,7 @@ public class UsernamePasswordAuthenticationToken implements Authentication {
     }
 
     @Override
-    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+    public void setAuthenticated(boolean isAuthenticated) {
         delegate.setAuthenticated(isAuthenticated);
     }
 

--- a/core/src/main/java/org/acegisecurity/providers/anonymous/AnonymousAuthenticationToken.java
+++ b/core/src/main/java/org/acegisecurity/providers/anonymous/AnonymousAuthenticationToken.java
@@ -79,7 +79,7 @@ public class AnonymousAuthenticationToken implements Authentication, Serializabl
     }
 
     @Override
-    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+    public void setAuthenticated(boolean isAuthenticated) {
         delegate.setAuthenticated(isAuthenticated);
     }
 


### PR DESCRIPTION
The aim of this RP is to remove violations of the Sonar rule S1130 Exceptions in 'throws' clauses should not be superfluous.

Superfluous exceptions within throws clauses have negative effects on the readability and maintainability of the code. An exception in a throws clause is superfluous if it is:

- listed multiple times
- a subclass of another listed exception
- not actually thrown by any execution path of the method (This case is not currently supported by Indepth)

These changes have been made automatically by our "Indepth" java code remediation solution, which aims to improve code quality. You can also use it periodically to remove issues that have appeared in the source code. Use of this solution is free for all open source projects. You can find all the documentation and the download link on the site https://www.indepth.fr/