### PR TITLE
[JENKINS-73129] Remove Windows path traversal escape hatch from SECURITY-2481 

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -90,11 +90,6 @@ public final class DirectoryBrowserSupport implements HttpResponse {
 
     private static final Pattern TMPDIR_PATTERN = Pattern.compile(".+@tmp/.*");
 
-    /**
-     * Escape hatch for the protection against SECURITY-2481. If enabled, the absolute paths on Windows will be allowed.
-     */
-    static final String ALLOW_ABSOLUTE_PATH_PROPERTY_NAME = DirectoryBrowserSupport.class.getName() + ".allowAbsolutePath";
-
     public final ModelObject owner;
 
     public final String title;
@@ -260,13 +255,11 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         if (base.isEmpty()) {
             baseFile = root;
         } else {
-            if (!SystemProperties.getBoolean(ALLOW_ABSOLUTE_PATH_PROPERTY_NAME, false)) {
-                boolean isAbsolute = root.run(new IsAbsolute(base));
-                if (isAbsolute) {
-                    LOGGER.info(() -> "SECURITY-2481 The path provided in the URL (" + base + ") is absolute and thus is refused.");
-                    rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
-                    return;
-                }
+            boolean isAbsolute = root.run(new IsAbsolute(base));
+            if (isAbsolute) {
+                LOGGER.info(() -> "SECURITY-2481 The path provided in the URL (" + base + ") is absolute and thus is refused.");
+                rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
             }
             baseFile = root.child(base);
         }

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -1115,33 +1115,6 @@ public class DirectoryBrowserSupportTest {
     }
 
     @Test
-    @Issue("SECURITY-2481")
-    public void windows_canViewAbsolutePath_withEscapeHatch() throws Exception {
-        Assume.assumeTrue("can only be tested this on Windows", Functions.isWindows());
-
-        String originalValue = System.getProperty(DirectoryBrowserSupport.ALLOW_ABSOLUTE_PATH_PROPERTY_NAME);
-        System.setProperty(DirectoryBrowserSupport.ALLOW_ABSOLUTE_PATH_PROPERTY_NAME, "true");
-        try {
-            Path targetTmpPath = Files.createTempFile("sec2481", "tmp");
-            String content = "random data provided as fixed value";
-            Files.writeString(targetTmpPath, content, StandardCharsets.UTF_8);
-
-            JenkinsRule.WebClient wc = j.createWebClient().withThrowExceptionOnFailingStatusCode(false);
-            Page page = wc.goTo("userContent/" + targetTmpPath.toAbsolutePath() + "/*view*", null);
-
-            MatcherAssert.assertThat(page.getWebResponse().getStatusCode(), equalTo(200));
-            MatcherAssert.assertThat(page.getWebResponse().getContentAsString(), containsString(content));
-        } finally {
-            if (originalValue == null) {
-                System.clearProperty(DirectoryBrowserSupport.ALLOW_ABSOLUTE_PATH_PROPERTY_NAME);
-            } else {
-                System.setProperty(DirectoryBrowserSupport.ALLOW_ABSOLUTE_PATH_PROPERTY_NAME, originalValue);
-            }
-        }
-
-    }
-
-    @Test
     @Issue("SECURITY-1807")
     public void tmpNotListed() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();


### PR DESCRIPTION
## Remove Windows path traversal escape hatch from SECURITY-2481 

[SECURITY-2481](https://www.jenkins.io/security/advisory/2021-10-06/#SECURITY-2481) was published in October 2021 with an escape hatch that allows users to enable the path traversal vulnerability on Windows. Jetty 12 detects the vulernability even before the request reaches Jenkins and returns an HTTP error, as required by the Servlet API specification.

Remove the escape hatch because the escape hatch is intended to be temporary and we don't want to reimplement it for Jetty 12.

[JENKINS-73129](https://issues.jenkins.io/browse/JENKINS-73129) includes further discussion of the alternatives.

### Testing done

Confirmed that tests pass without the escape hatch.

Confirmed that there are no references to the escape hatch in the Jenkins GitHub organization other than the references removed in this pull request.

### Proposed changelog entries

- Remove Windows path traversal vulnerability escape hatch that was provided with the SECURITY-2481 fix.

### Proposed upgrade guidelines

- The `hudson.model.DirectoryBrowserSupport.allowAbsolutePath` system property that allows the Windows path traversal vulnerability escape hatch has been removed.  Users that rely on it will need to adapt their usage to no longer require the Windows path traversal vulnerability.  No other workaround is planned.  Refer to [SECURITY-2481](https://www.jenkins.io/security/advisory/2021-10-06/#SECURITY-2481) for details.

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@daniel-beck

Happy to have suggestions for better text in the upgrade guide and in the changelog entry.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
