### PR TITLE
Display how many users there are on the 'Users' page

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <l:layout permission="${app.ADMINISTER}" title="${%Users}" type="one-column">
     <l:main-panel>
-      <l:app-bar title="${%Users}">
+      <l:app-bar title="${%Users}" subtitle="${it.allUsers.size()}">
         <l:isAdmin>
           <a href="addUser" class="jenkins-button jenkins-button--primary">
             <l:icon src="symbol-add" />

--- a/core/src/main/resources/lib/layout/app-bar.jelly
+++ b/core/src/main/resources/lib/layout/app-bar.jelly
@@ -31,6 +31,9 @@ THE SOFTWARE.
     <st:attribute name="headingLevel">
       Defaults to h1
     </st:attribute>
+    <st:attribute name="subtitle">
+      The subtitle for the application bar
+    </st:attribute>
     Generates a row containing the page title and an optional set of controls
   </st:documentation>
 
@@ -39,6 +42,9 @@ THE SOFTWARE.
       <div class="jenkins-app-bar__content">
         <x:element name="${headingLevel ?: 'h1'}">
           ${title}
+          <j:if test="${attrs.subtitle != null}">
+            <span class="jenkins-app-bar__subtitle">${attrs.subtitle}</span>
+          </j:if>
         </x:element>
       </div>
       <div class="jenkins-app-bar__controls">

--- a/war/src/main/scss/components/_app-bar.scss
+++ b/war/src/main/scss/components/_app-bar.scss
@@ -25,12 +25,6 @@
     }
   }
 
-  &--border {
-    margin-bottom: var(--section-padding);
-    padding-bottom: var(--section-padding);
-    border-bottom: 2px solid var(--panel-border-color);
-  }
-
   &--sticky {
     position: sticky;
     top: 40px;
@@ -68,6 +62,11 @@
   h2 {
     margin: 0;
     font-size: 1.5rem;
+  }
+
+  &__subtitle {
+    color: var(--text-color-secondary);
+    margin-left: 0.5ch;
   }
 }
 


### PR DESCRIPTION
Tiny one to show how many users there are on the 'Users' page. Follows the same pattern as the [prototype](https://jenkins-redesign.vercel.app/people).

<img width="338" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/a35f4936-61b8-4590-baa7-606e2ecffcd4">

### Testing done

* Shows how many users there are
* Displays 0 when there are no users

### Proposed changelog entries

- Display how many users there are on the 'Users' page

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
