### PR TITLE
Replace usages of `org.apache.commons.lang.StringEscapeUtils` with Guava

### DIFF
--- a/core/src/main/java/hudson/console/ConsoleAnnotationOutputStream.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotationOutputStream.java
@@ -36,8 +36,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.util.SourceCodeEscapers;
 import org.apache.commons.io.output.ProxyWriter;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.kohsuke.stapler.framework.io.WriterOutputStream;
 
 /**
@@ -122,7 +122,7 @@ public class ConsoleAnnotationOutputStream<T> extends LineTransformationOutputSt
                     }
                 } catch (IOException | ClassNotFoundException e) {
                     // if we failed to resurrect an annotation, ignore it.
-                    LOGGER.log(Level.FINE, "Failed to resurrect annotation from \"" + StringEscapeUtils.escapeJava(new String(in, next, rest, Charset.defaultCharset())) + "\"", e);
+                    LOGGER.log(Level.FINE, "Failed to resurrect annotation from \"" + SourceCodeEscapers.javaCharEscaper().escape(new String(in, next, rest, Charset.defaultCharset())) + "\"", e);
                 }
 
                 int bytesUsed = rest - b.available(); // bytes consumed by annotations

--- a/core/src/main/java/hudson/console/PlainTextConsoleOutputStream.java
+++ b/core/src/main/java/hudson/console/PlainTextConsoleOutputStream.java
@@ -31,7 +31,7 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.lang.StringEscapeUtils;
+import jenkins.util.SourceCodeEscapers;
 
 /**
  * Filters out console notes.
@@ -73,7 +73,7 @@ public class PlainTextConsoleOutputStream extends LineTransformationOutputStream
             try {
                 ConsoleNote.skip(new DataInputStream(b));
             } catch (IOException x) {
-                LOGGER.log(Level.FINE, "Failed to skip annotation from \"" + StringEscapeUtils.escapeJava(new String(in, next, rest, Charset.defaultCharset())) + "\"", x);
+                LOGGER.log(Level.FINE, "Failed to skip annotation from \"" + SourceCodeEscapers.javaCharEscaper().escape(new String(in, next, rest, Charset.defaultCharset())) + "\"", x);
             }
 
             int bytesUsed = rest - b.available(); // bytes consumed by annotations

--- a/core/src/main/java/jenkins/util/SourceCodeEscapers.java
+++ b/core/src/main/java/jenkins/util/SourceCodeEscapers.java
@@ -1,0 +1,51 @@
+package jenkins.util;
+
+import com.google.common.escape.ArrayBasedCharEscaper;
+import com.google.common.escape.CharEscaper;
+import com.google.common.escape.Escaper;
+import java.util.Map;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+public final class SourceCodeEscapers {
+
+    // Suppress default constructor for noninstantiability
+    private SourceCodeEscapers() {
+        throw new AssertionError();
+    }
+
+    private static final Map<Character, String> REPLACEMENTS = Map.of(
+            '\b', "\\b",
+            '\f', "\\f",
+            '\n', "\\n",
+            '\r', "\\r",
+            '\t', "\\t",
+            '\"', "\\\"",
+            '\\', "\\\\");
+
+    private static final char PRINTABLE_ASCII_MIN = 0x20;
+
+    private static final char PRINTABLE_ASCII_MAX = 0x7E;
+
+    private static final CharEscaper JAVA_CHAR_ESCAPER = new JavaCharEscaper();
+
+    /**
+     * Returns an {@link Escaper} instance that escapes special characters in a string so it can
+     * safely be included in either a Java character literal or string literal.
+     */
+    public static CharEscaper javaCharEscaper() {
+        return JAVA_CHAR_ESCAPER;
+    }
+
+    private static class JavaCharEscaper extends ArrayBasedCharEscaper {
+        JavaCharEscaper() {
+            super(REPLACEMENTS, PRINTABLE_ASCII_MIN, PRINTABLE_ASCII_MAX);
+        }
+
+        @Override
+        protected char[] escapeUnsafe(char c) {
+            return String.format("\\u%04X", (int) c).toCharArray();
+        }
+    }
+}

--- a/core/src/test/java/jenkins/util/SourceCodeEscapersTest.java
+++ b/core/src/test/java/jenkins/util/SourceCodeEscapersTest.java
@@ -1,0 +1,42 @@
+package jenkins.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+public class SourceCodeEscapersTest {
+
+    @Test
+    public void testJavaCharEscaper() {
+        assertThrows(NullPointerException.class, () -> SourceCodeEscapers.javaCharEscaper()
+                .escape(null));
+        assertEquals("", SourceCodeEscapers.javaCharEscaper().escape(""));
+
+        assertEquals("foo", SourceCodeEscapers.javaCharEscaper().escape("foo"));
+        assertEquals("\\t", SourceCodeEscapers.javaCharEscaper().escape("\t"));
+        assertEquals("\\\\", SourceCodeEscapers.javaCharEscaper().escape("\\"));
+        assertEquals("'", SourceCodeEscapers.javaCharEscaper().escape("'"));
+        assertEquals("\\\\\\b\\t\\r", SourceCodeEscapers.javaCharEscaper().escape("\\\b\t\r"));
+        assertEquals("\\u1234", SourceCodeEscapers.javaCharEscaper().escape("\u1234"));
+        assertEquals("\\u0234", SourceCodeEscapers.javaCharEscaper().escape("\u0234"));
+        assertEquals("\\u00EF", SourceCodeEscapers.javaCharEscaper().escape("\u00ef"));
+        assertEquals("\\u0001", SourceCodeEscapers.javaCharEscaper().escape("\u0001"));
+        assertEquals("\\uABCD", SourceCodeEscapers.javaCharEscaper().escape("\uabcd"));
+
+        assertEquals(
+                "He didn't say, \\\"stop!\\\"",
+                SourceCodeEscapers.javaCharEscaper().escape("He didn't say, \"stop!\""));
+        assertEquals(
+                "This space is non-breaking:\\u00A0",
+                SourceCodeEscapers.javaCharEscaper().escape("This space is non-breaking:\u00a0"));
+        assertEquals(
+                "\\uABCD\\u1234\\u012C", SourceCodeEscapers.javaCharEscaper().escape("\uABCD\u1234\u012C"));
+        assertEquals(
+                "\\uD83D\\uDC80\\uD83D\\uDD14",
+                SourceCodeEscapers.javaCharEscaper().escape("\ud83d\udc80\ud83d\udd14"));
+        assertEquals(
+                "String with a slash (/) in it",
+                SourceCodeEscapers.javaCharEscaper().escape("String with a slash (/) in it"));
+    }
+}


### PR DESCRIPTION
Replace the unmaintained Commons Lang 2 functionality with Guava. Note that the Guava functionality is not fully open-source pending https://github.com/google/guava/issues/1620, so I filled in the gap with a Jenkins-specific `SourceCodeEscapers` class and test. Once https://github.com/google/guava/issues/1620 is closed, then this class and test can be deleted in favor of the upstream version.

### Testing done

New unit test passes. In addition, I manually compared the output before and after this PR with realistic data in `ConsoleAnnotationOutputStream` and `PlainTextConsoleOutputStream` and found that there were no changes.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
