### PR TITLE
[JENKINS-66105] Allow follow redirects to work after 303 from `buildWithParameters`

### DIFF
--- a/core/src/main/java/hudson/model/BuildAuthorizationToken.java
+++ b/core/src/main/java/hudson/model/BuildAuthorizationToken.java
@@ -29,7 +29,6 @@ import hudson.Util;
 import hudson.security.ACL;
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
-import jenkins.security.ApiTokenProperty;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -79,10 +78,6 @@ public final class BuildAuthorizationToken {
         project.checkPermission(Item.BUILD);
 
         if (req.getMethod().equals("POST")) {
-            return;
-        }
-
-        if (req.getAttribute(ApiTokenProperty.class.getName()) instanceof User) {
             return;
         }
 

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -130,6 +130,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -2412,6 +2413,10 @@ public class Queue extends ResourceController implements Saveable {
             } else { // err on the safe side
                 return null;
             }
+        }
+
+        public HttpResponse doIndex(StaplerRequest req) {
+            return HttpResponses.text("Queue item exists. For details check, for example, " + req.getRequestURI() + "api/json?tree=cancelled,executable[url]");
         }
 
         protected Object readResolve() {

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -218,6 +218,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
 
         Queue.Item item = Jenkins.get().getQueue().schedule2(asJob(), delay.getTimeInSeconds(), getBuildCause(asJob(), req)).getItem();
         if (item != null) {
+            // TODO JENKINS-66105 use SC_SEE_OTHER if !ScheduleResult.created
             rsp.sendRedirect(SC_CREATED, req.getContextPath() + '/' + item.getUrl());
         } else {
             rsp.sendRedirect(".");


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/5615#issuecomment-2215364164 is a source of confusion. Users not familiar with the details of how Jenkins queue item requests are supposed to be processed may assume that they can instruct an API client to follow redirects and that they will always get a 2xx status code when a build trigger request was somehow successful. After #5615, a fresh queue item would return a 201 with a `Location` header that a client would normally ignore; but an existing queue item would return a 303 with a `Location` that points to a URL not usable on its own, and a typical client will follow the redirect as is, yielding a 404 which left the mistaken impression that the queue item did not exist. Now we return a 200 to clarify that the queue item is there, though to be _useful_ you need to actually append to the returned URL to define a particular query you want (such as looking up the build in this example, which in turn would require a polling loop).

### Testing done

Added a test case that was missing from #5615. Without fix, fails in the reported confusing way (even though nothing is actually wrong):

```
org.htmlunit.FailingHttpStatusCodeException: 404 Not Found for http://localhost:43021/jenkins/queue/item/1/
	at org.htmlunit.WebClient.throwFailingHttpStatusCodeExceptionIfNecessary(WebClient.java:719)
	at org.htmlunit.WebClient.getPage(WebClient.java:473)
	at org.htmlunit.WebClient.getPage(WebClient.java:370)
	at org.htmlunit.WebClient.getPage(WebClient.java:523)
	at hudson.model.ParametersDefinitionPropertyTest.codeFromBuildWithParameters(ParametersDefinitionPropertyTest.java:118)
	at hudson.model.ParametersDefinitionPropertyTest.statusCodes(ParametersDefinitionPropertyTest.java:114)
```

### Proposed changelog entries

- `/queue/item/nnnnn/` URLs (with no `api/…` suffix) now return a 200 `text/plain` response to emphasize that the queue item does exist but that you would need to construct a specific query to find out more.

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
