### PR TITLE
Log explanation for denial from `MappingWorksheet`

### DIFF
--- a/core/src/main/java/hudson/model/queue/MappingWorksheet.java
+++ b/core/src/main/java/hudson/model/queue/MappingWorksheet.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * Defines a mapping problem for answering "where do we execute this task?"
@@ -85,6 +86,9 @@ import java.util.Map;
  * @author Kohsuke Kawaguchi
  */
 public class MappingWorksheet {
+
+    private static final Logger LOGGER = Logger.getLogger(MappingWorksheet.class.getName());
+
     public final List<ExecutorChunk> executors;
     public final List<WorkChunk> works;
     /**
@@ -135,8 +139,10 @@ public class MappingWorksheet {
             if (c.assignedLabel != null && !c.assignedLabel.contains(node))
                 return false;   // label mismatch
 
-            if (!(Node.SKIP_BUILD_CHECK_ON_FLYWEIGHTS && item.task instanceof Queue.FlyweightTask) && !nodeAcl.hasPermission2(item.authenticate2(), Computer.BUILD))
-                return false;   // tasks don't have a permission to run on this node
+            if (!(Node.SKIP_BUILD_CHECK_ON_FLYWEIGHTS && item.task instanceof Queue.FlyweightTask) && !nodeAcl.hasPermission2(item.authenticate2(), Computer.BUILD)) {
+                LOGGER.fine(() -> "Agent/Build permission denied to " + item.authenticate2().getName() + " on " + node.getNodeName());
+                return false;
+            }
 
             return true;
         }


### PR DESCRIPTION
While experimenting with a setup which included a complex `AuthorizationStrategy` I was perplexed to find a queue item stuck in `CauseOfBlockage.BecauseNodeIsBusy` despite the agent actually being online and idle. `Queue` logging at `FINER` reported https://github.com/jenkinsci/jenkins/blob/5d05f1efc44dcdfc49d80dfa82b12cbb5b1cac40/core/src/main/java/hudson/model/Queue.java#L1667-L1671 which after a lot of working backwards in the script console I finally tracked down to the fact that https://github.com/jenkinsci/jenkins/blob/5d05f1efc44dcdfc49d80dfa82b12cbb5b1cac40/core/src/main/java/hudson/model/queue/MappingWorksheet.java#L125-L138 bypasses the default behavior applied in https://github.com/jenkinsci/jenkins/blob/5d05f1efc44dcdfc49d80dfa82b12cbb5b1cac40/core/src/main/java/hudson/security/AccessControlled.java#L89-L92 which the strategy neglected to honor.

It would probably be preferable for `ExecutorChunk.canAccept` to call `Node.hasPermission2` rather than go through `ACL`; and it would probably be appropriate for there to be a distinct `CauseOfBlockage` for this condition (though that would require complicated changes to `Queue`, and the only legitimate reason for this case is use of [Authorize Project](https://plugins.jenkins.io/authorize-project/) which is semi-deprecated). For the moment I am limiting myself to adding a log message for this case to at least make it more apparent.

### Testing done

None.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
