### PR TITLE
[JENKINS-73166] Fix PKCS#12 certificate save to credentials

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -589,10 +589,15 @@ function parseHtml(html) {
 
 /**
  * Evaluates the script in global context.
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval
  */
 function geval(script) {
-  eval(script);
+  // execScript chokes on "" but eval doesn't, so we need to reject it first.
+  if (script == null || script == "") {
+    return;
+  }
+  // see http://perfectionkills.com/global-eval-what-are-the-options/
+  // note that execScript cannot return value
+  (this.execScript || eval)(script);
 }
 
 /**


### PR DESCRIPTION
## [JENKINS-73166](https://issues.jenkins.io/browse/JENKINS-73166) - Revert part of "Remove dead JS code (#9136)"

See [JENKINS-73166](https://issues.jenkins.io/browse/JENKINS-73166) where it notes that the credentials code for certificates has a dependency on this JavaScript code.  Without this JavaScript, an attempt to add a new certificate credential type using PKCS#12 will fail with an HTTP 404 error.

The replacement of YUI.log with console.log is not involved in the bug report, so it is retained in the code change.

This reverts part of commit 38fdae40f3f3ae91ee409b8b7771f31bde10fcfc.

### Testing done

Confirmed with interactive testing that a PKCS#12 certificate cannot be added before this change and can be added after this change.

### Proposed changelog entries

- Allow PKCS 12 certificates to be added to the credentials store again.  Regression in 2.453.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@zbynek

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
