### PR TITLE
JENKINS-68822 added support for removing all builds with LogRotator

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -389,7 +389,9 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                             if (bd instanceof LogRotator) {
                                 LogRotator lr = (LogRotator) bd;
                                 if (lr.getArtifactNumToKeep() == -1) {
-                                    p.setBuildDiscarder(new LogRotator(lr.getDaysToKeep(), lr.getNumToKeep(), lr.getArtifactDaysToKeep(), 1));
+                                    LogRotator newLr = new LogRotator(lr.getDaysToKeep(), lr.getNumToKeep(), lr.getArtifactDaysToKeep(), 1);
+                                    newLr.setRemoveLastBuild(lr.isRemoveLastBuild());
+                                    p.setBuildDiscarder(newLr);
                                 } else {
                                     LOG.log(Level.WARNING, "will not clobber artifactNumToKeep={0} in {1}", new Object[] {lr.getArtifactNumToKeep(), p});
                                 }

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -111,7 +111,7 @@ public class LogRotator extends BuildDiscarder {
 
     /**
      * If enabled also remove last successful build.
-     * @since 2.464
+     * @since TODO
      */
     private boolean removeLastBuild;
 

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -50,6 +50,7 @@ import jenkins.model.BuildDiscarderDescriptor;
 import jenkins.util.io.CompositeIOException;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Default implementation of {@link BuildDiscarder}.
@@ -108,6 +109,12 @@ public class LogRotator extends BuildDiscarder {
      */
     private final Integer artifactNumToKeep;
 
+    /**
+     * If enabled also remove last successful build.
+     * @since 2.464
+     */
+    private boolean removeLastBuild;
+
     @DataBoundConstructor
     public LogRotator(String daysToKeepStr, String numToKeepStr, String artifactDaysToKeepStr, String artifactNumToKeepStr) {
         this (parse(daysToKeepStr), parse(numToKeepStr),
@@ -140,6 +147,11 @@ public class LogRotator extends BuildDiscarder {
 
     }
 
+    @DataBoundSetter
+    public void setRemoveLastBuild(boolean removeLastBuild) {
+        this.removeLastBuild = removeLastBuild;
+    }
+
     @Override
     @SuppressWarnings("rawtypes")
     public void perform(Job<?, ?> job) throws IOException, InterruptedException {
@@ -148,9 +160,9 @@ public class LogRotator extends BuildDiscarder {
 
         LOGGER.log(FINE, "Running the log rotation for {0} with numToKeep={1} daysToKeep={2} artifactNumToKeep={3} artifactDaysToKeep={4}", new Object[] {job, numToKeep, daysToKeep, artifactNumToKeep, artifactDaysToKeep});
 
-        // always keep the last successful and the last stable builds
-        Run lsb = job.getLastSuccessfulBuild();
-        Run lstb = job.getLastStableBuild();
+        // if configured keep the last successful and the last stable builds
+        Run lsb = removeLastBuild ? null : job.getLastSuccessfulBuild();
+        Run lstb = removeLastBuild ? null : job.getLastStableBuild();
 
         if (numToKeep != -1) {
             // Note that RunList.size is deprecated, and indeed here we are loading all the builds of the job.
@@ -268,6 +280,10 @@ public class LogRotator extends BuildDiscarder {
 
     public int getArtifactNumToKeep() {
         return unbox(artifactNumToKeep);
+    }
+
+    public boolean isRemoveLastBuild() {
+        return removeLastBuild;
     }
 
     public String getDaysToKeepStr() {

--- a/core/src/main/resources/hudson/tasks/LogRotator/config.jelly
+++ b/core/src/main/resources/hudson/tasks/LogRotator/config.jelly
@@ -41,5 +41,9 @@ THE SOFTWARE.
              description="${%if not empty, only up to this number of builds have their artifacts retained}" field="artifactNumToKeepStr">
       <f:number clazz="positive-number" min="1" step="1" />
     </f:entry>
+    <f:entry title="${%Remove last build}"
+             field="removeLastBuild">
+      <f:booleanRadio />
+    </f:entry>
   </f:advanced>
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-68822](https://issues.jenkins.io/browse/JENKINS-68822).

### Testing done
Verified configuration in UI
Checked that old configuration is loaded from disk
Run the unit tests

### Proposed changelog entries

- Allow all builds to be removed by the build discarder.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```
Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
