### PR TITLE
Clean up file parameter tests

### DIFF
--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -43,7 +43,6 @@ import java.util.regex.Pattern;
 import jenkins.util.SystemProperties;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemHeaders;
-import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.fileupload.util.FileItemHeadersImpl;
 import org.apache.commons.io.FilenameUtils;
 import org.kohsuke.accmod.Restricted;
@@ -54,12 +53,6 @@ import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * {@link ParameterValue} for {@link FileParameterDefinition}.
- *
- * <h2>Persistence</h2>
- * <p>
- * {@link DiskFileItem} is persistable via serialization,
- * (although the data may get very large in XML) so this object
- * as a whole is persistable.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/test/src/test/java/hudson/model/FileParameterValuePersistenceTest.java
+++ b/test/src/test/java/hudson/model/FileParameterValuePersistenceTest.java
@@ -1,0 +1,81 @@
+package hudson.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import hudson.Functions;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlInput;
+import org.htmlunit.html.HtmlPage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
+
+public class FileParameterValuePersistenceTest {
+
+    private static final String FILENAME = "file.txt";
+    private static final String CONTENTS = "foobar";
+
+    @Rule
+    public JenkinsSessionRule sessions = new JenkinsSessionRule();
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Issue("JENKINS-13536")
+    @Test
+    public void fileParameterValuePersistence() throws Throwable {
+        sessions.then(j -> {
+            FreeStyleProject p = j.createFreeStyleProject("p");
+            p.addProperty(new ParametersDefinitionProperty(new FileParameterDefinition(FILENAME, "The file.")));
+            p.getBuildersList().add(Functions.isWindows() ? new BatchFile("type " + FILENAME) : new Shell("cat " + FILENAME));
+            File test = tmp.newFile();
+            Files.writeString(test.toPath(), CONTENTS, StandardCharsets.UTF_8);
+            try (JenkinsRule.WebClient wc = j.createWebClient()) {
+                // ParametersDefinitionProperty/index.jelly sends a 405
+                wc.setThrowExceptionOnFailingStatusCode(false);
+                HtmlPage page = wc.goTo("job/" + p.getName() + "/build?delay=0sec");
+                assertEquals(405, page.getWebResponse().getStatusCode());
+                HtmlForm form = page.getFormByName("parameters");
+                HtmlInput input = form.getInputByName("file");
+                input.setValue(test.getPath());
+                page = j.submit(form);
+                assertEquals(200, page.getWebResponse().getStatusCode());
+            }
+            FreeStyleBuild b;
+            while ((b = p.getLastBuild()) == null) {
+                Thread.sleep(100);
+            }
+            j.assertBuildStatusSuccess(j.waitForCompletion(b));
+            FileParameterValue fpv = (FileParameterValue) b.getAction(ParametersAction.class).getParameter(FILENAME);
+            fpv.getFile().delete();
+            verifyPersistence(j);
+        });
+        sessions.then(FileParameterValuePersistenceTest::verifyPersistence);
+    }
+
+    private static void verifyPersistence(JenkinsRule j) throws Throwable {
+        FreeStyleProject p = j.jenkins.getItemByFullName("p", FreeStyleProject.class);
+        FreeStyleBuild b = p.getLastBuild();
+        j.assertLogContains(CONTENTS, b);
+        Path saved = b.getRootDir().toPath().resolve("fileParameters").resolve(FILENAME);
+        assertTrue(Files.isRegularFile(saved));
+        assertEquals(CONTENTS, Files.readString(saved, StandardCharsets.UTF_8));
+        assertTrue(b.getWorkspace().child(FILENAME).exists());
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            HtmlPage page = wc.goTo(p.getUrl() + "ws");
+            assertThat(page.getWebResponse().getContentAsString(), containsString(FILENAME));
+        }
+    }
+}

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -78,7 +78,6 @@ import hudson.tasks.Shell;
 import hudson.triggers.SCMTrigger.SCMTriggerCause;
 import hudson.triggers.TimerTrigger.TimerTriggerCause;
 import hudson.util.OneShotEvent;
-import hudson.util.XStream2;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -103,30 +102,17 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import jenkins.model.BlockedBecauseOfBuildInProgress;
 import jenkins.model.Jenkins;
 import jenkins.model.queue.QueueIdStrategy;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import org.acegisecurity.acls.sid.PrincipalSid;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.servlet.ServletHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
 import org.htmlunit.ScriptResult;
 import org.htmlunit.WebRequest;
 import org.htmlunit.html.DomElement;
 import org.htmlunit.html.DomNode;
-import org.htmlunit.html.HtmlFileInput;
-import org.htmlunit.html.HtmlForm;
-import org.htmlunit.html.HtmlFormUtil;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.xml.XmlPage;
 import org.junit.Assert;
@@ -292,60 +278,6 @@ public class QueueTest {
         assertTrue(q.cancel(items[0]));
         seq.done();
         r.assertBuildStatusSuccess(r.waitForCompletion(b1));
-    }
-
-    public static final class FileItemPersistenceTestServlet extends HttpServlet {
-        private static final long serialVersionUID = 1L;
-
-        @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-            resp.setContentType("text/html");
-            resp.getWriter().println(
-                    "<html><body><form action='/' method=post name=main enctype='multipart/form-data'>" +
-                    "<input type=file name=test><input type=submit>" +
-                    "</form></body></html>"
-            );
-        }
-
-        @Override protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
-            try {
-                ServletFileUpload f = new ServletFileUpload(new DiskFileItemFactory());
-                List<?> v = f.parseRequest(req);
-                assertEquals(1, v.size());
-                XStream2 xs = new XStream2();
-                System.out.println(xs.toXML(v.get(0)));
-            } catch (FileUploadException e) {
-                throw new ServletException(e);
-            }
-        }
-    }
-
-    @Test public void fileItemPersistence() throws Exception {
-        // TODO: write a synchronous connector?
-        byte[] testData = new byte[1024];
-        for (int i = 0; i < testData.length; i++)  testData[i] = (byte) i;
-
-
-        Server server = new Server();
-        ServerConnector connector = new ServerConnector(server);
-        server.addConnector(connector);
-
-        ServletHandler handler = new ServletHandler();
-        handler.addServletWithMapping(new ServletHolder(new FileItemPersistenceTestServlet()), "/");
-        server.setHandler(handler);
-
-        server.start();
-
-        try {
-            JenkinsRule.WebClient wc = r.createWebClient();
-            @SuppressWarnings("deprecation")
-            HtmlPage p = (HtmlPage) wc.getPage("http://localhost:" + connector.getLocalPort() + '/');
-            HtmlForm f = p.getFormByName("main");
-            HtmlFileInput input = f.getInputByName("test");
-            input.setData(testData);
-            HtmlFormUtil.submit(f);
-        } finally {
-            server.stop();
-        }
     }
 
     @Issue("JENKINS-33467")


### PR DESCRIPTION
While testing the upgrade of Commons FileUpload from v1 to v2, I noticed that `QueueTest#fileItemPersistence` started failing because the v2 `DiskFileItem` wasn't serializable with XStream, as it trips up JEP-200 class filtering. Looking at what this test does, it seems like a fairly artificial / contrived test. Back when it was added in commit 06d93cbc9babe98d8f7d4a93ead2d2688c05c6c5, `FileParameterValue` was indeed serializing a `FileItem` to disk, but that behavior was changed in commit 4dde24e62037439b7b73addd7cefae83a254eb3c, which (as far as I can tell) also broke the ability to queue a build with a file parameter and have that build successfully execute after a restart (since, even though the queue was saved correctly, the `FileParameterValue` wouldn't have its `FileItem` after the restart, resulting in a `NullPointerException` in the `BuildWrapper` returned by `FileParameterValue#createBuildWrapper`)—not that anyone seems to have missed this feature in the intervening decade. I tried various things in the UI but could not get a `DiskFileItem` to be serialized no matter what I tried, so I am concluding that this isn't possible anymore after commit 4dde24e62037439b7b73addd7cefae83a254eb3c and that `QueueTest#fileItemPersistence` is a pointless test that can be deleted. I did at least manage to write a test for the scenario described in JENKINS-13536, something that was apparently attempted in commit 4dde24e62037439b7b73addd7cefae83a254eb3c, though not successfully.

### Testing done

`mvn clean verify -Dtest=hudson.model.FileParameterValuePersistenceTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

Pinging @daniel-beck / @jglick for their encyclopedic knowledge of ancient Jenkins history to confirm that my above conclusions are correct

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
