### PR TITLE
[JENKINS-73453] make icons in table buttons resizable

### DIFF
--- a/war/src/main/scss/components/_table.scss
+++ b/war/src/main/scss/components/_table.scss
@@ -167,11 +167,12 @@
   .jenkins-button {
     margin: -10px 0;
     padding: 0.5rem 0.75rem;
+    min-height: 1.75rem;
 
     // Increase the size of symbols compared to regular buttons
     svg {
-      width: 1.375rem !important;
-      height: 1.375rem !important;
+      width: 1.5rem !important;
+      height: 1.5rem !important;
     }
   }
 
@@ -180,8 +181,8 @@
     svg,
     .build-status-icon__wrapper,
     img {
-      width: 1.375rem !important;
-      height: 1.375rem !important;
+      width: 1.5rem !important;
+      height: 1.5rem !important;
     }
   }
 
@@ -198,6 +199,15 @@
       svg,
       .build-status-icon__wrapper,
       img {
+        width: 1.3rem !important;
+        height: 1.3rem !important;
+      }
+    }
+
+    .jenkins-button {
+      padding: 0.4rem 0.6rem;
+
+      svg {
         width: 1.3rem !important;
         height: 1.3rem !important;
       }
@@ -221,6 +231,15 @@
       svg,
       .build-status-icon__wrapper,
       img {
+        width: 1rem !important;
+        height: 1rem !important;
+      }
+    }
+
+    .jenkins-button {
+      padding: 0.3rem 0.5rem;
+
+      svg {
         width: 1rem !important;
         height: 1rem !important;
       }


### PR DESCRIPTION
With #9131 the css class `jenkins-table__button` was replaced at certain places with `jenkins-button`. But this change caused regressions:
- The icon size for large table was almost the same as that for medium tables
- The icons wrapped in jenkins-button were not resizable
- with small table the buttons overflowed the table cell

Before:
![image](https://github.com/user-attachments/assets/505c6910-e740-4109-a824-47ac921548ed)
![image](https://github.com/user-attachments/assets/abbd0967-f5c4-4e7a-ae4f-8f11155f5d09)
![image](https://github.com/user-attachments/assets/401512cb-e617-4923-8200-70cb2cbaafa8)

After:
![image](https://github.com/user-attachments/assets/34230101-2b71-4f66-904c-74b656eb07d3)
![image](https://github.com/user-attachments/assets/d1361e03-d054-4b59-b5f4-795b2b656654)
![image](https://github.com/user-attachments/assets/dbc6f2e4-70a9-427f-ac1b-a26f33404814)


This change restores the old icon size for large tables and adds additional css rules for jenkins-button inside tables so they are properly resized and the padding is correct

See [JENKINS-73453](https://issues.jenkins.io/browse/JENKINS-73453).

### Testing done

Manual testing

### Proposed changelog entries

- Change icon size in table when resizing the table.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
