### PR TITLE
Backport Spring Security and plugin updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,7 +58,7 @@ updates:
         versions: [">=7.0.0"]
   - package-ecosystem: "maven"
     directory: "/"
-    target-branch: "stable-2.452"
+    target-branch: "stable-2.462"
     labels:
       - "into-lts"
       - "needs-justification"

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -64,7 +64,7 @@ THE SOFTWARE.
         <!-- https://docs.spring.io/spring-security/site/docs/5.5.4/reference/html5/#getting-maven-no-boot -->
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-bom</artifactId>
-        <version>5.8.12</version>
+        <version>5.8.13</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>5.3.36</version>
+        <version>5.3.37</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -67,7 +67,7 @@ THE SOFTWARE.
         <!-- RequireUpperBoundDeps between checks-api, plugin-util-api, and font-awesome-api -->
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>commons-text-api</artifactId>
-        <version>1.11.0-109.vfe16c66636eb_</version>
+        <version>1.12.0-119.v73ef73f2345d</version>
       </dependency>
       <dependency>
         <!-- RequireUpperBoundDeps between bootstrap5-api and echarts-api -->

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -252,7 +252,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>337.v1b_04ea_4df7c8</version>
+      <version>338.v848422169819</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>bouncycastle-api</artifactId>
-        <version>2.30.1.78.1-233.vfdcdeb_0a_08a_a_</version>
+        <version>2.30.1.78.1-248.ve27176eb_46cb_</version>
       </dependency>
       <dependency>
         <!-- RequireUpperBoundDeps via mailer and junit -->

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -126,7 +126,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>657.v03b_e8115821b_</version>
+        <version>678.v3ee58b_469476</version>
       </dependency>
       <dependency>
         <!-- Required by plugin-util-api -->


### PR DESCRIPTION
## Backport Spring Security and plugin updates

- [JENKINS-73441](https://issues.jenkins.io/browse/JENKINS-73441) Bump org.springframework.security:spring-security-bom from 5.8.12 to 5.8.13 
  #9398
- [JENKINS-73442](https://issues.jenkins.io/browse/JENKINS-73442) Bump org.springframework:spring-framework-bom from 5.3.36 to 5.3.37
  #9385
- [JENKINS-73443](https://issues.jenkins.io/browse/JENKINS-73443) Bump io.jenkins.plugins:commons-text-api from 1.11.0-109.vfe16c66636eb_ to 1.12.0-119.v73ef73f2345d 
  #9386
- [JENKINS-73444](https://issues.jenkins.io/browse/JENKINS-73444) Bump org.jenkins-ci.plugins:structs from 337.v1b_04ea_4df7c8 to 338.v848422169819 
  #9419
- [JENKINS-73445](https://issues.jenkins.io/browse/JENKINS-73445) Bump org.jenkins-ci.plugins:bouncycastle-api from 2.30.1.78.1-233.vfdcdeb_0a_08a_a_ to 2.30.1.78.1-248.ve27176eb_46cb_ 
  #9439
- [JENKINS-73446](https://issues.jenkins.io/browse/JENKINS-73446) Bump org.jenkins-ci.plugins.workflow:workflow-step-api from 657.v03b_e8115821b_ to 678.v3ee58b_469476 
  #9444

Backport of Spring Security and Spring Framework reduces the risk that scanners will complain.

The structs plugin backport assures that scanners won't complain that we're shipping a version of the plugin with a [known vulnerability](https://www.jenkins.io/security/advisory/2024-06-26/#SECURITY-3371).

Plugin backports use the most recent plugin updates from Jenkins weekly releases.  Those are plugin versions that are tested in the plugin bill of materials and have been working well for me since their release.

### Testing done

Confirmed that `mvn clean verify` is successful.  I've been running these plugin releases in my test environment since they were released without any issue.

### Proposed changelog entries

- Update Spring Security, Spring Framework, and several bundled plugins to their most recent releases

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
