### PR TITLE
Use `isEmpty()` where possible

### DIFF
--- a/core/src/main/java/hudson/DependencyRunner.java
+++ b/core/src/main/java/hudson/DependencyRunner.java
@@ -58,7 +58,7 @@ public class DependencyRunner implements Runnable {
             // Get all top-level projects
             LOGGER.fine("assembling top level projects");
             for (AbstractProject p : Jenkins.get().allItems(AbstractProject.class))
-                if (p.getUpstreamProjects().size() == 0) {
+                if (p.getUpstreamProjects().isEmpty()) {
                     LOGGER.fine("adding top level project " + p.getName());
                     topLevelProjects.add(p);
                 } else {

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -321,7 +321,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
             buf.append(m.group(1));
             path = path.substring(m.end());
         }
-        boolean isAbsolute = buf.length() > 0;
+        boolean isAbsolute = !buf.isEmpty();
         // Split remaining path into tokens, trimming any duplicate or trailing separators
         List<String> tokens = new ArrayList<>();
         int s = 0, end = path.length();
@@ -366,7 +366,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         }
         // Recombine tokens
         for (String token : tokens) buf.append(token);
-        if (buf.length() == 0) buf.append('.');
+        if (buf.isEmpty()) buf.append('.');
         return buf.toString();
     }
 

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1422,7 +1422,7 @@ public class Functions {
         StringBuilder buf = new StringBuilder();
         Item i = p;
         while (true) {
-            if (buf.length() > 0) buf.insert(0, separationString);
+            if (!buf.isEmpty()) buf.insert(0, separationString);
             buf.insert(0, useDisplayName ? i.getDisplayName() : i.getName());
             ItemGroup gr = i.getParent();
 
@@ -1873,7 +1873,7 @@ public class Functions {
         for (String s : components) {
             if (s.isEmpty())  continue;
 
-            if (buf.length() > 0) {
+            if (!buf.isEmpty()) {
                 if (buf.charAt(buf.length() - 1) != '/')
                     buf.append('/');
                 if (s.charAt(0) == '/')   s = s.substring(1);
@@ -2057,7 +2057,7 @@ public class Functions {
      * Prepend a prefix only when there's the specified body.
      */
     public String prepend(String prefix, String body) {
-        if (body != null && body.length() > 0)
+        if (body != null && !body.isEmpty())
             return prefix + body;
         return body;
     }

--- a/core/src/main/java/hudson/cli/CLIAction.java
+++ b/core/src/main/java/hudson/cli/CLIAction.java
@@ -217,7 +217,7 @@ public class CLIAction implements UnprotectedRootAction, StaplerProxy {
     @Override
     public Object getTarget() {
         StaplerRequest req = Stapler.getCurrentRequest();
-        if (req.getRestOfPath().length() == 0 && "POST".equals(req.getMethod())) {
+        if (req.getRestOfPath().isEmpty() && "POST".equals(req.getMethod())) {
             // CLI connection request
             if ("false".equals(req.getParameter("remoting"))) {
                 throw new PlainCliEndpointResponse();

--- a/core/src/main/java/hudson/cli/GroovyshCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyshCommand.java
@@ -77,7 +77,7 @@ public class GroovyshCommand extends CLICommand {
 
         StringBuilder commandLine = new StringBuilder();
         for (String arg : args) {
-            if (commandLine.length() > 0) {
+            if (!commandLine.isEmpty()) {
                 commandLine.append(" ");
             }
             commandLine.append(arg);

--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -218,7 +218,7 @@ public class OldDataMonitor extends AdministrativeMonitor {
                 buf.append(e.getClass().getSimpleName()).append(": ").append(e.getMessage());
             }
         }
-        if (buf.length() == 0) return;
+        if (buf.isEmpty()) return;
         Jenkins j = Jenkins.getInstanceOrNull();
         if (j == null) { // Need this path, at least for unit tests, but also in case of very broken startup
             // Startup failed, something is very broken, so report what we can.

--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -393,7 +393,7 @@ public class LogRecorder extends AbstractModelObject implements Loadable, Saveab
 
         void broadcast() {
             for (Computer c : Jenkins.get().getComputers()) {
-                if (c.getName().length() > 0) { // i.e. not master
+                if (!c.getName().isEmpty()) { // i.e. not master
                     VirtualChannel ch = c.getChannel();
                     if (ch != null) {
                         try {
@@ -595,7 +595,7 @@ public class LogRecorder extends AbstractModelObject implements Loadable, Saveab
             }
         });
         for (Computer c : Jenkins.get().getComputers()) {
-            if (c.getName().length() == 0) {
+            if (c.getName().isEmpty()) {
                 continue; // master
             }
             List<LogRecord> recs = new ArrayList<>();

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -230,7 +230,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                 String pathElement = pathTokens.nextToken();
                 // Treat * and ? as wildcard unless they match a literal filename
                 if ((pathElement.contains("?") || pathElement.contains("*"))
-                        && inBase && !root.child((_base.length() > 0 ? _base + "/" : "") + pathElement).exists())
+                        && inBase && !root.child((!_base.isEmpty() ? _base + "/" : "") + pathElement).exists())
                     inBase = false;
                 if (pathElement.equals("*zip*")) {
                     // the expected syntax is foo/bar/*zip*/bar.zip
@@ -245,7 +245,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                 }
 
                 StringBuilder sb = inBase ? _base : _rest;
-                if (sb.length() > 0)   sb.append('/');
+                if (!sb.isEmpty())   sb.append('/');
                 sb.append(pathElement);
                 if (!inBase)
                     restSize++;
@@ -315,7 +315,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
             }
 
             List<List<Path>> glob = null;
-            boolean patternUsed = rest.length() > 0;
+            boolean patternUsed = !rest.isEmpty();
             boolean containsSymlink = false;
             boolean containsTmpDir = false;
                 if (patternUsed) {

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -404,7 +404,7 @@ public class DownloadService {
                 }
                 jsonList.add(o);
             }
-            if (jsonList.size() == 0 && toolInstallerMetadataExists) {
+            if (jsonList.isEmpty() && toolInstallerMetadataExists) {
                 return FormValidation.warning("None of the tool installer metadata passed the signature check");
             } else if (!toolInstallerMetadataExists) {
                 LOGGER.log(Level.WARNING, "No tool installer metadata found for " + id);

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -608,7 +608,7 @@ public class Fingerprint implements ModelObject, Saveable {
         public synchronized String toString() {
             StringBuilder buf = new StringBuilder();
             for (Range r : ranges) {
-                if (buf.length() > 0)  buf.append(',');
+                if (!buf.isEmpty())  buf.append(',');
                 buf.append(r);
             }
             return buf.toString();
@@ -787,7 +787,7 @@ public class Fingerprint implements ModelObject, Saveable {
             public static String serialize(RangeSet src) {
                 StringBuilder buf = new StringBuilder(src.ranges.size() * 10);
                 for (Range r : src.ranges) {
-                    if (buf.length() > 0)  buf.append(',');
+                    if (!buf.isEmpty())  buf.append(',');
                     if (r.isSingle())
                         buf.append(r.start);
                     else

--- a/core/src/main/java/hudson/model/Items.java
+++ b/core/src/main/java/hudson/model/Items.java
@@ -208,7 +208,7 @@ public class Items {
     public static String toNameList(Collection<? extends Item> items) {
         StringBuilder buf = new StringBuilder();
         for (Item item : items) {
-            if (buf.length() > 0)
+            if (!buf.isEmpty())
                 buf.append(", ");
             buf.append(item.getFullName());
         }

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -591,7 +591,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     public static Set<LabelAtom> parse(@CheckForNull String labels) {
         final Set<LabelAtom> r = new TreeSet<>();
         labels = fixNull(labels);
-        if (labels.length() > 0) {
+        if (!labels.isEmpty()) {
             Jenkins j = Jenkins.get();
             LabelAtom labelAtom = j.tryGetLabelAtom(labels);
             if (labelAtom == null) {

--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -359,7 +359,7 @@ public class ListView extends View implements DirectlyModifiableView {
 
     private boolean needToAddToCurrentView(StaplerRequest req) throws ServletException {
         String json = req.getParameter("json");
-        if (json != null && json.length() > 0) {
+        if (json != null && !json.isEmpty()) {
             // Submitted via UI
             JSONObject form = req.getSubmittedForm();
             return form.has("addToCurrentView") && form.getBoolean("addToCurrentView");

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1341,7 +1341,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         private String combineLast(String[] token, int n) {
             StringBuilder buf = new StringBuilder();
             for (int i = Math.max(0, token.length - n); i < token.length; i++) {
-                if (buf.length() > 0)  buf.append('/');
+                if (!buf.isEmpty())  buf.append('/');
                 buf.append(token[i]);
             }
             return buf.toString();

--- a/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
+++ b/core/src/main/java/hudson/model/TopLevelItemDescriptor.java
@@ -239,7 +239,7 @@ public abstract class TopLevelItemDescriptor extends Descriptor<TopLevelItem> im
                 // this one is easy... too easy... also will never happen
                 return IconSet.toNormalizedIconNameClass(path);
             }
-            if (Jenkins.RESOURCE_PATH.length() > 0 && path.startsWith(Jenkins.RESOURCE_PATH)) {
+            if (!Jenkins.RESOURCE_PATH.isEmpty() && path.startsWith(Jenkins.RESOURCE_PATH)) {
                 // will to live falling
                 path = path.substring(Jenkins.RESOURCE_PATH.length());
             }

--- a/core/src/main/java/hudson/scm/ChangeLogSet.java
+++ b/core/src/main/java/hudson/scm/ChangeLogSet.java
@@ -238,7 +238,7 @@ public abstract class ChangeLogSet<T extends ChangeLogSet.Entry> implements Iter
             ChangeLogSet parent = getParent();
             if (null != parent) {
                 String kind = parent.getKind();
-                if (null != kind && kind.trim().length() > 0) scm = kind;
+                if (null != kind && !kind.trim().isEmpty()) scm = kind;
             }
             throw new UnsupportedOperationException("getAffectedFiles() is not implemented by " + scm);
         }

--- a/core/src/main/java/hudson/scm/browsers/QueryBuilder.java
+++ b/core/src/main/java/hudson/scm/browsers/QueryBuilder.java
@@ -38,7 +38,7 @@ public final class QueryBuilder {
 
     public QueryBuilder add(String s) {
         if (s == null)     return this; // nothing to add
-        if (buf.length() == 0) buf.append('?');
+        if (buf.isEmpty()) buf.append('?');
         else                buf.append('&');
         buf.append(s);
         return this;

--- a/core/src/main/java/hudson/search/ParsedQuickSilver.java
+++ b/core/src/main/java/hudson/search/ParsedQuickSilver.java
@@ -85,7 +85,7 @@ final class ParsedQuickSilver {
     private String splitName(String url) {
         StringBuilder buf = new StringBuilder(url.length() + 5);
         for (String token : url.split("(?<=[a-z])(?=[A-Z])")) {
-            if (buf.length() > 0)  buf.append(' ');
+            if (!buf.isEmpty())  buf.append(' ');
             buf.append(Introspector.decapitalize(token));
         }
         return buf.toString();

--- a/core/src/main/java/hudson/search/SuggestedItem.java
+++ b/core/src/main/java/hudson/search/SuggestedItem.java
@@ -111,7 +111,7 @@ public class SuggestedItem {
             buf.setLength(0);
             buf.append(f);
         } else {
-            if (buf.length() == 0 || buf.charAt(buf.length() - 1) != '/')
+            if (buf.isEmpty() || buf.charAt(buf.length() - 1) != '/')
                 buf.append('/');
             buf.append(f);
         }

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -449,7 +449,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
             si.errors.put("password1", Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordNotMatch());
         }
 
-        if (!(si.password1 != null && si.password1.length() != 0)) {
+        if (!(si.password1 != null && !si.password1.isEmpty())) {
             si.errors.put("password1", Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordRequired());
         }
 

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -326,7 +326,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         SecurityContextHolder.clearContext();
 
-        String contextPath = req.getContextPath().length() > 0 ? req.getContextPath() : "/";
+        String contextPath = !req.getContextPath().isEmpty() ? req.getContextPath() : "/";
         resetRememberMeCookie(req, rsp, contextPath);
         clearStaleSessionCookies(req, rsp, contextPath);
 

--- a/core/src/main/java/hudson/security/csrf/CrumbFilter.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbFilter.java
@@ -105,7 +105,7 @@ public class CrumbFilter implements Filter {
                 buf.append(token);
             }
             // translation: if (path.endsWith("/") && !buf.endsWith("/"))
-            if (path.endsWith("/") && (buf.length() == 0 || buf.charAt(buf.length() - 1) != '/'))
+            if (path.endsWith("/") && (buf.isEmpty() || buf.charAt(buf.length() - 1) != '/'))
                 buf.append('/');
             return buf.toString();
         }

--- a/core/src/main/java/hudson/security/csrf/CrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/CrumbIssuer.java
@@ -78,7 +78,7 @@ public abstract class CrumbIssuer implements Describable<CrumbIssuer>, Extension
         if (crumb == null) {
             crumb = issueCrumb(request, getDescriptor().getCrumbSalt());
             if (request != null) {
-                if (crumb != null && crumb.length() > 0) {
+                if (crumb != null && !crumb.isEmpty()) {
                     request.setAttribute(CRUMB_ATTRIBUTE, crumb);
                 } else {
                     request.removeAttribute(CRUMB_ATTRIBUTE);

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -182,7 +182,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
 
             Map<String, String> record = new HashMap<>();
 
-            if (targets.length() != 0) {
+            if (!targets.isEmpty()) {
                 String expandedTargets = targets;
                 if (build instanceof AbstractBuild) { // no expansion for pipelines
                     expandedTargets = environment.expand(expandedTargets);

--- a/core/src/main/java/hudson/tools/AbstractCommandInstaller.java
+++ b/core/src/main/java/hudson/tools/AbstractCommandInstaller.java
@@ -90,7 +90,7 @@ public abstract class AbstractCommandInstaller extends ToolInstaller {
             extends ToolInstallerDescriptor<TInstallerClass> {
 
         public FormValidation doCheckCommand(@QueryParameter String value) {
-            if (value.length() > 0) {
+            if (!value.isEmpty()) {
                 return FormValidation.ok();
             } else {
                 return FormValidation.error(Messages.CommandInstaller_no_command());
@@ -98,7 +98,7 @@ public abstract class AbstractCommandInstaller extends ToolInstaller {
         }
 
         public FormValidation doCheckToolHome(@QueryParameter String value) {
-            if (value.length() > 0) {
+            if (!value.isEmpty()) {
                 return FormValidation.ok();
             } else {
                 return FormValidation.error(Messages.CommandInstaller_no_toolHome());

--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -295,7 +295,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
     public String toStringWithQuote() {
         StringBuilder buf = new StringBuilder();
         for (String arg : args) {
-            if (buf.length() > 0)  buf.append(' ');
+            if (!buf.isEmpty())  buf.append(' ');
 
             if (arg.indexOf(' ') >= 0 || arg.isEmpty())
                 buf.append('"').append(arg).append('"');
@@ -400,7 +400,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      * @return true if there are any masked arguments; false otherwise
      */
     public boolean hasMaskedArguments() {
-        return mask.length() > 0;
+        return !mask.isEmpty();
     }
 
     /**
@@ -437,7 +437,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
             if (mask.get(i))
                 arg = "******";
 
-            if (buf.length() > 0)  buf.append(' ');
+            if (!buf.isEmpty())  buf.append(' ');
 
             if (arg.indexOf(' ') >= 0 || arg.isEmpty())
                 buf.append('"').append(arg).append('"');

--- a/core/src/main/java/jenkins/install/InstallUtil.java
+++ b/core/src/main/java/jenkins/install/InstallUtil.java
@@ -234,7 +234,7 @@ public class InstallUtil {
             if (configFile.exists()) {
                 try {
                     String lastVersion = XMLUtils.getValue("/hudson/version", configFile);
-                    if (lastVersion.length() > 0) {
+                    if (!lastVersion.isEmpty()) {
                         LOGGER.log(Level.FINE, "discovered serialized lastVersion {0}", lastVersion);
                         return lastVersion;
                     }

--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsDecorator.java
@@ -150,7 +150,7 @@ public class AdministrativeMonitorsDecorator extends PageDecorator {
         }
         List<Ancestor> ancestors = req.getAncestors();
 
-        if (ancestors == null || ancestors.size() == 0) {
+        if (ancestors == null || ancestors.isEmpty()) {
             // ???
             return null;
         }

--- a/core/src/main/java/jenkins/org/apache/commons/validator/routines/UrlValidator.java
+++ b/core/src/main/java/jenkins/org/apache/commons/validator/routines/UrlValidator.java
@@ -420,7 +420,7 @@ public class UrlValidator implements Serializable {
                 }
             }
             String port = authorityMatcher.group(PARSE_AUTHORITY_PORT);
-            if (port != null && port.length() > 0) {
+            if (port != null && !port.isEmpty()) {
                 try {
                     int iPort = Integer.parseInt(port);
                     if (iPort < 0 || iPort > MAX_UNSIGNED_16_BIT_INT) {
@@ -433,7 +433,7 @@ public class UrlValidator implements Serializable {
         }
 
         String extra = authorityMatcher.group(PARSE_AUTHORITY_EXTRA);
-        if (extra != null && extra.trim().length() > 0) {
+        if (extra != null && !extra.trim().isEmpty()) {
             return false;
         }
 

--- a/core/src/main/java/jenkins/util/TreeString.java
+++ b/core/src/main/java/jenkins/util/TreeString.java
@@ -64,7 +64,7 @@ public final class TreeString implements Serializable {
     }
 
     /* package */TreeString(final TreeString parent, final String label) {
-        assert parent == null || label.length() > 0; // if there's a parent,
+        assert parent == null || !label.isEmpty(); // if there's a parent,
                                                      // label can't be empty.
 
         this.parent = parent;

--- a/core/src/main/java/org/jenkins/ui/icon/Icon.java
+++ b/core/src/main/java/org/jenkins/ui/icon/Icon.java
@@ -279,7 +279,7 @@ public class Icon {
         // Trim all tokens first
         for (String classNameTok : classNameTokA) {
             String trimmedToken = classNameTok.trim();
-            if (trimmedToken.length() > 0) {
+            if (!trimmedToken.isEmpty()) {
                 classNameTokL.add(trimmedToken);
             }
         }

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -248,7 +248,7 @@ public class UtilTest {
             Util.createSymlink(d, buf.toString(), "x", l);
 
             String log = baos.toString(Charset.defaultCharset());
-            if (log.length() > 0)
+            if (!log.isEmpty())
                 System.err.println("log output: " + log);
 
             assertEquals(buf.toString(), Util.resolveSymlink(new File(d, "x")));


### PR DESCRIPTION
Fix an IntelliJ warning by using `isEmpty()` where possible.

### Testing done

`mvn clean verify -DskipTests`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
