### PR TITLE
Refine button appearances in sidebars, menus, pages and breadcrumbs

### DIFF
--- a/war/src/main/scss/components/_app-bar.scss
+++ b/war/src/main/scss/components/_app-bar.scss
@@ -9,7 +9,7 @@
     justify-content: center;
     flex-direction: column;
     width: 100%;
-    min-height: 36px;
+    min-height: 2.25rem;
   }
 
   .jenkins-app-bar__controls {
@@ -17,8 +17,8 @@
     align-items: center;
     justify-content: center;
     margin-left: var(--section-padding);
-    min-height: 36px;
-    gap: 1rem;
+    min-height: 2.25rem;
+    gap: 0.75rem;
 
     .jenkins-search {
       min-width: 260px;

--- a/war/src/main/scss/components/_breadcrumbs.scss
+++ b/war/src/main/scss/components/_breadcrumbs.scss
@@ -26,7 +26,7 @@
       justify-content: center;
       color: var(--text-color);
       font-weight: 500;
-      font-size: 0.85rem;
+      font-size: 0.875rem;
       padding: 0.2rem 0.4rem;
 
       & > a {

--- a/war/src/main/scss/components/_buttons.scss
+++ b/war/src/main/scss/components/_buttons.scss
@@ -50,7 +50,7 @@
   }
 
   &::after {
-    box-shadow: 0 0 0 0.5rem var(--accent-color);
+    box-shadow: 0 0 0 0.66rem var(--accent-color);
     opacity: 0;
   }
 
@@ -68,7 +68,7 @@
       }
 
       &::after {
-        box-shadow: 0 0 0 0.25rem var(--accent-color);
+        box-shadow: 0 0 0 0.33rem var(--accent-color);
         opacity: 0.2;
       }
     }
@@ -93,7 +93,7 @@
   }
 
   &::after {
-    box-shadow: 0 0 0 0.5rem currentColor;
+    box-shadow: 0 0 0 0.66rem currentColor;
     opacity: 0;
   }
 
@@ -110,7 +110,7 @@
       }
 
       &::after {
-        box-shadow: 0 0 0 0.25rem currentColor;
+        box-shadow: 0 0 0 0.33rem currentColor;
         opacity: 0.1;
       }
     }
@@ -127,7 +127,7 @@
   }
 
   &::after {
-    box-shadow: 0 0 0 0.5rem var(--color);
+    box-shadow: 0 0 0 0.66rem var(--color);
     opacity: 0;
   }
 
@@ -145,7 +145,7 @@
       }
 
       &::after {
-        box-shadow: 0 0 0 0.25rem var(--color);
+        box-shadow: 0 0 0 0.33rem var(--color);
         opacity: 0.3;
       }
     }

--- a/war/src/main/scss/components/_buttons.scss
+++ b/war/src/main/scss/components/_buttons.scss
@@ -14,15 +14,14 @@
   border: none;
   outline: none;
   margin: 0;
-  padding: 0.5rem 0.85rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.875rem;
   text-decoration: none !important;
   background: transparent;
   color: var(--text-color) !important;
   border-radius: 0.66rem;
   cursor: pointer;
-  min-height: 36px;
+  min-height: 2.25rem;
   white-space: nowrap;
   gap: 1ch;
   transition: var(--standard-transition);
@@ -32,8 +31,8 @@
   }
 
   svg {
-    width: 1.1rem;
-    height: 1.1rem;
+    width: 1.125rem;
+    height: 1.125rem;
   }
 
   &:disabled {
@@ -45,14 +44,13 @@
 
 .jenkins-button--primary {
   color: var(--button-color--primary) !important;
-  font-weight: 600;
 
   &::before {
     background: var(--accent-color) !important;
   }
 
   &::after {
-    box-shadow: 0 0 0 0.66rem var(--accent-color);
+    box-shadow: 0 0 0 0.5rem var(--accent-color);
     opacity: 0;
   }
 
@@ -70,7 +68,7 @@
       }
 
       &::after {
-        box-shadow: 0 0 0 0.33rem var(--accent-color);
+        box-shadow: 0 0 0 0.25rem var(--accent-color);
         opacity: 0.2;
       }
     }
@@ -95,7 +93,7 @@
   }
 
   &::after {
-    box-shadow: 0 0 0 0.66rem currentColor;
+    box-shadow: 0 0 0 0.5rem currentColor;
     opacity: 0;
   }
 
@@ -112,7 +110,7 @@
       }
 
       &::after {
-        box-shadow: 0 0 0 0.33rem currentColor;
+        box-shadow: 0 0 0 0.25rem currentColor;
         opacity: 0.1;
       }
     }
@@ -129,7 +127,7 @@
   }
 
   &::after {
-    box-shadow: 0 0 0 0.66rem var(--color);
+    box-shadow: 0 0 0 0.5rem var(--color);
     opacity: 0;
   }
 
@@ -147,7 +145,7 @@
       }
 
       &::after {
-        box-shadow: 0 0 0 0.33rem var(--color);
+        box-shadow: 0 0 0 0.25rem var(--color);
         opacity: 0.3;
       }
     }

--- a/war/src/main/scss/components/_dropdowns.scss
+++ b/war/src/main/scss/components/_dropdowns.scss
@@ -92,7 +92,7 @@ $dropdown-padding: 0.4rem;
     color: var(--text-color-secondary) !important;
     margin: $dropdown-padding 0.55rem;
     font-size: 0.8125rem;
-    font-weight: 600;
+    font-weight: 500;
     opacity: 0.8;
 
     &:not(:first-of-type) {
@@ -133,7 +133,7 @@ $dropdown-padding: 0.4rem;
     margin: 0;
     padding: $dropdown-padding 1.75rem $dropdown-padding 0.6rem;
     font-size: 0.8125rem;
-    font-weight: 500;
+    font-weight: 450;
     text-decoration: none !important;
     background: transparent;
     color: var(--text-color) !important;

--- a/war/src/main/scss/components/_side-panel-tasks.scss
+++ b/war/src/main/scss/components/_side-panel-tasks.scss
@@ -8,7 +8,7 @@ $background-outset: 0.7rem;
   display: flex;
   flex-direction: column;
   margin: var(--section-padding);
-  gap: 5px;
+  gap: 0.125rem;
 
   /* stylelint-disable-next-line media-query-no-invalid */
   @media (min-width: breakpoints.$tablet-breakpoint) {
@@ -63,11 +63,11 @@ $background-outset: 0.7rem;
   align-items: center;
   justify-content: flex-start;
   padding: 0.55rem $background-outset;
-  gap: 0.75rem;
+  gap: 0.65rem;
   width: 100%;
   cursor: pointer;
-  font-weight: 500 !important;
-  font-size: 0.9rem;
+  font-weight: 450 !important;
+  font-size: 0.875rem;
   color: var(--text-color) !important;
   background: transparent;
   outline: none;
@@ -101,11 +101,11 @@ $background-outset: 0.7rem;
   }
 
   &--active {
-    font-weight: 600 !important;
+    font-weight: 500 !important;
     cursor: default;
 
     svg * {
-      stroke-width: 38px;
+      stroke-width: 35px;
     }
 
     &::before {


### PR DESCRIPTION
Small one to refine the appearance of buttons in sidebars, menus, pages and breadcrumbs. In a similar fashion to https://github.com/jenkinsci/jenkins/pull/9366 font sizes and spacing has been adjusted for consistency and to also align with whole pixels.

**Before**
<img width="332" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/88b408cb-a33e-4ce9-825d-e66fa64f4f29">

**After**
<img width="338" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/ad8191e4-96ed-4633-aa24-321c00a312e9">

_Sidebars are now slightly more compact and less bold, allowing for more items on screen at once_

**Before**
<img width="316" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/9c9a3d9f-1a5a-47e6-a3cc-5c46c15852a2">

**After**
<img width="326" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/fcd9c7e0-0b21-4497-a637-e71c93e78fee">

_Buttons are slightly larger as a result of the increase in font size, bringing consistency with other font sizes_

**Before**
<img width="234" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/d0ee534f-28ed-4d41-9692-89ecf1cb6c8b">

**After**
<img width="214" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/a61c8c16-93c9-4cbc-930e-5ac3502deedd">

_Dropdowns are slightly less bold_

**Before**
<img width="250" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/afe22cfd-6cc0-4220-b102-befddf875d6f">

**After**
<img width="261" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/8ee3485b-17f1-4188-85e2-43c90e5ddf38">

_Breadcrumbs have had their font size adjusted slightly for consistency and to align with whole pixels_

### Testing done

* Using the Design Library everything looks as expected

### Proposed changelog entries

- Refine button appearances in sidebars, menus, pages and breadcrumbs.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
