### PR TITLE
Note the plugin responsible for loading a detached plugin

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -252,7 +252,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
 
         for (Dependency d : DetachedPluginsUtil.getImpliedDependencies(pluginName, jenkinsVersion)) {
             LOGGER.fine(() -> "implied dep " + pluginName + " → " + d.shortName);
-            pluginManager.considerDetachedPlugin(d.shortName);
+            pluginManager.considerDetachedPlugin(d.shortName, pluginName);
             optionalDependencies.add(d);
         }
     }

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -615,7 +615,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         }});
     }
 
-    void considerDetachedPlugin(String shortName) {
+    void considerDetachedPlugin(String shortName, String source) {
         if (new File(rootDir, shortName + ".jpi").isFile() ||
             new File(rootDir, shortName + ".hpi").isFile() ||
             new File(rootDir, shortName + ".jpl").isFile() ||
@@ -627,7 +627,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
         for (String loadedFile : loadPluginsFromWar(getDetachedLocation(), (dir, name) -> normalisePluginName(name).equals(shortName))) {
             String loaded = normalisePluginName(loadedFile);
             File arc = new File(rootDir, loaded + ".jpi");
-            LOGGER.info(() -> "Loading a detached plugin as a dependency: " + arc);
+            LOGGER.info(() -> "Loading a detached plugin " + arc + " as a dependency of " + source);
             try {
                 plugins.add(strategy.createPluginWrapper(arc));
             } catch (IOException e) {


### PR DESCRIPTION
Otherwise you can see that a detached plugin is being loaded, but you have no clue why. This indicates the plugin responsible (or at least one of them, if there are multiple).

### Testing done

Used this to identify an old version of `gradle` (via `jenkins-test-harness-tools`!) as the source of a bunch of unwanted detached plugins in a `RealJenkinsRule` test.

### Proposed changelog entries

- N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
