### PR TITLE
Codebase refactoring.

### DIFF
--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -36,9 +36,7 @@ import java.util.Set;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.StaplerProxy;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
@@ -102,6 +100,11 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
     protected AdministrativeMonitor(String id) {
         this.id = id;
     }
+
+    public HttpResponse doAct(@QueryParameter String no) throws IOException{
+        //send the traffic to  /manage by default, can be overridden for nuanced checks.
+        return HttpResponses.redirectViaContextPath("/manage");
+    };
 
     protected AdministrativeMonitor() {
         this.id = this.getClass().getName();

--- a/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
@@ -91,7 +91,7 @@ class BuildReferenceMapAdapter<R> implements SortedMap<Integer, R> {
 
     @Override
     public Set<Entry<Integer, R>> entrySet() {
-        return new SetAdapter(core.entrySet());
+        return new SetAdapter<>(core.entrySet(), loader);
     }
 
     @Override
@@ -264,122 +264,5 @@ class BuildReferenceMapAdapter<R> implements SortedMap<Integer, R> {
         }
     }
 
-    private class SetAdapter implements Set<Entry<Integer, R>> {
-        private final Set<Entry<Integer, BuildReference<R>>> core;
 
-        private SetAdapter(Set<Entry<Integer, BuildReference<R>>> core) {
-            this.core = core;
-        }
-
-        @Override
-        public int size() {
-            return core.size();
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return core.isEmpty();
-        }
-
-        @Override
-        public boolean contains(Object o) {
-            // TODO: to properly pass this onto core, we need to wrap o into BuildReference but also needs to figure out ID.
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Iterator<Entry<Integer, R>> iterator() {
-            return Iterators.removeNull(new AdaptedIterator<>(core.iterator()) {
-                @Override
-                protected Entry<Integer, R> adapt(Entry<Integer, BuildReference<R>> e) {
-                    return _unwrap(e);
-                }
-            });
-        }
-
-        @Override
-        public Object[] toArray() {
-            List<Object> list = new ArrayList<>(size());
-            for (var e : this) {
-                list.add(e);
-            }
-            return list.toArray();
-        }
-
-        @Override
-        public <T> T[] toArray(T[] a) {
-            return new ArrayList<>(this).toArray(a);
-        }
-
-        @Override
-        public boolean add(Entry<Integer, R> value) {
-            return core.add(_wrap(value));
-        }
-
-        @Override
-        public boolean remove(Object o) {
-//            return core.remove(o);
-            // TODO: to properly pass this onto core, we need to wrap o into BuildReference but also needs to figure out ID.
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean containsAll(Collection<?> c) {
-            for (Object o : c) {
-                if (!contains(o))
-                    return false;
-            }
-            return true;
-        }
-
-        @Override
-        public boolean addAll(Collection<? extends Entry<Integer, R>> c) {
-            boolean b = false;
-            for (Entry<Integer, R> r : c) {
-                b |= add(r);
-            }
-            return b;
-        }
-
-        @Override
-        public boolean removeAll(Collection<?> c) {
-            boolean b = false;
-            for (Object o : c) {
-                b |= remove(o);
-            }
-            return b;
-        }
-
-        @Override
-        public boolean retainAll(Collection<?> c) {
-            // TODO: to properly pass this onto core, we need to wrap o into BuildReference but also needs to figure out ID.
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void clear() {
-            core.clear();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return core.equals(o);
-        }
-
-        @Override
-        public int hashCode() {
-            return core.hashCode();
-        }
-
-        private Entry<Integer, BuildReference<R>> _wrap(Entry<Integer, R> e) {
-            return new AbstractMap.SimpleEntry<>(e.getKey(), wrap(e.getValue()));
-        }
-
-        private Entry<Integer, R> _unwrap(Entry<Integer, BuildReference<R>> e) {
-            R v = unwrap(e.getValue());
-            if (v == null)
-                return null;
-            return new AbstractMap.SimpleEntry<>(e.getKey(), v);
-        }
-    }
 }

--- a/core/src/main/java/jenkins/model/lazy/SetAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/SetAdapter.java
@@ -1,0 +1,141 @@
+package jenkins.model.lazy;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.util.AdaptedIterator;
+import hudson.util.Iterators;
+
+import java.util.*;
+
+public class SetAdapter<R> implements Set<Map.Entry<Integer, R>> {
+    private final Set<Map.Entry<Integer, BuildReference<R>>> core;
+    private AbstractLazyLoadRunMap<R> loader;
+    public SetAdapter(Set<Map.Entry<Integer, BuildReference<R>>> core, AbstractLazyLoadRunMap<R> loader) {
+        this.core = core;
+        this.loader = loader;
+    }
+
+    @Override
+    public int size() {
+        return core.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return core.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        // TODO: to properly pass this onto core, we need to wrap o into BuildReference but also needs to figure out ID.
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<Map.Entry<Integer, R>> iterator() {
+        return Iterators.removeNull(new AdaptedIterator<>(core.iterator()) {
+            @Override
+            protected Map.Entry<Integer, R> adapt(Map.Entry<Integer, BuildReference<R>> e) {
+                return _unwrap(e);
+            }
+        });
+    }
+
+    @Override
+    public Object[] toArray() {
+        List<Object> list = new ArrayList<>(size());
+        for (var e : this) {
+            list.add(e);
+        }
+        return list.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return new ArrayList<>(this).toArray(a);
+    }
+
+    @Override
+    public boolean add(Map.Entry<Integer, R> value) {
+        return core.add(_wrap(value));
+    }
+
+    @Override
+    public boolean remove(Object o) {
+//            return core.remove(o);
+        // TODO: to properly pass this onto core, we need to wrap o into BuildReference but also needs to figure out ID.
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        for (Object o : c) {
+            if (!contains(o))
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends Map.Entry<Integer, R>> c) {
+        boolean b = false;
+        for (Map.Entry<Integer, R> r : c) {
+            b |= add(r);
+        }
+        return b;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        boolean b = false;
+        for (Object o : c) {
+            b |= remove(o);
+        }
+        return b;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        // TODO: to properly pass this onto core, we need to wrap o into BuildReference but also needs to figure out ID.
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        core.clear();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return core.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return core.hashCode();
+    }
+
+    private Map.Entry<Integer, BuildReference<R>> _wrap(Map.Entry<Integer, R> e) {
+        return new AbstractMap.SimpleEntry<>(e.getKey(), wrap(e.getValue()));
+    }
+
+    private BuildReference<R> wrap(@Nullable R value) {
+        if (value == null)    return null;
+        return this.loader.createReference(value);
+    }
+
+    private R unwrap(@Nullable BuildReference<R> ref) {
+        if (ref == null)  return null;
+
+        R v = ref.get();
+        if (v == null)
+            v = loader.getById(ref.id);
+        return v;
+    }
+
+    private Map.Entry<Integer, R> _unwrap(Map.Entry<Integer, BuildReference<R>> e) {
+        R v = unwrap(e.getValue());
+        if (v == null)
+            return null;
+        return new AbstractMap.SimpleEntry<>(e.getKey(), v);
+    }
+}

--- a/core/src/main/java/jenkins/model/queue/DeletionLockManager.java
+++ b/core/src/main/java/jenkins/model/queue/DeletionLockManager.java
@@ -1,0 +1,43 @@
+package jenkins.model.queue;
+
+import hudson.model.Item;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import net.jcip.annotations.GuardedBy;
+import org.springframework.lang.NonNull;
+
+public class DeletionLockManager {
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    @GuardedBy("lock")
+    private final Set<Item> registrations = new HashSet<>();
+
+    public boolean register(@NonNull Item item) {
+        lock.writeLock().lock();
+        try {
+            return registrations.add(item);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void deregister(@NonNull Item item) {
+        lock.writeLock().lock();
+        try {
+            registrations.remove(item);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public boolean isRegistered(@NonNull Item item) {
+        lock.readLock().lock();
+        try {
+            return registrations.contains(item);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+}

--- a/core/src/main/java/jenkins/model/queue/ItemDeletion.java
+++ b/core/src/main/java/jenkins/model/queue/ItemDeletion.java
@@ -50,6 +50,7 @@ public class ItemDeletion extends Queue.QueueDecisionHandler {
     /**
      * Lock to guard the {@link #registrations} set.
      */
+    private static final DeletionLockManager deletionLockManager = new DeletionLockManager();
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     /**
      * The explicit deletions in progress.
@@ -104,16 +105,7 @@ public class ItemDeletion extends Queue.QueueDecisionHandler {
      * deletion.
      */
     public static boolean isRegistered(@NonNull Item item) {
-        ItemDeletion instance = instance();
-        if (instance == null) {
-            return false;
-        }
-        instance.lock.readLock().lock();
-        try {
-            return instance.registrations.contains(item);
-        } finally {
-            instance.lock.readLock().unlock();
-        }
+        return deletionLockManager.isRegistered(item);
     }
 
     /**
@@ -124,16 +116,7 @@ public class ItemDeletion extends Queue.QueueDecisionHandler {
      * {@link #deregister(Item)}.
      */
     public static boolean register(@NonNull Item item) {
-        ItemDeletion instance = instance();
-        if (instance == null) {
-            return false;
-        }
-        instance.lock.writeLock().lock();
-        try {
-            return instance.registrations.add(item);
-        } finally {
-            instance.lock.writeLock().unlock();
-        }
+        return deletionLockManager.register(item);
     }
 
     /**
@@ -142,15 +125,7 @@ public class ItemDeletion extends Queue.QueueDecisionHandler {
      * @param item the {@link Item} that was to be deleted and is now either deleted or the delete was aborted.
      */
     public static void deregister(@NonNull Item item) {
-        ItemDeletion instance = instance();
-        if (instance != null) {
-            instance.lock.writeLock().lock();
-            try {
-                instance.registrations.remove(item);
-            } finally {
-                instance.lock.writeLock().unlock();
-            }
-        }
+        deletionLockManager.deregister(item);
     }
 
     /**


### PR DESCRIPTION
Set I Refactoring:
Implemented renaming and method extraction to address a long method identifier in the RobustReflectionConverter.doUnmarshal method.
Decomposed conditionals in the same method to improve readability and maintainability.
Set II Refactoring:
Extracted the SetAdapter and CollectionAdapter inner classes from BuildReferenceMapAdapter.java into separate files for better modularity.
Pulled up the doAct method to the AdministrativeMonitor class to centralize redirection logic.
Moved the register and deregister methods to a new DeletionLockManager class, adhering to the Single Responsibility Principle.