### PR TITLE
Remove 'Disable project' button from project view

### DIFF
--- a/core/src/main/resources/lib/hudson/project/makeDisabled.jelly
+++ b/core/src/main/resources/lib/hudson/project/makeDisabled.jelly
@@ -41,14 +41,5 @@ THE SOFTWARE.
         </form>
       </div>
     </j:when>
-    <j:otherwise>
-      <div align="right">
-        <form method="post" id="disable-project" action="disable">
-          <l:hasPermission permission="${it.CONFIGURE}">
-            <f:submit value="${%Disable Project}" primary="false" />
-          </l:hasPermission>
-        </form>
-      </div>
-    </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/test/src/test/java/hudson/model/ProjectTest.java
+++ b/test/src/test/java/hudson/model/ProjectTest.java
@@ -644,15 +644,13 @@ public class ProjectTest {
 
         JenkinsRule.WebClient wc = j.createWebClient();
         wc.withBasicCredentials(user.getId(), "password");
-        HtmlPage p = wc.goTo(project.getUrl());
 
-        List<HtmlForm> forms = p.getForms();
-        for (HtmlForm form : forms) {
-            if ("disable".equals(form.getAttribute("action"))) {
-                j.submit(form);
-            }
-        }
-       assertTrue("Project should be disabled.", project.isDisabled());
+        HtmlPage p = wc.getPage(project, "configure");
+        HtmlForm form = p.getFormByName("config");
+        form.getInputByName("enable").click();
+        j.submit(form);
+
+        assertTrue("Project should be disabled.", project.isDisabled());
     }
 
     @Test


### PR DESCRIPTION
Reverts the revert in jenkinsci/jenkins#9272

Fix for the `workflow-job-plugin` test failure here https://github.com/jenkinsci/workflow-job-plugin/pull/437

---

Discussed briefly in the last UX Sig, the 'Disable project' (and 'Add/edit description') button take up a lot of vertical space (roughly 100px) and this forces useful information, such as stage view plugin etc down.

My proposal would be just to remove the 'Disable project' button altogether and instead have users rely on the configure screen to disable projects.

**Before**
<img width="1365" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/0f7b42c2-f17a-4adb-aa06-ef3dc59696ab">

**After**
<img width="1347" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/1f04ca5c-e9af-44f8-bff7-5669dde6febe">

### Testing done

* Disable button has been removed, still possible to reenable a project from that view however

### Proposed changelog entries

- Remove 'Disable project' button from project view.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
