### PR TITLE
`Lifecycle.onBootFailure`

### DIFF
--- a/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
@@ -26,6 +26,7 @@ package hudson.lifecycle;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
+import hudson.util.BootFailure;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -71,5 +72,10 @@ public class ExitLifecycle extends Lifecycle {
         }
 
         System.exit(exitOnRestart);
+    }
+
+    @Override
+    public void onBootFailure(BootFailure problem) {
+        restart();
     }
 }

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -32,6 +32,8 @@ import hudson.PluginManager;
 import hudson.Util;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import hudson.util.BootFailure;
+import hudson.util.JenkinsReloadFailed;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -322,6 +324,14 @@ public abstract class Lifecycle implements ExtensionPoint {
     @Restricted(Beta.class)
     public boolean supportsDynamicLoad() {
         return true;
+    }
+
+    /**
+     * Called when Jenkins has failed to boot.
+     * @param problem a boot failure (could be {@link JenkinsReloadFailed})
+     * @since TODO
+     */
+    public void onBootFailure(BootFailure problem) {
     }
 
     @Restricted(NoExternalUse.class)

--- a/core/src/main/java/hudson/util/BootFailure.java
+++ b/core/src/main/java/hudson/util/BootFailure.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletContext;
+import jenkins.model.Jenkins;
 import jenkins.util.groovy.GroovyHookScript;
 import org.kohsuke.stapler.WebApp;
 
@@ -51,6 +52,7 @@ public abstract class BootFailure extends ErrorObject {
                 .bind("servletContext", context)
                 .bind("attempts", loadAttempts(home))
                 .run();
+        Jenkins.get().getLifecycle().onBootFailure(this);
     }
 
     /**


### PR DESCRIPTION
Allows a `Lifecycle` implementation to respond to `BootFailure`s. Previously, Jenkins would simply keep running and serving (for example) https://github.com/jenkinsci/jenkins/blob/c47975525dbdd4b750ed02fcd450a99ebeafbe9d/core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly#L32-L33 which is a behavior that makes sense in an older world of Tomcat and the like (where the server is not going anywhere) but does not interact well with service wrappers or containers. I have updated `ExitLifecycle` (and thus also `SystemdLifecycle`) to deal with a boot failure by exiting, which seems a more appropriate response. Perhaps it could pick a different status code, though I am not sure if it matters in practice. `WindowsServiceLifecycle` and `SolarisSMFLifecycle` could perhaps benefit from similar changes; I would leave such a decision to someone familiar with these systems.

### Testing done

Started a (CloudBees CI) controller service based on this core patch but using an unpatched custom `Lifecycle`, using JCasC in a K8s `Deployment`. Introduced a bogus attribute to `jenkins.yaml` (mounted as a `ConfigMap`) and initiated a rolling restart. A `ConfigurationAsCodeBootFailure` was printed to pod output as expected and the container remained running. (Note https://github.com/jenkinsci/configuration-as-code-plugin/pull/2534.) Eventually a readiness/startup probe may have complained that the container had not started in a timely manner, but I did not wait for it (in general you need to leave a considerable grace period in case the controller has thousands of jobs). The rolling restart stalled because the new replica set did not become ready. At this point fixing the JCasC error would not help the existing pod, so you would have to manually delete the pod to recover.

Now implemented the new method in the custom lifecycle, simply calling `System.exit(1)`, and again triggered a rolling restart with a broken JCasC config. This time after printing the `ConfigurationAsCodeBootFailure` the container promptly exited. The pod was marked `CrashLoopBackOff` and began restarting the container at intervals. Now I fixed the JCasC error and waited; the next time the container restarted, it mounted the updated `ConfigMap` and the pod succeeded in becoming ready. After a while the `Deployment` completed its rolling restart successfully.

Did not try to add automated tests here; `LifecycleTest` and/or `BootFailureTest` could probably be extended to exercise the new method with some work, though the implementation is so trivial I am not sure it is worth testing, especially since the real question is not whether the method is called but whether the behavior of the implementation is helpful.

### Proposed changelog entries

- When using `ExitLifecycle`, exit the process immediately upon a boot failure. Allow custom lifecycles to react similarly.

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
