### PR TITLE
Remove Renovate LTS updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,18 +8,7 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "postUpdateOptions": ["yarnDedupeHighest"],
-  "baseBranches": ["master", "stable-2.462"],
   "packageRules": [
-    {
-      "matchBaseBranches": ["/stable-.+/"],
-      "matchManagers": ["maven"],
-      "labels": ["dependencies", "into-lts", "needs-justification"]
-    },
-    {
-      "matchBaseBranches": ["/stable-.+/"],
-      "matchManagers": ["custom.regex", "npm", "github-actions"],
-      "enabled": false
-    },
     {
       "matchDatasources": ["npm"],
       "addLabels": ["javascript"],


### PR DESCRIPTION
Renovate is opening PRs for all Java dependencies on the LTS branch, not just security updates. Renovate does have a way to only create [security updates](https://docs.renovatebot.com/presets-security/#securityonly-security-updates), but it is based on the GitHub Dependabot Alert mechanism, which fundamentally only works against the default branch. From this I conclude this use case is impossible at present, so disable this functionality to prevent PR spam.