### PR TITLE
Refine table and tabs

### DIFF
--- a/war/src/main/scss/abstracts/_theme.scss
+++ b/war/src/main/scss/abstracts/_theme.scss
@@ -174,8 +174,8 @@ $semantics: (
   --table-header-foreground: var(--text-color);
   --table-body-background: var(--background);
   --table-body-foreground: var(--text-color);
-  --table-border-radius: 10px;
-  --table-row-border-radius: 4px;
+  --table-border-radius: 0.75rem;
+  --table-row-border-radius: 0.3125rem;
 
   // Deprecated
   --even-row-color: var(--very-light-grey);

--- a/war/src/main/scss/components/_table.scss
+++ b/war/src/main/scss/components/_table.scss
@@ -3,13 +3,24 @@
 .jenkins-table {
   --table-padding: 0.55rem;
 
+  position: relative;
   width: 100%;
   background: var(--table-background);
-  border-radius: calc(var(--table-border-radius) + 2px);
-  border: 5px solid var(--table-background);
-  border-bottom-width: 3px;
+  border-radius: calc(var(--table-border-radius) + 4px);
+  border: 4px solid var(--table-background);
+  border-bottom-width: 2px;
   border-spacing: 0 2px;
+  background-clip: padding-box;
   margin-bottom: var(--section-padding);
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: -4px -4px -2px;
+    border: var(--card-border-width) solid var(--table-border-color);
+    border-radius: inherit;
+    pointer-events: none;
+  }
 
   * {
     -webkit-border-horizontal-spacing: 0;

--- a/war/src/main/scss/components/_table.scss
+++ b/war/src/main/scss/components/_table.scss
@@ -32,8 +32,8 @@
       & > th {
         color: var(--table-header-foreground);
         text-align: left;
-        padding-top: calc((var(--table-padding) * 1.7) - 7.5px);
-        padding-bottom: calc((var(--table-padding) * 1.7) - 2.5px);
+        padding-top: calc(var(--table-padding) * 0.9);
+        padding-bottom: calc((var(--table-padding) * 0.9) + 2px);
         padding-left: 1.6rem;
         font-weight: 600;
         font-size: 0.85rem;

--- a/war/src/main/scss/components/_tabs.scss
+++ b/war/src/main/scss/components/_tabs.scss
@@ -3,13 +3,23 @@
 }
 
 .tabBar {
+  position: relative;
   display: inline-flex;
   align-items: center;
   flex-wrap: wrap;
   background: var(--tabs-background);
   border-radius: var(--tabs-border-radius);
-  padding: 2.5px;
+  padding: 2px;
   margin-bottom: var(--section-padding);
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border: var(--card-border-width) solid var(--tabs-border-color);
+    border-radius: inherit;
+    pointer-events: none;
+  }
 
   .tab {
     float: left;
@@ -23,7 +33,7 @@
   justify-content: center;
   min-width: 3rem;
   text-decoration: none;
-  margin: 2.5px;
+  margin: 2px;
   padding: 0.4rem 1.2rem;
   border-radius: 100px;
   background: var(--tabs-item-background);


### PR DESCRIPTION
Really small/subtle pull request to refine the table and tabs components. These changes are more obvious in dark mode.

**Differences**
* Tightens up the padding, bringing it more inline with the recently introduced cards
* Slightly more rounded, again bringing it more inline with cards
* Borders are now visible when in dark mode (same as cards)

**Before**

<img width="391" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/29af3cb6-607b-453f-8716-d25b13d0f91f">

**After**

<img width="697" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/65860568-20f1-4cf6-ae95-b5af8dba4f8f">

**Before**

<img width="407" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/98212599-ae7f-459f-9125-105ea4360652">

**After**

<img width="723" alt="image" src="https://github.com/jenkinsci/jenkins/assets/43062514/9742ae94-759f-4674-8e12-77ea320a29db">

### Testing done

* Tables and tabs look as expected

### Proposed changelog entries

- Refine tables and tabs with reduced padding, rounded corners to match cards, and borders that are visible in dark mode.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
