### PR TITLE
[JENKINS-73467] No facility to try unsupported Remoting versions when using inbound agents

### DIFF
--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -36,6 +36,7 @@ import hudson.remoting.Capability;
 import hudson.remoting.ChannelBuilder;
 import hudson.remoting.ChunkHeader;
 import hudson.remoting.Engine;
+import hudson.slaves.SlaveComputer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -107,7 +108,9 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         Capability remoteCapability = Capability.fromASCII(remoteCapabilityStr);
         LOGGER.fine(() -> "received " + remoteCapability);
         rsp.setHeader(Capability.KEY, new Capability().toASCII());
-        rsp.setHeader(Engine.REMOTING_MINIMUM_VERSION_HEADER, RemotingVersionInfo.getMinimumSupportedVersion().toString());
+        if (!SlaveComputer.ALLOW_UNSUPPORTED_REMOTING_VERSIONS) {
+            rsp.setHeader(Engine.REMOTING_MINIMUM_VERSION_HEADER, RemotingVersionInfo.getMinimumSupportedVersion().toString());
+        }
         rsp.setHeader(Engine.WEBSOCKET_COOKIE_HEADER, cookie);
         return WebSockets.upgrade(new Session(state, agent, remoteCapability));
     }

--- a/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
+++ b/core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
@@ -40,8 +40,11 @@ THE SOFTWARE.
   <!-- reduce the number of client connection attempts during protocol negotiation -->
   <st:header name="X-Jenkins-Agent-Protocols" value="${app.tcpSlaveAgentListener.agentProtocolNames}"/>
   <!-- publish minimum supported version of remoting agent -->
-  <j:getStatic var="rmvh" className="hudson.remoting.Engine" field="REMOTING_MINIMUM_VERSION_HEADER"/>
-  <st:header name="${rmvh}" value="${app.tcpSlaveAgentListener.remotingMinimumVersion}"/>
+  <j:getStatic var="allowUnsupportedRemotingVersions" className="hudson.slaves.SlaveComputer" field="ALLOW_UNSUPPORTED_REMOTING_VERSIONS"/>
+  <j:if test="${!allowUnsupportedRemotingVersions}">
+    <j:getStatic var="rmvh" className="hudson.remoting.Engine" field="REMOTING_MINIMUM_VERSION_HEADER"/>
+    <st:header name="${rmvh}" value="${app.tcpSlaveAgentListener.remotingMinimumVersion}"/>
+  </j:if>
 
   Jenkins
 </j:jelly>


### PR DESCRIPTION
### Problem

[JENKINS-73467](https://issues.jenkins.io/browse/JENKINS-73467) was filed likely in response to #9440. A user was attempting to connect with an old inbound agent (WebSocket, in this case) and had configured the server with the `hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions` escape hatch as documented. However, the user found that the inbound agent client was never even attempting to connect to the server.

### Evaluation

The server unconditionally sends an `X-Remoting-Minimum-Version` header, and when old inbound agents (both TCP and WebSocket) see this, they don't bother to connect to the server. If the server was running with the escape hatch enabled, the server would have accepted the connection, but since the client never tried to connect, the agent cannot be started.

This wasn't caught by our test automation because it only uses outbound agents and not inbound/WebSocket agents.

### Solution

We considered adding a flag to the client to allow it to ignore the `X-Remoting-Minimum-Version` header in such cases and try to connect anyway. However, such a fix wouldn't apply retroactively to already released old versions of Remoting, so this wouldn't be all that helpful to current users.

Instead we are removing the header on the server side if the escape hatch is activated. When the escape hatch is activated, there is effectively no minimum version, so it is misleading to advertise one. And when no such header is advertised, the client will always try to connect.

### Testing done

- Manually confirmed that the header was present without the escape hatch and absent with the escape hatch.
- Reproduced the scenario in the bug report with both WebSocket agents and TCP inbound agents; in both cases the problem was fixed after this PR.
- Ran `mvn clean verify -Dtest=hudson.slaves.ChannelPingerTest,hudson.slaves.JNLPLauncherTest,hudson.slaves.PingThreadTest,hudson.slaves.SlaveComputerTest,jenkins.agents.WebSocketAgentsTest,jenkins.security.AgentToControllerSecurityTest,jenkins.security.CustomClassFilterTest,jenkins.slaves.OldRemotingAgentTest,jenkins.slaves.RemotingVersionInfoTest,jenkins.slaves.UnsupportedRemotingAgentEscapeHatchTest,jenkins.slaves.UnsupportedRemotingAgentTest`.

It is probably possible to write an automated test using `InboundAgent` rule, but for such an obscure use case I didn't feel compelled to do so. If people feel strongly that we add test automation for this, I can look into writing a test.

### Proposed changelog entries

- Fix the `hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions` escape hatch, which was previously not working with inbound agents.

### Proposed upgrade guidelines

N/A

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
