### PR TITLE
Add end of life dates for Alpine 3.20, Ubuntu 24.04, Fedora 40

### DIFF
--- a/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/end-of-life-data.json
+++ b/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/end-of-life-data.json
@@ -1,7 +1,7 @@
 [
   {
     "pattern": "AlmaLinux.* 8.*",
-    "endOfLife": "2029-03-31"
+    "endOfLife": "2029-03-01"
   },
   {
     "pattern": "AlmaLinux.* 9.*",
@@ -17,38 +17,39 @@
   },
   {
     "pattern": "Alpine Linux v3.16",
-    "endOfLife": "2024-05-01"
+    "endOfLife": "2024-05-23"
   },
   {
     "pattern": "Alpine Linux v3.17",
-    "endOfLife": "2024-11-01"
+    "endOfLife": "2024-11-22"
   },
   {
     "pattern": "Alpine Linux v3.18",
-    "endOfLife": "2025-05-01"
+    "endOfLife": "2025-05-09"
   },
   {
     "pattern": "Alpine Linux v3.19",
     "endOfLife": "2025-11-01"
   },
   {
+    "pattern": "Alpine Linux v3.20",
+    "endOfLife": "2026-04-01"
+  },
+  {
     "pattern": "Amazon Linux 2",
-    "start": "2023-05-01",
     "endOfLife": "2023-11-16"
   },
   {
     "pattern": "Amazon Linux 2023",
-    "start": "2027-09-15",
     "endOfLife": "2028-03-15"
   },
   {
     "pattern": "CentOS Linux.* 7.*",
-    "start": "2023-05-01",
     "endOfLife": "2023-11-16"
   },
   {
     "pattern": "CentOS Linux.* 8.*",
-    "endOfLife": "2029-03-31"
+    "endOfLife": "2021-12-31"
   },
   {
     "pattern": "Debian.* 10.*",
@@ -60,45 +61,47 @@
   },
   {
     "pattern": "Debian.* 12.*",
-    "endOfLife": "2028-06-30"
+    "endOfLife": "2028-06-10"
   },
   {
     "pattern": "Fedora.* 36.*",
-    "endOfLife": "2023-05-18"
+    "endOfLife": "2023-05-16"
   },
   {
     "pattern": "Fedora.* 37.*",
-    "endOfLife": "2023-12-15"
+    "endOfLife": "2023-12-05"
   },
   {
     "pattern": "Fedora.* 38.*",
-    "endOfLife": "2024-05-18"
+    "endOfLife": "2024-05-21"
   },
   {
     "pattern": "Fedora.* 39.*",
-    "endOfLife": "2024-12-07"
+    "endOfLife": "2024-11-12"
+  },
+  {
+    "pattern": "Fedora.* 40.*",
+    "endOfLife": "2025-05-13"
   },
   {
     "pattern": "Oracle Linux.* 7.*",
-    "start": "2023-05-01",
     "endOfLife": "2023-11-16"
   },
   {
     "pattern": "Oracle Linux.* 8.*",
-    "endOfLife": "2029-03-31"
+    "endOfLife": "2029-07-31"
   },
   {
     "pattern": "Oracle Linux.* 9.*",
-    "endOfLife": "2034-06-30"
+    "endOfLife": "2032-06-30"
   },
   {
     "pattern": "Red Hat Enterprise Linux.* 7.*",
-    "start": "2023-05-01",
     "endOfLife": "2023-11-16"
   },
   {
     "pattern": "Red Hat Enterprise Linux.* 8.*",
-    "endOfLife": "2029-03-31"
+    "endOfLife": "2029-05-31"
   },
   {
     "pattern": "Red Hat Enterprise Linux.* 9.*",
@@ -106,7 +109,7 @@
   },
   {
     "pattern": "Rocky Linux.* 8.*",
-    "endOfLife": "2029-03-31"
+    "endOfLife": "2029-05-31"
   },
   {
     "pattern": "Rocky Linux.* 9.*",
@@ -114,7 +117,6 @@
   },
   {
     "pattern": "Scientific Linux.* 7.*",
-    "start": "2023-05-01",
     "endOfLife": "2023-11-16"
   },
   {
@@ -152,5 +154,9 @@
   {
     "pattern": "Ubuntu.* 23.04.*",
     "endOfLife": "2024-01-20"
+  },
+  {
+    "pattern": "Ubuntu.* 24.04.*",
+    "endOfLife": "2029-04-25"
   }
 ]


### PR DESCRIPTION
## Add end of life dates for Alpine 3.20, Ubuntu 24.04, Fedora 40

Alpine 3.20, Ubuntu 24.04, and Fedora 40 were previously not included in the end of life data.  Include them so that users will be warned when they approach end of life.

Also update the end of life dates for other operating systems based on https://endoflife.date/ data.

Removes the 'start' entries because we are past the end of life date of the RHEL 7 derivatives and the one other start date is not needed because the default start date will cover it correctly.

Corrects the end of life date for CentOS 8.  The CentOS project declared the end of life of CentOS 8 was in 2021 but somehow I original listed it as 2029.

### Testing done

Confirmed with a CentOS 8 computer that the end of life message is displayed with the correct date for the CentOS 8 end of life.  The corrected end of life date has already passed, so there may be Jenkins users that are surprised when their next upgrade reports that they are running an unsupported operating system.

### Proposed changelog entries

- Add end of life dates for Alpine 3.20, Ubuntu 24.04, and Fedora 40. Correct several end of life dates, including CentOS 8.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
