### PR TITLE
[JENKINS-72577] Revert "Increase MavenTest#sensitiveParameters() timeout to 500s"

### DIFF
--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -191,7 +191,7 @@ public class MavenTest {
         assertNotNull(isp.installers.get(MavenInstaller.class));
     }
 
-    @Test @WithTimeout(500) public void sensitiveParameters() throws Exception {
+    @Test @WithTimeout(300) public void sensitiveParameters() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         ParametersDefinitionProperty pdb = new ParametersDefinitionProperty(
                 new StringParameterDefinition("string", "defaultValue", "string description"),

--- a/test/src/test/java/hudson/tasks/MavenTest.java
+++ b/test/src/test/java/hudson/tasks/MavenTest.java
@@ -66,7 +66,6 @@ import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.ToolInstallations;
-import org.jvnet.hudson.test.recipes.WithTimeout;
 import org.kohsuke.stapler.jelly.JellyFacet;
 
 /**
@@ -191,7 +190,7 @@ public class MavenTest {
         assertNotNull(isp.installers.get(MavenInstaller.class));
     }
 
-    @Test @WithTimeout(300) public void sensitiveParameters() throws Exception {
+    @Test public void sensitiveParameters() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         ParametersDefinitionProperty pdb = new ParametersDefinitionProperty(
                 new StringParameterDefinition("string", "defaultValue", "string description"),


### PR DESCRIPTION
See [JENKINS-72577](https://issues.jenkins.io/browse/JENKINS-72577).

Reverts jenkinsci/jenkins#8840 which was a workaround for slow tests in the ci.jenkins.io's agents infrastructure as described in https://github.com/jenkins-infra/helpdesk/issues/3890.

In the past 4 months, a lot of changes had been applied to the underlying infrastructure such as:

- JDK21 upgrade to 21.0.3+9
- Underlying Linux machines upgraded to powerful ones
- Underlying network fixed
- Agents workload fully migrated to an unified Azure cloud
- etc.

Fixes https://github.com/jenkins-infra/helpdesk/issues/3890

### Testing done

I can see that the last "main" branch test (see https://ci.jenkins.io/job/Core/job/jenkins/job/master/6227/testReport/hudson.tasks/MavenTest/) is around ~6s on Linux (on ALL JDKs) and ~13s on Windows (JDK17):

![Capture d’écran 2024-06-11 à 10 55 43](https://github.com/jenkinsci/jenkins/assets/1522731/b73a9532-a2c7-4b7b-8181-2ae64b5193f0)

### Proposed changelog entries

- Remove test timeout workaround added in jenkinsci/jenkins#8840 

### Proposed upgrade guidelines

N/A

### Desired reviewers

@Not-NotMyFault @basil 

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
