### PR TITLE
Refresh the style of alerts

### DIFF
--- a/war/src/main/scss/abstracts/_theme.scss
+++ b/war/src/main/scss/abstracts/_theme.scss
@@ -91,17 +91,45 @@ $semantics: (
 
   // Alert call outs
   --alert-success-text-color: var(--success-color);
-  --alert-success-bg-color: color-mix(in srgb, var(--success-color) 10%, transparent);
-  --alert-success-border-color: color-mix(in srgb, var(--success-color) 5%, transparent);
+  --alert-success-bg-color: color-mix(
+    in sRGB,
+    var(--success-color) 10%,
+    transparent
+  );
+  --alert-success-border-color: color-mix(
+    in sRGB,
+    var(--success-color) 5%,
+    transparent
+  );
   --alert-info-text-color: var(--blue);
-  --alert-info-bg-color: color-mix(in srgb, var(--blue) 10%, transparent);
-  --alert-info-border-color: color-mix(in srgb, var(--blue) 5%, transparent);
-  --alert-warning-text-color: color-mix(in srgb, var(--warning-color) 80%, var(--text-color));
-  --alert-warning-bg-color: color-mix(in srgb, var(--warning-color) 10%, transparent);
-  --alert-warning-border-color: color-mix(in srgb, var(--warning-color) 5%, transparent);
+  --alert-info-bg-color: color-mix(in sRGB, var(--blue) 10%, transparent);
+  --alert-info-border-color: color-mix(in sRGB, var(--blue) 5%, transparent);
+  --alert-warning-text-color: color-mix(
+    in sRGB,
+    var(--warning-color) 80%,
+    var(--text-color)
+  );
+  --alert-warning-bg-color: color-mix(
+    in sRGB,
+    var(--warning-color) 10%,
+    transparent
+  );
+  --alert-warning-border-color: color-mix(
+    in sRGB,
+    var(--warning-color) 5%,
+    transparent
+  );
   --alert-danger-text-color: var(--error-color);
-  --alert-danger-bg-color: color-mix(in srgb, var(--error-color) 10%, transparent);
-  --alert-danger-border-color: color-mix(in srgb, var(--error-color) 5%, transparent);
+  --alert-danger-bg-color: color-mix(
+    in sRGB,
+    var(--error-color) 10%,
+    transparent
+  );
+  --alert-danger-border-color: color-mix(
+    in sRGB,
+    var(--error-color) 5%,
+    transparent
+  );
 
   // Typography
   --text-color-secondary: var(--secondary);

--- a/war/src/main/scss/abstracts/_theme.scss
+++ b/war/src/main/scss/abstracts/_theme.scss
@@ -90,18 +90,18 @@ $semantics: (
   --breadcrumbs-bar-background: hsla(240, 20%, 96.5%, 0.8);
 
   // Alert call outs
-  --alert-success-text-color: #155724;
-  --alert-success-bg-color: #d4edda;
-  --alert-success-border-color: #c3e6cb;
-  --alert-info-text-color: #31708f;
-  --alert-info-bg-color: #d9edf7;
-  --alert-info-border-color: #bce8f1;
-  --alert-warning-text-color: #8a6d3b;
-  --alert-warning-bg-color: #fcf8e3;
-  --alert-warning-border-color: #faebcc;
-  --alert-danger-text-color: #a94442;
-  --alert-danger-bg-color: #f2dede;
-  --alert-danger-border-color: #ebccd1;
+  --alert-success-text-color: var(--success-color);
+  --alert-success-bg-color: color-mix(in srgb, var(--success-color) 10%, transparent);
+  --alert-success-border-color: color-mix(in srgb, var(--success-color) 5%, transparent);
+  --alert-info-text-color: var(--blue);
+  --alert-info-bg-color: color-mix(in srgb, var(--blue) 10%, transparent);
+  --alert-info-border-color: color-mix(in srgb, var(--blue) 5%, transparent);
+  --alert-warning-text-color: color-mix(in srgb, var(--warning-color) 80%, var(--text-color));
+  --alert-warning-bg-color: color-mix(in srgb, var(--warning-color) 10%, transparent);
+  --alert-warning-border-color: color-mix(in srgb, var(--warning-color) 5%, transparent);
+  --alert-danger-text-color: var(--error-color);
+  --alert-danger-bg-color: color-mix(in srgb, var(--error-color) 10%, transparent);
+  --alert-danger-border-color: color-mix(in srgb, var(--error-color) 5%, transparent);
 
   // Typography
   --text-color-secondary: var(--secondary);

--- a/war/src/main/scss/base/_style.scss
+++ b/war/src/main/scss/base/_style.scss
@@ -1048,57 +1048,6 @@ select.select-ajax-pending {
   display: none;
 }
 
-.alert {
-  font-size: var(--font-size-sm);
-  padding: 15px;
-  margin-bottom: 20px;
-  border: 1px solid transparent;
-  border-radius: var(--form-input-border-radius);
-}
-
-.alert a {
-  color: inherit;
-  text-decoration: underline;
-
-  &:hover,
-  &:focus,
-  &:active {
-    text-decoration: underline;
-  }
-}
-
-.alert-success {
-  color: var(--alert-success-text-color);
-  background-color: var(--alert-success-bg-color);
-  border-color: var(--alert-success-border-color);
-}
-
-.alert-info {
-  color: var(--alert-info-text-color);
-  background-color: var(--alert-info-bg-color);
-  border-color: var(--alert-info-border-color);
-}
-
-.alert-warning {
-  color: var(--alert-warning-text-color);
-  background-color: var(--alert-warning-bg-color);
-  border-color: var(--alert-warning-border-color);
-}
-
-.alert-warning p {
-  color: var(--alert-warning-text-color);
-}
-
-.alert-danger {
-  color: var(--alert-danger-text-color);
-  background-color: var(--alert-danger-bg-color);
-  border-color: var(--alert-danger-border-color);
-}
-
-.alert-danger p {
-  color: var(--alert-danger-text-color);
-}
-
 body.no-decoration #main-panel {
   margin: 0 auto !important;
 }

--- a/war/src/main/scss/components/_alert.scss
+++ b/war/src/main/scss/components/_alert.scss
@@ -1,0 +1,50 @@
+.alert {
+  font-size: var(--font-size-sm);
+  padding: 15px;
+  margin-bottom: 20px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+}
+
+.alert a {
+  color: inherit;
+  text-decoration: underline;
+
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: underline;
+  }
+}
+
+.alert-success {
+  color: var(--alert-success-text-color);
+  background-color: var(--alert-success-bg-color);
+  border-color: var(--alert-success-border-color);
+}
+
+.alert-info {
+  color: var(--alert-info-text-color);
+  background-color: var(--alert-info-bg-color);
+  border-color: var(--alert-info-border-color);
+}
+
+.alert-warning {
+  color: var(--alert-warning-text-color);
+  background-color: var(--alert-warning-bg-color);
+  border-color: var(--alert-warning-border-color);
+}
+
+.alert-warning p {
+  color: var(--alert-warning-text-color);
+}
+
+.alert-danger {
+  color: var(--alert-danger-text-color);
+  background-color: var(--alert-danger-bg-color);
+  border-color: var(--alert-danger-border-color);
+}
+
+.alert-danger p {
+  color: var(--alert-danger-text-color);
+}

--- a/war/src/main/scss/components/_alert.scss
+++ b/war/src/main/scss/components/_alert.scss
@@ -4,6 +4,10 @@
   margin-bottom: 20px;
   border: 1px solid transparent;
   border-radius: 10px;
+
+  strong {
+    font-weight: 500;
+  }
 }
 
 .alert a {

--- a/war/src/main/scss/components/_index.scss
+++ b/war/src/main/scss/components/_index.scss
@@ -1,4 +1,5 @@
 @use "app-bar";
+@use "alert";
 @use "badges";
 @use "breadcrumbs";
 @use "buttons-deprecated";


### PR DESCRIPTION
Small pull request to refresh the style of alerts. Some minor tweaks to colours, border radius and weights to bring alerts more inline with the rest of Jenkins.

**Before**
<img width="1073" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/97496891-178a-4355-bd97-6e5eb8298b0d">

**After**
<img width="1067" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/c349135a-da22-422d-85b5-a5ec56e1878f">

I'll open a pull request for the dark theme plugin to match.

### Testing done

* Modified the Manage Jenkins screen to display all monitors to test a variety of styles, works as expected

### Proposed changelog entries

- Refresh the style of alerts.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
