### PR TITLE
[JENKINS-65829] Fix WorkspaceCleanupThread to consider suffixed workspaces even if original is inexistent

### DIFF
--- a/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
+++ b/core/src/main/java/hudson/model/WorkspaceCleanupThread.java
@@ -24,6 +24,8 @@
 
 package hudson.model;
 
+import static hudson.Util.fileToPath;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
@@ -31,12 +33,19 @@ import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Functions;
 import hudson.Util;
+import hudson.remoting.VirtualChannel;
+import hudson.slaves.WorkspaceList;
+import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
 import jenkins.util.SystemProperties;
@@ -90,8 +99,7 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
                 if (check) {
                     listener.getLogger().println("Deleting " + ws + " on " + node.getDisplayName());
                     try {
-                        ws.deleteSuffixesRecursive();
-                        ws.deleteRecursive();
+                        ws.act(new CleanupOldWorkspaces());
                     } catch (IOException | InterruptedException x) {
                         Functions.printStackTrace(x, listener.error("Failed to delete " + ws + " on " + node.getDisplayName()));
                     }
@@ -101,21 +109,6 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
     }
 
     private boolean shouldBeDeleted(@NonNull TopLevelItem item, FilePath dir, @NonNull Node n) throws IOException, InterruptedException {
-        // TODO: the use of remoting is not optimal.
-        // One remoting can execute "exists", "lastModified", and "delete" all at once.
-        // (Could even invert master loop so that one FileCallable takes care of all known items.)
-        if (!dir.exists()) {
-            LOGGER.log(Level.FINE, "Directory {0} does not exist", dir);
-            return false;
-        }
-
-        // if younger than a month, keep it
-        long now = new Date().getTime();
-        if (dir.lastModified() + retainForDays * DAY > now) {
-            LOGGER.log(Level.FINE, "Directory {0} is only {1} old, so not deleting", new Object[] {dir, Util.getTimeSpanString(now - dir.lastModified())});
-            return false;
-        }
-
         // TODO could also be good to add checkbox that lets users configure a workspace to never be auto-cleaned.
 
         // TODO check instead for SCMTriggerItem:
@@ -143,9 +136,58 @@ public class WorkspaceCleanupThread extends AsyncPeriodicWork {
                 return false;
             }
         }
-
-        LOGGER.log(Level.FINER, "Going to delete directory {0}", dir);
         return true;
+    }
+
+    private static class CleanupOldWorkspaces extends MasterToSlaveFileCallable<Void> {
+
+        @Override
+        public Void invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+            File[] workspaces = null;
+            File parentWs = f.getParentFile();
+            if (parentWs != null) {
+                workspaces = parentWs.listFiles(new ShouldBeDeletedFilter(f.getName()));
+            }
+
+            if (workspaces != null) {
+                for (File workspace : workspaces) {
+                    LOGGER.log(Level.FINER, "Going to delete directory {0}", workspace);
+                    Util.deleteRecursive(fileToPath(workspace), Path::toFile);
+                }
+            }
+            return null;
+        }
+    }
+
+    private static class ShouldBeDeletedFilter implements FileFilter, Serializable {
+
+        private final String workspaceBaseName;
+
+        ShouldBeDeletedFilter(String workspaceBaseName) {
+            this.workspaceBaseName = workspaceBaseName;
+        }
+
+        @Override
+        public boolean accept(File dir) {
+
+            if (!dir.isDirectory()) {
+                return false;
+            }
+
+            // if not the workspace or a workspace suffix
+            if (!dir.getName().equals(workspaceBaseName) && !dir.getName().startsWith(workspaceBaseName + WorkspaceList.COMBINATOR)) {
+                return false;
+            }
+
+            // if younger than a month, keep it
+            long now = new Date().getTime();
+            if (dir.lastModified() + retainForDays * DAY > now) {
+                LOGGER.log(Level.FINE, "Directory {0} is only {1} old, so not deleting", new Object[] {dir, Util.getTimeSpanString(now - dir.lastModified())});
+                return false;
+            }
+
+            return true;
+        }
     }
 
     private static final Logger LOGGER = Logger.getLogger(WorkspaceCleanupThread.class.getName());

--- a/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
+++ b/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import jenkins.MasterToSlaveFileCallable;
+import jenkins.model.Jenkins;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -187,6 +188,22 @@ public class WorkspaceCleanupThreadTest {
         assertFalse("temporary directory should be cleaned up as well", tmp.exists());
     }
 
+    @Issue("JENKINS-65829")
+    @Test
+    public void deleteSoleTemporaryDirectory() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject();
+        FilePath jobWs = Jenkins.get().getWorkspaceFor(p);
+        FilePath libsWs = jobWs.withSuffix(WorkspaceList.COMBINATOR + "libs");
+        libsWs.child("test-libs").write("content", null);
+        libsWs.act(new Touch(0));
+//        FilePath jobWsOnNode = createOldWorkspaceOn(r.createOnlineSlave(), p);
+        assertFalse(jobWs.exists());
+        assertTrue(libsWs.exists());
+        performCleanup();
+        assertFalse(jobWs.exists());
+        assertFalse("libs directory should be cleaned up as well", libsWs.exists());
+    }
+
     private FilePath createOldWorkspaceOn(Node slave, FreeStyleProject p) throws Exception {
         p.setAssignedNode(slave);
         FreeStyleBuild b1 = r.buildAndAssertSuccess(p);
@@ -195,6 +212,13 @@ public class WorkspaceCleanupThreadTest {
         assertNotNull(ws);
         ws.act(new Touch(0));
         return ws;
+    }
+
+    private FilePath createOldLibsWorkspace(FreeStyleProject p) throws IOException, InterruptedException {
+        FilePath libsWs = Jenkins.get().getWorkspaceFor(p).withSuffix(WorkspaceList.COMBINATOR + "libs");
+        libsWs.child("test-libs").write("content", null);
+        libsWs.act(new Touch(0));
+        return libsWs;
     }
 
     private void performCleanup() throws InterruptedException, IOException {

--- a/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
+++ b/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
@@ -182,6 +182,7 @@ public class WorkspaceCleanupThreadTest {
         FilePath ws = createOldWorkspaceOn(r.jenkins, p);
         FilePath tmp = WorkspaceList.tempDir(ws);
         tmp.child("stuff").write("content", null);
+        tmp.act(new Touch(0));
         createOldWorkspaceOn(r.createOnlineSlave(), p);
         performCleanup();
         assertFalse(ws.exists());
@@ -190,13 +191,12 @@ public class WorkspaceCleanupThreadTest {
 
     @Issue("JENKINS-65829")
     @Test
-    public void deleteSoleTemporaryDirectory() throws Exception {
+    public void deleteSoleLibsDirectory() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
         FilePath jobWs = Jenkins.get().getWorkspaceFor(p);
         FilePath libsWs = jobWs.withSuffix(WorkspaceList.COMBINATOR + "libs");
         libsWs.child("test-libs").write("content", null);
         libsWs.act(new Touch(0));
-//        FilePath jobWsOnNode = createOldWorkspaceOn(r.createOnlineSlave(), p);
         assertFalse(jobWs.exists());
         assertTrue(libsWs.exists());
         performCleanup();


### PR DESCRIPTION
See [JENKINS-65829](https://issues.jenkins.io/browse/JENKINS-65829). The `WorkspaceCleanupThread` was not considering workspaces with suffixes if the original workspace did not exist. Typically `@libs` workspaces on a controller.

Reworked the `WorkspaceCleanupThread` to reduce the number of remoting calls by creating a `MasterToSlaveFileCallable` that do filtering + deletion. There used to be multiple calls to check if directory exists, the last modified date, do a delete recursive, do a delete of the suffixes. 

* https://github.com/jenkinsci/jenkins/blob/jenkins-2.451/core/src/main/java/hudson/model/WorkspaceCleanupThread.java#L107 (this was actually a problem because the we can have suffixed workspaces that exist but the workspace actually does not)
* https://github.com/jenkinsci/jenkins/blob/jenkins-2.451/core/src/main/java/hudson/model/WorkspaceCleanupThread.java#L114 
* https://github.com/jenkinsci/jenkins/blob/jenkins-2.451/core/src/main/java/hudson/model/WorkspaceCleanupThread.java#L93
* https://github.com/jenkinsci/jenkins/blob/jenkins-2.451/core/src/main/java/hudson/model/WorkspaceCleanupThread.java#L94

Now reduced to only one remoting call.

https://github.com/Dohbedoh/jenkins/blob/JENKINS-65829/core/src/main/java/hudson/model/WorkspaceCleanupThread.java#L102

**Note: the retention is check on each directory. Before, we used to check the last modified date of the WORKSPACE directory and if older than 30 day, we would delete it and all suffixed workspace. Now we check the last modified date of each directory. Which makes sense to me. WDYT ?**

### Testing done

#### Test 1

* Start Jenkins
* Set up a remote agent
* Create a pipeline that clones a library:

```
@Library("testLibs") _
node ('test') {
    writeFile(file: "test.txt", text: "test")
}
```

* Build the job
* Run the following in the script console to execute the thread run:

```
hudson.model.WorkspaceCleanupThread.retainForDays=0
hudson.model.AsyncPeriodicWork.all().get(WorkspaceCleanupThread.class).run()
```

--> Validate that the `$WORKSPACE@libs` on the controller is removed

#### Test 2

* Following Test 1, create suffixed workspaces in the agent workspace directory `$WORKSPACE@tmp`, `$WORKSPACE@test`.
* Edit the pipeline to run on the `built-in` node - we need to to this because the cleanup thread preserve [the workspace of the last build](https://github.com/jenkinsci/jenkins/blob/jenkins-2.303.3/core/src/main/java/hudson/model/WorkspaceCleanupThread.java#L126). So we want to test that everything on the agent (previous build) gets cleaned up.
* Run the following in the script console to execute the thread run:

```
hudson.model.WorkspaceCleanupThread.retainForDays=0
hudson.model.AsyncPeriodicWork.all().get(WorkspaceCleanupThread.class).run()
```

--> Validate that the `$WORKSPACE`, `$WORKSPACE@libs` and `$WORKSPACE@tmp` on the agent are removed

### Proposed changelog entries

- JENKINS-65829, Fix `WorkspaceCleanupThread` to consider workspaces with suffixes even if the original is inexistent
- Reduce number of remoting calls made by `WorkspaceCleanupThread`

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

-

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
