### PR TITLE
Backporting for LTS 2.452.2 (part 2)

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -419,7 +419,7 @@ THE SOFTWARE.
                   <!-- detached after 2.16 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>bouncycastle-api</artifactId>
-                  <version>2.30.1.77-225.v26ea_c9455fd9</version>
+                  <version>2.30.1.78.1-233.vfdcdeb_0a_08a_a_</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>

--- a/war/src/main/resources/images/symbols/weather-icon-health-00to19.svg
+++ b/war/src/main/resources/images/symbols/weather-icon-health-00to19.svg
@@ -1,5 +1,5 @@
-<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" stroke-width="36px" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M208 304L192 400H240V480L320 368H272L288 304" stroke="var(--yellow)" />
-  <path d="M404.33 152.89H392.2C384.71 84.85 326.14 32 256 32C227.819 31.9729 200.322 40.6756 177.289 56.9116C154.255 73.1476 136.817 96.1198 127.37 122.67H122.8C72.86 122.67 32 163.47 32 213.33C32 263.2 72.86 304 122.8 304H404.33C446 304 480 270 480 228.44C480 186.89 446 152.89 404.33 152.89Z" stroke="var(--text-color-secondary)" />
-  <path d="M120 352L96 400M136 432L120 464M400 352L376 400M416 432L400 464" stroke="var(--cyan)"/>
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg"  stroke-linecap="round" stroke-linejoin="round">
+  <path d="M208 304L192 400H240V480L320 368H272L288 304" stroke="var(--yellow)" stroke-width="36px"/>
+  <path d="M404.33 152.89H392.2C384.71 84.85 326.14 32 256 32C227.819 31.9729 200.322 40.6756 177.289 56.9116C154.255 73.1476 136.817 96.1198 127.37 122.67H122.8C72.86 122.67 32 163.47 32 213.33C32 263.2 72.86 304 122.8 304H404.33C446 304 480 270 480 228.44C480 186.89 446 152.89 404.33 152.89Z" stroke="var(--text-color-secondary)" stroke-width="36px"/>
+  <path d="M120 352L96 400M136 432L120 464M400 352L376 400M416 432L400 464" stroke="var(--cyan)" stroke-width="36px"/>
 </svg>

--- a/war/src/main/resources/images/symbols/weather-icon-health-20to39.svg
+++ b/war/src/main/resources/images/symbols/weather-icon-health-20to39.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" stroke="var(--text-color-secondary)" stroke-width="36px">
-    <path fill="transparent" d="M114.61,162.85A16.07,16.07,0,0,0,128,149.6C140.09,76.17,193.63,32,256,32c57.93,0,96.62,37.75,112.2,77.74a15.84,15.84,0,0,0,12.2,9.87c50,8.15,91.6,41.54,91.6,99.59C472,278.6,423.4,320,364,320H130c-49.5,0-90-24.7-90-79.2C40,192.33,78.67,168.58,114.61,162.85Z"/>
-    <line x1="144" y1="384" x2="112" y2="432" stroke="var(--cyan)" stroke-linecap="round" />
-    <line x1="224" y1="384" x2="160" y2="480" stroke="var(--cyan)" stroke-linecap="round" />
-    <line x1="304" y1="384" x2="272" y2="432" stroke="var(--cyan)" stroke-linecap="round" />
-    <line x1="384" y1="384" x2="320" y2="480" stroke="var(--cyan)" stroke-linecap="round" />
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" stroke="var(--text-color-secondary)" >
+    <path fill="transparent" d="M114.61,162.85A16.07,16.07,0,0,0,128,149.6C140.09,76.17,193.63,32,256,32c57.93,0,96.62,37.75,112.2,77.74a15.84,15.84,0,0,0,12.2,9.87c50,8.15,91.6,41.54,91.6,99.59C472,278.6,423.4,320,364,320H130c-49.5,0-90-24.7-90-79.2C40,192.33,78.67,168.58,114.61,162.85Z" stroke-width="36px"/>
+    <line x1="144" y1="384" x2="112" y2="432" stroke="var(--cyan)" stroke-linecap="round" stroke-width="36px"/>
+    <line x1="224" y1="384" x2="160" y2="480" stroke="var(--cyan)" stroke-linecap="round" stroke-width="36px"/>
+    <line x1="304" y1="384" x2="272" y2="432" stroke="var(--cyan)" stroke-linecap="round" stroke-width="36px"/>
+    <line x1="384" y1="384" x2="320" y2="480" stroke="var(--cyan)" stroke-linecap="round" stroke-width="36px"/>
 </svg>

--- a/war/src/main/resources/images/symbols/weather-icon-health-60to79.svg
+++ b/war/src/main/resources/images/symbols/weather-icon-health-60to79.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" stroke="var(--text-color-secondary)" stroke-width="36px">
-    <path d="M384.8,271.4a80,80,0,1,0-123.55-92" fill="transparent" stroke="var(--yellow)" />
-    <path d="M90.61,306.85A16.07,16.07,0,0,0,104,293.6C116.09,220.17,169.63,176,232,176c57.93,0,96.62,37.75,112.2,77.74a15.84,15.84,0,0,0,12.2,9.87c50,8.15,91.6,41.54,91.6,99.59C448,422.6,399.4,464,340,464H106c-49.5,0-90-24.7-90-79.2C16,336.33,54.67,312.58,90.61,306.85Z" fill="transparent" />
-    <line x1="464" y1="208" x2="496" y2="208" stroke="var(--yellow)" stroke-linecap="round" />
-    <line x1="336" y1="48" x2="336" y2="80" stroke="var(--yellow)" stroke-linecap="round" />
-    <line x1="222.86" y1="94.86" x2="245.49" y2="117.49" stroke="var(--yellow)" stroke-linecap="round" />
-    <line x1="449.14" y1="94.86" x2="426.51" y2="117.49" stroke="var(--yellow)" stroke-linecap="round" />
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" stroke="var(--text-color-secondary)">
+    <path d="M384.8,271.4a80,80,0,1,0-123.55-92" fill="transparent" stroke="var(--yellow)" stroke-width="36px"/>
+    <path d="M90.61,306.85A16.07,16.07,0,0,0,104,293.6C116.09,220.17,169.63,176,232,176c57.93,0,96.62,37.75,112.2,77.74a15.84,15.84,0,0,0,12.2,9.87c50,8.15,91.6,41.54,91.6,99.59C448,422.6,399.4,464,340,464H106c-49.5,0-90-24.7-90-79.2C16,336.33,54.67,312.58,90.61,306.85Z" fill="transparent" stroke-width="36px"/>
+    <line x1="464" y1="208" x2="496" y2="208" stroke="var(--yellow)" stroke-linecap="round" stroke-width="36px"/>
+    <line x1="336" y1="48" x2="336" y2="80" stroke="var(--yellow)" stroke-linecap="round" stroke-width="36px"/>
+    <line x1="222.86" y1="94.86" x2="245.49" y2="117.49" stroke="var(--yellow)" stroke-linecap="round" stroke-width="36px"/>
+    <line x1="449.14" y1="94.86" x2="426.51" y2="117.49" stroke="var(--yellow)" stroke-linecap="round" stroke-width="36px"/>
 </svg>


### PR DESCRIPTION
## Backporting for LTS 2.452.2 (part 2)

Backports of two pull requests included in Jenkins 2.461.

- #9227
- #9326

```shell
Latest core version: jenkins-2.459

Fixed
-----

JENKINS-73047           Minor                   2.461
        Strokes in most weather icons are too wide in Safari when the page is zoomed in (regression in 2.375)
        https://issues.jenkins.io/browse/JENKINS-73047

JENKINS-73252           Minor                   2.457
        Update bundled bouncycastle-api to 2.30.1.78.1-233.vfdcdeb_0a_08a_a_
        https://issues.jenkins.io/browse/JENKINS-73252
```

### Proposed changelog entries

- Fix width of weather icons in Safari when zoomed.
- Include most recent bouncycastle API plugin 2.30.1.78.1-233.vfdcdeb_0a_08a_a_.

### Proposed upgrade guidelines

N/A

### Testing done

Confirmed that automated tests pass.

Confirmed that `2.30.1.78.1-233.vfdcdeb_0a_08a_a_` bouncycastle API plugin version is bundled in the war file.

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@krisstern

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
