### PR TITLE
[JENKINS-73243] quote replacement string in symbol tooltips

### DIFF
--- a/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
+++ b/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -72,10 +73,10 @@ public final class Symbol {
                 .computeIfAbsent(identifier, key -> new ConcurrentHashMap<>())
                 .computeIfAbsent(name, key -> loadSymbol(identifier, key));
         if ((tooltip != null && !tooltip.isBlank()) && (htmlTooltip == null || htmlTooltip.isBlank())) {
-            symbol = symbol.replaceAll("<svg", "<svg tooltip=\"" + Functions.htmlAttributeEscape(tooltip) + "\"");
+            symbol = symbol.replaceAll("<svg", Matcher.quoteReplacement("<svg tooltip=\"" + Functions.htmlAttributeEscape(tooltip) + "\""));
         }
         if (htmlTooltip != null && !htmlTooltip.isBlank()) {
-            symbol = symbol.replaceAll("<svg", "<svg data-html-tooltip=\"" + Functions.htmlAttributeEscape(htmlTooltip) + "\"");
+            symbol = symbol.replaceAll("<svg", Matcher.quoteReplacement("<svg data-html-tooltip=\"" + Functions.htmlAttributeEscape(htmlTooltip) + "\""));
         }
         if (id != null && !id.isBlank()) {
             symbol = symbol.replaceAll("<svg", "<svg id=\"" + Functions.htmlAttributeEscape(id) + "\"");

--- a/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
+++ b/core/src/main/java/org/jenkins/ui/symbol/Symbol.java
@@ -79,7 +79,7 @@ public final class Symbol {
             symbol = symbol.replaceAll("<svg", Matcher.quoteReplacement("<svg data-html-tooltip=\"" + Functions.htmlAttributeEscape(htmlTooltip) + "\""));
         }
         if (id != null && !id.isBlank()) {
-            symbol = symbol.replaceAll("<svg", "<svg id=\"" + Functions.htmlAttributeEscape(id) + "\"");
+            symbol = symbol.replaceAll("<svg", Matcher.quoteReplacement("<svg id=\"" + Functions.htmlAttributeEscape(id) + "\""));
         }
         if (classes != null && !classes.isBlank()) {
             symbol = symbol.replaceAll("<svg", "<svg class=\"" + Functions.htmlAttributeEscape(classes) + "\"");

--- a/test/src/test/java/org/jenkins/ui/symbol/SymbolJenkinsTest.java
+++ b/test/src/test/java/org/jenkins/ui/symbol/SymbolJenkinsTest.java
@@ -16,6 +16,21 @@ public class SymbolJenkinsTest {
             .addPlugins("plugins/design-library.jpi", "plugins/prism-api.jpi", "plugins/bootstrap5-api.jpi");
 
     @Test
+    @DisplayName("When resolving a symbol where the tooltip contains '$' no error is thrown")
+    public void dollarInToolTipSucceeds() throws Throwable {
+        rjr.then(SymbolJenkinsTest::_dollarInTooltipSucceeds);
+    }
+
+    private static void _dollarInTooltipSucceeds(JenkinsRule j) {
+        String symbol = Symbol.get(new SymbolRequest.Builder()
+                .withName("add")
+                .withTooltip("$test")
+                .build()
+        );
+        assertThat(symbol, containsString("tooltip=\"$test\""));
+    }
+
+    @Test
     @DisplayName("When resolving a symbol from a missing plugin, the placeholder is generated instead")
     public void missingSymbolFromPluginDefaultsToPlaceholder() throws Throwable {
         rjr.then(SymbolJenkinsTest::_missingSymbolFromPluginDefaultsToPlaceholder);

--- a/test/src/test/java/org/jenkins/ui/symbol/SymbolJenkinsTest.java
+++ b/test/src/test/java/org/jenkins/ui/symbol/SymbolJenkinsTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.not;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 
@@ -16,6 +17,7 @@ public class SymbolJenkinsTest {
             .addPlugins("plugins/design-library.jpi", "plugins/prism-api.jpi", "plugins/bootstrap5-api.jpi");
 
     @Test
+    @Issue("JENKINS-73243")
     @DisplayName("When resolving a symbol where the tooltip contains '$' no error is thrown")
     public void dollarInToolTipSucceeds() throws Throwable {
         rjr.then(SymbolJenkinsTest::_dollarInTooltipSucceeds);


### PR DESCRIPTION
when the tooltip or html tooltip for a symbol contained the $ sign, then adding the tooltip failed with `Illegal group reference`.

a way to reproduce is with the Badge plugin. Add this to a pipeline
```
addInfoBadge(text: '$Info')
```
and the build history widget will fail.

See [JENKINS-73243](https://issues.jenkins.io/browse/JENKINS-73243).

### Testing done
Added unit test that ensures tooltips are properly quoted.
Without the fix the test fails.
Also manual testing

### Proposed changelog entries

- Quote replacement string in symbol tooltips.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A? 

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
