### PR TITLE
[JENKINS-73495] Clarify the plugin incompatibility message

### DIFF
--- a/core/src/main/resources/hudson/Messages.properties
+++ b/core/src/main/resources/hudson/Messages.properties
@@ -67,7 +67,7 @@ PluginManager.UnexpectedException=Unexpected exception going through the retryin
 
 
 PluginManager.compatWarning=\
- Warning: The new version of this plugin is marked as incompatible with the installed version. \
+ Warning: The new version of this plugin is marked as incompatible with the installed version of the plugin. \
  This is usually the case because its behavior or APIs changed, or because it uses a different settings format than the installed version. \
  Other plugins with a dependency on this plugin may be incompatible with this update and no longer work as expected, jobs using this plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
  Consult the plugin release notes for details.

--- a/core/src/main/resources/hudson/PluginManager/updates.properties
+++ b/core/src/main/resources/hudson/PluginManager/updates.properties
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 compatWarning=\
- Warning: The new version of this plugin is marked as incompatible with the installed version. \
+ Warning: The new version of this plugin is marked as incompatible with the installed version of the plugin. \
  This is usually the case because its behavior changed, or because it uses a different settings format than the installed version. \
  Jobs using this plugin may need to be reconfigured, and/or you may not be able to cleanly revert to the prior version without manually restoring old settings. \
  Consult the plugin release notes for details.


### PR DESCRIPTION
## [JENKINS-73495] Clarify the plugin incompatibility message

The issue submitter suggested that the plugin incompatibility message would be clearer if it specifically referred to the installed version of the plugin.  That seems like an easy change to make and if it helps a few users, that is great.

See [JENKINS-73495](https://issues.jenkins.io/browse/JENKINS-73495).

No automated tests because we generally do not test changes in messages.

### Testing done

None.  Rely on standard behavior of changes in message property files.

### Proposed changelog entries

- Clarify that the plugin incompatibility message applies to the current plugin.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
