### PR TITLE
Use pattern matching for `instanceof`

### DIFF
--- a/core/src/main/java/hudson/EnvVars.java
+++ b/core/src/main/java/hudson/EnvVars.java
@@ -114,8 +114,7 @@ public class EnvVars extends TreeMap<String, String> {
 
         // because of the backward compatibility, some parts of Jenkins passes
         // EnvVars as Map<String,String> so downcasting is safer.
-        if (m instanceof EnvVars) {
-            EnvVars lhs = (EnvVars) m;
+        if (m instanceof EnvVars lhs) {
             this.platform = lhs.platform;
         }
     }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -997,8 +997,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                 }
             }
 
-            if (con instanceof HttpURLConnection) {
-                HttpURLConnection httpCon = (HttpURLConnection) con;
+            if (con instanceof HttpURLConnection httpCon) {
                 int responseCode = httpCon.getResponseCode();
                 if (responseCode == HttpURLConnection.HTTP_MOVED_PERM
                         || responseCode == HttpURLConnection.HTTP_MOVED_TEMP) {

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -316,8 +316,7 @@ public class Functions {
      */
     public static <B> Class getTypeParameter(Class<? extends B> c, Class<B> base, int n) {
         Type parameterization = Types.getBaseClass(c, base);
-        if (parameterization instanceof ParameterizedType) {
-            ParameterizedType pt = (ParameterizedType) parameterization;
+        if (parameterization instanceof ParameterizedType pt) {
             return Types.erasure(Types.getTypeArgument(pt, n));
         } else {
             throw new AssertionError(c + " doesn't properly parameterize " + base);
@@ -1979,8 +1978,7 @@ public class Functions {
     @Deprecated
     public String getCheckUrl(String userDefined, Object descriptor, String field) {
         if (userDefined != null || field == null)   return userDefined;
-        if (descriptor instanceof Descriptor) {
-            Descriptor d = (Descriptor) descriptor;
+        if (descriptor instanceof Descriptor d) {
             return d.getCheckUrl(field);
         }
         return null;
@@ -1993,8 +1991,7 @@ public class Functions {
     public void calcCheckUrl(Map attributes, String userDefined, Object descriptor, String field) {
         if (userDefined != null || field == null)   return;
 
-        if (descriptor instanceof Descriptor) {
-            Descriptor d = (Descriptor) descriptor;
+        if (descriptor instanceof Descriptor d) {
             CheckMethod m = d.getCheckMethod(field);
             attributes.put("checkUrl", m.toStemUrl());
             attributes.put("checkDependsOn", m.getDependsOn());

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -607,8 +607,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P, R>, R extends A
             final Node currentNode = getCurrentNode();
             Launcher l = currentNode.createLauncher(listener);
 
-            if (project instanceof BuildableItemWithBuildWrappers) {
-                BuildableItemWithBuildWrappers biwbw = (BuildableItemWithBuildWrappers) project;
+            if (project instanceof BuildableItemWithBuildWrappers biwbw) {
                 for (BuildWrapper bw : biwbw.getBuildWrappersList())
                     l = bw.decorateLauncher(AbstractBuild.this, l, listener);
             }

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -551,8 +551,7 @@ public abstract class AbstractItem extends Actionable implements Loadable, Item,
             List<Ancestor> ancestors = req.getAncestors();
             if (!ancestors.isEmpty()) {
                 Ancestor last = ancestors.get(ancestors.size() - 1);
-                if (last.getObject() instanceof View) {
-                    View view = (View) last.getObject();
+                if (last.getObject() instanceof View view) {
                     if (view.getOwner().getItemGroup() == getParent() && !view.isDefault()) {
                         // Showing something inside a view, so should use that as the base URL.
                         String prefix = req.getContextPath() + "/";

--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -518,8 +518,7 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
         Executor e = Executor.currentExecutor();
         if (e != null) {
             Executable exe = e.getCurrentExecutable();
-            if (exe instanceof AbstractBuild) {
-                AbstractBuild b = (AbstractBuild) exe;
+            if (exe instanceof AbstractBuild b) {
                 if (b.getProject() == this)
                     return b;
             }

--- a/core/src/main/java/hudson/model/BooleanParameterDefinition.java
+++ b/core/src/main/java/hudson/model/BooleanParameterDefinition.java
@@ -59,8 +59,7 @@ public class BooleanParameterDefinition extends SimpleParameterDefinition {
 
     @Override
     public ParameterDefinition copyWithDefaultValue(ParameterValue defaultValue) {
-        if (defaultValue instanceof BooleanParameterValue) {
-            BooleanParameterValue value = (BooleanParameterValue) defaultValue;
+        if (defaultValue instanceof BooleanParameterValue value) {
             return new BooleanParameterDefinition(getName(), value.value, getDescription());
         } else {
             return this;

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -294,8 +294,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
 
         // detect an type error
         Type bt = Types.getBaseClass(getClass(), Descriptor.class);
-        if (bt instanceof ParameterizedType) {
-            ParameterizedType pt = (ParameterizedType) bt;
+        if (bt instanceof ParameterizedType pt) {
             // this 't' is the closest approximation of T of Descriptor<T>.
             Class t = Types.erasure(pt.getActualTypeArguments()[0]);
             if (!t.isAssignableFrom(clazz))
@@ -688,8 +687,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
 
         @Override
         public Object onConvert(Type targetType, Class targetTypeErasure, Object jsonSource) {
-            if (jsonSource instanceof JSONObject) {
-                JSONObject json = (JSONObject) jsonSource;
+            if (jsonSource instanceof JSONObject json) {
                 if (isApplicable(targetTypeErasure, json)) {
                     LOGGER.log(Level.FINE, "switching to newInstance {0} {1}", new Object[] {targetTypeErasure.getName(), json});
                     try {
@@ -895,8 +893,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
     protected List<String> getPossibleViewNames(String baseName) {
         List<String> names = new ArrayList<>();
         for (Facet f : WebApp.get(Jenkins.get().servletContext).facets) {
-            if (f instanceof JellyCompatibleFacet) {
-                JellyCompatibleFacet jcf = (JellyCompatibleFacet) f;
+            if (f instanceof JellyCompatibleFacet jcf) {
                 for (String ext : jcf.getScriptExtensions())
                     names.add(baseName + ext);
             }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -266,8 +266,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             // If any of the other ItemListeners modify the job, they effect
             // a save, which will clear the holdOffBuildUntilUserSave and
             // causing a regression of JENKINS-2494
-            if (item instanceof Job) {
-                Job job = (Job) item;
+            if (item instanceof Job job) {
                 synchronized (job) {
                     job.holdOffBuildUntilUserSave = false;
                 }
@@ -1110,8 +1109,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
         List<FeedItem> entries = new ArrayList<>();
         String scmDisplayName = "";
-        if (this instanceof SCMTriggerItem) {
-            SCMTriggerItem scmItem = (SCMTriggerItem) this;
+        if (this instanceof SCMTriggerItem scmItem) {
             List<String> scmNames = new ArrayList<>();
             for (SCM s : scmItem.getSCMs()) {
                 scmNames.add(s.getDescriptor().getDisplayName());

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -510,8 +510,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
             }
         }
         // Check root project for sub-job projects (e.g. matrix jobs).
-        if (item.task instanceof AbstractProject<?, ?>) {
-            AbstractProject<?, ?> project = (AbstractProject<?, ?>) item.task;
+        if (item.task instanceof AbstractProject<?, ?> project) {
             return viewItems.contains(project.getRootProject());
         }
         return false;
@@ -855,8 +854,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
     public void doRssLatest(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         List<Run> lastBuilds = new ArrayList<>();
         for (TopLevelItem item : getItems()) {
-            if (item instanceof Job) {
-                Job job = (Job) item;
+            if (item instanceof Job job) {
                 Run lb = job.getLastBuild();
                 if (lb != null)    lastBuilds.add(lb);
             }

--- a/core/src/main/java/hudson/util/DescribableList.java
+++ b/core/src/main/java/hudson/util/DescribableList.java
@@ -219,8 +219,7 @@ public class DescribableList<T extends Describable<T>, D extends Descriptor<T>> 
      */
     public void buildDependencyGraph(AbstractProject owner, DependencyGraph graph) {
         for (Object o : this) {
-            if (o instanceof DependencyDeclarer) {
-                DependencyDeclarer dd = (DependencyDeclarer) o;
+            if (o instanceof DependencyDeclarer dd) {
                 try {
                     dd.buildDependencyGraph(owner, graph);
                 } catch (RuntimeException e) {

--- a/core/src/main/java/hudson/views/ListViewColumn.java
+++ b/core/src/main/java/hudson/views/ListViewColumn.java
@@ -157,8 +157,7 @@ public abstract class ListViewColumn implements ExtensionPoint, Describable<List
         final JSONObject emptyJSON = new JSONObject();
         for (Descriptor<ListViewColumn> d : descriptors)
             try {
-                if (d instanceof ListViewColumnDescriptor) {
-                    ListViewColumnDescriptor ld = (ListViewColumnDescriptor) d;
+                if (d instanceof ListViewColumnDescriptor ld) {
                     if (!ld.shownByDefault()) {
                         continue;   // skip this
                     }

--- a/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
+++ b/core/src/main/java/jenkins/fingerprints/FileFingerprintStorage.java
@@ -101,11 +101,10 @@ public class FileFingerprintStorage extends FingerprintStorage {
 
         try {
             Object loaded = configFile.read();
-            if (!(loaded instanceof Fingerprint)) {
+            if (!(loaded instanceof Fingerprint f)) {
                 throw new IOException("Unexpected Fingerprint type. Expected " + Fingerprint.class + " or subclass but got "
                         + (loaded != null ? loaded.getClass() : "null"));
             }
-            Fingerprint f = (Fingerprint) loaded;
             if (f.getPersistedFacets() == null) {
                 logger.log(Level.WARNING, "Malformed fingerprint {0}: Missing facets", configFile);
                 Files.deleteIfExists(Util.fileToPath(file));

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3106,8 +3106,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
                 continue;
             }
 
-            if (ctx instanceof ItemGroup) {
-                ItemGroup g = (ItemGroup) ctx;
+            if (ctx instanceof ItemGroup g) {
                 Item i = g.getItem(s);
                 if (i == null || !i.hasPermission(Item.READ)) { // TODO consider DISCOVER
                     ctx = null;    // can't go up further

--- a/core/src/main/java/jenkins/security/ResourceDomainConfiguration.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainConfiguration.java
@@ -150,8 +150,7 @@ public final class ResourceDomainConfiguration extends GlobalConfiguration {
         // Send a request to /instance-identity/ at the resource root URL and check whether it is this Jenkins
         try {
             URLConnection urlConnection = new URI(resourceRootUrlString + "instance-identity/").toURL().openConnection();
-            if (urlConnection instanceof HttpURLConnection) {
-                HttpURLConnection httpURLConnection = (HttpURLConnection) urlConnection;
+            if (urlConnection instanceof HttpURLConnection httpURLConnection) {
                 int responseCode = httpURLConnection.getResponseCode();
 
                 if (responseCode == 200) {

--- a/core/src/main/java/jenkins/widgets/HistoryPageEntry.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageEntry.java
@@ -57,8 +57,7 @@ public class HistoryPageEntry<T> {
     protected static long getEntryId(@NonNull Object entry) {
         if (entry instanceof QueueItem) {
             return ((QueueItem) entry).getId();
-        } else if (entry instanceof Run) {
-            Run run = (Run) entry;
+        } else if (entry instanceof Run run) {
             return Long.MIN_VALUE + run.getNumber();
         } else if (entry instanceof Number) {
             // Used for testing purposes because of JENKINS-30899 and JENKINS-30909

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -578,8 +578,7 @@ public class PluginManagerTest {
             Thread.sleep(100);
             done = true;
             for (UpdateCenterJob job : r.jenkins.getUpdateCenter().getJobs()) {
-                if (job instanceof UpdateCenter.DownloadJob) {
-                    UpdateCenter.DownloadJob j = (UpdateCenter.DownloadJob) job;
+                if (job instanceof UpdateCenter.DownloadJob j) {
                     assertFalse(j.status instanceof UpdateCenter.DownloadJob.Failure);
                     done &= !(j.status instanceof UpdateCenter.DownloadJob.Pending ||
                             j.status instanceof UpdateCenter.DownloadJob.Installing);


### PR DESCRIPTION
Take advantage of [JEP-394](https://openjdk.org/jeps/394) where possible.

### Testing done

`mvn clean verify -DskipTests`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
