### PR TITLE
experimental flag to run Jenkins without YUI

### DIFF
--- a/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
+++ b/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
@@ -1,9 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2024, Markus Winter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package jenkins.model.experimentalflags;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 @Extension
+@Restricted(NoExternalUse.class)
 public class RemoveYuiUserExperimentalFlag extends BooleanUserExperimentalFlag {
     public RemoveYuiUserExperimentalFlag() {
         super("remove-yui.flag");

--- a/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
+++ b/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
@@ -1,0 +1,22 @@
+package jenkins.model.experimentalflags;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+
+@Extension
+public class RemoveYuiUserExperimentalFlag extends BooleanUserExperimentalFlag {
+    public RemoveYuiUserExperimentalFlag() {
+        super("remove-vui.flag");
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Remove YUI";
+    }
+
+    @Nullable
+    @Override
+    public String getShortDescription() {
+        return "Remove YUI from all Jenkins UI pages. This will break anything that depends on YUI";
+    }
+}

--- a/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
+++ b/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
@@ -6,7 +6,7 @@ import hudson.Extension;
 @Extension
 public class RemoveYuiUserExperimentalFlag extends BooleanUserExperimentalFlag {
     public RemoveYuiUserExperimentalFlag() {
-        super("remove-vui.flag");
+        super("remove-yui.flag");
     }
 
     @Override

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -128,31 +128,36 @@ THE SOFTWARE.
 
     <st:adjunct includes="org.kohsuke.stapler.bind"/>
 
-    <!-- To use the debug version of YUI, set the system property 'debug.YUI' to true -->
-    <j:set var="yuiSuffix" value="${h.yuiSuffix}" />
-    <l:yui module="yahoo" />
-    <l:yui module="dom" />
-    <l:yui module="event" />
-    <j:if test="${h.yuiSuffix=='debug'}">
-      <l:yui module="logger" />
+    <l:userExperimentalFlag var="removeYUI" flagClassName="jenkins.model.experimentalflags.RemoveYuiUserExperimentalFlag" />
+    <j:if test="${!removeYUI}">
+      <!-- To use the debug version of YUI, set the system property 'debug.YUI' to true -->
+      <j:set var="yuiSuffix" value="${h.yuiSuffix}" />
+      <l:yui module="yahoo" />
+      <l:yui module="dom" />
+      <l:yui module="event" />
+      <j:if test="${h.yuiSuffix=='debug'}">
+        <l:yui module="logger" />
+      </j:if>
+      <l:yui module="animation" />
+      <l:yui module="dragdrop" />
+      <l:yui module="container" />
+      <l:yui module="connection" />
+      <l:yui module="datasource" />
+      <l:yui module="autocomplete" />
+      <l:yui module="menu" />
+      <l:yui module="element" />
+      <l:yui module="button" />
+      <l:yui module="storage" />
     </j:if>
-    <l:yui module="animation" />
-    <l:yui module="dragdrop" />
-    <l:yui module="container" />
-    <l:yui module="connection" />
-    <l:yui module="datasource" />
-    <l:yui module="autocomplete" />
-    <l:yui module="menu" />
-    <l:yui module="element" />
-    <l:yui module="button" />
-    <l:yui module="storage" />
 
     <script src="${resURL}/scripts/hudson-behavior.js" type="text/javascript"></script>
     <script src="${resURL}/scripts/sortable.js" type="text/javascript"/>
 
-    <link rel="stylesheet" href="${resURL}/scripts/yui/container/assets/container.css" type="text/css"/>
-    <link rel="stylesheet" href="${resURL}/scripts/yui/container/assets/skins/sam/container.css" type="text/css"/>
-    <link rel="stylesheet" href="${resURL}/scripts/yui/menu/assets/skins/sam/menu.css" type="text/css" />
+    <j:if test="${!removeYUI}">
+      <link rel="stylesheet" href="${resURL}/scripts/yui/container/assets/container.css" type="text/css"/>
+      <link rel="stylesheet" href="${resURL}/scripts/yui/container/assets/skins/sam/container.css" type="text/css"/>
+      <link rel="stylesheet" href="${resURL}/scripts/yui/menu/assets/skins/sam/menu.css" type="text/css" />
+    </j:if>
 
     <l:hasPermission permission="${app.READ}">
       <link rel="search" type="application/opensearchdescription+xml" href="${rootURL}/opensearch.xml" title="Jenkins" />
@@ -173,7 +178,7 @@ THE SOFTWARE.
     <script src="${resURL}/jsbundles/sortable-drag-drop.js" type="text/javascript"/>
     <script src="${resURL}/jsbundles/app.js" type="text/javascript" defer="true" />
   </head>
-  <body id="jenkins" class="yui-skin-sam ${layoutType} jenkins-${h.version}" data-version="${h.version}" data-model-type="${it.class.name}">
+  <body id="jenkins" class="${removeYUI ? '' : 'yui-skin-sam'} ${layoutType} jenkins-${h.version}" data-version="${h.version}" data-model-type="${it.class.name}">
 
     <j:if test="${layoutType!='full-screen'}">
       <!-- for accessibility, skip the entire navigation bar and etc and go straight to the head of the content -->


### PR DESCRIPTION
The YUI library is old and no longer maintained.

Add a user experimental flag to disable YUI. The flag is disabled by default. When enabling the flag, all the YUI related js libraries and css classes are not loaded.

Following PR are required to get Jenkins to not show any errors
#9488
#9453
#7569

Some plugins that use YUI (not complete):
credentials
ldap
global-build-stats
build-monitor
categorized-view
matrix-project

Plugins that make use of makeButton (not complete) 
credentials (fixed with https://github.com/jenkinsci/credentials-plugin/pull/533)
openid

acceptance-test-harness

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

Add a user experimental flag to run Jenkins without the YUI JavaScript library. Plugin authors should enable this flag and fix any issues that result from the removal of the YUI library.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
