### PR TITLE
Replace usages of YUI framework by simple JS/CSS

### DIFF
--- a/core/src/main/java/hudson/console/ExpandableDetailsNote.java
+++ b/core/src/main/java/hudson/console/ExpandableDetailsNote.java
@@ -26,8 +26,8 @@ package hudson.console;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.Functions;
 import hudson.MarkupText;
+import hudson.Util;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -53,7 +53,8 @@ public class ExpandableDetailsNote extends ConsoleNote {
     @Override
     public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
         text.addMarkup(charPos,
-                "<input type=button value='" + Functions.htmlAttributeEscape(caption) + "' class='reveal-expandable-detail'><div class='expandable-detail'>" + html + "</div>");
+                "<button type='button' class='jenkins-button reveal-expandable-detail'>"
+                        + Util.xmlEscape(caption) + "</button><div class='expandable-detail'>" + html + "</div>");
         return null;
     }
 

--- a/core/src/main/resources/hudson/console/ExpandableDetailsNote/script.js
+++ b/core/src/main/resources/hudson/console/ExpandableDetailsNote/script.js
@@ -1,11 +1,11 @@
 (function () {
   Behaviour.specify(
-    "INPUT.reveal-expandable-detail",
+    "BUTTON.reveal-expandable-detail",
     "ExpandableDetailsNote",
     0,
     function (e) {
-      var detail = e.nextSibling;
-      makeButton(e, function () {
+      e.addEventListener("click", () => {
+        const detail = e.nextSibling;
         detail.style.display =
           detail.style.display == "block" ? "none" : "block";
       });

--- a/core/src/main/resources/hudson/console/ExpandableDetailsNote/style.css
+++ b/core/src/main/resources/hudson/console/ExpandableDetailsNote/style.css
@@ -1,6 +1,6 @@
 DIV.expandable-detail {
   display: none;
-  background-color: #d3d7cf;
+  background-color: var(--background);
   margin: 0.5em;
   padding: 0.5em;
 }

--- a/core/src/main/resources/hudson/model/View/index.jelly
+++ b/core/src/main/resources/hudson/model/View/index.jelly
@@ -44,7 +44,6 @@ THE SOFTWARE.
         </l:main-panel>
         <l:header>
           <!-- for screen resolution detection -->
-          <l:yui module="cookie" />
           <script id="screenResolution-script" data-use-secure-cookie="${request.secure}"/>
           <st:adjunct includes="hudson.model.View.screen-resolution"/>
         </l:header>

--- a/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
+++ b/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
@@ -10,7 +10,9 @@ SlowTriggerAdminMonitor tam = my
 dl {
     div(class: "jenkins-alert jenkins-alert-warning") {
         form(method: "post", name: "clear", action: rootURL + "/" + tam.url + "/clear") {
-            input(name: "clear", type: "submit", value: _("Dismiss"), class: "submit-button primary")
+            button(name: "clear", type: "submit", class: "jenkins-button jenkins-submit-button jenkins-button--primary") {
+                raw _("Dismiss")
+            }
         }
 
         text(_("blurb"))

--- a/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/RekeySecretAdminMonitor/message.groovy
@@ -50,7 +50,9 @@ if (my.isFixingActive()) {
 form(method: "post", action: "${rootURL}/${my.url}/scan", name:"rekey") {
     f.submit(name: "background", value:_("Re-key in background now"))
     if (my.isScanOnBoot()) {
-        input(type: "button", class: "yui-button", disabled: "true", value:_("Re-keying currently scheduled during the next startup"))
+        button(type: "button", class: "jenkins-button jenkins-button--primary", disabled: "true") {
+            raw _("Re-keying currently scheduled during the next startup")
+        }
     } else {
         f.submit(name: "schedule", value:_("Schedule a re-key during the next startup"))
     }

--- a/core/src/main/resources/lib/form/repeatable/repeatable.js
+++ b/core/src/main/resources/lib/form/repeatable/repeatable.js
@@ -43,8 +43,7 @@ var repeatableSupport = {
     // importNode isn't supported in IE.
     // nc = document.importNode(node,true);
     var nc = document.createElement("div");
-    nc.className = "repeated-chunk";
-    nc.style.opacity = 0;
+    nc.className = "repeated-chunk fade-in";
     nc.setAttribute("name", this.name);
     nc.innerHTML = this.blockHTML;
     if (!addOnTop) {
@@ -60,15 +59,7 @@ var repeatableSupport = {
       registerSortableDragDrop(nc);
     }
 
-    new YAHOO.util.Anim(
-      nc,
-      {
-        opacity: { to: 1 },
-      },
-      0.2,
-      YAHOO.util.Easing.easeIn,
-    ).animate();
-
+    nc.classList.remove("fade-in");
     Behaviour.applySubtree(nc, true);
     this.update();
   },
@@ -126,24 +117,27 @@ var repeatableSupport = {
   // called when 'delete' button is clicked
   onDelete: function (n) {
     n = n.closest(".repeated-chunk");
-    var a = new YAHOO.util.Anim(
-      n,
-      {
-        opacity: { to: 0 },
-        height: { to: 0 },
-      },
-      0.2,
-      YAHOO.util.Easing.easeIn,
-    );
-    a.onComplete.subscribe(function () {
+    n.ontransitionend = function (evt) {
+      if (evt.pseudoElement || !n.parentNode) {
+        return;
+      }
       var p = n.parentNode;
       p.removeChild(n);
       if (p.tag) {
         p.tag.update();
       }
+
       layoutUpdateCallback.call();
-    });
-    a.animate();
+    };
+    if (isRunAsTest) {
+      // transition end not triggered in tests
+      n.ontransitionend.call(n, {});
+    }
+    n.style.maxHeight = n.offsetHeight + "px";
+    n.classList.add("fade-out");
+    setTimeout(() => {
+      n.style.maxHeight = "0";
+    }, 0);
   },
 
   // called when 'add' button is clicked

--- a/test/src/test/java/jenkins/security/Security3245Test.java
+++ b/test/src/test/java/jenkins/security/Security3245Test.java
@@ -30,9 +30,9 @@ public class Security3245Test {
 
     @Issue("SECURITY-3245")
     @Test
-    public void captionCannotAttributeEscape() throws Exception {
+    public void captionCannotElementEscape() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject("p");
-        p.getBuildersList().add(new ExpandableDetailsNoteTestAction("' onclick=alert(1) foo='bar", "<h1></h1>"));
+        p.getBuildersList().add(new ExpandableDetailsNoteTestAction("<script>alert(1)</script>", "<h1></h1>"));
         FreeStyleBuild build = j.buildAndAssertSuccess(p);
 
         AtomicBoolean alerts = new AtomicBoolean();
@@ -40,12 +40,9 @@ public class Security3245Test {
             wc.setAlertHandler((pr, s) -> alerts.set(true));
             final HtmlPage page = wc.goTo(build.getUrl() + "console");
             String content = page.getWebResponse().getContentAsString();
-            assertThat(content, containsString("<input type=button value='&#39; onclick=alert(1) foo=&#39;bar' class='reveal-expandable-detail'>"));
-
-            // Execute JavaScript code to simulate click event
-            String jsCode = "document.querySelector('.reveal-expandable-detail').dispatchEvent(new MouseEvent('click'));";
-            page.executeJavaScript(jsCode);
-
+            assertThat(content, containsString("<button type='button' class='jenkins-button " +
+                    "reveal-expandable-detail'>&lt;script&gt;alert(1)&lt;/script&gt;</button>"));
+            // check that alert was not executed
             Assert.assertFalse("Alert not expected", alerts.get());
         }
     }

--- a/war/src/main/js/components/dropdowns/hetero-list.js
+++ b/war/src/main/js/components/dropdowns/hetero-list.js
@@ -77,11 +77,10 @@ function generateButtons() {
 
       function insert(instance, template) {
         let nc = document.createElement("div");
-        nc.className = "repeated-chunk";
+        nc.className = "repeated-chunk fade-in";
         nc.setAttribute("name", template.name);
         nc.setAttribute("descriptorId", template.descriptorId);
         nc.innerHTML = template.html;
-        nc.style.opacity = "0";
 
         instance.hide();
 
@@ -150,18 +149,9 @@ function generateButtons() {
             if (withDragDrop) {
               registerSortableDragDrop(nc);
             }
-
-            new YAHOO.util.Anim(
-              nc,
-              {
-                opacity: { to: 1 },
-              },
-              0.2,
-              YAHOO.util.Easing.easeIn,
-            ).animate();
-
             Behaviour.applySubtree(nc, true);
             ensureVisible(nc);
+            nc.classList.remove("fade-in");
             layoutUpdateCallback.call();
           },
           true,

--- a/war/src/main/scss/form/_reorderable-list.scss
+++ b/war/src/main/scss/form/_reorderable-list.scss
@@ -7,6 +7,14 @@
   border-radius: 10px;
   margin-bottom: 1rem;
   margin-top: 1rem;
+  transition:
+    opacity 0.2s ease-in,
+    max-height 0.2s ease-in;
+}
+
+.repeated-chunk.fade-in,
+.repeated-chunk.fade-out {
+  opacity: 0;
 }
 
 .repeated-chunk .show-if-last {

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1661,7 +1661,8 @@ function rowvgStartEachRow(recursive, f) {
         }
       }
       changeTo(e, "-hover.png");
-      YAHOO.util.Event.stopEvent(event);
+      event.stopPropagation();
+      event.preventDefault();
       return false;
     };
     e = null; // memory leak prevention

--- a/war/src/main/webapp/scripts/sortable.js
+++ b/war/src/main/webapp/scripts/sortable.js
@@ -133,16 +133,14 @@ var Sortable = (function () {
      */
     getStoredPreference: function () {
       var key = this.getStorageKey();
-      if (storage.hasKey(key)) {
-        var val = storage.getItem(key);
-        if (val) {
-          var vals = val.split(":");
-          if (vals.length == 2) {
-            return {
-              column: parseInt(vals[0]),
-              direction: arrowTable[vals[1]],
-            };
-          }
+      var val = sessionStorage.getItem(key);
+      if (val) {
+        var vals = val.split(":");
+        if (vals.length == 2) {
+          return {
+            column: parseInt(vals[0]),
+            direction: arrowTable[vals[1]],
+          };
         }
       }
       return null;
@@ -156,7 +154,13 @@ var Sortable = (function () {
 
     savePreference: function () {
       var key = this.getStorageKey();
-      storage.setItem(key, this.pref.column + ":" + this.pref.direction.id);
+      var value = this.pref.column + ":" + this.pref.direction.id;
+      try {
+        sessionStorage.setItem(key, value);
+      } catch (e) {
+        // storage could be full
+        console.warn(e);
+      }
     },
 
     /**
@@ -441,29 +445,6 @@ var Sortable = (function () {
       };
     },
   };
-
-  var storage;
-  try {
-    storage = YAHOO.util.StorageManager.get(
-      YAHOO.util.StorageEngineHTML5.ENGINE_NAME,
-      YAHOO.util.StorageManager.LOCATION_SESSION,
-      {
-        order: [YAHOO.util.StorageEngineGears],
-      },
-    );
-    // eslint-disable-next-line no-unused-vars
-  } catch (e) {
-    // no storage available
-    storage = {
-      setItem: function () {},
-      getItem: function () {
-        return null;
-      },
-      hasKey: function () {
-        return false;
-      },
-    };
-  }
 
   return {
     Sortable: Sortable,


### PR DESCRIPTION
This replaces a few usages of YUI in core:
* session storage for sortable tables (no need for compatibility layer provided by YUI)
* repeateble form elements use standard CSS transition instead of YUI animations
* avoid JS function `makeButton` and CSS selectors that trigger it (`submit-button`, `yui-button`)

This should mostly not cause changes in the UI except for a few button styles
<details>
<summary>Screenshots</summary>

Rekey dialog before:

<img width="390" alt="rekey-before" src="https://github.com/jenkinsci/jenkins/assets/1105305/c655ec77-84c0-4681-ac8e-588ab25c4267">

After:

<img width="375" alt="rekey-after" src="https://github.com/jenkinsci/jenkins/assets/1105305/4072cf57-68bf-43de-b399-6191dfebff8f">

Expandable console note (after)

<img width="232" alt="console-light" src="https://github.com/jenkinsci/jenkins/assets/1105305/485cfe16-b254-4938-972e-03333c246821">
<img width="261" alt="console-dark" src="https://github.com/jenkinsci/jenkins/assets/1105305/7ecf31c7-7fee-4e01-82b8-7559a358ecad">

Slow trigger monitor (after)

<img width="564" alt="monitor-dark" src="https://github.com/jenkinsci/jenkins/assets/1105305/f8384a15-d2ab-4579-b8b8-560dc33d6e5d">

</details>

### Testing done

* Manually tested the buttons in screenshot (had to hack the Java code to create custom Expandable Note and trigger the monitors)
* Manually tested adding steps to freestyle build and columns to a view to check the animations
* Manually checked that table sorting is preserved on refresh in dashboard

There are no new tests as there is no new functionality here.

### Proposed changelog entries

- Remove some usages of YUI framework in the user interface.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Remove JENKINS-XXXXX if there is no issue for the pull request.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- JENKINS-123456, First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
