### PR TITLE
Added communication model

### DIFF
--- a/core/src/main/java/jenkins/communication/CommunicationChannel.java
+++ b/core/src/main/java/jenkins/communication/CommunicationChannel.java
@@ -1,0 +1,29 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Jan Meiswinkel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.cli;
+
+abstract class CommunicationChannel {
+    abstract void sendMessage(String message);
+}

--- a/core/src/main/java/jenkins/communication/Email.java
+++ b/core/src/main/java/jenkins/communication/Email.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Jan Meiswinkel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.cli;
+
+import javax.mail.*;
+import javax.mail.internet.*;
+
+// Email communication channel
+public class Email extends CommunicationChannel {
+    private String recipient;
+    private String subject;
+    private String body;
+    private String host;
+    private String username;
+    private String password;
+    Properties props = new Properties();
+
+    public Email(String recipient, String subject, String body) {
+        this.recipient = recipient;
+        this.subject = subject;
+        this.body = body;
+        this.host = System.getenv("SMTP_SERVER");
+        this.username = System.getenv("SMTP_EMAIL_ID");
+        this.password = System.getenv("SMTP_PASSWORD");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.host", host);
+        props.put("mail.smtp.port", "587");
+    }
+
+    @Override
+    void sendMessage(String message) {
+        // Create session
+        Session session = Session.getInstance(props, new Authenticator() {
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(username, password);
+            }
+        });
+        // Send email
+        try {
+            Message mimeMessage = new MimeMessage(session);
+            mimeMessage.setFrom(new InternetAddress(username));
+            mimeMessage.setRecipients(Message.RecipientType.TO, InternetAddress.parse(recipient));
+            mimeMessage.setSubject(subject);
+            mimeMessage.setText(body + "\n\n" + message);
+            Transport.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/jenkins/communication/Slack.java
+++ b/core/src/main/java/jenkins/communication/Slack.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Jan Meiswinkel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.cli;
+
+import java.io.*;
+import java.net.*;
+
+// Slack communication channel
+public class Slack extends CommunicationChannel {
+    private String webhookUrl;
+
+    public Slack(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+
+    @Override
+    void sendMessage(String message) {
+        try {
+            URL url = new URL(webhookUrl);
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("POST");
+            con.setRequestProperty("Content-Type", "application/json");
+            con.setDoOutput(true);
+
+            String jsonMessage = "{\"Jenkins Output\":\"" + message + "\"}";
+
+            try (OutputStream os = con.getOutputStream()) {
+                byte[] input = jsonMessage.getBytes("utf-8");
+                os.write(input, 0, input.length);
+            }
+
+            try (BufferedReader br = new BufferedReader(
+                    new InputStreamReader(con.getInputStream(), "utf-8"))) {
+                StringBuilder response = new StringBuilder();
+                String responseLine;
+                while ((responseLine = br.readLine()) != null) {
+                    response.append(responseLine.trim());
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/core/src/test/java/jenkins/communication/EmailTest.java
+++ b/core/src/test/java/jenkins/communication/EmailTest.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013 RedHat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.anyString;
+
+public class EmailTest {
+
+    @Test
+    public void testSendMessage() {
+        // Test values
+        String recipient = "test@example.com";
+        String subject = "Test Subject";
+        String body = "Test Body";
+        String message = "Test Message";
+
+        // Mocking the Email class
+        Email email = Mockito.spy(new Email(recipient, subject, body));
+        Mockito.doNothing().when(email).sendEmail(anyString(), anyString(), anyString());
+        email.sendMessage(message);
+        Mockito.verify(email).sendEmail(recipient, subject, body + "\n\n" + message);
+    }
+}

--- a/core/src/test/java/jenkins/communication/SlackTest.java
+++ b/core/src/test/java/jenkins/communication/SlackTest.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013 RedHat Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.anyString;
+
+public class SlackTest {
+
+    @Test
+    public void testSendMessage() {
+        // Test values
+        String webhookUrl = "https://hooks.slack.com/services/test-url";
+        String message = "Test Message";
+
+        // Mocking the test class
+        Slack slack = Mockito.spy(new Slack(webhookUrl));
+        Mockito.doNothing().when(slack).sendMessageToSlack(anyString(), anyString());
+        slack.sendMessage(message);
+        Mockito.verify(slack).sendMessageToSlack(webhookUrl, message);
+    }
+}


### PR DESCRIPTION
Creates a jenkins communication module without any third integrations

This currently includes just email and slack communication and it can be further extended to other communication models.