### PR TITLE
[JENKINS-73007] Create-item button no longer disabled when duplicate name present

### DIFF
--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -60,6 +60,7 @@ $.when(getItems()).done(function (data) {
       }
       cleanValidationMessages(context);
       $(messageId).removeClass("input-message-disabled");
+      enableSubmit(false);
     }
 
     function cleanValidationMessages(context) {
@@ -69,7 +70,6 @@ $.when(getItems()).done(function (data) {
     }
 
     function enableSubmit(status) {
-      console.log("status", status)
       var btn = $(".bottom-sticker-inner button[type=submit]");
       if (status === true) {
         if (btn.hasClass("disabled")) {

--- a/war/src/main/js/add-item.js
+++ b/war/src/main/js/add-item.js
@@ -69,7 +69,8 @@ $.when(getItems()).done(function (data) {
     }
 
     function enableSubmit(status) {
-      var btn = $("form .footer .btn-decorator button[type=submit]");
+      console.log("status", status)
+      var btn = $(".bottom-sticker-inner button[type=submit]");
       if (status === true) {
         if (btn.hasClass("disabled")) {
           btn.removeClass("disabled");


### PR DESCRIPTION
See [JENKINS-73007](https://issues.jenkins.io/browse/JENKINS-73007).

Missed this selector in https://github.com/jenkinsci/jenkins/pull/9111 - this PR fixes that so the submit button disables as expected. Tried to reproduce 73007 in an older version of Jenkins and couldn't sadly, the button was enabled despite the duplicate name. To fix this I've added `enableSubmit(false);` to set the button to be disabled when there's a duplicate item.

### Testing done

* Button disables as expected, also when there's a duplicate project name
* Button enables as expected

### Proposed changelog entries

- [JENKINS-73007] Create-item button no longer disabled when duplicate name present

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
