### PR TITLE
move the header parts in a taglib

### DIFF
--- a/core/src/main/resources/jenkins/views/JenkinsHeader/headerContent.jelly
+++ b/core/src/main/resources/jenkins/views/JenkinsHeader/headerContent.jelly
@@ -1,78 +1,8 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt" xmlns:x="jelly:xml">
+<j:jelly xmlns:j="jelly:core" xmlns:h="/lib/layout/header">
     <header id="page-header" class="page-header">
-        <div class="page-header__brand">
-            <div class="logo">
-                <a id="jenkins-home-link" href="${rootURL}/">
-                    <img id="jenkins-head-icon" src="${imagesURL}/svgs/logo.svg" alt="[${logoAlt}]" />
-                    <img id="jenkins-name-icon" src="${imagesURL}/title.svg" alt="${title}" width="139" height="34" />
-                </a>
-            </div>
-
-            <a class="page-header__brand-link" href="${rootURL}/">
-                <img src="${imagesURL}/svgs/logo.svg"
-                     alt="[${logoAlt}]"
-                     class="page-header__brand-image" />
-                <span class="page-header__brand-name">Jenkins</span>
-            </a>
-        </div>
-
-        <div class="searchbox hidden-xs">
-            <!-- search box -->
-            <j:set var="searchURL" value="${h.searchURL}"/>
-            <form action="${searchURL}" method="get" style="position:relative;" class="no-json" name="search" role="search">
-                <!-- this div is used to calculate the width of the text box -->
-                <div id="search-box-sizer"/>
-                <div id="searchform">
-                    <input name="q" placeholder="${searchPlaceholder}" id="search-box" class="main-search__input" value="${request.getParameter('q')}" role="searchbox" />
-
-                    <span class="main-search__icon-leading">
-                        <l:icon src="symbol-search"/>
-                    </span>
-                    <a href="${searchHelpUrl}" class="main-search__icon-trailing">
-                        <l:icon src="symbol-help-circle"/>
-                    </a>
-
-                    <div id="search-box-completion" data-search-url="${searchURL}" />
-                    <st:adjunct includes="jenkins.views.JenkinsHeader.search-box" />
-                </div>
-            </form>
-        </div>
-
-        <div class="login page-header__hyperlinks">
-            <div id="visible-am-insertion" class="page-header__am-wrapper" />
-            <div id="visible-sec-am-insertion" class="page-header__am-wrapper" />
-
-            <!-- user icon and login/logout links; only show if authentication is enabled and we're not handling a servlet error -->
-            <j:if test="${app.useSecurity}">
-                <j:choose>
-                    <j:when test="${!h.isAnonymous()}">
-                        <j:invokeStatic var="user" className="hudson.model.User" method="current" />
-                        <j:choose>
-                            <j:when test="${user.fullName == null || user.fullName.trim().isEmpty()}">
-                                <j:set var="userName" value="${user.id}"/>
-                            </j:when>
-                            <j:otherwise>
-                                <j:set var="userName" value="${user.fullName}"/>
-                            </j:otherwise>
-                        </j:choose>
-                        <a href="${rootURL}/${user.url}" class="model-link">
-                            <l:icon src="symbol-person-circle" class="icon-md"/>
-                            <span class="hidden-xs hidden-sm">${userName}</span>
-                        </a>
-                        <j:if test="${app.securityRealm.canLogOut()}">
-                            <a href="${rootURL}/logout">
-                                <l:icon src="symbol-log-out" class="icon-md" />
-                                <span class="hidden-xs hidden-sm">${logout}</span>
-                            </a>
-                        </j:if>
-                    </j:when>
-                    <j:otherwise>
-                        <st:include it="${app.securityRealm}" page="loginLink.jelly" />
-                    </j:otherwise>
-                </j:choose>
-            </j:if>
-        </div>
+      <h:logo/>
+      <h:searchbox/>
+      <h:login/>
     </header>
-    <script src="${resURL}/jsbundles/keyboard-shortcuts.js" type="text/javascript"/>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/header/login.jelly
+++ b/core/src/main/resources/lib/layout/header/login.jelly
@@ -1,0 +1,37 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <div class="login page-header__hyperlinks">
+    <div id="visible-am-insertion" class="page-header__am-wrapper" />
+    <div id="visible-sec-am-insertion" class="page-header__am-wrapper" />
+
+    <!-- user icon and login/logout links; only show if authentication is enabled and we're not handling a servlet error -->
+    <j:if test="${app.useSecurity}">
+      <j:choose>
+        <j:when test="${!h.isAnonymous()}">
+          <j:invokeStatic var="user" className="hudson.model.User" method="current" />
+          <j:choose>
+            <j:when test="${user.fullName == null || user.fullName.trim().isEmpty()}">
+              <j:set var="userName" value="${user.id}"/>
+            </j:when>
+            <j:otherwise>
+              <j:set var="userName" value="${user.fullName}"/>
+            </j:otherwise>
+          </j:choose>
+          <a href="${rootURL}/${user.url}" class="model-link">
+            <l:icon src="symbol-person-circle" class="icon-md"/>
+            <span class="hidden-xs hidden-sm">${userName}</span>
+          </a>
+          <j:if test="${app.securityRealm.canLogOut()}">
+            <a href="${rootURL}/logout">
+              <l:icon src="symbol-log-out" class="icon-md" />
+              <span class="hidden-xs hidden-sm">${logout}</span>
+            </a>
+          </j:if>
+        </j:when>
+        <j:otherwise>
+          <st:include it="${app.securityRealm}" page="loginLink.jelly" />
+        </j:otherwise>
+      </j:choose>
+    </j:if>
+  </div>
+</j:jelly>

--- a/core/src/main/resources/lib/layout/header/logo.jelly
+++ b/core/src/main/resources/lib/layout/header/logo.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div class="page-header__brand">
+    <div class="logo">
+      <a id="jenkins-home-link" href="${rootURL}/">
+        <img id="jenkins-head-icon" src="${imagesURL}/svgs/logo.svg" alt="[${logoAlt}]" />
+        <img id="jenkins-name-icon" src="${imagesURL}/title.svg" alt="${title}" width="139" height="34" />
+      </a>
+    </div>
+
+    <a class="page-header__brand-link" href="${rootURL}/">
+      <img src="${imagesURL}/svgs/logo.svg"
+           alt="[${logoAlt}]"
+           class="page-header__brand-image" />
+      <span class="page-header__brand-name">Jenkins</span>
+    </a>
+  </div>
+</j:jelly>

--- a/core/src/main/resources/lib/layout/header/searchbox.jelly
+++ b/core/src/main/resources/lib/layout/header/searchbox.jelly
@@ -1,0 +1,25 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <div class="searchbox hidden-xs">
+    <!-- search box -->
+    <j:set var="searchURL" value="${h.searchURL}"/>
+    <form action="${searchURL}" method="get" style="position:relative;" class="no-json" name="search" role="search">
+      <!-- this div is used to calculate the width of the text box -->
+      <div id="search-box-sizer"/>
+      <div id="searchform">
+        <input name="q" placeholder="${searchPlaceholder}" id="search-box" class="main-search__input" value="${request.getParameter('q')}" role="searchbox" />
+
+        <span class="main-search__icon-leading">
+          <l:icon src="symbol-search"/>
+        </span>
+        <a href="${searchHelpUrl}" class="main-search__icon-trailing">
+          <l:icon src="symbol-help-circle"/>
+        </a>
+
+        <div id="search-box-completion" data-search-url="${searchURL}" />
+        <st:adjunct includes="jenkins.views.JenkinsHeader.search-box" />
+      </div>
+    </form>
+  </div>
+  <script src="${resURL}/jsbundles/keyboard-shortcuts.js" type="text/javascript"/>
+</j:jelly>

--- a/core/src/main/resources/lib/layout/header/taglib
+++ b/core/src/main/resources/lib/layout/header/taglib
@@ -1,0 +1,1 @@
+Tag library that defines components for headers


### PR DESCRIPTION
the taglib allows plugins to make use of the searchbox and the login stuff while easily being able to modify all the other aspects of the header.

### Testing done
Manually verified that the header is not modified. Also in the downstream PR using the taglib works without problems.

see https://github.com/jenkinsci/customizable-header-plugin/pull/101

### Proposed changelog entries

- Provide header parts as a tag library.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
