### PR TITLE
Tolerate `HttpResponse` thrown from `Descriptor.newInstance`

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
     <slf4jVersion>2.0.13</slf4jVersion>
     <!-- TODO https://github.com/jenkinsci/stapler/pull/571 -->
-    <stapler.version>999999-SNAPSHOT</stapler.version>
+    <stapler.version>1891.v4efde02f1509</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,8 @@ THE SOFTWARE.
   <properties>
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
     <slf4jVersion>2.0.13</slf4jVersion>
-    <stapler.version>1881.vd39f3ee5c629</stapler.version>
+    <!-- TODO https://github.com/jenkinsci/stapler/pull/571 -->
+    <stapler.version>999999-SNAPSHOT</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,8 +40,7 @@ THE SOFTWARE.
   <properties>
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
     <slf4jVersion>2.0.13</slf4jVersion>
-    <!-- TODO https://github.com/jenkinsci/stapler/pull/571 -->
-    <stapler.version>1891.v4efde02f1509</stapler.version>
+    <stapler.version>1892.v73465f3d074d</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -594,6 +594,9 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
                 return verifyNewInstance(bindJSON(req, clazz, formData, true));
             }
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException | RuntimeException e) {
+            if (e instanceof RuntimeException && e instanceof HttpResponse) {
+                throw (RuntimeException) e;
+            }
             throw new LinkageError("Failed to instantiate " + clazz + " from " + RedactSecretJsonInErrorMessageSanitizer.INSTANCE.sanitize(formData), e);
         }
     }
@@ -674,7 +677,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
                                 + actualType.getName() + " " + json);
                     }
                 } catch (Exception x) {
-                    LOGGER.log(Level.WARNING, "falling back to default instantiation " + actualType.getName() + " " + json, x);
+                    LOGGER.log(x instanceof HttpResponse ? Level.FINE : Level.WARNING, "falling back to default instantiation " + actualType.getName() + " " + json, x);
                     // If nested objects are not using newInstance, bindJSON will wind up throwing the same exception anyway,
                     // so logging above will result in a duplicated stack trace.
                     // However if they *are* then this is the only way to find errors in that newInstance.


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/stapler/pull/571. Appears to solve the problem described in https://github.com/jenkinsci/workflow-cps-plugin/pull/907#discussion_r1687721750: allows you to throw `Descriptor.FormException` from a `@DataBoundConstructor` and have it be rendered properly.

### Testing done

```diff
diff --git plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java
index eea31e59..2d04e223 100644
--- plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java
+++ plugin/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.cps;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Action;
+import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Queue;
@@ -75,15 +76,18 @@ public class CpsFlowDefinition extends FlowDefinition {
      * @deprecated use {@link #CpsFlowDefinition(String, boolean)} instead
      */
     @Deprecated
-    public CpsFlowDefinition(String script) {
+    public CpsFlowDefinition(String script) throws Descriptor.FormException {
         this(script, false);
     }
 
     @DataBoundConstructor
-    public CpsFlowDefinition(String script, boolean sandbox) {
+    public CpsFlowDefinition(String script, boolean sandbox) throws Descriptor.FormException {
         StaplerRequest req = Stapler.getCurrentRequest();
         this.script = sandbox ? script : ScriptApproval.get().configuring(script, GroovyLanguage.get(),
                 ApprovalContext.create().withCurrentUser().withItemAsKey(req != null ? req.findAncestorObject(Item.class) : null), req == null);
+        if (!sandbox) {
+            throw new Descriptor.FormException("Sandbox is mandatory", "sandbox");
+        }
         this.sandbox = sandbox;
     }
 
```

displays a polite page with the message when you **Save** a form with the `sandbox` field unchecked, rather than an “angry Jenkins” / UUID as before. Also if you **Apply** then the error is shown nicely in the bottom bar.

### Proposed changelog entries

- Developer: `HttpResponse` exceptions such as `Descriptor.FormException` are now rendered properly from `@DataBoundConstructor`s.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
```

### Desired reviewers

@amuniz

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
