### PR TITLE
Fill in since todos

### DIFF
--- a/cli/src/main/java/hudson/cli/CLIConnectionFactory.java
+++ b/cli/src/main/java/hudson/cli/CLIConnectionFactory.java
@@ -25,7 +25,7 @@ public class CLIConnectionFactory {
     /**
      * Skip TLS certificate and hostname verification checks.
      *
-     * @since TODO
+     * @since 2.444
      */
     public CLIConnectionFactory noCertificateCheck(boolean value) {
         this.noCertificateCheck = value;

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -317,7 +317,7 @@ public abstract class Lifecycle implements ExtensionPoint {
      * Whether {@link PluginManager#dynamicLoad(File)} should be supported at all.
      * If not, {@link RestartRequiredException} will always be thrown.
      * @return true by default
-     * @since TODO
+     * @since 2.449
      */
     @Restricted(Beta.class)
     public boolean supportsDynamicLoad() {

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -184,7 +184,7 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
      * @param dir The root directory the item was loaded from.
      * @param item the partially loaded item (take care what methods you call, the item will not have a reference to its parent).
      *
-     * @since TODO
+     * @since 2.444
      */
     default String getItemName(File dir, T item) {
         return dir.getName();

--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -98,7 +98,7 @@ public final class RunMap<R extends Run<?, R>> extends AbstractLazyLoadRunMap<R>
     /**
      * @param cons
      *      Used to create new instance of {@link Run}.
-     * @since TODO
+     * @since 2.451
      */
     public RunMap(@NonNull Job<?, ?> job, Constructor cons) {
         this.job = Objects.requireNonNull(job);

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -496,7 +496,7 @@ public class UpdateSite {
     /**
      *
      * @return the URL used by {@link jenkins.install.SetupWizard} for suggested plugins to install at setup time
-     * @since TODO
+     * @since 2.446
      */
     @Exported
     public String getSuggestedPluginsUrl() {

--- a/core/src/main/java/hudson/security/AbstractPasswordBasedSecurityRealm.java
+++ b/core/src/main/java/hudson/security/AbstractPasswordBasedSecurityRealm.java
@@ -84,7 +84,7 @@ public abstract class AbstractPasswordBasedSecurityRealm extends SecurityRealm {
 
     /**
      * A public alias of @{link {@link #authenticate2(String, String)}.
-     * @since TODO
+     * @since 2.444
      */
     @Restricted(Beta.class)
     public final UserDetails authenticateByPassword(String username, String password) throws AuthenticationException {

--- a/core/src/main/java/hudson/util/io/ArchiverFactory.java
+++ b/core/src/main/java/hudson/util/io/ArchiverFactory.java
@@ -55,7 +55,7 @@ public abstract class ArchiverFactory implements Serializable {
      * Creates an archiver on top of the given stream.
      *
      * @param filenamesEncoding the encoding to be used in the archive for file names
-     * @since TODO
+     * @since 2.449
      */
     @NonNull
     public abstract Archiver create(OutputStream out, Charset filenamesEncoding) throws IOException;

--- a/core/src/main/java/jenkins/websocket/WebSockets.java
+++ b/core/src/main/java/jenkins/websocket/WebSockets.java
@@ -70,7 +70,7 @@ public class WebSockets {
 
     /**
      * Variant of {@link #upgrade} that does not presume a {@link StaplerRequest}.
-     * @since TODO
+     * @since 2.446
      */
     public static void upgradeResponse(WebSocketSession session, HttpServletRequest req, HttpServletResponse rsp) throws IOException, ServletException {
         if (provider == null) {

--- a/core/src/main/resources/lib/layout/badge.jelly
+++ b/core/src/main/resources/lib/layout/badge.jelly
@@ -26,16 +26,16 @@ THE SOFTWARE.
   <st:documentation>
     If a Badge is informed it will be displayed, otherwise nothing is done.
     
-    @since TODO
+    @since 2.445
     <st:attribute name="badge" type="jenkins.management.Badge">
       Badge to be displayed, accepts null value.
       
-      @since TODO
+      @since 2.445
     </st:attribute>
     <st:attribute name="class" use="optional">
       Additional class to be applied.
       
-      @since TODO
+      @since 2.445
     </st:attribute>
   </st:documentation>
   <j:if test="${attrs.badge != null}">

--- a/core/src/main/resources/lib/layout/copyButton.jelly
+++ b/core/src/main/resources/lib/layout/copyButton.jelly
@@ -45,7 +45,7 @@ THE SOFTWARE.
     </st:attribute>
     <st:attribute name="ref" use="required">
       The id of the target element to be copied
-      @since TODO
+      @since 2.449
     </st:attribute>
   </st:documentation>
 


### PR DESCRIPTION
```
Analyzing cli/src/main/java/hudson/cli/CLIConnectionFactory.java:28
        first sha: 48f0f923d54bc43358e458874a6cf4e42cc875df
        first tag was jenkins-2.444
        Updating file in place
Analyzing core/src/main/java/hudson/lifecycle/Lifecycle.java:320
        first sha: 46b0db778344fd705418535bc6a7f55b88e4db30
        first tag was jenkins-2.449
        Updating file in place
Analyzing core/src/main/java/hudson/model/ItemGroup.java:187
        first sha: 57419f43b9bb89d564cee4913dd4a3216ba1e360
        first tag was jenkins-2.444
        Updating file in place
Analyzing core/src/main/java/hudson/model/RunMap.java:101
        first sha: 5cec09d7edc74b40a58c6ded83e86e18241be3a0
        first tag was jenkins-2.451
        Updating file in place
Analyzing core/src/main/java/hudson/model/UpdateSite.java:499
        first sha: 824f64c23e52e5c765cc7604414740aab3436f8d
        first tag was jenkins-2.446
        Updating file in place
Analyzing core/src/main/java/hudson/security/AbstractPasswordBasedSecurityRealm.java:87
        first sha: 81679b4598a3550d5e776ca070661efb8f2eb862
        first tag was jenkins-2.444
        Updating file in place
Analyzing core/src/main/java/hudson/util/io/ArchiverFactory.java:58
        first sha: 9f68c181de2b710ce6b9f05b09d9475a89ab6fe8
        first tag was jenkins-2.449
        Updating file in place
Analyzing core/src/main/java/jenkins/websocket/WebSockets.java:73
        first sha: db61f04af8e553dc55d2cb2fa18fa5581dab4310
        first tag was jenkins-2.446
        Updating file in place
Analyzing core/src/main/resources/lib/layout/badge.jelly:29
        first sha: 8b949243a92cc0ff89742be6b509920db0e0a456
        first tag was jenkins-2.445
        Updating file in place
Analyzing core/src/main/resources/lib/layout/badge.jelly:33
        first sha: 8b949243a92cc0ff89742be6b509920db0e0a456
        first tag was jenkins-2.445
        Updating file in place
Analyzing core/src/main/resources/lib/layout/badge.jelly:38
        first sha: 8b949243a92cc0ff89742be6b509920db0e0a456
        first tag was jenkins-2.445
        Updating file in place
Analyzing core/src/main/resources/lib/layout/copyButton.jelly:48
        first sha: b0a251ab8cfbad9c5ed32fb1fdd2081a869d4e1e
        first tag was jenkins-2.449
        Updating file in place
```

List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.444
  - https://github.com/jenkinsci/jenkins/commit/48f0f923d54bc43358e458874a6cf4e42cc875df
  - https://github.com/jenkinsci/jenkins/commit/57419f43b9bb89d564cee4913dd4a3216ba1e360
  - https://github.com/jenkinsci/jenkins/commit/81679b4598a3550d5e776ca070661efb8f2eb862
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.445
  - https://github.com/jenkinsci/jenkins/commit/8b949243a92cc0ff89742be6b509920db0e0a456
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.446
  - https://github.com/jenkinsci/jenkins/commit/824f64c23e52e5c765cc7604414740aab3436f8d
  - https://github.com/jenkinsci/jenkins/commit/db61f04af8e553dc55d2cb2fa18fa5581dab4310
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.449
  - https://github.com/jenkinsci/jenkins/commit/46b0db778344fd705418535bc6a7f55b88e4db30
  - https://github.com/jenkinsci/jenkins/commit/9f68c181de2b710ce6b9f05b09d9475a89ab6fe8
  - https://github.com/jenkinsci/jenkins/commit/b0a251ab8cfbad9c5ed32fb1fdd2081a869d4e1e
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.451
  - https://github.com/jenkinsci/jenkins/commit/5cec09d7edc74b40a58c6ded83e86e18241be3a0
