### PR TITLE
[JENKINS-73114] avoid conflicts with css classes from bootstrap

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/message.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginCycleDependenciesMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-danger">
+  <div class="jenkins-alert jenkins-alert-danger">
     <dl>
         <dt>${%PluginCycles}</dt>
         <j:forEach var="p" items="${it.pluginsWithCycle}">

--- a/core/src/main/resources/hudson/PluginManager/PluginDeprecationMonitor/message.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginDeprecationMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
     <dl>
       <dt>${%DeprecatedPlugins}</dt>
       <j:forEach var="e" items="${it.getDeprecatedPlugins()}">

--- a/core/src/main/resources/hudson/PluginManager/PluginUpdateMonitor/message.jelly
+++ b/core/src/main/resources/hudson/PluginManager/PluginUpdateMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-danger">
+  <div class="jenkins-alert jenkins-alert-danger">
     <dl>
         <dt>${%RequiredPluginUpdates}</dt>
         <j:forEach var="p" items="${it.pluginsToBeUpdated}">

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
         <l:main-panel>
           <l:app-bar title="${%Advanced settings}"/>
 
-          <div class="alert alert-info">
+          <div class="jenkins-alert jenkins-alert-info">
               <strong>${%proxyMovedBlurb(rootURL+"/manage/configure")}</strong>
           </div>
 

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -54,7 +54,7 @@ THE SOFTWARE.
             data-is-restart-required="${app.updateCenter.isRestartRequiredForCompletion()}" />
 
       <j:if test="${app.updateCenter.isRestartRequiredForCompletion()}">
-        <div class="alert alert-warning"><strong>${%Warning}</strong>: ${%requires.restart}</div>
+        <div class="jenkins-alert jenkins-alert-warning"><strong>${%Warning}</strong>: ${%requires.restart}</div>
       </j:if>
 
       <template id="i18n"
@@ -130,7 +130,7 @@ THE SOFTWARE.
                       </div>
                     </j:if>
                     <j:if test="${!p.getActiveWarnings().isEmpty()}">
-                      <div class="alert alert-danger">${%securityWarning}
+                      <div class="jenkins-alert jenkins-alert-danger">${%securityWarning}
                         <ul>
                           <j:forEach var="warning" items="${p.getActiveWarnings()}">
                             <li>
@@ -143,13 +143,13 @@ THE SOFTWARE.
                       </div>
                     </j:if>
                     <j:if test="${p.isDeprecated()}">
-                      <div class="alert alert-warning">
+                      <div class="jenkins-alert jenkins-alert-warning">
                         <!-- figure out a way how to present deprecations by multiple update sites instead of just the first one -->
                         ${%deprecationWarning(p.getDeprecations().get(0).url)}
                       </div>
                     </j:if>
                     <j:if test="${it.hasAdoptThisPluginLabel(p)}">
-                      <div class="alert alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0">
+                      <div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0">
                         ${%adoptThisPlugin}
                       </div>
                     </j:if>
@@ -252,7 +252,7 @@ THE SOFTWARE.
                         ${p.name}
                       </div>
                     </j:if>
-                    <div class="alert alert-danger jenkins-!-margin-top-1 jenkins-!-margin-bottom-0">
+                    <div class="jenkins-alert jenkins-alert-danger jenkins-!-margin-top-1 jenkins-!-margin-bottom-0">
                       <pre>${p.cause.message}</pre>
                     </div>
                   </td>

--- a/core/src/main/resources/hudson/PluginManager/updates.jelly
+++ b/core/src/main/resources/hudson/PluginManager/updates.jelly
@@ -136,7 +136,7 @@ THE SOFTWARE.
                           </div>
                         </j:if>
                         <j:if test="${!p.isCompatibleWithInstalledVersion()}">
-                          <div class="alert alert-danger">${%compatWarning}
+                          <div class="jenkins-alert jenkins-alert-danger">${%compatWarning}
                             <j:if test="${p.hasIncompatibleParentPlugins()}">
                               <br/>${%parentCompatWarning}
                               <ul>
@@ -153,15 +153,15 @@ THE SOFTWARE.
                           </div>
                         </j:if>
                         <j:if test="${p.isForNewerHudson()}">
-                          <div class="alert alert-danger">${%coreWarning(p.requiredCore)}</div>
+                          <div class="jenkins-alert jenkins-alert-danger">${%coreWarning(p.requiredCore)}</div>
                         </j:if>
                         <j:if test="${p.fixesSecurityVulnerabilities()}">
-                          <div class="alert alert-warning">
+                          <div class="jenkins-alert jenkins-alert-warning">
                             ${%Applying this update will address security vulnerabilities in the currently installed version.}
                           </div>
                         </j:if>
                         <j:if test="${!p.isNeededDependenciesCompatibleWithInstalledVersion(cache)}">
-                          <div class="alert alert-danger">${%depCompatWarning}
+                          <div class="jenkins-alert jenkins-alert-danger">${%depCompatWarning}
                             <br/>${%parentDepCompatWarning}
                             <ul>
                               <j:forEach var="d"
@@ -177,12 +177,12 @@ THE SOFTWARE.
                           </div>
                         </j:if>
                         <j:if test="${p.isNeededDependenciesForNewerJenkins(cache)}">
-                          <div class="alert alert-danger">
+                          <div class="jenkins-alert jenkins-alert-danger">
                             ${%depCoreWarning(p.getNeededDependenciesRequiredCore().toString())}
                           </div>
                         </j:if>
                         <j:if test="${p.hasWarnings()}">
-                          <div class="alert alert-danger">${%securityWarning}
+                          <div class="jenkins-alert jenkins-alert-danger">${%securityWarning}
                             <ul>
                               <j:forEach var="warning" items="${p.getWarnings()}">
                                 <li>
@@ -195,12 +195,12 @@ THE SOFTWARE.
                           </div>
                         </j:if>
                         <j:if test="${p.isDeprecated()}">
-                          <div class="alert alert-warning">
+                          <div class="jenkins-alert jenkins-alert-warning">
                             ${%deprecationWarning(p.getDeprecation().url)}
                           </div>
                         </j:if>
                         <j:if test="${it.hasAdoptThisPluginLabel(p)}">
-                          <div class="alert alert-warning">
+                          <div class="jenkins-alert jenkins-alert-warning">
                             ${%adoptThisPlugin}
                           </div>
                         </j:if>

--- a/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/hudson/PluginWrapper/PluginWrapperAdministrativeMonitor/message.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-  <div class="alert alert-danger" role="alert">
+  <div class="jenkins-alert jenkins-alert-danger" role="alert">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="correct" value="${%Correct}"/>
     </form>

--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<div class="alert alert-warning">
+<div class="jenkins-alert jenkins-alert-warning">
   <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
     <f:submit name="yes" value="${%Tell me more}"/>
     <f:submit name="no" value="${%Dismiss}"/>

--- a/core/src/main/resources/hudson/diagnosis/NullIdDescriptorMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/NullIdDescriptorMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<div class="alert alert-danger">
+<div class="jenkins-alert jenkins-alert-danger">
   <dl>
     <dt>${%blurb}</dt>
     <j:forEach var="d" items="${it.problems}">

--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
       <f:submit name="no" value="${%Dismiss}"/>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout">
-  <div id="redirect-error" class="alert alert-danger reverse-proxy__hidden"
+  <div id="redirect-error" class="jenkins-alert jenkins-alert-danger reverse-proxy__hidden"
        data-url="${rootURL}/${it.url}/test" data-context="${rootURL}">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>

--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div id="tooManyJobsButNoView" class="alert alert-warning">
+  <div id="tooManyJobsButNoView" class="jenkins-alert jenkins-alert-warning">
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
         <f:submit name="yes" value="${%Create a view now}"/>

--- a/core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
     </l:app-bar>
 
     <f:form method="post" name="config" action="configSubmit">
-      <div class="alert alert-info jenkins-form-item">
+      <div class="jenkins-alert jenkins-alert-info jenkins-form-item">
         ${%fine_warning}
       </div>
       <j:set var="instance" value="${it}" />

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
       </l:overflowButton>
     </l:app-bar>
 
-    <div class="alert alert-info">
+    <div class="jenkins-alert jenkins-alert-info">
       Log messages at a level more verbose than INFO (i.e., CONFIG, FINE, FINER, FINEST) are never recorded in the Jenkins log. Use <a href=".">log recorders</a> to record these log messages.
     </div>
     <t:logRecords logRecords="${h.logRecords}"/>

--- a/core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/message.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-info">
+  <div class="jenkins-alert jenkins-alert-info">
     <j:set var="ucData" value="${it.data}" />
     <j:set var="upJob" value="${app.updateCenter.hudsonJob}" />
     <j:choose>

--- a/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
+++ b/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/disable">
       <f:submit value="${%Dismiss}"/>
     </form>

--- a/core/src/main/resources/hudson/triggers/SCMTrigger/AdministrativeMonitorImpl/message.jelly
+++ b/core/src/main/resources/hudson/triggers/SCMTrigger/AdministrativeMonitorImpl/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:t="/lib/hudson">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
     ${%blurb(rootURL)}
   </div>
 </j:jelly>

--- a/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
+++ b/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
@@ -8,7 +8,7 @@ import org.apache.commons.jelly.tags.fmt.FmtTagLibrary
 SlowTriggerAdminMonitor tam = my
 
 dl {
-    div(class: "alert alert-warning") {
+    div(class: "jenkins-alert jenkins-alert-warning") {
         form(method: "post", name: "clear", action: rootURL + "/" + tam.url + "/clear") {
             input(name: "clear", type: "submit", value: _("Dismiss"), class: "submit-button primary")
         }

--- a/core/src/main/resources/hudson/util/AdministrativeError/message.jelly
+++ b/core/src/main/resources/hudson/util/AdministrativeError/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-danger">
+  <div class="jenkins-alert jenkins-alert-danger">
     <j:out value="${it.message}"/>
     <a href="${rootURL}/${it.url}/">${%See the log for more details}</a>.
   </div>

--- a/core/src/main/resources/hudson/util/DoubleLaunchChecker/message.jelly
+++ b/core/src/main/resources/hudson/util/DoubleLaunchChecker/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
       <p>
         ${%message(it.home)}
       </p>

--- a/core/src/main/resources/jenkins/diagnosis/HsErrPidList/message.jelly
+++ b/core/src/main/resources/jenkins/diagnosis/HsErrPidList/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-danger">
+  <div class="jenkins-alert jenkins-alert-danger">
     ${%blurb(rootURL+'/'+it.url)}
   </div>
 </j:jelly>

--- a/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/CompletedInitializationMonitor/message.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
       ${%blurb(app.initLevel)}
       ${%Example: usage of} <code>@Initializer(after = InitMilestone.COMPLETED)</code> ${%in a plugin}
       (<a href="https://www.jenkins.io/redirect/troubleshooting/initialization-not-completed" rel="noopener noreferrer" target="_blank">${%See documentation}</a>).

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
      <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
       <f:submit name="no" value="${%Dismiss}"/>

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="agent" value="${%Set up agent}"/>
       <f:submit name="cloud" value="${%Set up cloud}"/>

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/disable">
         <f:submit value="${%Dismiss}"/>

--- a/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Setup Security}"/>
       <f:submit name="no" value="${%Dismiss}"/>

--- a/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
+++ b/core/src/main/resources/jenkins/install/SetupWizard/authenticate-security-token.jelly
@@ -19,7 +19,7 @@
                     <p>${%jenkins.install.findSecurityTokenMessage(it.initialAdminPasswordFile)}</p>
                     <p>${%authenticate-security-token.copy.password}</p>
                     <j:if test="${error}">
-                        <div class="alert alert-danger">
+                        <div class="jenkins-alert jenkins-alert-danger">
                           <strong>${%authenticate-security-token.error}</strong> ${%authenticate-security-token.password.incorrect}
                         </div>
                     </j:if>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -66,7 +66,7 @@ installWizard_installIncomplete_message=Jenkins was restarted during installatio
 installWizard_installIncomplete_resumeInstallationButtonLabel=Resume
 installWizard_saveFirstUser=Save and Continue
 installWizard_skipFirstUser=Skip and continue as admin
-installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 You have skipped the <strong>setup of an admin user</strong>. <br /><br />\
 To log in, use the username: "admin" and the administrator password you used to access the setup wizard.\
 </div>
@@ -76,7 +76,7 @@ installWizard_addFirstUser_title=Getting Started
 installWizard_configureInstance_title=Instance Configuration
 installWizard_saveConfigureInstance=Save and Finish
 installWizard_skipConfigureInstance=Not now
-installWizard_configureInstanceSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 You have skipped the configuration of the Jenkins URL. <br/><br/>\
 To configure the Jenkins URL, go to "Manage Jenkins" page.\
 </div>
@@ -103,7 +103,7 @@ installWizard_pluginsInstalled_banner=Welcome to Jenkins {0}!
 installWizard_upgradeComplete_message=Congratulations! You have upgraded to Jenkins {0}.</p><p>To learn more about its great new features, visit <a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">the Jenkins website</a>!
 installWizard_upgradeSkipped_title=Upgrade
 installWizard_upgradeSkipped_banner=Features Not Installed
-installWizard_upgradeSkipped_message=<div class="alert alert-warning fade in">Suggested plugins will not be installed.</div> \
+installWizard_upgradeSkipped_message=<div class="jenkins-alert jenkins-alert-warning fade in">Suggested plugins will not be installed.</div> \
 <p style="padding: 0 4px">You can also install new features from the Plugin Manager, if you change your mind.</p> \
 <p style="padding: 0 4px">Learn how these new features can improve your Jenkins experience by \
 <a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">visiting the homepage</a>.</p>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_fr.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_fr.properties
@@ -41,7 +41,7 @@ certains plugins n\'ont pas l\'air d\'avoir été installés.
 installWizard_installIncomplete_resumeInstallationButtonLabel=Reprendre
 installWizard_saveFirstUser=Sauver et continuer
 installWizard_skipFirstUser=Continuer en tant qu\'Administrateur
-installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 Vous avez passé la <strong>création d\'un utilisateur administrateur</strong>. <br /><br />\
 Pour vous connecter, utilisez le login : "admin" et le mot de passe administrateur que vous avez utilisé pour accéder au \
 wizard d\'installation.</div>
@@ -49,7 +49,7 @@ installWizard_addFirstUser_title=Démarrage
 
 # instance configuration page
 installWizard_configureInstance_title=Démarrage
-installWizard_configureInstanceSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 Vous avez passé la <strong>configuration de l\'instance</strong>. <br /><br /> \
 Vous pouvez toujours vous rendre sur les pages de configuration pour remplir les informations qui pourraient manquer.\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_it.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_it.properties
@@ -23,7 +23,7 @@
 
 installWizard_addFirstUser_title=Attività iniziali
 installWizard_configureInstanceSkippedMessage=\
-  <div class="alert alert-warning fade in">La configurazione dell''URL di \
+  <div class="jenkins-alert jenkins-alert-warning fade in">La configurazione dell''URL di \
   Jenkins è stata omessa.<br/><br/>Per configurare l''URL di Jenkins, aprire \
   la pagina "Gestisci Jenkins".</div>
 installWizard_configureInstance_title=Configurazione istanza
@@ -37,7 +37,7 @@ installWizard_error_restartNotSupported=Il riavvio non è supportato, \
   riavviare quest''istanza manualmente
 installWizard_error_title=Errore
 installWizard_firstUserSkippedMessage=\
-  <div class="alert alert-warning fade in">La <strong>configurazione di un \
+  <div class="jenkins-alert jenkins-alert-warning fade in">La <strong>configurazione di un \
   utente amministratore</strong> è stata omessa.<br /><br />Per accedere, \
   utilizzare il nome utente "admin" e la password di amministrazione che si \
   è utilizzata per accedere alla configurazione guidata.</div>
@@ -113,7 +113,7 @@ installWizard_upgradePanel_message=Jenkins {0} include delle nuove \
 installWizard_upgradePanel_skipRecommendedPlugins=No, grazie
 installWizard_upgradePanel_title=Aggiornamento
 installWizard_upgradeSkipped_banner=Funzionalità non installate
-installWizard_upgradeSkipped_message=<div class="alert alert-warning fade \
+installWizard_upgradeSkipped_message=<div class="jenkins-alert jenkins-alert-warning fade \
   in">I componenti aggiuntivi consigliati non saranno installati.</div>\
   <p style="padding: 0 4px">È possibile anche installare nuove funzionalità \
   dal Gestore componenti aggiuntivi se si cambia idea.</p><p style="padding: \

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_lt.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_lt.properties
@@ -39,7 +39,7 @@ installWizard_installIncomplete_message=Jenkinsas buvo iš naujo paleistas diegi
 installWizard_installIncomplete_resumeInstallationButtonLabel=Tęsti
 installWizard_saveFirstUser=Įrašyti ir baigti
 installWizard_skipFirstUser=Tęsti kaip administratoriumi
-installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 Jūs praleidote administratoriaus naudotojo kūrimą. Norėdami prisijungti, naudokite vardą: „admin“ ir \
 administratoriaus slaptažodį, kurį naudojote prisijungimui prie nustatymo vedlio.\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_pl.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_pl.properties
@@ -31,7 +31,7 @@ installWizard_jenkinsVersionTitle=Jenkins
 installWizard_installComplete_banner=Jenkins jest gotowy!
 installWizard_installComplete_finishButtonLabel=Zacznij korzystać z Jenkinsa
 installWizard_installComplete_message=Konfiguracja Jenkinsa została zakończona.
-installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 Pominięto utworzenie konta administratora. Aby się zalogować, użyj loginu 'admin' i hasła użytego podczas konfigurowania Jenkinsa.\
 </div>
 installWizard_addFirstUser_title=Dodawanie pierwszego użytkownika
@@ -79,7 +79,7 @@ installWizard_installComplete_installComplete_restartRequiredNotSupportedMessage
 installWizard_gettingStarted_title=Zaczynamy
 installWizard_saveSecurity=Zapisz i kontynuuj
 installWizard_installIncomplete_dependenciesLabel=Zależności
-installWizard_configureInstanceSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 Pominięto konfiguracje bazowego adresu URL Jenkinsa. <br/><br/>\
 Aby go skonfigurować, przejdź do strony "Zarządzaj Jenkinsem".\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_pt_BR.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_pt_BR.properties
@@ -38,7 +38,7 @@ installWizard_error_connection=Incapaz de conectar ao Jenkins
 installWizard_installing_detailsLink=Detalhes...
 installWizard_gettingStarted_title=Começando
 installWizard_installIncomplete_title=Prosseguir com a instalação
-installWizard_configureInstanceSkippedMessage=<div class="alert alert-warning fade in">Você pulou a configuração da \
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">Você pulou a configuração da \
   URL do Jenkins. <br/><br/>Para configurá-la, vá para a página "Gerenciar o Jenkins".</div>
 installWizard_installIncomplete_banner=Prosseguir com a instalação
 installWizard_welcomePanel_recommendedActionTitle=Instalar as extensões sugeridas
@@ -52,7 +52,7 @@ installWizard_installComplete_installComplete_restartRequiredMessage=A configura
 installWizard_installComplete_bannerRestart=O Jenkins está quase pronto!
 installWizard_skipFirstUser=Pular e continuar como administrador
 installWizard_installCustom_dependenciesPrefix=Dependências
-installWizard_upgradeSkipped_message=<div class="alert alert-warning fade in">As extensões sugeridas não serão \
+installWizard_upgradeSkipped_message=<div class="jenkins-alert jenkins-alert-warning fade in">As extensões sugeridas não serão \
   instaladas.</div> <p style="padding: 0 4px">Você pode instalar extensões com o Gerenciador de Extensões, caso mude \
   de ideia.</p> <p style="padding: 0 4px">Aprenda como estas novas funcionalidades podem melhorar sua experiência com \
   o Jenkins <a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">visitando sua página \
@@ -82,7 +82,7 @@ installWizard_installComplete_finishButtonLabel=Começar a usar o Jenkins
 installWizard_goInstall=Instalar
 installWizard_installCustom_selectNone=Nenhum
 installWizard_installComplete_title=Começar
-installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">Você pulou a <strong>configuração do \
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">Você pulou a <strong>configuração do \
   usuário admin</strong>. <br /><br />Para entrar, use o nome de usuário "admin" e a senha de administrador que você \
   usou para acessar o assistente de configuração.</div>
 installWizard_configureProxy_save=Salvar e continuar

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_sr.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_sr.properties
@@ -40,7 +40,7 @@ installWizard_installIncomplete_banner=Настави са инсталациј�
 installWizard_installIncomplete_message=
 installWizard_saveFirstUser=Сачувај и настави
 installWizard_skipFirstUser=Настави са администраторским налогом
-installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 Прескочили сте креирањем административог корисника. Пријавите се како што ће те користити име: 'admin' и лозинку коју сте користили инсталацијом.\
 </div>
 installWizard_addFirstUser_title=Почетак
@@ -65,7 +65,7 @@ installWizard_pluginsInstalled_banner=Добродошли на Jenkins {0}!
 installWizard_upgradeComplete_message=Честитамо! Ажурирали сте Jenkins на верзију {0}.</p><p>Прочитајте још на <a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">Jenkins страници</a>!
 installWizard_upgradeSkipped_title=Ажурирај
 installWizard_upgradeSkipped_banner=Одлике које нису инсталиране
-installWizard_upgradeSkipped_message=<div class="alert alert-warning fade in">предложие модуле неће бити инсталиране.</div> \
+installWizard_upgradeSkipped_message=<div class="jenkins-alert jenkins-alert-warning fade in">предложие модуле неће бити инсталиране.</div> \
 <p style="padding: 0 4px">Ако сте предомислите, можете инсталирати нове модуле са Управљачем модула.</p> \
 <p style="padding: 0 4px">Прочитајте како модуле усавршавају Jenkins \
 <a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">на Jenkins станици</a>.</p>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_sv_SE.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_sv_SE.properties
@@ -66,7 +66,7 @@ installWizard_installIncomplete_message=Jenkins startades om under installatione
 installWizard_installIncomplete_resumeInstallationButtonLabel=Återuppta
 installWizard_saveFirstUser=Spara och fortsätt
 installWizard_skipFirstUser=Hoppa över och fortsätt som administratör
-installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 Du har hoppat över <strong>installationen av en administratörsanvändare</strong>. <br /><br />\
 Använd användarnamnet "admin" och administratörslösenordet du använde för att komma åt installationsguiden för att logga in.\
 </div>
@@ -76,7 +76,7 @@ installWizard_addFirstUser_title=Kom igång
 installWizard_configureInstance_title=Konfigurera instans
 installWizard_saveConfigureInstance=Spara och avsluta
 installWizard_skipConfigureInstance=Inte nu
-installWizard_configureInstanceSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 Du har hoppat över konfigurationen av Jenkins-webbadressen. <br/><br/>\
 Gå till sidan "Hantera Jenkins" för att konfigurera Jenkins-webbadressen.\
 </div>
@@ -103,7 +103,7 @@ installWizard_pluginsInstalled_banner=Välkommen till Jenkins {0}!
 installWizard_upgradeComplete_message=Grattis! Du har uppgraderat till Jenkins {0}.</p><p>Besök <a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">Jenkins webbplats</a> för att läsa mer om dessa fantastiska nya funktioner!
 installWizard_upgradeSkipped_title=Uppgradera
 installWizard_upgradeSkipped_banner=Oinstallerade funktioner
-installWizard_upgradeSkipped_message=<div class="alert alert-warning fade in">Föreslagna insticksprogram kommer inte att installeras.</div> \
+installWizard_upgradeSkipped_message=<div class="jenkins-alert jenkins-alert-warning fade in">Föreslagna insticksprogram kommer inte att installeras.</div> \
 <p style="padding: 0 4px">Du kan också installera nya funktioner från insticksprogramshanteraren om du ångrar dig.</p> \
 <p style="padding: 0 4px">Läs om hur dessa nya funktioner kan förbättra din Jenkins-upplevelse genom att \
 <a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">besöka hemsidan</a>.</p>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_zh_CN.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_zh_CN.properties
@@ -64,7 +64,7 @@ installWizard_installIncomplete_message=Jenkins在安装过程已重启，部分
 installWizard_installIncomplete_resumeInstallationButtonLabel=恢复
 installWizard_saveFirstUser=保存并完成
 installWizard_skipFirstUser=使用admin账户继续
-installWizard_firstUserSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 你已跳过创建admin用户的步骤。要登录请使用用户名：'admin' \
 及用于访问安装向导的管理员密码。\
 </div> 
@@ -74,7 +74,7 @@ installWizard_addFirstUser_title=新手入门
 installWizard_configureInstance_title=实例配置
 installWizard_saveConfigureInstance=保存并完成
 installWizard_skipConfigureInstance=现在不要
-installWizard_configureInstanceSkippedMessage=<div class="alert alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
 您已经跳过了 Jenkins URL的配置。 <br/><br/>\
 要配置 Jenkins URL的话，到“Jenkins管理”页面。\
 </div>
@@ -100,7 +100,7 @@ installWizard_pluginsInstalled_banner=欢迎使用Jenkins {0} ！
 installWizard_upgradeComplete_message=恭喜！你已更新到Jenkins {0} 。</p><p>访问<a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">Jenkins网站</a>了解更多新特性的信息。
 installWizard_upgradeSkipped_title=更新
 installWizard_upgradeSkipped_banner=特性未安装
-installWizard_upgradeSkipped_message=<div class="alert alert-warning fade in">建议的插件将不被安装。</div> \
+installWizard_upgradeSkipped_message=<div class="jenkins-alert jenkins-alert-warning fade in">建议的插件将不被安装。</div> \
 <p style="padding: 0 4px">如果你改变主意了，还可以从插件管理器安装新特性。</p>\
 <p style="padding: 0 4px">访问<a rel="noopener noreferrer" target="_blank" href="https://www.jenkins.io/2.0/">Jenkins官网</a>，了解这些新特性如何提升Jenkins体验。</p>
 installWizard_upgrading_title=正在安装插件

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_zh_TW.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_zh_TW.properties
@@ -61,14 +61,14 @@ installWizard_installIncomplete_message=Jenkins 在安裝期間重新啟動，�
 installWizard_installIncomplete_resumeInstallationButtonLabel=繼續
 installWizard_saveFirstUser=儲存並繼續
 installWizard_skipFirstUser=跳過並以 admin 繼續
-installWizard_firstUserSkippedMessage=<div class\="alert alert-warning fade in">您已略過<strong>設定管理員使用者</strong>。<br /><br />請使用帳號：「admin」和您進入安裝精靈的管理員密碼登入。</div>
+installWizard_firstUserSkippedMessage=<div class\="jenkins-alert jenkins-alert-warning fade in">您已略過<strong>設定管理員使用者</strong>。<br /><br />請使用帳號：「admin」和您進入安裝精靈的管理員密碼登入。</div>
 installWizard_addFirstUser_title=開始使用
 
 # instance configuration page
 installWizard_configureInstance_title=執行個體組態
 installWizard_saveConfigureInstance=儲存並完成
 installWizard_skipConfigureInstance=暫時不要
-installWizard_configureInstanceSkippedMessage=<div class\="alert alert-warning fade in">您已略過設定 Jenkins URL。<br/><br/>您之後可以到「管理 Jenkins」頁面設定 Jenkins URL。</div>
+installWizard_configureInstanceSkippedMessage=<div class\="jenkins-alert jenkins-alert-warning fade in">您已略過設定 Jenkins URL。<br/><br/>您之後可以到「管理 Jenkins」頁面設定 Jenkins URL。</div>
 
 installWizard_configureProxy_label=設定代理伺服器
 installWizard_configureProxy_save=儲存並繼續
@@ -91,6 +91,6 @@ installWizard_pluginsInstalled_banner=歡迎使用 Jenkins {0}\!
 installWizard_upgradeComplete_message=恭喜！您已升級到 Jenkins {0}。</p><p>造訪 <a rel\="noopener noreferrer" target\="_blank" href\="https\://www.jenkins.io/2.0/">Jenkins 網站</a>以了解更多新功能的資訊！
 installWizard_upgradeSkipped_title=升级
 installWizard_upgradeSkipped_banner=功能未安裝
-installWizard_upgradeSkipped_message=<div class\="alert alert-warning fade in">不會安裝推薦的外掛。</div> <p style\="padding\: 0 4px">如果您改變主意了，您可從外掛總管安裝新功能。</p> <p style\="padding\: 0 4px">Learn how these new features can improve your Jenkins experience by <a rel\="noopener noreferrer" target\="_blank" href\="https\://www.jenkins.io/2.0/">造訪首頁</a>以了解這些新功能如何提升您的 Jenkins 使用體驗。</p>
+installWizard_upgradeSkipped_message=<div class\="jenkins-alert jenkins-alert-warning fade in">不會安裝推薦的外掛。</div> <p style\="padding\: 0 4px">如果您改變主意了，您可從外掛總管安裝新功能。</p> <p style\="padding\: 0 4px">Learn how these new features can improve your Jenkins experience by <a rel\="noopener noreferrer" target\="_blank" href\="https\://www.jenkins.io/2.0/">造訪首頁</a>以了解這些新功能如何提升您的 Jenkins 使用體驗。</p>
 installWizard_upgrading_title=正在安裝外掛
 installWizard_upgradeComplete_finishButtonLabel=完成

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
@@ -106,7 +106,8 @@
   margin: 0;
 }
 
-.am-container .am-message .alert form {
+.am-container .am-message .alert form,
+.am-container .am-message .jenkins-alert form {
   position: relative;
   float: right;
   margin: -6px 0 0 0 !important;
@@ -115,11 +116,13 @@
   padding-left: 0.5rem;
 }
 
-.am-container .am-message .alert form span {
+.am-container .am-message .alert form span,
+.am-container .am-message .jenkins-alert form span {
   margin: 0 0 0 4px !important;
 }
 
-.am-container .am-message .alert {
+.am-container .am-message .alert,
+.am-container .am-message .jenkins-alert {
   margin-bottom: 0 !important;
 }
 
@@ -148,19 +151,19 @@
   text-decoration: var(--link-text-decoration--hover);
 }
 
-.am-container .am-list .alert-success a {
+.am-container .am-list .jenkins-alert-success a {
   color: var(--alert-success-text-color);
 }
 
-.am-container .am-list .alert-info a {
+.am-container .am-list .jenkins-alert-info a {
   color: var(--alert-info-text-color);
 }
 
-.am-container .am-list .alert-warning a {
+.am-container .am-list .jenkins-alert-warning a {
   color: var(--alert-warning-text-color);
 }
 
-.am-container .am-list .alert-danger a {
+.am-container .am-list .jenkins-alert-danger a {
   color: var(--alert-danger-text-color);
 }
 

--- a/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
+++ b/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <div class="alert alert-warning">
+    <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Apply Migration}"/>
             <f:submit name="no" value="${%Dismiss}"/>

--- a/core/src/main/resources/jenkins/model/Jenkins/EnforceSlaveAgentPortAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/EnforceSlaveAgentPortAdministrativeMonitor/message.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <div class="alert alert-warning">
+  <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="reset" value="${%reset(it.expectedPort)}"/>
     </form>

--- a/core/src/main/resources/jenkins/model/Jenkins/downgrade.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/downgrade.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <j:if test="${app.updateCenter.downgradable}">
-<div class="alert alert-warning">
+<div class="jenkins-alert jenkins-alert-warning">
   ${%Restore the previous version of Jenkins}
   <form method="post" action="${rootURL}/updateCenter/downgrade">
     <f:submit value="${%buttonText(app.updateCenter.backupVersion)}"/>

--- a/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/message.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-    <div class="alert alert-${it.severityAsString}">
+    <div class="jenkins-alert jenkins-alert-${it.severityAsString}">
         <form id="JavaVersionRecommendationAdminMonitor" method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%More Info}"/>
             <l:isAdmin>

--- a/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/message.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-    <div class="alert alert-danger">
+    <div class="jenkins-alert jenkins-alert-danger">
         <form id="${it.id}" method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%More Info}"/>
             <l:isAdmin>

--- a/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/message.groovy
@@ -26,22 +26,22 @@ package jenkins.security.RekeySecretAdminMonitor
 def f = namespace(lib.FormTagLib)
 
 if (!my.isDone()) {
-    div(class:"alert alert-danger") {
+    div(class:"jenkins-alert jenkins-alert-danger") {
         raw _("pleaseRekeyAsap", app.rootDir, my.url)
     }
 }
 
 if (my.isFixingActive()) {
-    div(class:"alert alert-info") {
+    div(class:"jenkins-alert jenkins-alert-info") {
         raw _("rekeyInProgress", my.url)
     }
 } else if (my.logFile.exists()) {
     if (my.isDone()) {
-        div(class:"alert alert-info") {
+        div(class:"jenkins-alert jenkins-alert-info") {
             raw _("rekeySuccessful", my.url)
         }
     } else {
-        div(class:"alert alert-warning") {
+        div(class:"jenkins-alert jenkins-alert-warning") {
             raw _("rekeyHadProblems", my.url)
         }
     }

--- a/core/src/main/resources/jenkins/security/ResourceDomainRecommendation/message.groovy
+++ b/core/src/main/resources/jenkins/security/ResourceDomainRecommendation/message.groovy
@@ -27,7 +27,7 @@ def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 
 dl {
-    div(class: "alert alert-info") {
+    div(class: "jenkins-alert jenkins-alert-info") {
         a(name: "resource-root-url")
         l.isAdmin() {
           form(method: "post", action: "${rootURL}/${my.url}/act") {

--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
@@ -64,7 +64,7 @@ def listWarnings(warnings, boolean core) {
 def coreWarnings = my.activeCoreWarnings
 def pluginWarnings = my.activePluginWarningsByPlugin
 
-div(class: "alert alert-danger", role: "alert") {
+div(class: "jenkins-alert jenkins-alert-danger", role: "alert") {
 
     l.isAdmin() {
         form(method: "post", action: "${rootURL}/${my.url}/forward") {

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/message.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <div class="alert alert-warning">
+    <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Disable automatic generation of legacy API tokens}"/>
             <f:submit name="no" value="${%Dismiss}"/>

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/message.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <div class="alert alert-warning">
+    <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Prevent users from manually creating legacy API tokens}"/>
             <f:submit name="no" value="${%Dismiss}"/>

--- a/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/LegacyApiTokenAdministrativeMonitor/message.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <div class="alert alert-warning">
+    <div class="jenkins-alert jenkins-alert-warning">
         ${%warningMessage(rootURL, it.url)}
     </div>
 </j:jelly>

--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <div class="alert alert-warning">
+    <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/disable">
             <f:submit value="${%Dismiss}"/>
         </form>

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -806,7 +806,7 @@ public class PluginManagerTest {
 
             PluginManagerUtil.getCheckForUpdatesButton(p).click();
             HtmlPage available = wc.goTo("pluginManager/available");
-            assertTrue(available.querySelector(".alert-danger")
+            assertTrue(available.querySelector(".jenkins-alert-danger")
                     .getTextContent().contains("This plugin is built for Jenkins 9999999"));
             wc.waitForBackgroundJavaScript(100);
 

--- a/war/src/main/js/templates/plugin-manager/available.hbs
+++ b/war/src/main/js/templates/plugin-manager/available.hbs
@@ -31,12 +31,12 @@
                 </div>
             {{/if}}
             {{#if this.newerCoreRequired }}
-                <div class="alert alert-danger">
+                <div class="jenkins-alert jenkins-alert-danger">
                     {{{ this.newerCoreRequired }}}
                 </div>
             {{/if}}
             {{#if this.unresolvedSecurityWarnings }}
-                <div class="alert alert-danger">
+                <div class="jenkins-alert jenkins-alert-danger">
                     {{ this.unresolvedSecurityWarnings.text }}
                     <ul>
                         {{#each this.unresolvedSecurityWarnings.warnings}}
@@ -50,12 +50,12 @@
                 </div>
             {{/if}}
             {{#if this.deprecated }}
-                <div class="alert alert-warning">
+                <div class="jenkins-alert jenkins-alert-warning">
                     {{{ this.deprecated }}}
                 </div>
             {{/if}}
             {{#if this.adoptMe }}
-                <div class="alert alert-warning">
+                <div class="jenkins-alert jenkins-alert-warning">
                     {{{ this.adoptMe }}}
                 </div>
             {{/if}}

--- a/war/src/main/scss/components/_alert.scss
+++ b/war/src/main/scss/components/_alert.scss
@@ -1,4 +1,5 @@
-.alert {
+.alert,
+.jenkins-alert {
   font-size: var(--font-size-sm);
   padding: 15px;
   margin-bottom: 20px;
@@ -8,47 +9,47 @@
   strong {
     font-weight: 500;
   }
-}
 
-.alert a {
-  color: inherit;
-  text-decoration: underline;
-
-  &:hover,
-  &:focus,
-  &:active {
+  a {
+    color: inherit;
     text-decoration: underline;
+
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: underline;
+    }
   }
-}
 
-.alert-success {
-  color: var(--alert-success-text-color);
-  background-color: var(--alert-success-bg-color);
-  border-color: var(--alert-success-border-color);
-}
+  &-success {
+    color: var(--alert-success-text-color);
+    background-color: var(--alert-success-bg-color);
+    border-color: var(--alert-success-border-color);
+  }
 
-.alert-info {
-  color: var(--alert-info-text-color);
-  background-color: var(--alert-info-bg-color);
-  border-color: var(--alert-info-border-color);
-}
+  &-info {
+    color: var(--alert-info-text-color);
+    background-color: var(--alert-info-bg-color);
+    border-color: var(--alert-info-border-color);
+  }
 
-.alert-warning {
-  color: var(--alert-warning-text-color);
-  background-color: var(--alert-warning-bg-color);
-  border-color: var(--alert-warning-border-color);
-}
+  &-warning {
+    color: var(--alert-warning-text-color);
+    background-color: var(--alert-warning-bg-color);
+    border-color: var(--alert-warning-border-color);
 
-.alert-warning p {
-  color: var(--alert-warning-text-color);
-}
+    p {
+      color: var(--alert-warning-text-color);
+    }
+  }
 
-.alert-danger {
-  color: var(--alert-danger-text-color);
-  background-color: var(--alert-danger-bg-color);
-  border-color: var(--alert-danger-border-color);
-}
+  &-danger {
+    color: var(--alert-danger-text-color);
+    background-color: var(--alert-danger-bg-color);
+    border-color: var(--alert-danger-border-color);
 
-.alert-danger p {
-  color: var(--alert-danger-text-color);
+    p {
+      color: var(--alert-danger-text-color);
+    }
+  }
 }

--- a/war/src/main/scss/pages/_manage-jenkins.scss
+++ b/war/src/main/scss/pages/_manage-jenkins.scss
@@ -34,32 +34,29 @@
   content: ": ";
 }
 
-.manage-messages {
-  .alert:last-of-type {
+.manage-messages .alert,
+.manage-messages .jenkins-alert {
+  &:last-of-type {
     margin-bottom: 30px;
   }
-}
 
-.manage-messages .alert a {
-  text-decoration: underline;
-}
-
-.manage-messages .alert a:hover {
-  text-decoration: underline;
-}
-
-.manage-messages .alert form {
-  position: relative;
-  float: right;
-  margin: -6px 0 0 !important;
-  display: flex;
-  gap: 0.5rem;
-
-  & > div {
-    display: contents;
+  a {
+    text-decoration: underline;
   }
-}
 
-.manage-messages .alert form span {
-  margin: 0 0 0 4px !important;
+  form {
+    position: relative;
+    float: right;
+    margin: -6px 0 0 !important;
+    display: flex;
+    gap: 0.5rem;
+
+    & > div {
+      display: contents;
+    }
+
+    span {
+      margin: 0 0 0 4px !important;
+    }
+  }
 }

--- a/war/src/main/scss/simple-page.scss
+++ b/war/src/main/scss/simple-page.scss
@@ -104,6 +104,7 @@
   border-color: var(--danger-color, #c4000a);
 }
 
-.simple-page .alert {
+.simple-page .alert,
+.simple-page .jenkins-alert {
   color: var(--danger-color, #c4000a);
 }


### PR DESCRIPTION
jenkins and bootstrap both have definitions for `alert` and `alert-warning`, `alert-info` and `alert-danger`. Bootstrap css definitions are included when e.g. the warning-ng plugin is installed and a job is configured to scan for warnings. The css classes from bootstrap are then chosen instead of the ones for Jenkins for things like the admin monitors. To make things unambiguous, add additional classes prefixed with `jenkins-` and make use of them in code. Keep the old definitions for backward compatibility with plugins.
Follow-up changes are needed in plugins (Mostly those that define admin monitors) and the design-library

After:
for a plugin message:
![image](https://github.com/jenkinsci/jenkins/assets/17767050/c076a5b8-a415-4930-a03e-90c16ba3daa8)

for a core message:
![image](https://github.com/jenkinsci/jenkins/assets/17767050/885b53dd-ebf6-46fa-8b09-fd1fee5e7309)

See [JENKINS-73114](https://issues.jenkins.io/browse/JENKINS-73114).

Originally reported as https://github.com/jenkinsci/customizable-header-plugin/issues/99


### Testing done

Manual testing
1. Create new Jenkins instance, it should have some executors for built-in, this will trigger the corresponding monitor
2. Visit page `/manage/` -> monitors are displayed properly
3. install warnings-ng plugin
4. create freestyle job and configure post build action to scan for e.g. stylellint.
5. run the job once
6. In the header click on the warning shield -> monitor is displayed properly (If there are monitors from plugins they might not be properly styled here)


### Proposed changelog entries

- Add new CSS classes to avoid conflicts with CSS classes from bootstrap.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
