### PR TITLE
Adjust heading weights and sizes

### DIFF
--- a/war/src/main/scss/base/_typography.scss
+++ b/war/src/main/scss/base/_typography.scss
@@ -49,7 +49,7 @@ h5,
 h6,
 .h6 {
   line-height: var(--line-height-heading);
-  font-weight: 650;
+  font-weight: 600;
   display: block;
   margin-top: 0;
   margin-bottom: var(--section-padding);
@@ -62,12 +62,12 @@ h1,
 
 h2,
 .h2 {
-  font-size: 1.35rem;
+  font-size: 1.375rem;
 }
 
 h3,
 .h3 {
-  font-size: 1.2rem;
+  font-size: 1.1875rem;
 }
 
 h4,
@@ -77,12 +77,12 @@ h4,
 
 h5,
 .h5 {
-  font-size: 0.8rem;
+  font-size: 0.8125rem;
 }
 
 h6,
 .h6 {
-  font-size: 0.6rem;
+  font-size: 0.625rem;
 }
 
 .jenkins-description {

--- a/war/src/main/scss/components/_app-bar.scss
+++ b/war/src/main/scss/components/_app-bar.scss
@@ -9,7 +9,7 @@
     justify-content: center;
     flex-direction: column;
     width: 100%;
-    min-height: 36px;
+    min-height: 2.25rem;
   }
 
   .jenkins-app-bar__controls {
@@ -17,8 +17,8 @@
     align-items: center;
     justify-content: center;
     margin-left: var(--section-padding);
-    min-height: 36px;
-    gap: 1rem;
+    min-height: 2.25rem;
+    gap: 0.75rem;
 
     .jenkins-search {
       min-width: 260px;

--- a/war/src/main/scss/components/_app-bar.scss
+++ b/war/src/main/scss/components/_app-bar.scss
@@ -9,7 +9,7 @@
     justify-content: center;
     flex-direction: column;
     width: 100%;
-    min-height: 2.25rem;
+    min-height: 36px;
   }
 
   .jenkins-app-bar__controls {
@@ -17,8 +17,8 @@
     align-items: center;
     justify-content: center;
     margin-left: var(--section-padding);
-    min-height: 2.25rem;
-    gap: 0.75rem;
+    min-height: 36px;
+    gap: 1rem;
 
     .jenkins-search {
       min-width: 260px;

--- a/war/src/main/scss/components/_section.scss
+++ b/war/src/main/scss/components/_section.scss
@@ -30,8 +30,8 @@
 
 .jenkins-section__title {
   margin: 0 0 var(--section-padding) 0;
-  font-size: 1.1rem;
-  font-weight: 600;
+  font-size: 1rem;
+  font-weight: 500;
 }
 
 .jenkins-section__items {
@@ -106,17 +106,17 @@
   }
 
   dt {
-    font-size: 0.925rem;
-    font-weight: 600;
+    font-size: 0.9375rem;
+    font-weight: 500;
     margin: 0.1rem 0 0.2rem;
     color: var(--text-color);
   }
 
   dd {
     color: var(--text-color-secondary);
-    font-weight: 500;
+    font-weight: 450;
     line-height: 1.6;
     margin: 0 0.66rem 0 0;
-    font-size: 0.925rem;
+    font-size: 0.9375rem;
   }
 }


### PR DESCRIPTION
Small and subtle merge request to decrease the weight of headings slightly and to adjust their sizes so they align with whole pixels.

Previously for example, `h2` was `1.35rem` which is `1.35 * 16 = 21.6`, now it's been adjusted to `1.375 * 16 = 22`. This should result in slightly crisper text.

**Before**
<img width="1728" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/a4f26221-7368-42f2-ac14-41cb5a5a9950">

**After**
<img width="1728" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/1b05cd3f-caed-4099-aefa-b9a71f1963a1">

### Testing done

* Headings appear as expected

### Proposed changelog entries

- Adjust heading weights and sizes.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
