### PR TITLE
Flake in `GNUCLibraryTest`

### DIFF
--- a/core/src/test/java/hudson/util/jna/GNUCLibraryTest.java
+++ b/core/src/test/java/hudson/util/jna/GNUCLibraryTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
-import com.sun.jna.Native;
 import hudson.Functions;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -15,7 +14,6 @@ import org.junit.Test;
 
 public class GNUCLibraryTest {
 
-    private static final int EBADF = 9;
     private static final int O_CREAT = "Linux".equals(System.getProperty("os.name")) ? 64 : 512;
     private static final int O_RDWR = 2;
 
@@ -28,10 +26,6 @@ public class GNUCLibraryTest {
 
         int result = GNUCLibrary.LIBC.close(fd);
         assertEquals(0, result);
-
-        result = GNUCLibrary.LIBC.close(fd);
-        assertEquals(-1, result);
-        assertEquals(EBADF, Native.getLastError());
 
         Path tmpFile = Files.createTempFile("openTest", null);
         Files.delete(tmpFile);
@@ -56,10 +50,6 @@ public class GNUCLibraryTest {
 
         int result = GNUCLibrary.LIBC.close(fd);
         assertEquals(0, result);
-
-        result = GNUCLibrary.LIBC.close(fd);
-        assertEquals(-1, result);
-        assertEquals(EBADF, Native.getLastError());
     }
 
     @Test


### PR DESCRIPTION
Observed this flake in several core PRs:

```
java.lang.AssertionError: expected:<-1> but was:<0>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at hudson.util.jna.GNUCLibraryTest.closeTest(GNUCLibraryTest.java:61)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```

I couldn't reproduce the failure locally, even after running the test in a loop hundreds of thousands of times, but reasoning about this I suppose it is possible for a different thread (such as some JVM background worker thread) to open a new file handle in between the two close calls (e.g. when loading classes) such that the second close call is actually closing a real open file (although apparently not one that was very important, as the JVM kept running). There isn't really a way to ensure this in a multithreaded process, so just skip the second close test, as it wasn't very important anyway.

### Testing done

Ran the test locally.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
