### PR TITLE
[JENKINS-73168] Restore 'No changes' label when there are no changes in a build

### DIFF
--- a/core/src/main/resources/jenkins/scm/RunWithSCM/changesets.jelly
+++ b/core/src/main/resources/jenkins/scm/RunWithSCM/changesets.jelly
@@ -25,13 +25,18 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <j:set var="changeSets" value="${it.changeSets}"/>
-  <j:if test="${!changeSets.isEmpty()}">
-    <table>
-      <t:summary icon="symbol-changes">
-        <j:forEach var="changeSet" items="${changeSets}">
-          <st:include it="${changeSet}" page="digest.jelly"/>
-        </j:forEach>
-      </t:summary>
-    </table>
-  </j:if>
+  <table>
+    <t:summary icon="symbol-changes">
+      <j:choose>
+        <j:when test="${!changeSets.isEmpty()}">
+          <j:forEach var="changeSet" items="${changeSets}">
+            <st:include it="${changeSet}" page="digest.jelly"/>
+          </j:forEach>
+        </j:when>
+        <j:otherwise>
+          <st:include class="hudson.scm.EmptyChangeLogSet" page="digest.jelly" />
+        </j:otherwise>
+      </j:choose>
+    </t:summary>
+  </table>
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-73168](https://issues.jenkins.io/browse/JENKINS-73168).

Will need some input on this, unsure if this is the right approach. 

`core/src/main/resources/hudson/model/AbstractBuild/changes.jelly` uses `${it.changeSet}` to load change sets, which returns an `EmptyChangeLogSet` when there are none. `core/src/main/resources/jenkins/scm/RunWithSCM/changesets.jelly` on the other hand uses `${it.changeSets}` which returns an empty list. As a rather rudimentary fix I'm injecting the `EmptyChangeLogSet` `digest.jelly` when the list is empty - which works, albeit I'm not sure if these two files should be unified in their approach to loading change sets.

### Testing done

* `No changes` label appears when there are no changes 

### Proposed changelog entries

- Restore 'No changes' label when there are no changes in a build.  Regression in 2.453.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
