### PR TITLE
[JENKINS-10629] Migrate from Commons Compress to Ant

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -131,14 +131,14 @@ import jenkins.security.MasterToSlaveCallable;
 import jenkins.util.ContextResettingExecutorService;
 import jenkins.util.SystemProperties;
 import jenkins.util.VirtualFile;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.fileupload2.core.FileItem;
 import org.apache.commons.io.input.CountingInputStream;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.tar.TarEntry;
+import org.apache.tools.tar.TarInputStream;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipFile;
 import org.jenkinsci.remoting.RoleChecker;
@@ -3079,14 +3079,13 @@ public final class FilePath implements SerializableOnlyOverRemoting {
 
     /**
      * Reads from a tar stream and stores obtained files to the base dir.
-     * Supports large files > 10 GB since 1.627 when this was migrated to use commons-compress.
+     * Supports large files &gt; 10 GB since 1.627.
      */
     private static void readFromTar(String name, File baseDir, InputStream in, Charset filenamesEncoding) throws IOException {
 
-        // TarInputStream t = new TarInputStream(in);
-        try (TarArchiveInputStream t = new TarArchiveInputStream(in, filenamesEncoding.name())) {
-            TarArchiveEntry te;
-            while ((te = t.getNextTarEntry()) != null) {
+        try (TarInputStream t = new TarInputStream(in, filenamesEncoding.name())) {
+            TarEntry te;
+            while ((te = t.getNextEntry()) != null) {
                 File f = new File(baseDir, te.getName());
                 if (!f.toPath().normalize().startsWith(baseDir.toPath())) {
                     throw new IOException(

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -26,6 +26,7 @@ package hudson.tasks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -51,6 +52,8 @@ import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -61,6 +64,7 @@ import jenkins.util.VirtualFile;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -390,6 +394,59 @@ public class ArtifactArchiverTest {
         VirtualFile artifacts = project.getBuildByNumber(1).getArtifactManager().root();
         assertTrue(artifacts.child(".svn").child("file").exists());
         assertTrue(artifacts.child("dir").child(".svn").child("file").exists());
+    }
+
+    @Ignore("Test is too slow and requires a lot of disk space")
+    @Issue("JENKINS-10629")
+    @Test
+    public void testLargeArchiveFromAgent() throws Exception {
+        final String filename = "large";
+        final long size = 10L * 1024L * 1024L * 1024L; // 10 GB
+
+        Slave agent = j.createOnlineSlave();
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.setAssignedNode(agent);
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                FilePath filePath = build.getWorkspace().child(filename);
+                try (OutputStream os = filePath.write()) {
+                    // Create byte array and fill it with data
+                    byte[] megabyte = new byte[1024 * 1024];
+                    for (int i = 0; i < megabyte.length; i++) {
+                        megabyte[i] = (byte) (i % 128);
+                    }
+                    // Fill file with 1 MB chunks
+                    for (int i = 0; i < size / megabyte.length; i++) {
+                        os.write(megabyte);
+                    }
+                }
+                return true;
+            }
+        });
+        project.getPublishersList().add(new ArtifactArchiver(filename));
+
+        // Assert that the build succeeded
+        FreeStyleBuild build = j.buildAndAssertSuccess(project);
+        VirtualFile virtualFile = build.getArtifactManager().root().child(filename);
+
+        // Assert that the artifact was copied
+        assertTrue(virtualFile.exists());
+
+        // Assert that it has the right size
+        assertEquals(size, virtualFile.length());
+
+        // Assert that the data at the end of the file is the expected data
+        try (InputStream is = virtualFile.open()) {
+            is.skip(size - 1024 * 1024);
+            byte[] expected = new byte[1024 * 1024];
+            for (int i = 0; i < expected.length; i++) {
+                expected[i] = (byte) (i % 128);
+            }
+            byte[] actual = new byte[1024 * 1024];
+            is.read(actual);
+            assertArrayEquals(expected, actual);
+        }
     }
 
     @LocalData


### PR DESCRIPTION
We originally used Ant for tar/untar functionality, but we migrated to Commons Compress in #1670, which also added the Commons Compress library to the WAR. Fast forward to today, and recent releases of Commons Compress depend on Commons Lang 3. We don't want to keep increasing the API surface area of the WAR by pulling in these random libraries. And pulling in Commons Lang 3 would override the library plugin we ship today.

A solution can be found by migrating from Commons Compress back to Ant. Our original reason for migrating away from it was that it did not support large files > 8 GiB in size. Today, it does, and I verified this with an automated test. We are unlikely to ever remove Ant from Jenkins core, as it is used in a lot of places in core, so why not use it for tar/untar functionality as well. And unlike Commons Compress, it has no dependency on Commons Lang 3.

In the meantime, we're still blocked from upgrading to the latest release of Commons Compress, because the latest release depends on Commons Lang 3 which we do not want to introduce. But this PR shows a path forward. With core's dependency on Commons Compress removed, plugins can then be adapted, and we can eventually remove Commons Compress from core. Plugins could be adapted by either migrating to core's copy of Ant (as in this PR) or a new Commons Compress library plugin could be created and plugins migrated to that instead. That Commons Compress library plugin could depend on Commons Lang 3 as a plugin-to-plugin dependency.

### Testing done

Ran the new test and it passed after about 2 minutes. I am not enabling it by default as it requires a lot of time and disk space to run.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
