### PR TITLE
Warn  Java 11 users of 18 Jun 2024 end of life in weekly

### DIFF
--- a/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
@@ -78,7 +78,16 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
 
     static {
         NavigableMap<Integer, LocalDate> supportedVersions = new TreeMap<>();
-        supportedVersions.put(11, LocalDate.of(2024, 9, 30)); // Temurin: 2024-10-31
+        // Adjust Java 11 end of life date for weekly and LTS
+        if (Jenkins.VERSION.split("[.]").length > 2) {
+            // LTS will require Java 17 or newer beginning 30 Oct 2024
+            // https://groups.google.com/g/jenkinsci-dev/c/gsXAqOQQEPc/m/VT9IBYdmAQAJ
+            supportedVersions.put(11, LocalDate.of(2024, 10, 30)); // Temurin: 2024-10-31
+        } else {
+            // Weekly will require Java 17 or newer beginning 18 Jun 2024
+            // https://groups.google.com/g/jenkinsci-dev/c/gsXAqOQQEPc/m/4fn4Un1iAwAJ
+            supportedVersions.put(11, LocalDate.of(2024, 6, 18)); // Temurin: 2024-10-31
+        }
         supportedVersions.put(17, LocalDate.of(2026, 3, 31)); // Temurin: 2027-10-31
         supportedVersions.put(21, LocalDate.of(2027, 9, 30)); // Temurin: 2029-09-30
         SUPPORTED_JAVA_VERSIONS = Collections.unmodifiableNavigableMap(supportedVersions);


### PR DESCRIPTION
## Warn Java 11 users of 18 Jun 2024 end of life in weekly

The June 18, 2024 weekly release will require Java 17 or newer so that the upgrade from Jetty 10 to Jetty 12 has more time to complete before the eventual Oct 30, 2024 release that will require Java 17 or newer.

The administrative monitor will be activated even for those users that had previously cleared the administrative monitor because the date is part of the administrative monitor key.

Also updates the Java 11 end of life date for Java 11 users running with the long term support release.

### Testing done

Verified that the correct message is displayed when run on Jenkins weekly snapshot with this change.

![weekly-shows-correct-end-of-life-date](https://github.com/jenkinsci/jenkins/assets/156685/06ee9245-c670-41e1-a23a-2a1fa6efe5a2)


Verified that the correct message is displayed when run on Jenkins LTS snapshot with this change.


![lts-shows-correct-end-of-life-date](https://github.com/jenkinsci/jenkins/assets/156685/f12d4cf7-e6bf-4af4-9977-57ef39edafb2)

### Proposed changelog entries

- Warn Java 11 users of the new 2024-06-18 end of life in weekly releases. This is a change from the previously announced date of 2024-09-30.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
