### PR TITLE
[JENKINS-73011] Round-trip `JNLPLauncher.tunnel` to `null` not `""`

### DIFF
--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -175,7 +175,7 @@ public class JNLPLauncher extends ComputerLauncher {
      */
     @DataBoundSetter
     public void setTunnel(String tunnel) {
-        this.tunnel = tunnel;
+        this.tunnel = Util.fixEmptyAndTrim(tunnel);
     }
 
     @Override

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -27,6 +27,7 @@ package hudson.slaves;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -110,6 +111,31 @@ public class JNLPLauncherTest {
                 jnlpLauncher.getWorkDirSettings());
         assertTrue("Work directory should be disabled for the migrated agent",
                 jnlpLauncher.getWorkDirSettings().isDisabled());
+    }
+
+    @Issue("JENKINS-73011")
+    @SuppressWarnings("deprecation")
+    @Test
+    public void deprecatedFields() throws Exception {
+        var launcher = new JNLPLauncher();
+        launcher.setWebSocket(true);
+        launcher.setWorkDirSettings(new RemotingWorkDirSettings(false, null, "remoting2", false));
+        launcher.setTunnel("someproxy");
+        var agent = j.createSlave();
+        agent.setLauncher(launcher);
+        agent = j.configRoundtrip(agent);
+        launcher = (JNLPLauncher) agent.getLauncher();
+        assertThat(launcher.isWebSocket(), is(true));
+        assertThat(launcher.getWorkDirSettings().getInternalDir(), is("remoting2"));
+        assertThat(launcher.getTunnel(), is("someproxy"));
+        launcher = new JNLPLauncher();
+        launcher.setWebSocket(true);
+        agent.setLauncher(launcher);
+        agent = j.configRoundtrip(agent);
+        launcher = (JNLPLauncher) agent.getLauncher();
+        assertThat(launcher.isWebSocket(), is(true));
+        assertThat(launcher.getWorkDirSettings().getInternalDir(), is("remoting"));
+        assertThat(launcher.getTunnel(), nullValue());
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-73011](https://issues.jenkins.io/browse/JENKINS-73011). Amends #8762 + #8793.

### Testing done

Automated test; also confirmed bug interactively in 2.426.3 → 2.440.2.

### Proposed changelog entries

- After reconfiguring a static inbound agent in the GUI using fields such as WebSocket deprecated in 2.440.x, the suggested launch instructions would incorrectly include `-tunnel` (with no argument) even if that field had been left blank.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
