### PR TITLE
`ItemListener.onCheckDelete` & `ItemDeletion.cancelBuildsInProgress`

### DIFF
--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -35,6 +35,8 @@ import hudson.security.ACL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.Listeners;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Receives notifications about CRUD operations of {@link Item}.
@@ -92,6 +94,17 @@ public class ItemListener implements ExtensionPoint {
      * object.
      */
     public void onLoaded() {
+    }
+
+    /**
+     * Called before an item is deleted, providing the ability to veto the deletion operation before it starts.
+     * @param item the item being deleted
+     * @param parent the proposed parent
+     * @throws Failure to veto the operation.
+     * @throws InterruptedException If a blocking condition was interrupted, also vetoing the operation.
+     * @since TODO
+     */
+    public void onCheckDelete(Item item) throws Failure, InterruptedException {
     }
 
     /**
@@ -203,6 +216,19 @@ public class ItemListener implements ExtensionPoint {
 
     public static void fireOnUpdated(final Item item) {
         Listeners.notify(ItemListener.class, false, l -> l.onUpdated(item));
+    }
+
+    @Restricted(NoExternalUse.class)
+    public static void checkBeforeDelete(Item item) throws Failure, InterruptedException {
+        for (ItemListener l : all()) {
+            try {
+                l.onCheckDelete(item);
+            } catch (Failure e) {
+                throw e;
+            } catch (RuntimeException x) {
+                LOGGER.log(Level.WARNING, "failed to send event to listener of " + l.getClass(), x);
+            }
+        }
     }
 
     /** @since 1.548 */

--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -99,7 +99,6 @@ public class ItemListener implements ExtensionPoint {
     /**
      * Called before an item is deleted, providing the ability to veto the deletion operation before it starts.
      * @param item the item being deleted
-     * @param parent the proposed parent
      * @throws Failure to veto the operation.
      * @throws InterruptedException If a blocking condition was interrupted, also vetoing the operation.
      * @since TODO

--- a/core/src/main/java/jenkins/model/queue/ItemDeletion.java
+++ b/core/src/main/java/jenkins/model/queue/ItemDeletion.java
@@ -28,24 +28,41 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.model.AbstractItem;
 import hudson.model.Action;
+import hudson.model.Computer;
+import hudson.model.Executor;
+import hudson.model.Failure;
 import hudson.model.Item;
+import hudson.model.Messages;
 import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.queue.Executables;
+import hudson.model.queue.SubTask;
 import hudson.model.queue.Tasks;
+import hudson.model.queue.WorkUnit;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 import net.jcip.annotations.GuardedBy;
 
 /**
  * A {@link Queue.QueueDecisionHandler} that blocks items being deleted from entering the queue.
- *
+ * @see AbstractItem#delete()
  * @since 2.55
  */
 @Extension
 public class ItemDeletion extends Queue.QueueDecisionHandler {
+
+    private static final Logger LOGGER = Logger.getLogger(ItemDeletion.class.getName());
 
     /**
      * Lock to guard the {@link #registrations} set.
@@ -176,4 +193,94 @@ public class ItemDeletion extends Queue.QueueDecisionHandler {
         }
         return true;
     }
+
+    /**
+     * Cancels any builds in progress of this item (if a job) or descendants (if a folder).
+     * Also cancels any associated queue items.
+     * @param initiatingItem an item being deleted
+     * @since TODO
+     */
+    public static void cancelBuildsInProgress(@NonNull Item initiatingItem) throws Failure, InterruptedException {
+        Queue queue = Queue.getInstance();
+        if (initiatingItem instanceof Queue.Task) {
+            // clear any items in the queue so they do not get picked up
+            queue.cancel((Queue.Task) initiatingItem);
+        }
+        // now cancel any child items - this happens after ItemDeletion registration, so we can use a snapshot
+        for (Queue.Item i : queue.getItems()) {
+            Item item = Tasks.getItemOf(i.task);
+            while (item != null) {
+                if (item == initiatingItem) {
+                    if (!queue.cancel(i)) {
+                        LOGGER.warning(() -> "failed to cancel " + i);
+                    }
+                    break;
+                }
+                if (item.getParent() instanceof Item) {
+                    item = (Item) item.getParent();
+                } else {
+                    break;
+                }
+            }
+        }
+        // interrupt any builds in progress (and this should be a recursive test so that folders do not pay
+        // the 15 second delay for every child item). This happens after queue cancellation, so will be
+        // a complete set of builds in flight
+        Map<Executor, Queue.Executable> buildsInProgress = new LinkedHashMap<>();
+        for (Computer c : Jenkins.get().getComputers()) {
+            for (Executor e : c.getAllExecutors()) {
+                final WorkUnit workUnit = e.getCurrentWorkUnit();
+                final Queue.Executable executable = workUnit != null ? workUnit.getExecutable() : null;
+                final SubTask subtask = executable != null ? Executables.getParentOf(executable) : null;
+                if (subtask != null) {
+                    Item item = Tasks.getItemOf(subtask);
+                    while (item != null) {
+                        if (item == initiatingItem) {
+                            buildsInProgress.put(e, e.getCurrentExecutable());
+                            e.interrupt(Result.ABORTED);
+                            break;
+                        }
+                        if (item.getParent() instanceof Item) {
+                            item = (Item) item.getParent();
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        if (!buildsInProgress.isEmpty()) {
+            // give them 15 seconds or so to respond to the interrupt
+            long expiration = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+            // comparison with executor.getCurrentExecutable() == computation currently should always be true
+            // as we no longer recycle Executors, but safer to future-proof in case we ever revisit recycling
+            while (!buildsInProgress.isEmpty() && expiration - System.nanoTime() > 0L) {
+                // we know that ItemDeletion will prevent any new builds in the queue
+                // ItemDeletion happens-before Queue.cancel so we know that the Queue will stay clear
+                // Queue.cancel happens-before collecting the buildsInProgress list
+                // thus buildsInProgress contains the complete set we need to interrupt and wait for
+                for (Iterator<Map.Entry<Executor, Queue.Executable>> iterator =
+                     buildsInProgress.entrySet().iterator();
+                     iterator.hasNext(); ) {
+                    Map.Entry<Executor, Queue.Executable> entry = iterator.next();
+                    // comparison with executor.getCurrentExecutable() == executable currently should always be
+                    // true as we no longer recycle Executors, but safer to future-proof in case we ever
+                    // revisit recycling.
+                    if (!entry.getKey().isAlive()
+                            || entry.getValue() != entry.getKey().getCurrentExecutable()) {
+                        iterator.remove();
+                    }
+                    // I don't know why, but we have to keep interrupting
+                    entry.getKey().interrupt(Result.ABORTED);
+                }
+                Thread.sleep(50L);
+            }
+            if (!buildsInProgress.isEmpty()) {
+                throw new Failure(Messages.AbstractItem_FailureToStopBuilds(
+                        buildsInProgress.size(), initiatingItem.getFullDisplayName()
+                ));
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
In CloudBees CI running in HA mode we need to augment the current behavior of `AbstractItem.delete` & `ItemDeletion`, which aborts running builds of a job before it is deleted, to accommodate multiple replicas. `ItemListener.onDeleted` is not helpful because it is called _after_ the job has been deleted, by which point it is too late to terminate any running builds gracefully. Additionally, the somewhat complex implementation of the abort section of the `delete` method (the part prior to that patched in #8645) makes the whole method very long and hard to follow, and would best not be duplicated.

This change introduces an extension to `ItemListener` allowing listeners to be notified of a proposed deletion and either veto it or clean up ongoing processes first, by analogy with an existing callback for copying. It also moves the cancel behavior into a standalone utility method in `ItemDeletion`, since it is closely related to the other queue code there.

(I also looked into making `ItemDeletion` register its own `ItemListener` so it would be self-contained, not referenced from `AbstractItem.delete`. This did not seem practical because the `register` and `deregister` calls need to be paired around the actual deletion, which would have required yet another listener method like `onDeleted` but always called even if the deletion failed. That just seemed like it would be confusing.)

### Testing done

An integration test in CloudBees CI exercises an implementation of the new listener callback, which calls the newly available utility method.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
