### PR TITLE
Show plugin source URL when downloading it

### DIFF
--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1311,7 +1311,7 @@ public class UpdateCenter extends AbstractModelObject implements Loadable, Savea
                 File dst = job.getDestination();
                 File tmp = new File(dst.getPath() + ".tmp");
 
-                LOGGER.info("Downloading " + job.getName());
+                LOGGER.info(() -> "Downloading " + job.getName() + " from " + src);
                 Thread t = Thread.currentThread();
                 String oldName = t.getName();
                 t.setName(oldName + ": " + src);

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1311,7 +1311,7 @@ public class UpdateCenter extends AbstractModelObject implements Loadable, Savea
                 File dst = job.getDestination();
                 File tmp = new File(dst.getPath() + ".tmp");
 
-                LOGGER.info(() -> "Downloading " + job.getName() + " from " + src);
+                LOGGER.info("Downloading " + job.getName());
                 Thread t = Thread.currentThread();
                 String oldName = t.getName();
                 t.setName(oldName + ": " + src);
@@ -1322,6 +1322,10 @@ public class UpdateCenter extends AbstractModelObject implements Loadable, Savea
                                              sha512 != null ? new DigestOutputStream(_out, sha512) : _out, sha256) : _out, sha1) : _out;
                      InputStream in = con.getInputStream();
                      CountingInputStream cin = new CountingInputStream(in)) {
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        var connectionUrl = con.getURL();
+                        LOGGER.fine(() -> "Downloading " + job.getName() + " from " + getSourceUrl(src, connectionUrl));
+                    }
                     while ((len = cin.read(buf)) >= 0) {
                         out.write(buf, 0, len);
                         final int count = cin.getCount();
@@ -1366,6 +1370,16 @@ public class UpdateCenter extends AbstractModelObject implements Loadable, Savea
                     extraMessage = " (redirected to: " + con.getURL() + ")";
                 }
                 throw new IOException("Failed to download from " + src + extraMessage, e);
+            }
+        }
+
+        private static String getSourceUrl(@NonNull URL src, @NonNull URL connectionURL) {
+            var sourceUrlString = src.toExternalForm();
+            var finalUrlString = connectionURL.toExternalForm();
+            if (!sourceUrlString.equals(finalUrlString)) {
+                return sourceUrlString + " → " + finalUrlString;
+            } else {
+                return sourceUrlString;
             }
         }
 

--- a/core/src/main/java/hudson/model/UpdateCenter.java
+++ b/core/src/main/java/hudson/model/UpdateCenter.java
@@ -1323,8 +1323,8 @@ public class UpdateCenter extends AbstractModelObject implements Loadable, Savea
                      InputStream in = con.getInputStream();
                      CountingInputStream cin = new CountingInputStream(in)) {
                     if (LOGGER.isLoggable(Level.FINE)) {
-                        var connectionUrl = con.getURL();
-                        LOGGER.fine(() -> "Downloading " + job.getName() + " from " + getSourceUrl(src, connectionUrl));
+                        var sourceUrlString = getSourceUrl(src, con);
+                        LOGGER.fine(() -> "Downloading " + job.getName() + " from " + sourceUrlString);
                     }
                     while ((len = cin.read(buf)) >= 0) {
                         out.write(buf, 0, len);
@@ -1362,25 +1362,22 @@ public class UpdateCenter extends AbstractModelObject implements Loadable, Savea
                 return tmp;
             } catch (IOException e) {
                 // assist troubleshooting in case of e.g. "too many redirects" by printing actual URL
-                String extraMessage = "";
-                if (con != null && con.getURL() != null && !src.toString().equals(con.getURL().toString())) {
-                    // Two URLs are considered equal if different hosts resolve to same IP. Prefer to log in case of string inequality,
-                    // because who knows how the server responds to different host name in the request header?
-                    // Also, since it involved name resolution, it'd be an expensive operation.
-                    extraMessage = " (redirected to: " + con.getURL() + ")";
-                }
-                throw new IOException("Failed to download from " + src + extraMessage, e);
+                throw new IOException("Failed to download from " + getSourceUrl(src, con), e);
             }
         }
 
-        private static String getSourceUrl(@NonNull URL src, @NonNull URL connectionURL) {
+        private static String getSourceUrl(@NonNull URL src, @CheckForNull URLConnection connection) {
             var sourceUrlString = src.toExternalForm();
-            var finalUrlString = connectionURL.toExternalForm();
-            if (!sourceUrlString.equals(finalUrlString)) {
-                return sourceUrlString + " → " + finalUrlString;
-            } else {
-                return sourceUrlString;
+            if (connection != null) {
+                var connectionURL = connection.getURL();
+                if (connectionURL != null) {
+                    var finalUrlString = connectionURL.toExternalForm();
+                    if (!sourceUrlString.equals(finalUrlString)) {
+                        return sourceUrlString + " → " + finalUrlString;
+                    }
+                }
             }
+            return sourceUrlString;
         }
 
         /**


### PR DESCRIPTION
Example: `Downloading email-ext from https://updates.jenkins.io/download/plugins/email-ext/1814.v404722f34263/email-ext.hpi`

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Display the source URL in logs when installing a plugin.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
