### PR TITLE
[JENKINS-73090] Handle CR from `LineTransformationOutputStream`

### DIFF
--- a/core/src/main/java/hudson/console/HyperlinkNote.java
+++ b/core/src/main/java/hudson/console/HyperlinkNote.java
@@ -88,10 +88,8 @@ public class HyperlinkNote extends ConsoleNote {
         // If text contains newlines, then its stored length will not match its length when being
         // displayed, since the display length will only include text up to the first newline,
         // which will cause an IndexOutOfBoundsException in MarkupText#rangeCheck when
-        // ConsoleAnnotationOutputStream converts the note into markup. That stream treats '\n' as
-        // the sole end-of-line marker on all platforms, so we ignore '\r' because it will not
-        // break the conversion.
-        text = text.replace('\n', ' ');
+        // ConsoleAnnotationOutputStream converts the note into markup.
+        text = text.replace('\n', ' ').replace('\r', ' ');
         try {
             return constructor.apply(url, text.length()).encode() + text;
         } catch (IOException e) {

--- a/core/src/main/java/hudson/console/LineTransformationOutputStream.java
+++ b/core/src/main/java/hudson/console/LineTransformationOutputStream.java
@@ -38,6 +38,7 @@ import java.io.OutputStream;
  * @since 1.349
  */
 public abstract class LineTransformationOutputStream extends OutputStream {
+    private boolean sawCR;
     private ByteArrayOutputStream2 buf = new ByteArrayOutputStream2();
 
     /**
@@ -53,8 +54,15 @@ public abstract class LineTransformationOutputStream extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
+        if (sawCR && b != '\n') {
+            eol();
+        }
         buf.write(b);
-        if (b == LF) eol();
+        if (b == '\n') {
+            eol();
+        } else if (b == '\r') {
+            sawCR = true;
+        }
     }
 
     private void eol() throws IOException {
@@ -65,6 +73,7 @@ public abstract class LineTransformationOutputStream extends OutputStream {
             buf = new ByteArrayOutputStream2();
         else
             buf.reset();
+        sawCR = false;
     }
 
     @Override
@@ -109,8 +118,6 @@ public abstract class LineTransformationOutputStream extends OutputStream {
         line = line.substring(0, slen);
         return line;
     }
-
-    private static final int LF = 0x0A;
 
     /**
      * Convenience subclass for cases where you wish to process lines being sent to an underlying stream.

--- a/core/src/test/java/hudson/console/LineTransformationOutputStreamTest.java
+++ b/core/src/test/java/hudson/console/LineTransformationOutputStreamTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.console;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicLong;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import org.junit.Test;
+
+public final class LineTransformationOutputStreamTest {
+
+    @Test public void nl() throws Exception {
+        test("\n");
+    }
+
+    @Test public void crnl() throws Exception {
+        test("\r\n");
+    }
+
+    @Test public void cr() throws Exception {
+        test("\r");
+    }
+
+    private void test(String linefeed) throws Exception {
+        var count = new AtomicLong();
+        long max = 1_000_000; // to see OOME in cr without fix: 1_000_000_000
+        try (var counter = new LineTransformationOutputStream() {
+            @Override protected void eol(byte[] b, int len) throws IOException {
+                count.addAndGet(Integer.parseInt(trimEOL(new String(b, 0, len))));
+            }
+        }) {
+            for (long i = 0; i < max; i++) {
+                counter.write((i + linefeed).getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        assertThat(count.get(), is((max * (max - 1)) / 2));
+    }
+
+}

--- a/core/src/test/java/hudson/console/LineTransformationOutputStreamTest.java
+++ b/core/src/test/java/hudson/console/LineTransformationOutputStreamTest.java
@@ -25,6 +25,7 @@
 package hudson.console;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
@@ -51,7 +52,9 @@ public final class LineTransformationOutputStreamTest {
         long max = 1_000_000; // to see OOME in cr without fix: 1_000_000_000
         try (var counter = new LineTransformationOutputStream() {
             @Override protected void eol(byte[] b, int len) throws IOException {
-                count.addAndGet(Integer.parseInt(trimEOL(new String(b, 0, len))));
+                var line = new String(b, 0, len);
+                assertThat(line, endsWith(linefeed));
+                count.addAndGet(Integer.parseInt(trimEOL(line)));
             }
         }) {
             for (long i = 0; i < max; i++) {

--- a/core/src/test/java/hudson/console/LineTransformationOutputStreamTest.java
+++ b/core/src/test/java/hudson/console/LineTransformationOutputStreamTest.java
@@ -24,11 +24,12 @@
 
 package hudson.console;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLong;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import org.junit.Test;
 
 public final class LineTransformationOutputStreamTest {


### PR DESCRIPTION
See [JENKINS-73090](https://issues.jenkins.io/browse/JENKINS-73090) for background.

### Testing done

Without the fix, the `cr` test with the count set to a billion failed with

```
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3745)
	at java.base/java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
	at java.base/java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:95)
	at java.base/java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:137)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:56)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:75)
	at java.base/java.io.OutputStream.write(OutputStream.java:122)
	at hudson.console.LineTransformationOutputStreamTest.cr(LineTransformationOutputStreamTest.java:45)
```

(I am not leaving this count that high in the committed test since when it passes it takes over two minutes of high CPU on my laptop.)

I also tried installing the Timestamper plugin, enabling the global decorator (auto timestamps in all Pipeline builds), and running the Windows `git clone` pipeline mentioned in Jira. This produced timestamped output, though the output did seem to come all at once, though that seemed to be an aspect of Git not Jenkins so far as I could tell from looking at the `jenkins.log` file in the workspace temp dir; so I also tried

```groovy
node('linux') {
    sh 'set +x; for i in `seq 00 99`; do printf "$i\r"; sleep 1; done'
}
```

which did produce live timestamped output, though the classic console does not reliably show it; Pipeline Graph View plugin does. (`tail -f …/builds/…/log` from a terminal actually updates the line in place.)

### Proposed changelog entries

- Treat lines of text (mainly in build logs) as completed by a single carriage return in addition to a newline or carriage return plus newline, avoiding an out of memory error if a large number of such lines are printed in sequence.

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
