### PR TITLE
Update javadoc and other docs with dates of API changes

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -269,17 +269,17 @@ public class ClassicPluginStrategy implements PluginStrategy {
     }
 
     /**
-     * @deprecated since TODO use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
+     * @deprecated since 2.459 use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
      */
-    @Deprecated(since = "TODO")
+    @Deprecated(since = "2.459")
     protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent) throws IOException {
         return createClassLoader(paths, parent, null);
     }
 
     /**
-     * @deprecated since TODO use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
+     * @deprecated since 2.459 use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
      */
-    @Deprecated(since="TODO")
+    @Deprecated(since="2.459")
     protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent, Attributes atts) throws IOException {
         // generate a legacy id so at least we can track to something
         return createClassLoader("unidentified-" + UUID.randomUUID(), paths, parent, atts);
@@ -287,7 +287,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
 
     /**
      * Creates a  classloader that can load all the specified jar files and delegate to the given parent.
-     * @since TODO
+     * @since 2.459
      */
     protected ClassLoader createClassLoader(String name, List<File> paths, ClassLoader parent, Attributes atts) throws IOException {
         boolean usePluginFirstClassLoader =

--- a/core/src/main/java/hudson/model/ExecutorListener.java
+++ b/core/src/main/java/hudson/model/ExecutorListener.java
@@ -30,7 +30,7 @@ import hudson.slaves.SlaveComputer;
 /**
  * A listener for task related events from executors.
  * A {@link Computer#getRetentionStrategy} or {@link SlaveComputer#getLauncher} may implement this interface.
- * Or you may create an implementation as an extension (since TODO).
+ * Or you may create an implementation as an extension (since 2.318).
 * @author Stephen Connolly
 * @since 1.312
 */

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -298,7 +298,7 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
     /**
      * @deprecated Remove any code calling this method, history widget is now created via {@link jenkins.widgets.WidgetFactory} implementation.
      */
-    @Deprecated(forRemoval = true, since = "TODO")
+    @Deprecated(forRemoval = true, since = "2.459")
     public final HistoryWidget createHistoryWidget() {
         throw new IllegalStateException("HistoryWidget is now created via WidgetFactory implementation");
     }

--- a/core/src/main/java/jenkins/security/seed/UserSeedChangeListener.java
+++ b/core/src/main/java/jenkins/security/seed/UserSeedChangeListener.java
@@ -35,7 +35,7 @@ import jenkins.util.Listeners;
 
 /**
  * Listener notified when a user was requested to changed their seed
- * @since 2.160 and 2.150.2, but restricted (unavailable to plugins) before TODO
+ * @since 2.160 and 2.150.2, but restricted (unavailable to plugins) before 2.406
  */
 public abstract class UserSeedChangeListener implements ExtensionPoint {
     private static final Logger LOGGER = Logger.getLogger(SecurityListener.class.getName());

--- a/core/src/main/java/jenkins/util/URLClassLoader2.java
+++ b/core/src/main/java/jenkins/util/URLClassLoader2.java
@@ -20,7 +20,7 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
     /**
      * @deprecated use {@link URLClassLoader2#URLClassLoader2(String, URL[])}
      */
-    @Deprecated(since = "TODO")
+    @Deprecated(since = "2.459")
     public URLClassLoader2(URL[] urls) {
         super(urls);
     }
@@ -28,7 +28,7 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
     /**
      * @deprecated use {@link URLClassLoader2#URLClassLoader2(String, URL[], ClassLoader)}
      */
-    @Deprecated(since = "TODO")
+    @Deprecated(since = "2.459")
     public URLClassLoader2(URL[] urls, ClassLoader parent) {
         super(urls, parent);
     }
@@ -37,7 +37,7 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
      * Create a new {@link URLClassLoader2} with the given name and URLS and the {@link #getSystemClassLoader()} as its parent.
      * @param name name of this classloader.
      * @param urls the list of URLS to find classes in.
-     * @since TODO
+     * @since 2.459
      */
     public URLClassLoader2(String name, URL[] urls) {
         super(name, urls, getSystemClassLoader());
@@ -48,7 +48,7 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
      * @param name name of this classloader.
      * @param urls the list of URLS to find classes in.
      * @param parent the parent to search for classes before we look in the {@code urls}
-     * @since TODO
+     * @since 2.459
      */
     public URLClassLoader2(String name, URL[] urls, ClassLoader parent) {
         super(name, urls, parent);

--- a/core/src/main/resources/lib/layout/search-bar.jelly
+++ b/core/src/main/resources/lib/layout/search-bar.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
     <st:attribute name="hasKeyboardShortcut">
       If false the default keyboard shortcut for the input is disabled. Defaults to true.
     </st:attribute>
-    <st:attribute name="enabled" since="TODO">
+    <st:attribute name="enabled" since="2.420">
       Defaults to true. Sets whether the search bar is enabled or not.
     </st:attribute>
     Creates a search input

--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -80,7 +80,7 @@ THE SOFTWARE.
     <st:attribute name="onclick" deprecated="true">
       Onclick inline JS handler. Deprecated, specify data-callback attribute instead.
     </st:attribute>
-    <st:attribute name="data-callback" since="TODO">
+    <st:attribute name="data-callback" since="2.437">
       Name of a global function to call when clicked.
       It will be called with an element (currently 'a') as first argument, and the event as second argument.
       You can specify further data-* attributes to customize behavior, those will be defined on the element passed as first argument.
@@ -97,7 +97,7 @@ THE SOFTWARE.
       Message to use for confirmation, if requested; defaults to title.
       (since 1.512)
     </st:attribute>
-    <st:attribute name="destructive" type="boolean" since="TODO">
+    <st:attribute name="destructive" type="boolean" since="2.415">
       Show red confirmation button.
     </st:attribute>
   </st:documentation>


### PR DESCRIPTION
## Update javadoc and other docs with dates of API changes

Several of the changes are not detected by the Python script but were detected by `git grep TODO | grep since` with review of the output.

The cases that are not detected by the Python script seem obscure enough to not bother with additions to the script.  If they become common practice, then we can extend the Python script.

### Testing done

Confirmed that `mvn -am -pl war,bom -P quick-build clean install` reports no errors

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@janfaracik (for the changes to 3 jelly files)

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
