### PR TITLE
[JENKINS-64356] fix legacyIds missing when creating jobs via REST API or CLI

### DIFF
--- a/core/src/main/java/hudson/model/ItemGroupMixIn.java
+++ b/core/src/main/java/hudson/model/ItemGroupMixIn.java
@@ -290,6 +290,7 @@ public abstract class ItemGroupMixIn {
 
             add(result);
 
+            result.onCreatedFromScratch();
             ItemListener.fireOnCreated(result);
             Jenkins.get().rebuildDependencyGraphAsync();
 

--- a/test/src/test/java/jenkins/model/RunIdMigratorTest.java
+++ b/test/src/test/java/jenkins/model/RunIdMigratorTest.java
@@ -58,7 +58,6 @@ public class RunIdMigratorTest {
         assertTrue(legacyIds.exists());
     }
 
-    @Ignore("TODO Item#onCreatedFromScratch is not called")
     @Issue("JENKINS-64356")
     @Test
     public void legacyIdsPresentViaRestApi() throws Exception {
@@ -82,7 +81,6 @@ public class RunIdMigratorTest {
         assertTrue(legacyIds.exists());
     }
 
-    @Ignore("TODO Item#onCreatedFromScratch is not called")
     @Issue("JENKINS-64356")
     @Test
     public void legacyIdsPresentViaCli() {

--- a/test/src/test/java/jenkins/model/RunIdMigratorTest.java
+++ b/test/src/test/java/jenkins/model/RunIdMigratorTest.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;


### PR DESCRIPTION
When creating jobs via the rest api or cli the call to onCreatedFromScratch was missing. This can lead to long startup times when many jobs are created this way.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-64356](https://issues.jenkins.io/browse/JENKINS-64356).

### Testing done

Unit tests are no longer ignored and succeed


### Proposed changelog entries

- Improve startup performance when jobs have been created via REST API or command line interface.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
