### PR TITLE
Deprecating `SubTask.getLastBuiltOn`

### DIFF
--- a/core/src/main/java/hudson/model/AbstractProject.java
+++ b/core/src/main/java/hudson/model/AbstractProject.java
@@ -1011,6 +1011,7 @@ public abstract class AbstractProject<P extends AbstractProject<P, R>, R extends
      *      null if no information is available (for example,
      *      if no build was done yet.)
      */
+    @SuppressWarnings("deprecation")
     @Override
     public Node getLastBuiltOn() {
         // where was it built on?

--- a/core/src/main/java/hudson/model/queue/MappingWorksheet.java
+++ b/core/src/main/java/hudson/model/queue/MappingWorksheet.java
@@ -190,7 +190,9 @@ public class MappingWorksheet {
          * If the previous execution of this task run on a certain node
          * and this task prefers to run on the same node, return that.
          * Otherwise null.
+         * @deprecated Unused.
          */
+        @Deprecated
         public final ExecutorChunk lastBuiltOn;
 
 
@@ -200,6 +202,7 @@ public class MappingWorksheet {
             this.index = index;
             this.assignedLabel = getAssignedLabel(base.get(0));
 
+            @SuppressWarnings("deprecation")
             Node lbo = base.get(0).getLastBuiltOn();
             for (ExecutorChunk ec : executors) {
                 if (ec.node == lbo) {

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -52,6 +52,7 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.getAssignedLabel();
     }
 
+    @Deprecated
     @Override
     public Node getLastBuiltOn() {
         return base.getLastBuiltOn();

--- a/core/src/main/java/hudson/model/queue/SubTask.java
+++ b/core/src/main/java/hudson/model/queue/SubTask.java
@@ -62,7 +62,9 @@ public interface SubTask extends ResourceActivity {
      * and this task prefers to run on the same node, return that.
      * Otherwise null.
      * @return by default, null
+     * @deprecated Unused.
      */
+    @Deprecated
     default Node getLastBuiltOn() {
         return null;
     }

--- a/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
+++ b/test/src/test/java/hudson/model/queue/BuildKeepsRunningWhenFaultySubTasksTest.java
@@ -107,6 +107,7 @@ public class BuildKeepsRunningWhenFaultySubTasksTest {
                     return null;
                 }
 
+                @Deprecated
                 @Override
                 public Node getLastBuiltOn() {
                     return null;


### PR DESCRIPTION
I was poking around in `SubTask`, noticed this method, and tried to find how it was used by the scheduler. So far as I can tell, it is not. It was introduced perhaps in d362c5609ddfc07feb43a740c6089f00bc64abaa or eedac7b0fcb4ca848111409817f8b431b5e77d6b (the history is hard to follow) but it seems that the usage was deleted the same day in 839ba1d772e889a0bd36b935100c49efb49f24aa.

### Testing done

None, just find usages within the repo.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
