### PR TITLE
replace usage of old build status sprite svgs with the new symbol-status svgs

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/updates.jelly
+++ b/core/src/main/resources/hudson/PluginManager/updates.jelly
@@ -236,11 +236,5 @@ THE SOFTWARE.
         <d:invokeBody/>
       </form>
     </l:main-panel>
-    <div class="grey-anime-preload" style="display:none">
-      <l:icon class="icon-grey-anime icon-md"/>
-      <l:icon class="icon-blue icon-md"/>
-      <l:icon class="icon-red icon-md"/>
-      <l:icon class="icon-grey icon-md"/>
-    </div>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/CompleteBatchJob/Failure/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/CompleteBatchJob/Failure/status.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
-    <l:icon class="icon-red icon-md"/> ${%Failure}
+    <l:icon src="symbol-status-red" class="icon-md"/> ${%Failure}
     -
     <a class="update-center-job-failure-show-details" href="">${%Details}</a>
   </div>

--- a/core/src/main/resources/hudson/model/UpdateCenter/CompleteBatchJob/Pending/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/CompleteBatchJob/Pending/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:icon class="icon-nobuilt icon-md"/> ${%Pending}
+  <l:icon src="symbol-status-nobuilt" class="icon-md"/> ${%Pending}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/CompleteBatchJob/Running/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/CompleteBatchJob/Running/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:icon class="icon-nobuilt-anime icon-md"/> ${%Running}
+  <l:icon src="symbol-status-nobuilt-anime" class="icon-md"/> ${%Running}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/CompleteBatchJob/Success/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/CompleteBatchJob/Success/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:icon class="icon-blue icon-md"/> ${%Success}
+  <l:icon src="symbol-status-blue" class="icon-md"/> ${%Success}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Failure/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Failure/status.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
-    <l:icon class="icon-red icon-md"/> ${%Failure}
+    <l:icon src="symbol-status-red" class="icon-md"/> ${%Failure}
     -
     <a class="update-center-job-failure-show-details" href="">${%Details}</a>
   </div>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Installing/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Installing/status.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
-    <l:icon class="icon-nobuilt-anime icon-md"/> ${%Installing}
+    <l:icon src="symbol-status-nobuilt-anime" class="icon-md"/> ${%Installing}
   </div>
   <div style="padding-left: 32px">
     <t:progressBar pos="${it.percentage}" animate="true"/>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Pending/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Pending/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:icon class="icon-nobuilt icon-md"/> ${%Pending}
+  <l:icon src="symbol-status-nobuilt" class="icon-md"/> ${%Pending}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Skipped/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Skipped/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:icon class="icon-nobuilt icon-md"/> ${%Skipped}
+  <l:icon src="symbol-status-aborted" class="icon-md" /> ${%Skipped}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Success/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Success/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:icon class="icon-blue icon-md"/> ${%Success}
+  <l:icon src="symbol-status-blue" class="icon-md"/> ${%Success}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/SuccessButRequiresRestart/status.groovy
+++ b/core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/SuccessButRequiresRestart/status.groovy
@@ -24,6 +24,6 @@
 
 def l = namespace(lib.LayoutTagLib)
 
-l.icon(class: 'icon-yellow icon-md')
+l.icon(src:'symbol-status-yellow', class: 'icon-md')
 text(" ")
 text(my.message)

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Canceled/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Canceled/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:icon class="icon-red icon-md"/> ${%Canceled}
+  <l:icon src="symbol-status-red" class="icon-md"/> ${%Canceled}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Failure/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:icon class="icon-red icon-md"/> ${%Failure}
+  <l:icon src="symbol-status-red" class="icon-md"/> ${%Failure}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Pending/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:icon class="icon-nobuilt icon-md"/> ${%Pending}
+  <l:icon src="symbol-status-nobuilt" class="icon-md"/> ${%Pending}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Running/status.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/RestartJenkinsJob/Running/status.jelly
@@ -24,5 +24,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:icon class="icon-nobuilt-anime icon-md"/> ${%Running}
+  <l:icon src="symbol-status-nobuilt-anime" class="icon-md"/> ${%Running}
 </j:jelly>

--- a/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/body.jelly
@@ -43,12 +43,6 @@ THE SOFTWARE.
           (${%you can start using the installed plugins right away}) <!-- leave this text in for a while until users are retrained to expect plugins to work right away without restart -->
         </p>
         <l:isAdmin>
-          <div class="grey-anime-preload" style="display:none">
-            <l:icon class="icon-nobuilt-anime icon-md"/>
-            <l:icon class="icon-blue icon-md"/>
-            <l:icon class="icon-red icon-md"/>
-            <l:icon class="icon-nobuilt icon-md"/>
-          </div>
           <j:if test="${app.lifecycle.canRestart()}">
             <p class="info">
               <f:checkbox checked="${app.isQuietingDown() or it.isRestartScheduled()}" id="scheduleRestartCheckbox" name="scheduleRestart" title="${%warning}" />

--- a/core/src/main/resources/jenkins/widgets/HistoryPageFilter/queue-items.jelly
+++ b/core/src/main/resources/jenkins/widgets/HistoryPageFilter/queue-items.jelly
@@ -38,7 +38,7 @@ THE SOFTWARE.
 	<td class="build-row-cell">
 	  <div class="pane build-name">
 	    <div class="build-icon">
-	      <l:icon class="icon-nobuilt icon-sm"/>
+        <l:icon src="symbol-status-nobuilt" class="icon-sm"/>
 	    </div>
 	    <!-- Don't use math unless needed, in case nextBuildNumber is not numeric -->
 	    <div class="display-name" title="${%Expected build number}">


### PR DESCRIPTION
Updatecenter and the queued items in the build history still made use of the old svg status sprite svgs
Use the aborted symbol for skipped download jobs to have a better visual differentiation

remove the caching of icons in Updatecenter introduced with #4445. We have svgs so caching them doesn't make much sense.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->


<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Manual testing that icons still work as expected 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- skip changelog

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
