### PR TITLE
[JENKINS-73170] Upgrade Commons FileUpload from 1.5 to 2.0.0-M2

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
     <slf4jVersion>2.0.13</slf4jVersion>
     <!-- TODO https://github.com/jenkinsci/stapler/pull/542 -->
-    <stapler.version>1861.v1e935e64198a_</stapler.version>
+    <stapler.version>1862.v0e91c9d4b_e59</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,8 +40,7 @@ THE SOFTWARE.
   <properties>
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
     <slf4jVersion>2.0.13</slf4jVersion>
-    <!-- TODO https://github.com/jenkinsci/stapler/pull/542 -->
-    <stapler.version>1862.v0e91c9d4b_e59</stapler.version>
+    <stapler.version>1863.vd250086e9885</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -38,8 +38,10 @@ THE SOFTWARE.
   <description>The module contains dependencies that are used by a specific Jenkins version</description>
 
   <properties>
+    <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
     <slf4jVersion>2.0.13</slf4jVersion>
-    <stapler.version>1860.vb_89682cf8d96</stapler.version>
+    <!-- TODO https://github.com/jenkinsci/stapler/pull/542 -->
+    <stapler.version>1861.v1e935e64198a_</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 
@@ -120,11 +122,6 @@ THE SOFTWARE.
         <version>3.2.2</version>
       </dependency>
       <dependency>
-        <groupId>commons-fileupload</groupId>
-        <artifactId>commons-fileupload</artifactId>
-        <version>1.5</version>
-      </dependency>
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.16.1</version>
@@ -188,6 +185,41 @@ THE SOFTWARE.
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>1.26.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-fileupload2</artifactId>
+        <version>${commons-fileupload2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-fileupload2-core</artifactId>
+        <version>${commons-fileupload2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-fileupload2-distribution</artifactId>
+        <version>${commons-fileupload2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
+        <version>${commons-fileupload2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+        <version>${commons-fileupload2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-fileupload2-javax</artifactId>
+        <version>${commons-fileupload2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-fileupload2-portlet</artifactId>
+        <version>${commons-fileupload2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -161,10 +161,6 @@ THE SOFTWARE.
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -283,6 +279,14 @@ THE SOFTWARE.
           <artifactId>commons-lang3</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-fileupload2-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-fileupload2-javax</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -132,7 +132,7 @@ import jenkins.util.SystemProperties;
 import jenkins.util.VirtualFile;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 import org.apache.commons.io.input.CountingInputStream;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
@@ -1166,7 +1166,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     public void copyFrom(FileItem file) throws IOException, InterruptedException {
         if (channel == null) {
             try {
-                file.write(new File(remote));
+                file.write(Paths.get(remote));
             } catch (IOException e) {
                 throw e;
             } catch (Exception e) {
@@ -1178,6 +1178,14 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                 org.apache.commons.io.IOUtils.copy(i, o);
             }
         }
+    }
+
+    /**
+     * @deprecated use {@link #copyFrom(FileItem)}
+     */
+    @Deprecated
+    public void copyFrom(org.apache.commons.fileupload.FileItem file) throws IOException, InterruptedException {
+        copyFrom(file.toFileUpload2FileItem());
     }
 
     /**

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -80,6 +80,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.RandomAccessFile;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -1167,6 +1168,8 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         if (channel == null) {
             try {
                 file.write(Paths.get(remote));
+            } catch (UncheckedIOException e) {
+                throw e.getCause();
             } catch (IOException e) {
                 throw e;
             } catch (Exception e) {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1835,7 +1835,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
         @Override
         public void copy(File target) throws IOException {
-            fileItem.write(Util.fileToPath(target));
+            try {
+                fileItem.write(Util.fileToPath(target));
+            } catch (UncheckedIOException e) {
+                throw e.getCause();
+            }
         }
 
         @Override

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -139,10 +139,12 @@ import jenkins.util.io.OnMaster;
 import jenkins.util.xml.RestrictiveEntityResolver;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload2.core.DiskFileItem;
+import org.apache.commons.fileupload2.core.DiskFileItemFactory;
+import org.apache.commons.fileupload2.core.FileItem;
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.javax.JavaxServletDiskFileUpload;
+import org.apache.commons.fileupload2.javax.JavaxServletFileUpload;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -1832,13 +1834,17 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         }
 
         @Override
-        public void copy(File target) throws Exception {
-            fileItem.write(target);
+        public void copy(File target) throws IOException {
+            fileItem.write(Util.fileToPath(target));
         }
 
         @Override
         public void cleanup() {
-            fileItem.delete();
+            try {
+                fileItem.delete();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 
@@ -1873,8 +1879,8 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             String fileName = "";
             PluginCopier copier;
             File tmpDir = Files.createTempDirectory("uploadDir").toFile();
-            ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory(DiskFileItemFactory.DEFAULT_SIZE_THRESHOLD, tmpDir));
-            List<FileItem> items = upload.parseRequest(req);
+            JavaxServletFileUpload<DiskFileItem, DiskFileItemFactory> upload = new JavaxServletDiskFileUpload(DiskFileItemFactory.builder().setFile(tmpDir).get());
+            List<DiskFileItem> items = upload.parseRequest(req);
             String string = items.get(1).getString();
             if (string != null && !string.isBlank()) {
                 // this is a URL deployment

--- a/core/src/main/java/hudson/model/FileParameterDefinition.java
+++ b/core/src/main/java/hudson/model/FileParameterDefinition.java
@@ -35,7 +35,7 @@ import java.nio.file.Files;
 import java.util.Objects;
 import javax.servlet.ServletException;
 import net.sf.json.JSONObject;
-import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload2.core.FileItem;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/core/src/main/java/hudson/model/FileParameterDefinition.java
+++ b/core/src/main/java/hudson/model/FileParameterDefinition.java
@@ -90,7 +90,7 @@ public class FileParameterDefinition extends ParameterDefinition {
     public ParameterValue createValue(StaplerRequest req) {
         FileItem src;
         try {
-            src = req.getFileItem(getName());
+            src = req.getFileItem2(getName());
         } catch (ServletException | IOException e) {
             // Not sure what to do here. We might want to raise this
             // but that would involve changing the throws for this call

--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -39,11 +40,13 @@ import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.regex.Pattern;
 import jenkins.util.SystemProperties;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemHeaders;
-import org.apache.commons.fileupload.util.FileItemHeadersImpl;
+import org.apache.commons.fileupload2.core.FileItem;
+import org.apache.commons.fileupload2.core.FileItemFactory;
+import org.apache.commons.fileupload2.core.FileItemHeaders;
+import org.apache.commons.fileupload2.core.FileItemHeadersProvider;
 import org.apache.commons.io.FilenameUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -90,8 +93,16 @@ public class FileParameterValue extends ParameterValue {
         this(name, file, FilenameUtils.getName(file.getName()));
     }
 
+    /**
+     * @deprecated use {@link #FileParameterValue(String, FileItem)}
+     */
+    @Deprecated
+    public FileParameterValue(String name, org.apache.commons.fileupload.FileItem file) {
+        this(name, file.toFileUpload2FileItem(), FilenameUtils.getName(file.getName()));
+    }
+
     public FileParameterValue(String name, File file, String originalFileName) {
-        this(name, new FileItemImpl(file), originalFileName);
+        this(name, new FileItemImpl2(file), originalFileName);
     }
 
     protected FileParameterValue(String name, FileItem file, String originalFileName) {
@@ -139,8 +150,13 @@ public class FileParameterValue extends ParameterValue {
         return originalFileName;
     }
 
+    @WithBridgeMethods(value = org.apache.commons.fileupload.FileItem.class, adapterMethod = "fromFileUpload2FileItem")
     public FileItem getFile() {
         return file;
+    }
+
+    private Object fromFileUpload2FileItem(FileItem fileItem, Class<?> type) {
+        return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(fileItem);
     }
 
     @Override
@@ -241,11 +257,120 @@ public class FileParameterValue extends ParameterValue {
 
     /**
      * Default implementation from {@link File}.
+     *
+     * @deprecated use {@link FileItemImpl2}
      */
-    public static final class FileItemImpl implements FileItem {
-        private final File file;
+    @Deprecated
+    public static final class FileItemImpl implements org.apache.commons.fileupload.FileItem {
+        private final FileItem delegate;
 
         public FileItemImpl(File file) {
+            if (file == null) {
+                throw new NullPointerException("file");
+            }
+            this.delegate = new FileItemImpl2(file);
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getInputStream();
+        }
+
+        @Override
+        public String getContentType() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getContentType();
+        }
+
+        @Override
+        @SuppressFBWarnings(value = "FILE_UPLOAD_FILENAME", justification = "for compatibility")
+        public String getName() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getName();
+        }
+
+        @Override
+        public boolean isInMemory() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).isInMemory();
+        }
+
+        @Override
+        public long getSize() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getSize();
+        }
+
+        @Override
+        public byte[] get() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).get();
+        }
+
+        @Override
+        public String getString(String encoding) throws UnsupportedEncodingException {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getString(encoding);
+        }
+
+        @Override
+        public String getString() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getString();
+        }
+
+        @Override
+        public void write(File to) throws Exception {
+            org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).write(to);
+        }
+
+        @Override
+        public void delete() {
+            org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).delete();
+        }
+
+        @Override
+        public String getFieldName() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getFieldName();
+        }
+
+        @Override
+        public void setFieldName(String name) {
+            org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).setFieldName(name);
+        }
+
+        @Override
+        public boolean isFormField() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).isFormField();
+        }
+
+        @Override
+        public void setFormField(boolean state) {
+            org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).setFormField(state);
+        }
+
+        @Override
+        @Deprecated
+        public OutputStream getOutputStream() throws IOException {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getOutputStream();
+        }
+
+        @Override
+        public org.apache.commons.fileupload.FileItemHeaders getHeaders() {
+            return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).getHeaders();
+        }
+
+        @Override
+        public void setHeaders(org.apache.commons.fileupload.FileItemHeaders headers) {
+            org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(delegate).setHeaders(headers);
+        }
+
+        @Override
+        public FileItem toFileUpload2FileItem() {
+            return delegate;
+        }
+    }
+
+    /**
+     * Default implementation from {@link File}.
+     */
+    public static final class FileItemImpl2 implements FileItem {
+        private final File file;
+
+        public FileItemImpl2(File file) {
             if (file == null) {
                 throw new NullPointerException("file");
             }
@@ -287,8 +412,12 @@ public class FileParameterValue extends ParameterValue {
         }
 
         @Override
-        public String getString(String encoding) throws UnsupportedEncodingException {
-            return new String(get(), encoding);
+        public String getString(Charset toCharset) throws IOException {
+            try {
+                return new String(get(), toCharset);
+            } catch (UncheckedIOException e) {
+                throw e.getCause();
+            }
         }
 
         @Override
@@ -297,17 +426,19 @@ public class FileParameterValue extends ParameterValue {
         }
 
         @Override
-        public void write(File to) throws Exception {
-            new FilePath(file).copyTo(new FilePath(to));
+        public FileItem write(Path to) throws IOException {
+            try {
+                new FilePath(file).copyTo(new FilePath(to.toFile()));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return this;
         }
 
         @Override
-        public void delete() {
-            try {
-                Files.deleteIfExists(file.toPath());
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+        public FileItem delete() throws IOException {
+            Files.deleteIfExists(Util.fileToPath(file));
+            return this;
         }
 
         @Override
@@ -316,7 +447,8 @@ public class FileParameterValue extends ParameterValue {
         }
 
         @Override
-        public void setFieldName(String name) {
+        public FileItem setFieldName(String name) {
+            return this;
         }
 
         @Override
@@ -325,7 +457,8 @@ public class FileParameterValue extends ParameterValue {
         }
 
         @Override
-        public void setFormField(boolean state) {
+        public FileItem setFormField(boolean state) {
+            return this;
         }
 
         @Override
@@ -336,11 +469,12 @@ public class FileParameterValue extends ParameterValue {
 
         @Override
         public FileItemHeaders getHeaders() {
-            return new FileItemHeadersImpl();
+            return FileItemFactory.AbstractFileItemBuilder.newFileItemHeaders();
         }
 
         @Override
-        public void setHeaders(FileItemHeaders headers) {
+        public FileItemHeadersProvider setHeaders(FileItemHeaders headers) {
+            return this;
         }
     }
 }

--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -24,7 +24,6 @@
 
 package hudson.model;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -150,13 +149,16 @@ public class FileParameterValue extends ParameterValue {
         return originalFileName;
     }
 
-    @WithBridgeMethods(value = org.apache.commons.fileupload.FileItem.class, adapterMethod = "fromFileUpload2FileItem")
-    public FileItem getFile() {
+    public FileItem getFile2() {
         return file;
     }
 
-    private Object fromFileUpload2FileItem(FileItem fileItem, Class<?> type) {
-        return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(fileItem);
+    /**
+     * @deprecated use {@link #getFile2}
+     */
+    @Deprecated
+    public org.apache.commons.fileupload.FileItem getFile() {
+        return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(getFile2());
     }
 
     @Override

--- a/core/src/main/java/hudson/util/MultipartFormDataParser.java
+++ b/core/src/main/java/hudson/util/MultipartFormDataParser.java
@@ -127,7 +127,7 @@ public class MultipartFormDataParser implements AutoCloseable {
     }
 
     /**
-     * @deprecated use {@link getFileItem2(String)}
+     * @deprecated use {@link #getFileItem2(String)}
      */
     @Deprecated
     public org.apache.commons.fileupload.FileItem getFileItem(String key) {

--- a/core/src/main/java/hudson/util/MultipartFormDataParser.java
+++ b/core/src/main/java/hudson/util/MultipartFormDataParser.java
@@ -24,7 +24,6 @@
 
 package hudson.util;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.File;
 import java.io.IOException;
@@ -123,13 +122,16 @@ public class MultipartFormDataParser implements AutoCloseable {
         return fi.getString();
     }
 
-    @WithBridgeMethods(value = org.apache.commons.fileupload.FileItem.class, adapterMethod = "fromFileUpload2FileItem")
-    public FileItem getFileItem(String key) {
+    public FileItem getFileItem2(String key) {
         return byName.get(key);
     }
 
-    private Object fromFileUpload2FileItem(FileItem fileItem, Class<?> type) {
-        return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(fileItem);
+    /**
+     * @deprecated use {@link getFileItem2(String)}
+     */
+    @Deprecated
+    public org.apache.commons.fileupload.FileItem getFileItem(String key) {
+        return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(getFileItem2(key));
     }
 
     /**

--- a/core/src/main/java/hudson/util/MultipartFormDataParser.java
+++ b/core/src/main/java/hudson/util/MultipartFormDataParser.java
@@ -24,20 +24,25 @@
 
 package hudson.util;
 
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import org.apache.commons.fileupload.FileCountLimitExceededException;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadBase;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload2.core.DiskFileItem;
+import org.apache.commons.fileupload2.core.DiskFileItemFactory;
+import org.apache.commons.fileupload2.core.FileItem;
+import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
+import org.apache.commons.fileupload2.core.FileUploadSizeException;
+import org.apache.commons.fileupload2.javax.JavaxServletDiskFileUpload;
+import org.apache.commons.fileupload2.javax.JavaxServletFileUpload;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -52,7 +57,7 @@ public class MultipartFormDataParser implements AutoCloseable {
 
     /**
      * Limits the number of form fields that can be processed in one multipart/form-data request.
-     * Used to set {@link org.apache.commons.fileupload.servlet.ServletFileUpload#setFileCountMax(long)}.
+     * Used to set {@link org.apache.commons.fileupload2.javax.JavaxServletFileUpload#setFileCountMax(long)}.
      * Despite the name, this applies to all form fields, not just actual file attachments.
      * Set to {@code -1} to disable limits.
      */
@@ -60,7 +65,7 @@ public class MultipartFormDataParser implements AutoCloseable {
 
     /**
      * Limits the size (in bytes) of individual fields that can be processed in one multipart/form-data request.
-     * Used to set {@link org.apache.commons.fileupload.servlet.ServletFileUpload#setFileSizeMax(long)}.
+     * Used to set {@link org.apache.commons.fileupload2.javax.JavaxServletFileUpload#setFileSizeMax(long)}.
      * Despite the name, this applies to all form fields, not just actual file attachments.
      * Set to {@code -1} to disable limits.
      */
@@ -68,7 +73,7 @@ public class MultipartFormDataParser implements AutoCloseable {
 
     /**
      * Limits the total request size (in bytes) that can be processed in one multipart/form-data request.
-     * Used to set {@link org.apache.commons.fileupload.servlet.ServletFileUpload#setSizeMax(long)}.
+     * Used to set {@link org.apache.commons.fileupload2.javax.JavaxServletFileUpload#setSizeMax(long)}.
      * Set to {@code -1} to disable limits.
      */
     private static /* nonfinal for Jenkins script console */ long FILEUPLOAD_MAX_SIZE = Long.getLong(MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_SIZE", -1);
@@ -82,20 +87,20 @@ public class MultipartFormDataParser implements AutoCloseable {
             throw new ServletException("Error creating temporary directory", e);
         }
         tmpDir.deleteOnExit();
-        ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory(DiskFileItemFactory.DEFAULT_SIZE_THRESHOLD, tmpDir));
+        JavaxServletFileUpload<DiskFileItem, DiskFileItemFactory> upload = new JavaxServletDiskFileUpload(DiskFileItemFactory.builder().setFile(tmpDir).get());
         upload.setFileCountMax(maxParts);
         upload.setFileSizeMax(maxPartSize);
         upload.setSizeMax(maxSize);
         try {
             for (FileItem fi : upload.parseRequest(request))
                 byName.put(fi.getFieldName(), fi);
-        } catch (FileCountLimitExceededException e) {
+        } catch (FileUploadFileCountLimitException e) {
             throw new ServletException("File upload field count limit exceeded. Consider setting the Java system property "
                     + MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_FILES to a value greater than " + FILEUPLOAD_MAX_FILES + ", or to -1 to disable this limit.", e);
-        } catch (FileUploadBase.FileSizeLimitExceededException e) {
+        } catch (FileUploadByteCountLimitException e) {
             throw new ServletException("File upload field size limit exceeded. Consider setting the Java system property "
                     + MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_FILE_SIZE to a value greater than " + FILEUPLOAD_MAX_FILE_SIZE + ", or to -1 to disable this limit.", e);
-        } catch (FileUploadBase.SizeLimitExceededException e) {
+        } catch (FileUploadSizeException e) {
             throw new ServletException("File upload total size limit exceeded. Consider setting the Java system property "
                     + MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_SIZE to a value greater than " + FILEUPLOAD_MAX_SIZE + ", or to -1 to disable this limit.", e);
         } catch (FileUploadException e) {
@@ -118,8 +123,13 @@ public class MultipartFormDataParser implements AutoCloseable {
         return fi.getString();
     }
 
+    @WithBridgeMethods(value = org.apache.commons.fileupload.FileItem.class, adapterMethod = "fromFileUpload2FileItem")
     public FileItem getFileItem(String key) {
         return byName.get(key);
+    }
+
+    private Object fromFileUpload2FileItem(FileItem fileItem, Class<?> type) {
+        return org.apache.commons.fileupload.FileItem.fromFileUpload2FileItem(fileItem);
     }
 
     /**
@@ -127,8 +137,13 @@ public class MultipartFormDataParser implements AutoCloseable {
      * Even if this method is not called, the resource will be still cleaned up later by GC.
      */
     public void cleanUp() {
-        for (FileItem item : byName.values())
-            item.delete();
+        for (FileItem item : byName.values()) {
+            try {
+                item.delete();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
     }
 
     /** Alias for {@link #cleanUp}. */

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4492,7 +4492,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 rsp.sendError(HttpServletResponse.SC_FORBIDDEN, "No crumb found");
             }
             rsp.sendRedirect2(req.getContextPath() + "/fingerprint/" +
-                Util.getDigestOf(p.getFileItem("name").getInputStream()) + '/');
+                Util.getDigestOf(p.getFileItem2("name").getInputStream()) + '/');
         }
     }
 

--- a/test/src/test/java/hudson/model/FileParameterValuePersistenceTest.java
+++ b/test/src/test/java/hudson/model/FileParameterValuePersistenceTest.java
@@ -59,7 +59,7 @@ public class FileParameterValuePersistenceTest {
             }
             j.assertBuildStatusSuccess(j.waitForCompletion(b));
             FileParameterValue fpv = (FileParameterValue) b.getAction(ParametersAction.class).getParameter(FILENAME);
-            fpv.getFile().delete();
+            fpv.getFile2().delete();
             verifyPersistence(j);
         });
         sessions.then(FileParameterValuePersistenceTest::verifyPersistence);

--- a/test/src/test/java/jenkins/security/Security3030Test.java
+++ b/test/src/test/java/jenkins/security/Security3030Test.java
@@ -43,9 +43,10 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import javax.servlet.ServletException;
-import org.apache.commons.fileupload.FileCountLimitExceededException;
-import org.apache.commons.fileupload.FileUploadBase;
-import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
+import org.apache.commons.fileupload2.core.FileUploadSizeException;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.junit.Assert;
@@ -71,18 +72,18 @@ public class Security3030Test {
 
     @Test
     public void tooManyFilesStapler() throws Exception {
-        ServletException ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 10, 1000, 20, FileCountLimitExceededException.class);
+        ServletException ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 10, 1000, 20, FileUploadFileCountLimitException.class);
         assertThat(ex.getMessage(), containsString(RequestImpl.class.getName() + ".FILEUPLOAD_MAX_FILES"));
-        ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 1000, 10, 10, FileCountLimitExceededException.class);
+        ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 1000, 10, 10, FileUploadFileCountLimitException.class);
         assertThat(ex.getMessage(), containsString(RequestImpl.class.getName() + ".FILEUPLOAD_MAX_FILES"));
         try (FieldValue v = withStaticField(RequestImpl.class, "FILEUPLOAD_MAX_FILES", 10_000)) {
             assertSubmissionOK(StaplerRequestFormAction.instance(), 1000, 10, 10);
-            ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 10_000, 10, 10, FileCountLimitExceededException.class);
+            ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 10_000, 10, 10, FileUploadFileCountLimitException.class);
             assertThat(ex.getMessage(), containsString(RequestImpl.class.getName() + ".FILEUPLOAD_MAX_FILES"));
         }
-        ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 10, 1000, 20, FileCountLimitExceededException.class);
+        ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 10, 1000, 20, FileUploadFileCountLimitException.class);
         assertThat(ex.getMessage(), containsString(RequestImpl.class.getName() + ".FILEUPLOAD_MAX_FILES"));
-        ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 1000, 10, 10, FileCountLimitExceededException.class);
+        ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 1000, 10, 10, FileUploadFileCountLimitException.class);
         assertThat(ex.getMessage(), containsString(RequestImpl.class.getName() + ".FILEUPLOAD_MAX_FILES"));
     }
 
@@ -91,7 +92,7 @@ public class Security3030Test {
         assertSubmissionOK(StaplerRequestFormAction.instance(), 1, 50, 10 * 1024 * 1024);
         try (FieldValue v = withStaticField(RequestImpl.class, "FILEUPLOAD_MAX_FILE_SIZE", 1024 * 1024)) {
             assertSubmissionOK(StaplerRequestFormAction.instance(), 200, 100, 1024);
-            ServletException ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 1, 50, 10 * 1024 * 1024, FileUploadBase.FileSizeLimitExceededException.class);
+            ServletException ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 1, 50, 10 * 1024 * 1024, FileUploadByteCountLimitException.class);
             assertThat(ex.getMessage(), containsString(RequestImpl.class.getName() + ".FILEUPLOAD_MAX_FILE_SIZE"));
         }
         assertSubmissionOK(StaplerRequestFormAction.instance(), 1, 50, 10 * 1024 * 1024);
@@ -102,7 +103,7 @@ public class Security3030Test {
         assertSubmissionOK(StaplerRequestFormAction.instance(), 1, 50, 10 * 1024 * 1024);
         try (FieldValue v = withStaticField(RequestImpl.class, "FILEUPLOAD_MAX_SIZE", 1024 * 1024)) {
             assertSubmissionOK(StaplerRequestFormAction.instance(), 200, 100, 1024);
-            ServletException ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 1, 50, 10 * 1024 * 1024, FileUploadBase.SizeLimitExceededException.class);
+            ServletException ex = assertSubmissionThrows(StaplerRequestFormAction.instance(), 1, 50, 10 * 1024 * 1024, FileUploadSizeException.class);
             assertThat(ex.getMessage(), containsString(RequestImpl.class.getName() + ".FILEUPLOAD_MAX_SIZE"));
         }
         assertSubmissionOK(StaplerRequestFormAction.instance(), 1, 50, 10 * 1024 * 1024);
@@ -116,18 +117,18 @@ public class Security3030Test {
 
     @Test
     public void tooManyFilesParser() throws Exception {
-        ServletException ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 10, 1000, 20, FileCountLimitExceededException.class);
+        ServletException ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 10, 1000, 20, FileUploadFileCountLimitException.class);
         assertThat(ex.getMessage(), containsString(MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_FILES"));
-        ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 1000, 10, 10, FileCountLimitExceededException.class);
+        ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 1000, 10, 10, FileUploadFileCountLimitException.class);
         assertThat(ex.getMessage(), containsString(MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_FILES"));
         try (FieldValue v = withStaticField(MultipartFormDataParser.class, "FILEUPLOAD_MAX_FILES", 10_000)) {
             assertSubmissionOK(MultipartFormDataParserAction.instance(), 1000, 10, 10);
-            ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 10_000, 10, 10, FileCountLimitExceededException.class);
+            ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 10_000, 10, 10, FileUploadFileCountLimitException.class);
             assertThat(ex.getMessage(), containsString(MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_FILES"));
         }
-        ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 10, 1000, 20, FileCountLimitExceededException.class);
+        ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 10, 1000, 20, FileUploadFileCountLimitException.class);
         assertThat(ex.getMessage(), containsString(MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_FILES"));
-        ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 1000, 10, 10, FileCountLimitExceededException.class);
+        ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 1000, 10, 10, FileUploadFileCountLimitException.class);
         assertThat(ex.getMessage(), containsString(MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_FILES"));
     }
 
@@ -136,7 +137,7 @@ public class Security3030Test {
         assertSubmissionOK(MultipartFormDataParserAction.instance(), 1, 50, 10 * 1024 * 1024);
         try (FieldValue v = withStaticField(MultipartFormDataParser.class, "FILEUPLOAD_MAX_FILE_SIZE", 1024 * 1024)) {
             assertSubmissionOK(MultipartFormDataParserAction.instance(), 200, 100, 1024);
-            ServletException ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 1, 50, 10 * 1024 * 1024, FileUploadBase.FileSizeLimitExceededException.class);
+            ServletException ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 1, 50, 10 * 1024 * 1024, FileUploadByteCountLimitException.class);
             assertThat(ex.getMessage(), containsString(MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_FILE_SIZE"));
         }
         assertSubmissionOK(MultipartFormDataParserAction.instance(), 1, 50, 10 * 1024 * 1024);
@@ -147,7 +148,7 @@ public class Security3030Test {
         assertSubmissionOK(MultipartFormDataParserAction.instance(), 1, 50, 10 * 1024 * 1024);
         try (FieldValue v = withStaticField(MultipartFormDataParser.class, "FILEUPLOAD_MAX_SIZE", 1024 * 1024)) {
             assertSubmissionOK(MultipartFormDataParserAction.instance(), 200, 100, 1024);
-            ServletException ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 1, 50, 10 * 1024 * 1024, FileUploadBase.SizeLimitExceededException.class);
+            ServletException ex = assertSubmissionThrows(MultipartFormDataParserAction.instance(), 1, 50, 10 * 1024 * 1024, FileUploadSizeException.class);
             assertThat(ex.getMessage(), containsString(MultipartFormDataParser.class.getName() + ".FILEUPLOAD_MAX_SIZE"));
         }
         assertSubmissionOK(MultipartFormDataParserAction.instance(), 1, 50, 10 * 1024 * 1024);

--- a/test/src/test/java/jenkins/security/Security3030Test.java
+++ b/test/src/test/java/jenkins/security/Security3030Test.java
@@ -312,7 +312,7 @@ public class Security3030Test {
         }
 
         protected HttpResponse processMultipart(StaplerRequest req) throws ServletException, IOException {
-            req.getFileItem("any-name");
+            req.getFileItem2("any-name");
             return HttpResponses.ok();
         }
     }


### PR DESCRIPTION
**[JENKINS-73170](https://issues.jenkins.io/browse/JENKINS-73170) Upgrade Commons FileUpload from 1.5 to 2.0.0-M2**

### Context

[JENKINS-73169](https://issues.jenkins.io/browse/JENKINS-73169) describes the long-term goal of removing Commons FileUpload from Stapler and Jenkins core, decreasing API surface area and maintenance burden by eliminating an unneeded library.

This long-term strategy carries a certain amount of risk and labor:

- New APIs need to be designed and validated across a variety of consumers (both core consumers and plugin consumers), which is more laborious than a textual package/class rename operation.
- New implementations need to be written and tested, ensuring that existing behavior remains the same and no new security issues are introduced. Given the general lack of realistic automated testing for file uploading, there is a high risk of behavioral regression. Even worse is the potential for a security regression that a new implementation brings. Testing all of these scenarios thoroughly will require a large amount of manual testing and is far more laborious than staying with a battle-tested implementation with known (and tested) security modalities.
- Implementing this change throughout the ecosystem would require the new APIs to ship in a weekly/LTS release, for plugins to adopt that LTS release, and then for those plugins to be adapted to using the new APIs. The list is:
    ```credentials|282644
    plain-credentials|278830
    subversion|86698
    uno-choice|37949
    google-oauth-plugin|12220
    m2release|9733
    scriptler|6767
    sidebar-link|6678
    file-parameters|5507
    xcode-plugin|4506
    kpp-management-plugin|2262
    miniorange-saml-sp|2099
    hp-application-automation-tools-plugin|1611
    custom-folder-icon|1158
    promoted-builds-simple|1038
    custom-job-icon|712
    jclouds-jenkins|583
    patch-parameter|559
    svn-partial-release-mgr|517
    htmlresource|515
    BlameSubversion|405
    deployer-framework|271
    avatar|214
    ios-device-connector|125
    pom2config|90
    recipe|51
    clif-performance-testing|22
    ```
    Our experience has shown that it takes many months for such changes to propagate through the ecosystem and to be adopted by plugins. Upgrading a plugin's baseline, patching it to use new APIs, and getting the result merged and released can be a time-consuming exercise, if not a frustrating one—especially for the long tail of plugins.

### Problem

We have a desire to upgrade Spring Security to a recent version in a relatively timely fashion. Recent versions of Spring Security require Java EE 9 or later, while Commons FileUpload 1.x only supports Java EE 8 and earlier, implying in the long term the completion of the abovementioned project as a prerequisite to moving to Java EE 9 or later (or, in the short term, creating a custom fork of Commons FileUpload 1.x with the `javax` imports changed to `jakarta` imports—a high-maintenance prospect that would also regress our previous efforts to unfork this library). Yet this long-term solution is laborious and carries a high risk of regression (both functionally and security-wise); moreover, file uploading is not a central feature of the software, and focusing a huge amount of effort on it seems out of place relative to the value to end users it will provide—certainly a higher priority would be to focus on the actual Jakarta EE 9 migration itself, which brings with it the tangible benefits of security updates for Spring Security and thus a clear benefit to Jenkins users.

### Solution

A medium-term compromise is possible via Commons FileUpload 2.x, which supports both `javax` and `jakarta` imports. Consider that Stapler and Jenkins core provide a number of APIs that work with Commons FileUpload `FileItem` objects, in contrast to the low-level `DiskFileItem` objects and the classes that produce them (like `DiskFileItemFactory`). These APIs somewhat shelter their consumers from low-level implementation details, like the instantiation of a factory against a particular servlet API. The key observation is that the vast majority of plugins (all open-source plugins with more than 3,000 installations, and all but two proprietary plugins) consume these higher-level Jenkins APIs, which still tie us to Commons FileUpload, but not necessarily to low-level implementation details like `DiskFileItem`; moreover, any cases I found of plugins that directly consume the low-level APIs can be trivially converted to the higher-level Stapler APIs. Unfortunately, the package name has changed between 1.x and 2.x; however, since the `FileItem` interface is very similar between 1.x and 2.x, and since it _is_ an interface, we can bridge between the two versions somewhat transparently.

The implications are as follows: once a handful of plugins are migrated from direct usages of `DiskFileItem` to the simpler `FileItem` wrappers provided by Stapler (which is a trivial and low-risk change, and moreover only needs to be done for 2-4 plugins in the short term), we can upgrade core to FileUpload 2.x (with both `javax` and `jakarta` support) maintaining full plugin compatibility (in both production and build/test) with any plugins that consume the 1.x APIs via `FileItem` (and not through the low-level `DiskFileItem`). These existing plugins, which link against FileUpload 1.x, will call into Stapler to get their `FileItem`, which will be a 2.x object wrapped in a 1.x compatibility object, and any methods they call on that 1.x compatibility object will vector back into the 2.x methods at runtime.

In other words, core will be fully running on FileUpload 2.x, with both `javax` and `jakarta` support, unblocking the Java EE 9 migration project. Even better, this can be achieved through a fraction of the labor and the risk of the long-term strategy. Commons FileUpload 2.x is largely a package/class rename release, but the code is basically the battle-tested implementation we have always relied on, so the risk of functional and security regression is very low. Rather than having to sweep through dozens of plugins, we'll have to sweep through a handful at most—and the results of that sweep can be released _proactively_, rather than having to wait for a new API to be available (perhaps even in LTS) in order to consume it. Finally, this gets file uploading out of the way for the time being so that Jenkins contributors can focus on the higher-priority task of dealing with the Jakarta EE 9 migration.

Some might object to the use of a milestone release of Commons FileUpload, and this is a fair point. Yet it is advertised on both the project's home page and their GitHub page; also, it is published to Maven Central (unlike a `SNAPSHOT` release). It would appear as if the authors are getting close to a release but simply looking for feedback on the API. The Jenkins project could provide a valuable service to the Apache Commons project by confirming that the API is working for our use case. Moreover, I suspect the Spring 5.3.x EOL will likely push the whole Java ecosystem toward Java EE 9+, and I suspect (or at least hope) that this will push Commons FileUpload 2.x toward GA this year. Nevertheless, since it is still in milestone status, I am not recommending that we go ahead and migrate plugins from FileUpload 1.x to 2.x APIs at this time. The 1.x compatibility methods are tried and true, and not subject to change, so it is prudent to remain on them at least until the GA release of 2.x. Moreover, going on a sweep of plugin consumers is exactly the kind of activity that we wanted to avoid doing as part of this exercise; and if we are going to do a sweep of plugin consumers, then we might as well simply implement the long-term solution—something which this medium-term solution in no way precludes, but simply postpones to a later date to focus on more pressing concerns. Finally, with the exception of the `FileItem` compatibility interface, this is a lateral move in API surface area (removal of 1.x and addition of 2.x) rather than an increase (addition of 2.x to the existing 1.x).

Looking at the bigger picture, shipping this immediately will cross out one major portion of the risk and labor associated with the Jakarta EE 9 upgrade—that which is associated with file uploading. Getting this out into weekly releases early will ensure that we have plenty of time to deal with any issues. The next major change after this will be to require Java 17, at which point we can switch to Jetty 12.x with Jakarta EE 8 and get another big wad of changes out into production. Then, the only remaining part of the problem will be to switch from Jetty 12 (EE 8) and FileUpload 2 (EE 8) to Jetty 12 (EE 9) and FileUpload 2 (EE 9), a much more bounded problem, whose risk will also be a lot lower, since some of its major prerequisites will have already been shipping for weeks earlier. In contrast, trying to ship a FileUpload change, a Jetty upgrade, and a Jakarta migration all in the same release sounds like a scope that is far too great to be practical.

### Implementation

Usages in core and Stapler are migrated to 2.x. A full compatibility layer is provided for plugins that use the high-level `FileItem` API (but not the low-level `DiskFileItem` API). This compatibilty layer extends to both production as well as compilation/tests.

The [compatibility chart](https://docs.google.com/spreadsheets/d/1kav8TF8x1-aYJ5R3xRsPrGhjZUp8WqdPPWLaNAwq4d4/edit) is here (there are also two CloudBees plugins, and I will find someone to update those). The only open-source plugins with over 1,000 installations are `miniorange-saml-sp` and `hp-application-automation-tools-plugin`—those are the only two I plan to help with or mention in the release notes, but even those are installed on only 0.72% of controllers so I don't think they should block the integration of this PR into the weekly line (this is just too important a milestone and we are just on too tight of a timeline to wait).

### Testing done

- Full PCT and ATH (both passing)
- Manual testing of file uploading in both core (via the upload plugin feature) and two plugins (Scriptler and Sidebar Link) using the compatibility methods
- Existing security-related unit tests still pass, as does the unit test I added recently for file upload persistence.


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Upgrade Commons FileUpload from 1.5 to 2.0.0-M2. Users of the `miniorange-saml-sp` plugin should upgrade to a compatible version in lockstep with upgrading Jenkins core.

### Proposed upgrade guidelines

- Upgrade Commons FileUpload from 1.5 to 2.0.0-M2. Users of the `miniorange-saml-sp` plugin should upgrade to a compatible version in lockstep with upgrading Jenkins core.

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
