### PR TITLE
[JENKINS-72622] Rename CloudSet query parameter to avoid conflict

### DIFF
--- a/core/src/main/java/jenkins/agents/CloudSet.java
+++ b/core/src/main/java/jenkins/agents/CloudSet.java
@@ -242,9 +242,9 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
      */
     @POST
     public synchronized void doDoCreate(StaplerRequest req, StaplerResponse rsp,
-                                            @QueryParameter String type) throws IOException, ServletException, Descriptor.FormException {
+                                            @QueryParameter String cloudDescriptorName) throws IOException, ServletException, Descriptor.FormException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-        Cloud cloud = Cloud.all().find(type).newInstance(req, req.getSubmittedForm());
+        Cloud cloud = Cloud.all().findByName(cloudDescriptorName).newInstance(req, req.getSubmittedForm());
         if (!Jenkins.get().clouds.add(cloud)) {
             LOGGER.log(Level.WARNING, () -> "Creating duplicate cloud name " + cloud.name + ". Plugin " + Jenkins.get().getPluginManager().whichPlugin(cloud.getClass()) + " should be updated to support user provided name.");
         }

--- a/core/src/main/java/jenkins/agents/CloudSet.java
+++ b/core/src/main/java/jenkins/agents/CloudSet.java
@@ -244,7 +244,11 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
     public synchronized void doDoCreate(StaplerRequest req, StaplerResponse rsp,
                                             @QueryParameter String cloudDescriptorName) throws IOException, ServletException, Descriptor.FormException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-        Cloud cloud = Cloud.all().findByName(cloudDescriptorName).newInstance(req, req.getSubmittedForm());
+        Descriptor<Cloud> cloudDescriptor = Cloud.all().findByName(cloudDescriptorName);
+        if (cloudDescriptor == null) {
+            throw new Failure(String.format("No cloud type ‘%s’ is known", cloudDescriptorName));
+        }
+        Cloud cloud = cloudDescriptor.newInstance(req, req.getSubmittedForm());
         if (!Jenkins.get().clouds.add(cloud)) {
             LOGGER.log(Level.WARNING, () -> "Creating duplicate cloud name " + cloud.name + ". Plugin " + Jenkins.get().getPluginManager().whichPlugin(cloud.getClass()) + " should be updated to support user provided name.");
         }

--- a/core/src/main/resources/jenkins/agents/CloudSet/_new.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/_new.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
         <st:include it="${requestScope.instance}" class="${requestScope.descriptor.clazz}" page="config.jelly" optional="true" />
         
         <f:bottomButtonBar>
-          <input type="hidden" name="type" value="${request.getParameter('mode')}"/>
+          <input type="hidden" name="cloudDescriptorName" value="${request.getParameter('mode')}"/>
 
           <f:submit value="${%Save}"/>
         </f:bottomButtonBar>


### PR DESCRIPTION
See [JENKINS-72622](https://issues.jenkins.io/browse/JENKINS-72622).

The parameter `type` is quite generic. For example it conflict with one of the AmazonEC2Cloud form attribute. proposing to use more specici attribute `cloudDescriptorName` to fix this and also avoid conflict in the future.

### Testing done

* Tested creation of Amazon EC2 Cloud with AMI (`ec2-plugin`)
* Tested creation of Kubernetes Cloud (`kubernetes-plugin`)
* Tested creation of Docker Cloud (`docker-plugin`)

### Proposed changelog entries

- Rename CloudSet query parameter `type` to `cloudDescriptorName` to avoid conflicts in Clouds implementations.

### Proposed upgrade guidelines

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
