### PR TITLE
[JENKINS-73246] Fix text shown in unexpected locale

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -1007,6 +1007,10 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
             if (url != null)    return url;
             url = c.getResource(base + '_' + locale.getLanguage() + ".html");
             if (url != null)    return url;
+            if (locale.getLanguage().equals("en")) {
+                url = c.getResource(base + ".html");
+                if (url != null)    return url;
+            }
         }
 
         // default

--- a/core/src/test/java/hudson/GetLocaleStaticHelpUrlTest.java
+++ b/core/src/test/java/hudson/GetLocaleStaticHelpUrlTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.lang.Klass;
 
@@ -189,6 +190,24 @@ public class GetLocaleStaticHelpUrlTest {
         );
         URL id = Descriptor.getStaticHelpUrl(req, klass, "-id");
         assertThatLocaleResourceIs(id, "help-id_zh_CN.html");
+    }
+
+    @Issue("JENKINS-73246")
+    @Test
+    public void getStaticHelpUrlAcceptEnFirst() {
+        // Accept-Language: en-US,en;q=0.9,de;q=0.8
+        StaplerRequest req = mockStaplerRequest(
+                Locale.US,
+                Locale.ENGLISH,
+                Locale.GERMAN
+        );
+
+        Klass klass = mockKlass(
+                "help-id.html",
+                "help-id_de.html"
+        );
+        URL id = Descriptor.getStaticHelpUrl(req, klass, "-id");
+        assertThatLocaleResourceIs(id, "help-id.html");
     }
 
     private StaplerRequest mockStaplerRequest(Locale... localeArr) {


### PR DESCRIPTION
See [JENKINS-73246](https://issues.jenkins.io/browse/JENKINS-73246).

Ref: https://github.com/jenkinsci/jenkins/pull/8912#issuecomment-2131170362

Special treatment if language is `en`

### Testing done

run
```
mvn clean verify
```

Interactive test before this change shows Italian help text for "Manage Jenkins" -> "System" -> "Quiet period" when I am running in English language.  After this change the help text for "Manage Jenkins" -> "System" -> "Quiet period" is correctly displayed as English.

### Proposed changelog entries

- Show help text in the correct locale even if user has an alternate language option defined in their browser (regression in 2.444).

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
