### PR TITLE
Ensure `ClassLoader`s have names for debugging

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -271,7 +271,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
     /**
      * @deprecated since TODO use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
      */
-    @Deprecated(since = "//TODO")
+    @Deprecated(since = "TODO")
     protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent) throws IOException {
         return createClassLoader(paths, parent, null);
     }
@@ -279,15 +279,15 @@ public class ClassicPluginStrategy implements PluginStrategy {
     /**
      * @deprecated since TODO use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
      */
-    @Deprecated(since="@TODO")
+    @Deprecated(since="TODO")
     protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent, Attributes atts) throws IOException {
         // generate a legacy id so at least we can track to something
-        return createClassLoader("legacy"+UUID.randomUUID(), paths, parent, atts);
+        return createClassLoader("unidentified-" + UUID.randomUUID(), paths, parent, atts);
     }
 
     /**
      * Creates a  classloader that can load all the specified jar files and delegate to the given parent.
-     * @since //TODO
+     * @since TODO
      */
     protected ClassLoader createClassLoader(String name, List<File> paths, ClassLoader parent, Attributes atts) throws IOException {
         boolean usePluginFirstClassLoader =

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -52,6 +52,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -235,7 +236,11 @@ public class ClassicPluginStrategy implements PluginStrategy {
         dependencyLoader = getBaseClassLoader(atts, dependencyLoader);
 
         return new PluginWrapper(pluginManager, archive, manifest, baseResourceURL,
-                createClassLoader(paths, dependencyLoader, atts), disableFile, dependencies, optionalDependencies);
+                createClassLoader(computeClassLoaderName(manifest, archive), paths, dependencyLoader, atts), disableFile, dependencies, optionalDependencies);
+    }
+
+    private static String computeClassLoaderName(Manifest mf, File archive) {
+        return "PluginClassLoader for " + PluginWrapper.computeShortName(mf, archive.getName());
     }
 
     private void fix(Attributes atts, List<PluginWrapper.Dependency> optionalDependencies) {
@@ -263,15 +268,28 @@ public class ClassicPluginStrategy implements PluginStrategy {
         return DetachedPluginsUtil.getImpliedDependencies(pluginName, jenkinsVersion);
     }
 
-    @Deprecated
+    /**
+     * @deprecated since TODO use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
+     */
+    @Deprecated(since = "//TODO")
     protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent) throws IOException {
         return createClassLoader(paths, parent, null);
     }
 
     /**
-     * Creates the classloader that can load all the specified jar files and delegate to the given parent.
+     * @deprecated since TODO use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
      */
+    @Deprecated(since="@TODO")
     protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent, Attributes atts) throws IOException {
+        // generate a legacy id so at least we can track to something
+        return createClassLoader("legacy"+UUID.randomUUID(), paths, parent, atts);
+    }
+
+    /**
+     * Creates a  classloader that can load all the specified jar files and delegate to the given parent.
+     * @since //TODO
+     */
+    protected ClassLoader createClassLoader(String name, List<File> paths, ClassLoader parent, Attributes atts) throws IOException {
         boolean usePluginFirstClassLoader =
                 atts != null && Boolean.parseBoolean(atts.getValue("PluginFirstClassLoader"));
 
@@ -285,9 +303,9 @@ public class ClassicPluginStrategy implements PluginStrategy {
         }
         URLClassLoader2 classLoader;
         if (usePluginFirstClassLoader) {
-            classLoader = new PluginFirstClassLoader2(urls.toArray(new URL[0]), parent);
+            classLoader = new PluginFirstClassLoader2(name, urls.toArray(new URL[0]), parent);
         } else {
-            classLoader = new URLClassLoader2(urls.toArray(new URL[0]), parent);
+            classLoader = new URLClassLoader2(name, urls.toArray(new URL[0]), parent);
         }
         return classLoader;
     }
@@ -561,7 +579,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
         }
 
         DependencyClassLoader(ClassLoader parent, File archive, List<Dependency> dependencies, PluginManager pluginManager) {
-            super(parent);
+            super("dependency ClassLoader for " + archive.getPath(), parent);
             this._for = archive;
             this.dependencies = List.copyOf(dependencies);
             this.pluginManager = pluginManager;

--- a/core/src/main/java/hudson/PluginFirstClassLoader2.java
+++ b/core/src/main/java/hudson/PluginFirstClassLoader2.java
@@ -25,8 +25,9 @@ public class PluginFirstClassLoader2 extends URLClassLoader2 {
         registerAsParallelCapable();
     }
 
-    public PluginFirstClassLoader2(@NonNull URL[] urls, @NonNull ClassLoader parent) {
-        super(Objects.requireNonNull(urls), Objects.requireNonNull(parent));
+
+    public PluginFirstClassLoader2(String name, @NonNull URL[] urls, @NonNull ClassLoader parent) {
+        super(name, Objects.requireNonNull(urls), Objects.requireNonNull(parent));
     }
 
     /**

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2337,7 +2337,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         }
 
         public UberClassLoader(List<PluginWrapper> activePlugins) {
-            super(activePlugins.stream().map(PluginWrapper::getShortName).collect(Collectors.joining(", ", "UberClassLoader for ", "")), PluginManager.class.getClassLoader());
+            super("UberClassLoader", PluginManager.class.getClassLoader());
             this.activePlugins = activePlugins;
         }
 

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1099,7 +1099,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
 
     /*package*/ static @CheckForNull Manifest parsePluginManifest(URL bundledJpi) {
-        try (URLClassLoader cl = new URLClassLoader(new URL[]{bundledJpi})) {
+        try (URLClassLoader cl = new URLClassLoader("Temporary classloader for parsing " + bundledJpi.toString(), new URL[]{bundledJpi}, ClassLoader.getSystemClassLoader())) {
             InputStream in = null;
             try {
                 URL res = cl.findResource(PluginWrapper.MANIFEST_FILENAME);
@@ -2337,7 +2337,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         }
 
         public UberClassLoader(List<PluginWrapper> activePlugins) {
-            super(PluginManager.class.getClassLoader());
+            super(activePlugins.stream().map(PluginWrapper::getShortName).collect(Collectors.joining(", ", "UberClassLoader for ", "")), PluginManager.class.getClassLoader());
             this.activePlugins = activePlugins;
         }
 

--- a/core/src/main/java/hudson/util/MaskingClassLoader.java
+++ b/core/src/main/java/hudson/util/MaskingClassLoader.java
@@ -59,7 +59,7 @@ public class MaskingClassLoader extends ClassLoader {
     }
 
     public MaskingClassLoader(ClassLoader parent, Collection<String> masks) {
-        super(parent);
+        super("Masking ClassLoader of " + parent.getName(), parent);
         this.masksClasses = List.copyOf(masks);
 
         /*

--- a/core/src/main/java/jenkins/util/URLClassLoader2.java
+++ b/core/src/main/java/jenkins/util/URLClassLoader2.java
@@ -20,7 +20,7 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
     /**
      * @deprecated use {@link URLClassLoader2#URLClassLoader2(String, URL[])}
      */
-    @Deprecated(since = "//TODO")
+    @Deprecated(since = "TODO")
     public URLClassLoader2(URL[] urls) {
         super(urls);
     }
@@ -28,7 +28,7 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
     /**
      * @deprecated use {@link URLClassLoader2#URLClassLoader2(String, URL[], ClassLoader)}
      */
-    @Deprecated(since = "//TODO")
+    @Deprecated(since = "TODO")
     public URLClassLoader2(URL[] urls, ClassLoader parent) {
         super(urls, parent);
     }
@@ -37,7 +37,7 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
      * Create a new {@link URLClassLoader2} with the given name and URLS and the {@link #getSystemClassLoader()} as its parent.
      * @param name name of this classloader.
      * @param urls the list of URLS to find classes in.
-     * @since //TODO
+     * @since TODO
      */
     public URLClassLoader2(String name, URL[] urls) {
         super(name, urls, getSystemClassLoader());
@@ -48,7 +48,7 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
      * @param name name of this classloader.
      * @param urls the list of URLS to find classes in.
      * @param parent the parent to search for classes before we look in the {@code urls}
-     * @since //TODO
+     * @since TODO
      */
     public URLClassLoader2(String name, URL[] urls, ClassLoader parent) {
         super(name, urls, parent);

--- a/core/src/main/java/jenkins/util/URLClassLoader2.java
+++ b/core/src/main/java/jenkins/util/URLClassLoader2.java
@@ -17,12 +17,41 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
         registerAsParallelCapable();
     }
 
+    /**
+     * @deprecated use {@link URLClassLoader2#URLClassLoader2(String, URL[])}
+     */
+    @Deprecated(since = "//TODO")
     public URLClassLoader2(URL[] urls) {
         super(urls);
     }
 
+    /**
+     * @deprecated use {@link URLClassLoader2#URLClassLoader2(String, URL[], ClassLoader)}
+     */
+    @Deprecated(since = "//TODO")
     public URLClassLoader2(URL[] urls, ClassLoader parent) {
         super(urls, parent);
+    }
+
+    /**
+     * Create a new {@link URLClassLoader2} with the given name and URLS and the {@link #getSystemClassLoader()} as its parent.
+     * @param name name of this classloader.
+     * @param urls the list of URLS to find classes in.
+     * @since //TODO
+     */
+    public URLClassLoader2(String name, URL[] urls) {
+        super(name, urls, getSystemClassLoader());
+    }
+
+    /**
+     *  Create a new {@link URLClassLoader2} with the given name, URLS parent.
+     * @param name name of this classloader.
+     * @param urls the list of URLS to find classes in.
+     * @param parent the parent to search for classes before we look in the {@code urls}
+     * @since //TODO
+     */
+    public URLClassLoader2(String name, URL[] urls, ClassLoader parent) {
+        super(name, urls, parent);
     }
 
     @Override

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -105,7 +105,7 @@ public class PluginWrapperTest {
     @Issue("JENKINS-66563")
     @Test
     public void insertJarsIntoClassPath() throws Exception {
-        try (URLClassLoader2 cl = new URLClassLoader2(new URL[0])) {
+        try (URLClassLoader2 cl = new URLClassLoader2("Test", new URL[0])) {
             assertInjectingJarsWorks(cl);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3206.vb_15dcf73f6a_9</remoting.version>
+    <remoting.version>3229.v96d6148deb_f9</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3229.v96d6148deb_f9</remoting.version>
+    <remoting.version>3242.vfe5ce6301591</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@ THE SOFTWARE.
     <!-- Bundled Remoting version -->
     <remoting.version>3244.vf7f977e04755</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
-    <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
+    <remoting.minimum.supported.version>3244.vf7f977e04755</remoting.minimum.supported.version>
 
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3244.vf7f977e04755</remoting.version>
+    <remoting.version>3247.v5472f9a_4131a_</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
-    <remoting.minimum.supported.version>3244.vf7f977e04755</remoting.minimum.supported.version>
+    <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
 
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Medium</spotbugs.threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3242.vfe5ce6301591</remoting.version>
+    <remoting.version>3244.vf7f977e04755</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ THE SOFTWARE.
     <changelog.url>https://www.jenkins.io/changelog</changelog.url>
 
     <!-- Bundled Remoting version -->
-    <remoting.version>3247.v5472f9a_4131a_</remoting.version>
+    <remoting.version>3248.v65ecb_254c298</remoting.version>
     <!-- Minimum Remoting version, which is tested for API compatibility -->
     <remoting.minimum.supported.version>4.13</remoting.minimum.supported.version>
 

--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -266,7 +266,7 @@ public class Main {
         // locate the Winstone launcher
         ClassLoader cl;
         try {
-            cl = new URLClassLoader(new URL[] {tmpJar.toURI().toURL()});
+            cl = new URLClassLoader("Jenkins Main ClassLoader", new URL[] {tmpJar.toURI().toURL()}, ClassLoader.getSystemClassLoader());
         } catch (MalformedURLException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
giving a `ClassLoader` a name can make it easier to debug class loading issues that occur on agents.

with https://github.com/jenkinsci/remoting/pull/741 this gets propagated to the remote side so you can see what the `RemoteClassLoader` is actually loading from.

tested a build of this to try and debug an issue with an `ssh-slaves` based agent and added a breakpoint on the classloading code with I was having issues with and connected to the agent process.

Validated that the classloading issue I was attempting to diagnose has more diagnostics.

e.g. 

<img width="526" alt="image" src="https://github.com/jenkinsci/jenkins/assets/494726/4f8b7f6f-14d5-4141-af99-f81d695e02d9">

**Note:** as the classloaders now have names, this will be shown in the default stack traces (similar to how we see `java.base/java.net.URLClassLoader`  (due to this being present in the [`StackTraceElement`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/StackTraceElement.html)

e.g. 

```
		at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
		at hudson.model.ResourceController.execute(ResourceController.java:101)
		at hudson.model.Executor.run(Executor.java:446)
Caused by: org.eclipse.jgit.api.errors.TransportException: ssh://172.17.32.1:2222/srv/git/your-repo.git/: remote hung up unexpectedly
	at PluginClassLoader for git-client//org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:249)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.JGitAPIImpl$3.execute(JGitAPIImpl.java:851)
	... 10 more
Caused by: org.eclipse.jgit.errors.TransportException: ssh://172.17.32.1:2222/srv/git/your-repo.git/: remote hung up unexpectedly
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.TransportGitSsh$SshFetchConnection.<init>(TransportGitSsh.java:311)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.TransportGitSsh.openFetch(TransportGitSsh.java:152)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.FetchProcess.executeImp(FetchProcess.java:153)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.FetchProcess.execute(FetchProcess.java:105)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.Transport.fetch(Transport.java:1482)
	at PluginClassLoader for git-client//org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:238)
	... 11 more
Caused by: java.lang.NoClassDefFoundError: net/i2p/crypto/eddsa/spec/EdDSAParameterSpec
	at PluginClassLoader for mina-sshd-api-common//org.apache.sshd.common.util.security.SecurityUtils.getEDDSAPublicKeyEntryDecoder(SecurityUtils.java:580)
	at PluginClassLoader for mina-sshd-api-common//org.apache.sshd.common.config.keys.KeyUtils.<clinit>(KeyUtils.java:187)
	at PluginClassLoader for mina-sshd-api-common//org.apache.sshd.common.config.keys.loader.openssh.OpenSSHRSAPrivateKeyDecoder.<clinit>(OpenSSHRSAPrivateKeyDecoder.java:51)
	at PluginClassLoader for mina-sshd-api-common//org.apache.sshd.common.config.keys.loader.openssh.OpenSSHKeyPairResourceParser.<clinit>(OpenSSHKeyPairResourceParser.java:89)
	at PluginClassLoader for mina-sshd-api-common//org.apache.sshd.common.util.security.SecurityUtils.getKeyPairResourceParser(SecurityUtils.java:681)
	at PluginClassLoader for mina-sshd-api-common//org.apache.sshd.common.util.security.SecurityUtils.loadKeyPairIdentities(SecurityUtils.java:518)
	at PluginClassLoader for git-client//org.jenkinsci.plugins.gitclient.JGitAPIImpl$1.getDefaultKeys(JGitAPIImpl.java:307)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.sshd.SshdSessionFactory.lambda$0(SshdSessionFactory.java:212)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.sshd.SshdSession.<init>(SshdSession.java:93)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.sshd.SshdSessionFactory.getSession(SshdSessionFactory.java:196)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.sshd.SshdSessionFactory.getSession(SshdSessionFactory.java:1)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.SshTransport.getSession(SshTransport.java:107)
	at PluginClassLoader for git-client//org.eclipse.jgit.transport.TransportGitSsh$SshFetchConnection.<init>(TransportGitSsh.java:279)
	... 16 more
Caused by: java.lang.ClassNotFoundException: net.i2p.crypto.eddsa.spec.EdDSAParameterSpec
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at jenkins.util.URLClassLoader2.findClass(URLClassLoader2.java:64)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
	at hudson.remoting.RemoteClassLoader$ClassLoaderProxy.fetch4(RemoteClassLoader.java:1014)
	at hudson.remoting.RemoteClassLoader$ClassLoaderProxy.fetch3(RemoteClassLoader.java:1059)
	at jdk.internal.reflect.GeneratedMethodAccessor7.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at hudson.remoting.RemoteInvocationHandler$RPCRequest.perform(RemoteInvocationHandler.java:924)
	at hudson.remoting.Request$2.run(Request.java:377)
	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
	at org.jenkinsci.remoting.CallableDecorator.call(CallableDecorator.java:18)
	at hudson.remoting.CallableDecoratorList.lambda$applyDecorator$0(CallableDecoratorList.java:19)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
	Suppressed: hudson.remoting.Channel$CallSiteStackTrace: Remote call to channel
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1787)
		at hudson.remoting.Request.call(Request.java:199)
		at hudson.remoting.RemoteInvocationHandler.invoke(RemoteInvocationHandler.java:288)
		at com.sun.proxy.$Proxy7.fetch3(Unknown Source)
		at hudson.remoting.RemoteClassLoader.prefetchClassReference(RemoteClassLoader.java:362)
		at hudson.remoting.RemoteClassLoader.loadWithMultiClassLoader(RemoteClassLoader.java:267)
		at hudson.remoting.RemoteClassLoader.findClass(RemoteClassLoader.java:237)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
		at PluginClassLoader for mina-sshd-api-common//org.apache.sshd.common.util.security.SecurityUtils.getEDDSAPublicKeyEntryDecoder(SecurityUtils.java:580)
		at PluginClassLoader for mina-sshd-api-common//org.apache.sshd.common.config.keys.KeyUtils.<clinit>(KeyUtils.java:187)
```

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->


<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

interactive debugging with an agent from `ssh-slaves` plugin and a breakpoint on some code that loads classes.
inspected the classloader for several classes that are expected to come from different plugins.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Adds debugging information to remote classloaders.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

Agents that provide their own version of `agent.jar` will need to be updated to to use at least version [`3244.vf7f977e04755`](https://github.com/jenkinsci/remoting/releases/tag/3244.vf7f977e04755) of remoting.
Generally this would impact inbound agents, ssh based agents should be updated automatically.


[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.


### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
