### PR TITLE
[JENKINS-73158] avoid jumping layout due to tooltips

### DIFF
--- a/core/src/main/resources/jenkins/widgets/HistoryPageFilter/queue-items.jelly
+++ b/core/src/main/resources/jenkins/widgets/HistoryPageFilter/queue-items.jelly
@@ -57,8 +57,8 @@ THE SOFTWARE.
 	      </j:otherwise>
 	    </j:choose>
 	  <j:if test="${!item.params.isEmpty()}">
-	    <div style="float:right;margin-right:10px;">
-	      <l:icon src="symbol-parameters" class="icon-sm" tooltip="Build Parameters:${item.params}"/>
+	    <div style="float:right;margin-right:10px;" tooltip="Build Parameters:${item.params}" data-tooltip-append-to="parent">
+	      <l:icon src="symbol-parameters" class="icon-sm" />
 	    </div>
 	  </j:if>
 	  </div>

--- a/core/src/main/resources/jenkins/widgets/HistoryPageFilter/queue-items.jelly
+++ b/core/src/main/resources/jenkins/widgets/HistoryPageFilter/queue-items.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
 	      </j:otherwise>
 	    </j:choose>
 	  <j:if test="${!item.params.isEmpty()}">
-	    <div style="float:right;margin-right:10px;" tooltip="Build Parameters:${item.params}" -parent="true">
+	    <div style="float:right;margin-right:10px;" tooltip="Build Parameters:${item.params}" data-tooltip-append-to-parent="true">
 	      <l:icon src="symbol-parameters" class="icon-sm" />
 	    </div>
 	  </j:if>

--- a/core/src/main/resources/jenkins/widgets/HistoryPageFilter/queue-items.jelly
+++ b/core/src/main/resources/jenkins/widgets/HistoryPageFilter/queue-items.jelly
@@ -57,7 +57,7 @@ THE SOFTWARE.
 	      </j:otherwise>
 	    </j:choose>
 	  <j:if test="${!item.params.isEmpty()}">
-	    <div style="float:right;margin-right:10px;" tooltip="Build Parameters:${item.params}" data-tooltip-append-to="parent">
+	    <div style="float:right;margin-right:10px;" tooltip="Build Parameters:${item.params}" -parent="true">
 	      <l:icon src="symbol-parameters" class="icon-sm" />
 	    </div>
 	  </j:if>

--- a/core/src/main/resources/lib/hudson/progressBar.jelly
+++ b/core/src/main/resources/lib/hudson/progressBar.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
     <x:attribute name="class">app-progress-bar ${attrs.large?'app-progress-bar--large':null} ${attrs.red?'app-progress-bar--error':null}</x:attribute>
     <x:attribute name="href">${attrs.href}</x:attribute>
     <x:attribute name="tooltip">${attrs.tooltip}</x:attribute>
-    <x:attribute name="data-tooltip-append-to">parent</x:attribute>
+    <x:attribute name="data-tooltip-append-to-parent">true</x:attribute>
     <x:attribute name="id">${attrs.id}</x:attribute>
     <x:attribute name="data-tooltip-template">${attrs.tooltipTemplate}</x:attribute>
       <j:choose>

--- a/core/src/main/resources/lib/hudson/progressBar.jelly
+++ b/core/src/main/resources/lib/hudson/progressBar.jelly
@@ -55,6 +55,7 @@ THE SOFTWARE.
     <x:attribute name="class">app-progress-bar ${attrs.large?'app-progress-bar--large':null} ${attrs.red?'app-progress-bar--error':null}</x:attribute>
     <x:attribute name="href">${attrs.href}</x:attribute>
     <x:attribute name="tooltip">${attrs.tooltip}</x:attribute>
+    <x:attribute name="data-tooltip-append-to">parent</x:attribute>
     <x:attribute name="id">${attrs.id}</x:attribute>
     <x:attribute name="data-tooltip-template">${attrs.tooltipTemplate}</x:attribute>
       <j:choose>

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -74,7 +74,9 @@ THE SOFTWARE.
               <j:set var="stuck" value="${item.isStuck()}"/>
               <j:choose>
                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
-                  <a href="${rootURL}/${item.task.url}" class="model-link inside tl-tr" tooltip="${item.causesDescription} ${item.why} ${item.params} \n ${%WaitingFor(item.inQueueForString)}">
+                  <a href="${rootURL}/${item.task.url}" class="model-link inside tl-tr"
+                     tooltip="${item.causesDescription} ${item.why} ${item.params} \n ${%WaitingFor(item.inQueueForString)}"
+                     data-tooltip-append-to="parent">
                     <l:breakable value="${item.displayName}"/>
                   </a>
                   <!-- TODO include estimated number as in BuildHistoryWidget/entries.jelly if possible -->

--- a/core/src/main/resources/lib/hudson/queue.jelly
+++ b/core/src/main/resources/lib/hudson/queue.jelly
@@ -76,7 +76,7 @@ THE SOFTWARE.
                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                   <a href="${rootURL}/${item.task.url}" class="model-link inside tl-tr"
                      tooltip="${item.causesDescription} ${item.why} ${item.params} \n ${%WaitingFor(item.inQueueForString)}"
-                     data-tooltip-append-to="parent">
+                     data-tooltip-append-to-parent="true">
                     <l:breakable value="${item.displayName}"/>
                   </a>
                   <!-- TODO include estimated number as in BuildHistoryWidget/entries.jelly if possible -->

--- a/core/src/main/resources/lib/layout/stopButton.jelly
+++ b/core/src/main/resources/lib/layout/stopButton.jelly
@@ -39,12 +39,12 @@ THE SOFTWARE.
     </st:documentation>
     <j:choose>
       <j:when test="${confirm == null}">
-        <a class="stop-button-link" href="${href}" tooltip="${alt}">
+        <a class="stop-button-link" href="${href}" tooltip="${alt}" data-tooltip-append-to="parent">
           <l:icon src="symbol-close" />
         </a>
       </j:when>
       <j:otherwise>
-        <a class="stop-button-link" href="${href}" data-confirm="${confirm}" tooltip="${alt}">
+        <a class="stop-button-link" href="${href}" data-confirm="${confirm}" tooltip="${alt}" data-tooltip-append-to="parent">
           <l:icon src="symbol-close" />
         </a>
       </j:otherwise>

--- a/core/src/main/resources/lib/layout/stopButton.jelly
+++ b/core/src/main/resources/lib/layout/stopButton.jelly
@@ -39,12 +39,12 @@ THE SOFTWARE.
     </st:documentation>
     <j:choose>
       <j:when test="${confirm == null}">
-        <a class="stop-button-link" href="${href}" tooltip="${alt}" data-tooltip-append-to="parent">
+        <a class="stop-button-link" href="${href}" tooltip="${alt}" data-tooltip-append-to-parent="true">
           <l:icon src="symbol-close" />
         </a>
       </j:when>
       <j:otherwise>
-        <a class="stop-button-link" href="${href}" data-confirm="${confirm}" tooltip="${alt}" data-tooltip-append-to="parent">
+        <a class="stop-button-link" href="${href}" data-confirm="${confirm}" tooltip="${alt}" data-tooltip-append-to-parent="true">
           <l:icon src="symbol-close" />
         </a>
       </j:otherwise>

--- a/war/src/main/js/components/tooltips/index.js
+++ b/war/src/main/js/components/tooltips/index.js
@@ -21,8 +21,8 @@ function registerTooltip(element) {
   const tooltip = element.getAttribute("tooltip");
   const htmlTooltip = element.getAttribute("data-html-tooltip");
   let appendTo = document.body;
-  if (element.hasAttribute("data-tooltip-append-to")) {
-    appendTo = element.getAttribute("data-tooltip-append-to");
+  if (element.hasAttribute("data-tooltip-append-to-parent")) {
+    appendTo = "parent";
   }
   if (
     tooltip !== null &&

--- a/war/src/main/js/components/tooltips/index.js
+++ b/war/src/main/js/components/tooltips/index.js
@@ -5,7 +5,6 @@ const TOOLTIP_BASE = {
   arrow: false,
   theme: "tooltip",
   animation: "tooltip",
-  appendTo: "parent",
 };
 
 /**
@@ -21,6 +20,10 @@ function registerTooltip(element) {
 
   const tooltip = element.getAttribute("tooltip");
   const htmlTooltip = element.getAttribute("data-html-tooltip");
+  let appendTo = document.body;
+  if (element.hasAttribute("data-tooltip-append-to")) {
+    appendTo = element.getAttribute("data-tooltip-append-to");
+  }
   if (
     tooltip !== null &&
     tooltip.trim().length > 0 &&
@@ -40,6 +43,7 @@ function registerTooltip(element) {
           onHidden(instance) {
             instance.reference.setAttribute("title", instance.props.content);
           },
+          appendTo: appendTo,
         },
         TOOLTIP_BASE,
       ),
@@ -58,6 +62,7 @@ function registerTooltip(element) {
               instance.reference.getAttribute("data-tooltip-interactive") ===
               "true";
           },
+          appendTo: appendTo,
         },
         TOOLTIP_BASE,
       ),


### PR DESCRIPTION
The fix for JENKINS-72744 made the tooltip get appended to the parent element. But this can also cause troubles in some cases. To avoid this one can now decide whether the tooltip should be appended to the body (the default) or to the parent.
Adjust all locations where a tooltip is displayed inside a widget to append it to the parent. This works well with those tooltips and avoids a jumping layout in the custom-folder-icon and potentially other places.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-73158](https://issues.jenkins.io/browse/JENKINS-73158).

### Testing done
Manual testing that in widgets the tooltips are properly removed while with custom-folder-icon plugin, the layout stays stable.

### Proposed changelog entries

- Avoid jumping layout due to tooltips.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
