### PR TITLE
Update restart banner to align with updated banners

### DIFF
--- a/war/src/main/scss/simple-page.scss
+++ b/war/src/main/scss/simple-page.scss
@@ -41,9 +41,12 @@
   border-radius: 10px;
   text-align: center;
   margin: 5% auto auto;
-  color: var(--alert-success-text-color);
   background-color: var(--alert-success-bg-color);
   border: 1px solid var(--alert-success-border-color);
+
+  * {
+    color: var(--alert-success-text-color) !important;
+  }
 
   strong {
     font-weight: 500;

--- a/war/src/main/scss/simple-page.scss
+++ b/war/src/main/scss/simple-page.scss
@@ -36,14 +36,18 @@
 }
 
 .simple-page .safe-restarting {
+  font-size: var(--font-size-sm);
+  padding: 15px;
+  border-radius: 10px;
   text-align: center;
-  border-color: var(--alert-success-border-color);
-  background-color: var(--alert-success-bg-color);
-  border-width: 2px;
-  border-radius: 2px;
-  border-style: solid;
   margin: 5% auto auto;
-  padding: 5px;
+  color: var(--alert-success-text-color);
+  background-color: var(--alert-success-bg-color);
+  border: 1px solid var(--alert-success-border-color);
+
+  strong {
+    font-weight: 500;
+  }
 }
 
 .simple-page .safe-restarting > p {


### PR DESCRIPTION
Raised as part of the UX Sig today - the restart banner doesn't follow the same style as the updated banners in #9115.

**Before**
<img width="515" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/26f3bec0-f179-4a68-a7ef-bbf81777533e">

**After**
<img width="515" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/ef365530-256e-4957-b606-e4bffccd45ed">

### Testing done

* Banner appears as expected

### Proposed changelog entries

- Update restart banner to align with updated banners.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux @uhafner 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
