### PR TITLE
Remove duplicate words in Javadoc and test comments

### DIFF
--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -454,7 +454,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     public abstract <V, P> V accept(LabelVisitor<V, P> visitor, P param);
 
     /**
-     * Lists up all the atoms contained in in this label.
+     * Lists all the atoms contained in this label.
      *
      * @since 1.420
      */

--- a/core/src/main/java/hudson/util/StackedAreaRenderer2.java
+++ b/core/src/main/java/hudson/util/StackedAreaRenderer2.java
@@ -109,7 +109,7 @@ public class StackedAreaRenderer2 extends StackedAreaRenderer
 
         double value = dataValue.doubleValue();
 
-        // leave the y values (y1, y0) untranslated as it is going to be be
+        // leave the y values (y1, y0) untranslated as it is going to be
         // stacked up later by previous series values, after this it will be
         // translated.
         double xx1 = domainAxis.getCategoryMiddle(column, getColumnCount(),

--- a/test/src/test/java/hudson/model/UserTest.java
+++ b/test/src/test/java/hudson/model/UserTest.java
@@ -256,7 +256,7 @@ public class UserTest {
         user.addProperty(prop);
         assertNotNull("User should have SomeUserProperty property.", user.getProperty(SomeUserProperty.class));
         assertEquals("UserProperty1 should be assigned to its descriptor", prop, user.getProperties().get(prop.getDescriptor()));
-        assertTrue("User should should contain SomeUserProperty.", user.getAllProperties().contains(prop));
+        assertTrue("User should contain SomeUserProperty.", user.getAllProperties().contains(prop));
         }
         j.jenkins.reload();
         {


### PR DESCRIPTION
Remove duplicated words in Javadoc and test comments

### Testing done

No automated tests because the changes only affect Javadoc comments.  Confirmed that no new warnings or errors are reported by Javadoc generation.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
