### PR TITLE
Do not reuse `WebClient` in `StaplerAbstractTest`

### DIFF
--- a/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
+++ b/test/src/test/java/jenkins/security/stapler/DoActionFilterTest.java
@@ -23,6 +23,7 @@ import org.htmlunit.WebRequest;
 import org.htmlunit.util.NameValuePair;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.CapturedParameterNames;
@@ -87,17 +88,19 @@ public class DoActionFilterTest extends StaplerAbstractTest {
 
     @Test
     public void testProtectedMethodDispatch() throws Exception {
-        try {
-            wc.goTo("testAccessModifierUrl/public/value", null);
-        } catch (FailingHttpStatusCodeException e) {
-            throw new AssertionError("should have access to a public method", e);
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            try {
+                wc.goTo("testAccessModifierUrl/public/value", null);
+            } catch (FailingHttpStatusCodeException e) {
+                throw new AssertionError("should have access to a public method", e);
+            }
+            FailingHttpStatusCodeException x = assertThrows("should not have allowed protected access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/protected/value", null));
+            assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
+            x = assertThrows("should not have allowed internal access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/internal/value", null));
+            assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
+            x = assertThrows("should not have allowed private access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/private/value", null));
+            assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
         }
-        FailingHttpStatusCodeException x = assertThrows("should not have allowed protected access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/protected/value", null));
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
-        x = assertThrows("should not have allowed internal access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/internal/value", null));
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
-        x = assertThrows("should not have allowed private access", FailingHttpStatusCodeException.class, () -> wc.goTo("testAccessModifierUrl/private/value", null));
-        assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
     }
 
     //================================= doXxx methods =================================
@@ -354,15 +357,19 @@ public class DoActionFilterTest extends StaplerAbstractTest {
         WebRequest settings = new WebRequest(new URL(j.getURL(), "testNewRulesOk/annotatedJsonResponse/"));
         settings.setHttpMethod(HttpMethod.POST);
         settings.setRequestBody(JSONObject.fromObject(Collections.emptyMap()).toString());
-        Page page = wc.getPage(settings);
-        assertEquals(200, page.getWebResponse().getStatusCode());
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            Page page = wc.getPage(settings);
+            assertEquals(200, page.getWebResponse().getStatusCode());
+        }
     }
 
     @Test
     public void testAnnotatedMethodOk_annotatedLimitedTo() {
-        FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> wc.getPage(new URL(j.getURL(), "testNewRulesOk/annotatedLimitedTo/")));
-        assertEquals(500, e.getStatusCode());
-        assertTrue(e.getResponse().getContentAsString().contains("Needs to be in role"));
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> wc.getPage(new URL(j.getURL(), "testNewRulesOk/annotatedLimitedTo/")));
+            assertEquals(500, e.getStatusCode());
+            assertTrue(e.getResponse().getContentAsString().contains("Needs to be in role"));
+        }
     }
 
     @Test

--- a/test/src/test/java/jenkins/security/stapler/StaplerAbstractTest.java
+++ b/test/src/test/java/jenkins/security/stapler/StaplerAbstractTest.java
@@ -55,8 +55,6 @@ public abstract class StaplerAbstractTest {
     public static JenkinsRule rule = new JenkinsRule();
     protected JenkinsRule j;
 
-    protected JenkinsRule.WebClient wc;
-
     protected WebApp webApp;
 
     protected static boolean filteredGetMethodTriggered = false;
@@ -67,7 +65,6 @@ public abstract class StaplerAbstractTest {
     public void setUp() throws Exception {
         j = rule;
         j.jenkins.setCrumbIssuer(null);
-        wc = j.createWebClient();
 
         this.webApp = (WebApp) j.jenkins.servletContext.getAttribute(WebApp.class.getName());
 
@@ -176,7 +173,7 @@ public abstract class StaplerAbstractTest {
     }
 
     protected void assertReachable(String url, HttpMethod method) throws IOException {
-        try {
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
             Page page = wc.getPage(new WebRequest(new URL(j.getURL(), url), method));
             assertEquals(200, page.getWebResponse().getStatusCode());
             assertThat(page.getWebResponse().getContentAsString(), startsWith("ok"));
@@ -194,14 +191,16 @@ public abstract class StaplerAbstractTest {
     }
 
     protected void assertReachableWithSettings(WebRequest request) throws IOException {
-        Page page = wc.getPage(request);
-        assertEquals(200, page.getWebResponse().getStatusCode());
-        assertEquals("ok", page.getWebResponse().getContentAsString());
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            Page page = wc.getPage(request);
+            assertEquals(200, page.getWebResponse().getStatusCode());
+            assertEquals("ok", page.getWebResponse().getContentAsString());
+        }
         assertDoActionRequestWasNotBlocked();
     }
 
     protected void assertReachableWithoutOk(String url) throws IOException {
-        try {
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
             Page page = wc.getPage(new URL(j.getURL(), url));
             assertEquals(200, page.getWebResponse().getStatusCode());
         } catch (FailingHttpStatusCodeException e) {
@@ -210,7 +209,9 @@ public abstract class StaplerAbstractTest {
     }
 
     protected void assertNotReachable(String url) throws IOException {
-        FailingHttpStatusCodeException e = assertThrows("Url " + url + " is reachable but should not be, a not-found error is expected", FailingHttpStatusCodeException.class, () -> wc.getPage(new URL(j.getURL(), url)));
-        assertEquals("Url " + url + " returns an error different from 404", 404, e.getResponse().getStatusCode());
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            FailingHttpStatusCodeException e = assertThrows("Url " + url + " is reachable but should not be, a not-found error is expected", FailingHttpStatusCodeException.class, () -> wc.getPage(new URL(j.getURL(), url)));
+            assertEquals("Url " + url + " returns an error different from 404", 404, e.getResponse().getStatusCode());
+        }
     }
 }


### PR DESCRIPTION
Implements https://github.com/jenkinsci/jenkins/pull/9148#issuecomment-2083026215. See that thread for the test failures motivating this change, in particular https://github.com/jenkinsci/jenkins/pull/9148#issuecomment-2082536670.

### Testing done

    mvn clean install -Dtest='StaticRoutingDecisionProviderTest' -Dspotbugs.skip -Dcheckstyle.skip -rf :jenkins-test

on that branch

### Proposed changelog entries

Non-production code only

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
