### PR TITLE
Backporting for 2.452.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>5.3.33</version>
+        <version>5.3.34</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -298,9 +298,11 @@ public abstract class ExtensionFinder implements ExtensionPoint {
         }
 
         private void refreshExtensionAnnotations() {
+            LOGGER.finer(() -> "refreshExtensionAnnotations()");
             for (ExtensionComponent<GuiceExtensionAnnotation> ec : moduleFinder.find(GuiceExtensionAnnotation.class, Hudson.getInstance())) {
                 GuiceExtensionAnnotation gea = ec.getInstance();
                 extensionAnnotations.put(gea.annotationType, gea);
+                LOGGER.finer(() -> "found " + gea.getClass());
             }
         }
 
@@ -328,6 +330,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
          */
         @Override
         public synchronized ExtensionComponentSet refresh() throws ExtensionRefreshException {
+            LOGGER.finer(() -> "refresh()");
             refreshExtensionAnnotations();
             // figure out newly discovered sezpoz components
             List<IndexItem<?, Object>> delta = new ArrayList<>();

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -175,7 +175,7 @@ public class JNLPLauncher extends ComputerLauncher {
      */
     @DataBoundSetter
     public void setTunnel(String tunnel) {
-        this.tunnel = tunnel;
+        this.tunnel = Util.fixEmptyAndTrim(tunnel);
     }
 
     @Override

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -27,6 +27,7 @@ package hudson.slaves;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -110,6 +111,31 @@ public class JNLPLauncherTest {
                 jnlpLauncher.getWorkDirSettings());
         assertTrue("Work directory should be disabled for the migrated agent",
                 jnlpLauncher.getWorkDirSettings().isDisabled());
+    }
+
+    @Issue("JENKINS-73011")
+    @SuppressWarnings("deprecation")
+    @Test
+    public void deprecatedFields() throws Exception {
+        var launcher = new JNLPLauncher();
+        launcher.setWebSocket(true);
+        launcher.setWorkDirSettings(new RemotingWorkDirSettings(false, null, "remoting2", false));
+        launcher.setTunnel("someproxy");
+        var agent = j.createSlave();
+        agent.setLauncher(launcher);
+        agent = j.configRoundtrip(agent);
+        launcher = (JNLPLauncher) agent.getLauncher();
+        assertThat(launcher.isWebSocket(), is(true));
+        assertThat(launcher.getWorkDirSettings().getInternalDir(), is("remoting2"));
+        assertThat(launcher.getTunnel(), is("someproxy"));
+        launcher = new JNLPLauncher();
+        launcher.setWebSocket(true);
+        agent.setLauncher(launcher);
+        agent = j.configRoundtrip(agent);
+        launcher = (JNLPLauncher) agent.getLauncher();
+        assertThat(launcher.isWebSocket(), is(true));
+        assertThat(launcher.getWorkDirSettings().getInternalDir(), is("remoting"));
+        assertThat(launcher.getTunnel(), nullValue());
     }
 
     @Test


### PR DESCRIPTION
```shell
Latest core version: jenkins-2.455

Fixed
-----

JENKINS-72998           Minor                   2.454
        GuiceExtensionFinder does not correctly pick up new GuiceExtensionAnnotation
        https://issues.jenkins.io/browse/JENKINS-72998

JENKINS-73011           Major                   2.454
        Deprecated JNLPLauncher.tunnel round-trips null to empty string
        https://issues.jenkins.io/browse/JENKINS-73011

JENKINS-73064           Minor                   2.454
        Backport Spring 5.3.34 into 2.452.x
        https://issues.jenkins.io/browse/JENKINS-73064
```