### PR TITLE
Add Unit Test to Prevent Duplicate Job Creation via CLI

### DIFF
--- a/test/src/test/java/hudson/cli/CreateJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/CreateJobCommandTest.java
@@ -63,6 +63,20 @@ public class CreateJobCommandTest {
         assertThat(invoker.withStdin(new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8))).invokeWithArgs("d/p"), succeededSilently());
         assertNotNull(d.getItem("p"));
     }
+    
+    @Test public void cannotCreateDuplicateJob() {
+        CLICommand cmd = new CreateJobCommand();
+        CLICommandInvoker invoker = new CLICommandInvoker(r, cmd);
+        assertThat(r.jenkins.getItems(), Matchers.hasSize(0));
+
+        assertThat(invoker.withStdin(new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8))).invokeWithArgs("job1"), succeededSilently());
+        assertThat(r.jenkins.getItems(), Matchers.hasSize(1));
+
+        CLICommandInvoker.Result result = invoker.withStdin(new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8))).invokeWithArgs("job1");
+        assertThat(result.stderr(), containsString("already exists"));
+        assertThat(result, failedWith(4));
+        assertThat(r.jenkins.getItems(), Matchers.hasSize(1));
+    }
 
     @Issue("SECURITY-2424")
     @Test public void cannotCreateJobWithTrailingDot_withoutOtherJob() {


### PR DESCRIPTION
This PR adds a new unit test in the Jenkins test suite to verify that the system correctly handles attempts to create duplicate jobs via the CLI. This test is aimed at strengthening our robustness in CLI operations and preventing unintended behaviors in job management.

Changes Made:
Introduced a new test method cannotCreateDuplicateJob() in the appropriate test class.
The test first checks that no jobs are present at the start.
It successfully creates a job named "job1" and checks that the job count is incremented.
Attempts to create another job with the same name "job1" and checks that it fails with an appropriate error message and error code (4), ensuring that the job count remains unchanged.