### PR TITLE
Remove Jira issue from changelog summary in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,22 +28,28 @@ For refactoring and code cleanup changes, exercise the code before and after the
 
 ### Proposed changelog entries
 
-- JENKINS-XXXXX, human-readable text
+- human-readable text
 
 <!-- Comment:
 The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
 For examples, see: https://www.jenkins.io/changelog/
 
-Remove JENKINS-XXXXX if there is no issue for the pull request.
+Do not include the Jira issue in the changelog entry.
+Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.
 
 You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
-- JENKINS-123456, First changelog entry
+- First changelog entry
 - Second changelog entry
 -->
 
 ### Proposed upgrade guidelines
 
 N/A
+
+<!-- Comment:
+Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
+The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
+-->
 
 ```[tasklist]
 ### Submitter checklist


### PR DESCRIPTION
## Remove Jira issue from changelog summary in PR template

When the Jira issue is included in the changelog summary, it is included in the generated changelog as the initial text of the changelog entry.  The same issue link is then included by the changelog generator at the end of the changelog description.  Remove the example that places the issue at the start of the changelog text and explain that the issue link should be elsewhere in the pull request so that the changelog generator can use it.

When the Jira issue is included in the changelog summary, the changelog maintainers must remove it before the changelog is published.  It is better to not include the Jira issue in the changelog summary so that changelog maintainers do not need to remove it.

Remind submitters that they should not delete the upgrade guidelines section because the presence of the upgrade guidelines section is used by the changelog generator as the terminator for the proposed changelog entries.

### Testing done

None.  Multiple pull request descriptions that I've edited have needed this change.  Reduce the work by not suggesting that PR authors include the Jira issue in the changelog summary.

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
