### PR TITLE
Update version numbers of new APIs in Javadoc

### DIFF
--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -236,7 +236,7 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
      *
      * @return true if the current user has the minimum required permission to view any administrative monitor.
      *
-     * @since TODO
+     * @since 2.468
      */
     public static boolean hasPermissionToDisplay() {
         return Jenkins.get().hasAnyPermission(Jenkins.SYSTEM_READ, Jenkins.MANAGE);

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -344,7 +344,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
      * The properties not included in the list will be let untouched.
      * It will call the {@link UserProperty#setUser(User)} method and at the end, {@link #save()} once.
      *
-     * @since TODO
+     * @since 2.468
      */
     public synchronized void addProperties(@NonNull List<UserProperty> multipleProperties) throws IOException {
         List<UserProperty> newProperties = new ArrayList<>(this.properties);

--- a/core/src/main/java/hudson/model/UserProperty.java
+++ b/core/src/main/java/hudson/model/UserProperty.java
@@ -86,7 +86,7 @@ public abstract class UserProperty implements ReconfigurableDescribable<UserProp
     /**
      * Returns all the registered {@link UserPropertyCategory} descriptors for a given category.
      *
-     * @since TODO
+     * @since 2.468
      */
     public static List<UserPropertyDescriptor> allByCategoryClass(@NonNull Class<? extends UserPropertyCategory> categoryClass) {
         DescriptorExtensionList<UserProperty, UserPropertyDescriptor> all = all();

--- a/core/src/main/java/hudson/model/UserPropertyDescriptor.java
+++ b/core/src/main/java/hudson/model/UserPropertyDescriptor.java
@@ -85,7 +85,7 @@ public abstract class UserPropertyDescriptor extends Descriptor<UserProperty> {
      *
      * @return never null, always the same value for a given instance of {@link Descriptor}.
      *
-     * @since TODO
+     * @since 2.468
      */
     public @NonNull UserPropertyCategory getUserPropertyCategory() {
         // As this method is expected to be overloaded by subclasses
@@ -120,7 +120,7 @@ public abstract class UserPropertyDescriptor extends Descriptor<UserProperty> {
      *
      * @return String name corresponding to the symbol of {@link #getUserPropertyCategory()}
      *
-     * @since TODO
+     * @since 2.468
      */
     @Deprecated
     protected @CheckForNull String getUserPropertyCategoryAsString() {

--- a/core/src/main/java/hudson/model/userproperty/UserPropertyCategory.java
+++ b/core/src/main/java/hudson/model/userproperty/UserPropertyCategory.java
@@ -43,7 +43,7 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
  * as the catch-all "unclassified".) Categories themselves are extensible &mdash; plugins may introduce
  * its own category as well, although that should only happen if you are creating a big enough subsystem.
  *
- * @since TODO
+ * @since 2.468
  * @see UserProperty
  */
 public abstract class UserPropertyCategory implements ExtensionPoint, ModelObject {

--- a/core/src/main/java/jenkins/model/GlobalComputerRetentionCheckIntervalConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalComputerRetentionCheckIntervalConfiguration.java
@@ -23,7 +23,7 @@ public class GlobalComputerRetentionCheckIntervalConfiguration extends GlobalCon
     /**
      * Gets the check interval for computer retention.
      *
-     * @since TODO
+     * @since 2.463
      */
     public int getComputerRetentionCheckInterval() {
         if (computerRetentionCheckInterval <= 0) {
@@ -42,7 +42,7 @@ public class GlobalComputerRetentionCheckIntervalConfiguration extends GlobalCon
      *
      * @param interval new check interval in seconds
      * @throws IllegalArgumentException interval must be greater than zero
-     * @since TODO
+     * @since 2.463
      */
     private void setComputerRetentionCheckInterval(int interval) throws IllegalArgumentException {
         if (interval <= 0) {


### PR DESCRIPTION
## Update API releases in Javadoc

Used the Python script to update the API releases in the Javadoc comments.

No automated testing because the Javadoc generator already validates javadoc well enough.

### Testing done

Ran `mvn javadoc:javadoc` and confirmed there were no new warnings or surprises.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
