### PR TITLE
Retain Java 11 EOL date for LTS lines

### DIFF
--- a/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
@@ -82,7 +82,7 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
         if (Jenkins.VERSION.split("[.]").length > 2) {
             // LTS will require Java 17 or newer beginning 30 Oct 2024
             // https://groups.google.com/g/jenkinsci-dev/c/gsXAqOQQEPc/m/VT9IBYdmAQAJ
-            supportedVersions.put(11, LocalDate.of(2024, 10, 30)); // Temurin: 2024-10-31
+            supportedVersions.put(11, LocalDate.of(2024, 9, 30)); // Temurin: 2024-10-31
         } else {
             // Weekly will require Java 17 or newer beginning 18 Jun 2024
             // https://groups.google.com/g/jenkinsci-dev/c/gsXAqOQQEPc/m/4fn4Un1iAwAJ


### PR DESCRIPTION
## Retain Java 11 EOL date for LTS lines

Return to the Java 11 end of life date of 30 Sep 2024 for the LTS lines rather than changing it to match the expected 30 Oct 2024 release date of the first LTS to require Java 17.

Little benefit to LTS users to extend the end of life message until end of October.

Changing the date will cause the administrative monitor to reappear.  Better to leave it hidden if they have decided to hide it.

### Testing done

Testing was performed in earlier pull request:

* #9314

### Proposed changelog entries

- Restore the 30 Sep 2024 Java 11 end of life date for LTS releases.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@daniel-beck

No crisis if this does not merge until the next weekly release, so long as it is merged before the next LTS baseline is selected.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
