### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/announce-lts-rc.yml
+++ b/.github/workflows/announce-lts-rc.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   post:
     runs-on: ubuntu-latest
+    permissions: {} # Empty because permissions should be defined for the secret being used
+
     steps:
       - name: Post on Discourse
         uses: roots/discourse-topic-github-release-action@c30dc233349b7c6f24f52fb1c659cc64f13b5474 # v1.0.1

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -7,9 +7,14 @@ on:
 permissions:
   contents: read # to fetch code (actions/checkout)
 
+concurrency: 
+  group: ${{github.workflow}} - ${{github.ref}}
+  cancel-in-progress: true  # Cancel release if release is started again for same tag. 
+
 jobs:
   determine-version:
     runs-on: ubuntu-latest
+    if: github.repository == 'jenkinsci/jenkins'
     outputs:
       project-version: ${{ steps.set-version.outputs.project-version }}
       is-lts: ${{ steps.set-version.outputs.is-lts }}
@@ -51,7 +56,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
-    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' && github.repository == 'jenkinsci/jenkins' }}
     steps:
       - name: Fetch war
         id: fetch-war
@@ -84,7 +89,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
-    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' && github.repository == 'jenkinsci/jenkins'}}
     steps:
       - name: Fetch Deb
         id: fetch-deb
@@ -119,7 +124,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
-    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' && github.repository == 'jenkinsci/jenkins'}}
     steps:
       - name: Fetch RPM
         id: fetch-rpm
@@ -155,7 +160,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
-    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' && github.repository == 'jenkinsci/jenkins' }}
     steps:
       - name: Fetch MSI
         id: fetch-msi
@@ -191,7 +196,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: determine-version
-    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' && github.repository == 'jenkinsci/jenkins'}}
     steps:
       - name: Fetch suse rpm
         id: fetch-suse-rpm

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read # to fetch code (actions/checkout)
 
-concurrency: 
-  group: ${{github.workflow}} - ${{github.ref}}
-  cancel-in-progress: true  # Cancel release if release is started again for same tag. 
-
 jobs:
   determine-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hey! 🙂
I want to contribute the following changes to your workflow:

- Define permissions for workflows with external actions
- Avoid starting new workflow whilst the previous one is still running
- Avoid deploying jobs on forks

(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))

### Testing done

None

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
