### PR TITLE
Miscellaneous code cleanup

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1445,7 +1445,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         public Void invoke(File f, VirtualChannel channel) throws IOException {
             for (File file : listParentFiles(f)) {
                 if (file.getName().startsWith(f.getName() + WorkspaceList.COMBINATOR)) {
-                    Util.deleteRecursive(file.toPath(), path -> path.toFile());
+                    Util.deleteRecursive(file.toPath(), Path::toFile);
                 }
             }
 
@@ -1476,7 +1476,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
 
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
-            Util.deleteRecursive(fileToPath(f), path -> path.toFile());
+            Util.deleteRecursive(fileToPath(f), Path::toFile);
             return null;
         }
     }
@@ -1493,7 +1493,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
 
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException {
-            Util.deleteContentsRecursive(fileToPath(f), path -> path.toFile());
+            Util.deleteContentsRecursive(fileToPath(f), Path::toFile);
             return null;
         }
     }

--- a/core/src/main/java/hudson/model/CauseAction.java
+++ b/core/src/main/java/hudson/model/CauseAction.java
@@ -61,8 +61,7 @@ public class CauseAction implements FoldableAction, RunAction2 {
 
     private void addCause(Cause c) {
         synchronized (causeBag) {
-            Integer cnt = causeBag.get(c);
-            causeBag.put(c, cnt == null ? 1 : cnt + 1);
+            causeBag.compute(c, (unused, cnt) -> cnt == null ? 1 : cnt + 1);
         }
     }
 

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.LinkOption;
 import java.nio.file.OpenOption;
@@ -530,7 +531,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
     private static void zip(StaplerResponse rsp, VirtualFile root, VirtualFile dir, String glob) throws IOException, InterruptedException {
         OutputStream outputStream = rsp.getOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(outputStream)) {
-            zos.setEncoding(System.getProperty("file.encoding")); // TODO JENKINS-20663 make this overridable via query parameter
+            zos.setEncoding(Charset.defaultCharset().displayName()); // TODO JENKINS-20663 make this overridable via query parameter
             // TODO consider using run(Callable) here
 
             if (glob.isEmpty()) {

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -390,7 +390,7 @@ public class UpdateCenter extends AbstractModelObject implements Loadable, Savea
         if (size > 0) {
             StringBuilder tooltip = new StringBuilder();
             Badge.Severity severity = Badge.Severity.WARNING;
-            int securityFixSize = (int) plugins.stream().filter(plugin -> plugin.fixesSecurityVulnerabilities()).count();
+            int securityFixSize = (int) plugins.stream().filter(Plugin::fixesSecurityVulnerabilities).count();
             int incompatibleSize = (int) plugins.stream().filter(plugin -> !plugin.isCompatibleWithInstalledVersion()).count();
             if (size > 1) {
                 tooltip.append(jenkins.management.Messages.PluginsLink_updatesAvailable(size));

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -192,7 +192,7 @@ public class UpdateSite {
     @Deprecated
     public @CheckForNull Future<FormValidation> updateDirectly(final boolean signatureCheck) {
         if (! getDataFile().exists() || isDue()) {
-            return Jenkins.get().getUpdateCenter().updateService.submit(new Callable<FormValidation>() {
+            return Jenkins.get().getUpdateCenter().updateService.submit(new Callable<>() {
                 @Override public FormValidation call() throws Exception {
                     return updateDirectlyNow(signatureCheck);
                 }

--- a/core/src/main/java/hudson/tools/InstallerTranslator.java
+++ b/core/src/main/java/hudson/tools/InstallerTranslator.java
@@ -59,11 +59,8 @@ public class InstallerTranslator extends ToolLocationTranslator {
             if (installer.appliesTo(node)) {
                 Semaphore semaphore;
                 synchronized (mutexByNode) {
-                    Map<ToolInstallation, Semaphore> mutexByTool = mutexByNode.computeIfAbsent(node, k -> new WeakHashMap<>());
-                    semaphore = mutexByTool.get(tool);
-                    if (semaphore == null) {
-                        mutexByTool.put(tool, semaphore = new Semaphore(1));
-                    }
+                    Map<ToolInstallation, Semaphore> mutexByTool = mutexByNode.computeIfAbsent(node, unused -> new WeakHashMap<>());
+                    semaphore = mutexByTool.computeIfAbsent(tool, unused -> new Semaphore(1));
                 }
                 semaphore.acquire();
                 try {

--- a/core/src/main/java/hudson/util/ProcessTree.java
+++ b/core/src/main/java/hudson/util/ProcessTree.java
@@ -455,7 +455,7 @@ public abstract class ProcessTree implements Iterable<OSProcess>, IProcessTree, 
         }
 
         // Null-check in case the previous call worked
-        boolean vetoes = vetoersExist == null ? true : vetoersExist;
+        boolean vetoes = vetoersExist == null || vetoersExist;
 
         try {
             if (File.pathSeparatorChar == ';')

--- a/core/src/main/java/hudson/util/XStream2.java
+++ b/core/src/main/java/hudson/util/XStream2.java
@@ -469,7 +469,7 @@ public class XStream2 extends XStream {
      */
     private static final class AssociatedConverterImpl implements Converter {
         private final XStream xstream;
-        private static final ClassValue<Class<? extends ConverterMatcher>> classCache = new ClassValue<Class<? extends ConverterMatcher>>() {
+        private static final ClassValue<Class<? extends ConverterMatcher>> classCache = new ClassValue<>() {
             @Override
             protected Class<? extends ConverterMatcher> computeValue(Class<?> type) {
                 return computeConverterClass(type);

--- a/core/src/main/java/jenkins/agents/CloudSet.java
+++ b/core/src/main/java/jenkins/agents/CloudSet.java
@@ -41,7 +41,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
@@ -131,7 +130,7 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
     @Override
     public ModelObjectWithContextMenu.ContextMenu doChildrenContextMenu(StaplerRequest request, StaplerResponse response) throws Exception {
         ModelObjectWithContextMenu.ContextMenu m = new ModelObjectWithContextMenu.ContextMenu();
-        Jenkins.get().clouds.stream().forEach(c -> m.add(c));
+        Jenkins.get().clouds.stream().forEach(m::add);
         return m;
     }
 
@@ -265,7 +264,7 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
         }
         var namesList = Arrays.asList(names);
         var clouds = new ArrayList<>(Jenkins.get().clouds);
-        Collections.sort(clouds, Comparator.comparingInt(c -> getIndexOf(namesList, c)));
+        clouds.sort(Comparator.comparingInt(c -> getIndexOf(namesList, c)));
         Jenkins.get().clouds.replaceBy(clouds);
         rsp.sendRedirect2(".");
     }

--- a/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
+++ b/core/src/main/java/jenkins/diagnostics/URICheckEncodingMonitor.java
@@ -7,6 +7,7 @@ import hudson.Util;
 import hudson.model.AdministrativeMonitor;
 import hudson.util.FormValidation;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,7 +23,7 @@ public class URICheckEncodingMonitor extends AdministrativeMonitor {
     private static final Logger LOGGER = Logger.getLogger(URICheckEncodingMonitor.class.getName());
 
     public boolean isCheckEnabled() {
-        return !"ISO-8859-1".equalsIgnoreCase(System.getProperty("file.encoding"));
+        return !"ISO-8859-1".equalsIgnoreCase(Charset.defaultCharset().displayName());
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -499,7 +499,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      *     STARTUP_MARKER_FILE.get(); // returns false if we are on a fresh startup. True for next startups.
      * }
      */
-    private static transient FileBoolean STARTUP_MARKER_FILE;
+    private static FileBoolean STARTUP_MARKER_FILE;
 
     private volatile List<JDK> jdks = new ArrayList<>();
 
@@ -3477,10 +3477,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         File d = new File(replacedValue);
         if (!d.isDirectory()) {
             // if dir does not exist (almost guaranteed) need to make sure nearest existing ancestor can be written to
-            d = d.getParentFile();
-            while (!d.exists()) {
+            do {
                 d = d.getParentFile();
-            }
+            } while (!d.exists());
             if (!d.canWrite()) {
                 throw new InvalidBuildsDir(newBuildsDirValue +  " does not exist and probably cannot be created");
             }

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -346,7 +346,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
          * (Would have been done entirely as an interface with default methods had this been designed for Java 8.)
          */
         default ParameterizedJobMixIn<JobT, RunT> getParameterizedJobMixIn() {
-            return new ParameterizedJobMixIn<JobT, RunT>() {
+            return new ParameterizedJobMixIn<>() {
                 @SuppressWarnings("unchecked") // untypable
                 @Override protected JobT asJob() {
                     return (JobT) ParameterizedJob.this;

--- a/core/src/main/java/jenkins/security/RedactSecretJsonInErrorMessageSanitizer.java
+++ b/core/src/main/java/jenkins/security/RedactSecretJsonInErrorMessageSanitizer.java
@@ -88,7 +88,6 @@ public class RedactSecretJsonInErrorMessageSanitizer implements JsonInErrorMessa
         }
     }
 
-    @SuppressWarnings("unchecked")
     private JSONObject copyAndSanitizeObject(JSONObject jsonObject) {
         Set<String> redactedKeySet = retrieveRedactedKeys(jsonObject);
         JSONObject result = new JSONObject();

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -46,6 +46,7 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.OpenOption;
@@ -375,7 +376,7 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
         Collection<String> files = list(includes, excludes, useDefaultExcludes, openOptions);
         try (ZipOutputStream zos = new ZipOutputStream(outputStream)) {
-            zos.setEncoding(System.getProperty("file.encoding")); // TODO JENKINS-20663 make this overridable via query parameter
+            zos.setEncoding(Charset.defaultCharset().displayName()); // TODO JENKINS-20663 make this overridable via query parameter
 
             for (String relativePath : files) {
                 VirtualFile virtualFile = this.child(relativePath);

--- a/core/src/test/java/hudson/cli/ListJobsCommandTest.java
+++ b/core/src/test/java/hudson/cli/ListJobsCommandTest.java
@@ -191,7 +191,7 @@ public class ListJobsCommandTest {
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
-                Set<String> jobs = new HashSet<>(Arrays.asList(item.toString(charset).split(System.getProperty("line.separator"))));
+                Set<String> jobs = new HashSet<>(Arrays.asList(item.toString(charset).split(System.lineSeparator())));
 
                 return new HashSet<>(Arrays.asList(expected)).equals(jobs);
             }

--- a/core/src/test/java/hudson/model/RunTest.java
+++ b/core/src/test/java/hudson/model/RunTest.java
@@ -197,7 +197,7 @@ public class RunTest {
         for (int i = 1; i < 10; i++) {
             assertEquals("dummy" + (10 + i), logLines.get(i));
         }
-        int truncatedCount = 10 * ("dummyN".length() + System.getProperty("line.separator").length()) - 2;
+        int truncatedCount = 10 * ("dummyN".length() + System.lineSeparator().length()) - 2;
         assertEquals("[...truncated " + truncatedCount + " B...]", logLines.get(0));
     }
 

--- a/core/src/test/java/hudson/util/RetrierTest.java
+++ b/core/src/test/java/hudson/util/RetrierTest.java
@@ -160,7 +160,7 @@ public class RetrierTest {
                             throw new IndexOutOfBoundsException("Exception allowed considered as failure");
                         },
                         // check the result and return true (boolean primitive type) if success
-                        (currentAttempt, result) -> result == null ? false : result,
+                        (currentAttempt, result) -> result != null && result,
                         //name of the action
                         ACTION
                 )

--- a/core/src/test/java/hudson/util/SecretRewriterTest.java
+++ b/core/src/test/java/hudson/util/SecretRewriterTest.java
@@ -54,7 +54,7 @@ public class SecretRewriterTest {
         Files.writeString(path, before, Charset.defaultCharset());
         sr.rewrite(path.toFile());
         //assert after.replaceAll(System.getProperty("line.separator"), "\n").trim()==f.text.replaceAll(System.getProperty("line.separator"), "\n").trim()
-        return Files.readString(path, Charset.defaultCharset()).replaceAll(System.getProperty("line.separator"), "\n").trim();
+        return Files.readString(path, Charset.defaultCharset()).replaceAll(System.lineSeparator(), "\n").trim();
     }
 
     @SuppressWarnings("deprecation")

--- a/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/core/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -39,7 +39,7 @@ public final class PeepholePermalinkTest {
         PeepholePermalink.initialized();
         Thread t = new Thread(() -> {
             assertThat("successfully loaded permalinks",
-                PermalinkProjectAction.Permalink.BUILTIN.stream().map(p -> p.getId()).collect(Collectors.toSet()),
+                PermalinkProjectAction.Permalink.BUILTIN.stream().map(PermalinkProjectAction.Permalink::getId).collect(Collectors.toSet()),
                 containsInAnyOrder("lastBuild", "lastStableBuild", "lastSuccessfulBuild", "lastFailedBuild", "lastUnstableBuild", "lastUnsuccessfulBuild", "lastCompletedBuild"));
         });
         t.start();

--- a/test/src/test/java/hudson/cli/Security3315Test.java
+++ b/test/src/test/java/hudson/cli/Security3315Test.java
@@ -34,7 +34,7 @@ public class Security3315Test {
 
     public Security3315Test(String allowWs) {
         this.allowWs = allowWs == null ? null : Boolean.valueOf(allowWs);
-        this.escapeHatch = new FlagRule<>(() -> CLIAction.ALLOW_WEBSOCKET, v -> { CLIAction.ALLOW_WEBSOCKET = v; }, this.allowWs);
+        this.escapeHatch = new FlagRule<>(() -> CLIAction.ALLOW_WEBSOCKET, v -> CLIAction.ALLOW_WEBSOCKET = v, this.allowWs);
     }
 
     @Test

--- a/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
+++ b/test/src/test/java/hudson/console/ConsoleAnnotatorTest.java
@@ -76,7 +76,7 @@ public class ConsoleAnnotatorTest {
         // make sure raw console output doesn't include the garbage
         TextPage raw = (TextPage) r.createWebClient().goTo(b.getUrl() + "consoleText", "text/plain");
         System.out.println(raw.getContent());
-        String nl = System.getProperty("line.separator");
+        String nl = System.lineSeparator();
         assertTrue(raw.getContent().contains(nl + "---" + nl + "ooo" + nl + "ooo" + nl));
 
         // there should be two 'ooo's
@@ -96,7 +96,7 @@ public class ConsoleAnnotatorTest {
     }
 
     public static class DemoAnnotator extends ConsoleAnnotator<FreeStyleBuild> {
-        private static final String ANNOTATE_TEXT = "ooo" + System.getProperty("line.separator");
+        private static final String ANNOTATE_TEXT = "ooo" + System.lineSeparator();
 
         @Override
         public ConsoleAnnotator<FreeStyleBuild> annotate(FreeStyleBuild build, MarkupText text) {

--- a/test/src/test/java/hudson/model/DownloadService2Test.java
+++ b/test/src/test/java/hudson/model/DownloadService2Test.java
@@ -60,7 +60,7 @@ public class DownloadService2Test {
         URL resource = DownloadService2Test.class.getResource(file);
         assertNotNull(file, resource);
         JSONObject json = JSONObject.fromObject(DownloadService.loadJSONHTML(resource));
-        @SuppressWarnings("unchecked") Set<String> keySet = json.keySet();
+        Set<String> keySet = json.keySet();
         assertEquals(expected, new TreeSet<>(keySet).toString());
     }
 

--- a/test/src/test/java/hudson/model/DownloadServiceTest.java
+++ b/test/src/test/java/hudson/model/DownloadServiceTest.java
@@ -34,7 +34,7 @@ public class DownloadServiceTest {
     private static void assertRoots(String expected, URL resource) throws Exception {
         assertNotNull(resource);
         JSONObject json = JSONObject.fromObject(DownloadService.loadJSON(resource));
-        @SuppressWarnings("unchecked") Set<String> keySet = json.keySet();
+        Set<String> keySet = json.keySet();
         assertEquals(expected, new TreeSet<>(keySet).toString());
     }
 

--- a/test/src/test/java/hudson/model/SlaveTest.java
+++ b/test/src/test/java/hudson/model/SlaveTest.java
@@ -160,7 +160,7 @@ public class SlaveTest {
     private void assertJnlpJarUrlFails(@NonNull Slave slave, @NonNull String url) throws Exception {
         // Raw access to API
         Slave.JnlpJar jnlpJar = slave.getComputer().getJnlpJars(url);
-        assertThrows(MalformedURLException.class, () -> jnlpJar.getURL());
+        assertThrows(MalformedURLException.class, jnlpJar::getURL);
     }
 
     private void assertJnlpJarUrlIsAllowed(@NonNull Slave slave, @NonNull String url) throws Exception {

--- a/test/src/test/java/jenkins/ClassPathTest.java
+++ b/test/src/test/java/jenkins/ClassPathTest.java
@@ -26,9 +26,7 @@ package jenkins;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,7 +44,7 @@ public class ClassPathTest {
     @Rule
     public ErrorCollector errors = new ErrorCollector();
 
-    private static final Set<String> KNOWN_VIOLATIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<String> KNOWN_VIOLATIONS = Set.of(
             // TODO duplicated in [jline-2.14.6.jar, jansi-1.11.jar]
             "org/fusesource/hawtjni/runtime/Callback.class",
             "org/fusesource/hawtjni/runtime/JNIEnv.class",
@@ -75,7 +73,7 @@ public class ClassPathTest {
             "org/fusesource/jansi/internal/Kernel32$SMALL_RECT.class",
             "org/fusesource/jansi/internal/Kernel32.class",
             "org/fusesource/jansi/internal/WindowsSupport.class",
-            "org/fusesource/jansi/WindowsAnsiOutputStream.class")));
+            "org/fusesource/jansi/WindowsAnsiOutputStream.class");
 
     @Issue("JENKINS-46754")
     @Test

--- a/test/src/test/java/jenkins/security/SecurityContextExecutorServiceTest.java
+++ b/test/src/test/java/jenkins/security/SecurityContextExecutorServiceTest.java
@@ -106,7 +106,7 @@ public class SecurityContextExecutorServiceTest {
     @Test
     @PresetData(PresetData.DataSet.NO_ANONYMOUS_READACCESS)
     public void testCallableAgainstAllContexts() throws Exception {
-        Callable<SecurityContext> c = () -> SecurityContextHolder.getContext();
+        Callable<SecurityContext> c = SecurityContextHolder::getContext;
         SecurityContextHolder.setContext(systemContext);
         Future<SecurityContext> result = wrappedService.submit(c);
         // Assert the context inside the callable thread was set to ACL.SYSTEM2
@@ -127,7 +127,7 @@ public class SecurityContextExecutorServiceTest {
     @PresetData(PresetData.DataSet.NO_ANONYMOUS_READACCESS)
     public void testCallableCollectionAgainstAllContexts() throws Exception {
         Collection<Callable<SecurityContext>> callables = new ArrayList<>();
-        Callable<SecurityContext> c = () -> SecurityContextHolder.getContext();
+        Callable<SecurityContext> c = SecurityContextHolder::getContext;
         callables.add(c);
         callables.add(c);
         callables.add(c);


### PR DESCRIPTION
Fixing various IntelliJ warnings.

### Testing done

`mvn clean verify -DskipTests`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
