### PR TITLE
[JENKINS-72854] fix the enum jelly to take readOnlyMode into account

### DIFF
--- a/core/src/main/resources/lib/form/enum.jelly
+++ b/core/src/main/resources/lib/form/enum.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <j:set target="${attrs}" property="field" value="${entry.field}" />
   </j:if>
   <div class="jenkins-select">
-    <select class="jenkins-select__input" name="${attrs.field}">
+    <select disabled="${readOnlyMode ? 'true' : null}" class="jenkins-select__input" name="${attrs.field}">
       <j:forEach var="it" items="${descriptor.getPropertyType(instance,attrs.field).getEnumConstants()}">
         <f:option value="${it.name()}" selected="${instance[attrs.field]!=null ? it==instance[attrs.field] : it.name()==attrs.default}">
           <d:invokeBody />


### PR DESCRIPTION
## [JENKINS-72854](https://issues.jenkins.io/browse/JENKINS-72854) fix the enum jelly to take readOnlyMode into account

During fixing UX issue in kubernetes-plugin it was found that enum.jelly do not work with readOnlyMode, see PR https://github.com/jenkinsci/kubernetes-plugin/pull/1566 for the reference.


### Testing done

Manually tested this PR + https://github.com/jenkinsci/kubernetes-plugin/pull/1566. With that change readOnlyMode works.
<img width="1552" alt="Screenshot 2024-05-31 at 09 20 34" src="https://github.com/jenkinsci/jenkins/assets/47667812/15a64a3f-2a51-47a7-befd-99273a00961c">


### Proposed changelog entries

- Honor read-only mode when displaying enumerations on pages.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
