### PR TITLE
Remove usage of `org.apache.commons.lang.StringUtils`

### DIFF
--- a/core/src/test/java/hudson/util/TextFileTest.java
+++ b/core/src/test/java/hudson/util/TextFileTest.java
@@ -8,7 +8,6 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -80,7 +79,7 @@ public class TextFileTest {
         }
 
         String tail = t.fastTail(35, Charset.forName("Shift_JIS"));
-        assertEquals(StringUtils.repeat("\u30e2", 34) + "\n", tail);
+        assertEquals("\u30e2".repeat(34) + "\n", tail);
         assertEquals(35, tail.length());
 
         // add one more byte to force fastTail to read from one byte ahead
@@ -91,7 +90,7 @@ public class TextFileTest {
         }
 
         tail = t.fastTail(35, Charset.forName("Shift_JIS"));
-        assertEquals(StringUtils.repeat("\u30e2", 33) + "\n\n", tail);
+        assertEquals("\u30e2".repeat(33) + "\n\n", tail);
         assertEquals(35, tail.length());
     }
 


### PR DESCRIPTION
Trivial change to a test to remove usage of this unmaintained library in favor of native Java Platform functionality.

### Testing done

`mvn clean verify -Dtest=hudson.util.TextFileTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
