### PR TITLE
Updates to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,6 @@ This page provides information about contributing code to the Jenkins core codeb
    - Apache Maven 3.8.1 or above. You can [download Maven here](https://maven.apache.org/download.cgi).
      In the Jenkins project we usually use the most recent Maven release.
    - Any IDE which supports importing Maven projects.
-   - Install [Node.js 20.x](https://nodejs.org/en/). **Note:** only needed to work on the frontend assets found in the `war` module.
-     - Frontend tasks are run using [yarn](https://yarnpkg.com/). Run `npm install -g yarn` to install it.
 4. Set up your development environment as described in [Preparing for Plugin Development](https://www.jenkins.io/doc/developer/tutorial/prepare/)
 
 If you want to contribute to Jenkins, or just learn about the project,
@@ -27,6 +25,8 @@ You can find them by using this query (check the link) for [newbie friendly issu
 
 The Jenkins core build flow is built around Maven.
 You can read a description of the [building and debugging process here](https://www.jenkins.io/doc/developer/building/).
+
+### Building the WAR file
 
 If you want simply to build the `jenkins.war` file as fast as possible without tests, run:
 
@@ -40,13 +40,30 @@ If you want to debug the WAR file without using Maven plugins,
 You can run the executable with [Remote Debug Flags](https://stackoverflow.com/questions/975271/remote-debugging-a-java-application)
 and then attach IDE Debugger to it.
 
-To launch a development instance, after the above command, run:
+### Launching a development instance
+
+To launch a development instance, after [building the WAR file](#building-the-war-file), run:
 
 ```sh
-mvn -pl war jetty:run
+MAVEN_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED' mvn -pl war jetty:run
 ```
 
 (Beware that `maven-plugin` builds will not work in this mode, due to class loading conflicts.)
+
+### Running the Yarn frontend build
+
+To run the Yarn frontend build, after [building the WAR file](#building-the-war-file), add the downloaded versions of Node and Yarn to your path:
+
+```sh
+export PATH=$PWD/war/node:$PWD/war/node/yarn/dist/bin:$PATH
+```
+
+Then you can run Yarn with e.g.
+
+```sh
+cd war
+yarn
+```
 
 ### Building frontend assets
 
@@ -55,13 +72,14 @@ To work on the `war` module frontend assets, two processes are needed at the sam
 On one terminal, start a development server that will not process frontend assets:
 
 ```sh
-mvn -pl war jetty:run -Dskip.yarn
+MAVEN_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED' mvn -pl war jetty:run -Dskip.yarn
 ```
 
-On another terminal, move to the war folder and start a [webpack](https://webpack.js.org/) dev server:
+On another terminal, move to the `war` folder and start a [webpack](https://webpack.js.org/) dev server, after [adding Node and Yarn to your path](#running-the-yarn-frontend-build):
 
 ```sh
-cd war; yarn start
+cd war
+yarn start
 ```
 
 ### Gitpod
@@ -86,11 +104,24 @@ For linting we use a number of tools:
 
 These are all configured to run as part of the Maven build, although they will be skipped if you are building with the `quick-build` profile.
 
-To automatically fix most issues run:
+To automatically fix backend issues, run:
 
-```bash
+```sh
 mvn spotless:apply
-mvn -pl war frontend:yarn -Dfrontend.yarn.arguments=lint:fix
+```
+
+To view frontend issues, after [adding Node and Yarn to your path](#running-the-yarn-frontend-build), run:
+
+```sh
+cd war
+yarn lint
+```
+
+To fix frontend issues, after [adding Node and Yarn to your path](#running-the-yarn-frontend-build), run:
+
+```sh
+cd war
+yarn lint:fix
 ```
 
 ## Testing changes
@@ -110,14 +141,6 @@ There are 3 profiles for tests:
 In addition to the included tests, you can also find extra integration and UI
 tests in the [Acceptance Test Harness (ATH)](https://github.com/jenkinsci/acceptance-test-harness) repository.
 If you propose complex UI changes, you should create new ATH tests for them.
-
-### JavaScript unit tests
-
-In case there's only need to run the JS tests:
-
-```sh
-cd war; yarn test
-```
 
 ## Proposing Changes
 


### PR DESCRIPTION
Refreshes the `CONTRIBUTING.md` guide to fix a few issues:

1. In https://github.com/jenkinsci/jenkins/pull/9153#issuecomment-2106314083 there were complaints that it was possible to run `yarn lint` through Maven but not outside of Maven. This was caused by bad instructions, telling people to install a global copy of Yarn that differs from the version used by our build. I have fixed this by changing the instructions to recommend that people add our build's version of Node and Yarn to their path. I confirmed that with this setup I can run `yarn lint` both through Maven and also outside of Maven.
2. `jetty:run` doesn't add the `--add-opens` options needed for Java 17. Rather than add these options to all Maven invocations, I have documented a workaround just for `jetty:run` in order to limit the surface area of the workaround, as suggested in [JENKINS-68860 (comment)](https://issues.jenkins.io/browse/JENKINS-68860?focusedId=448271&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-448271).
3. The `yarn test` instructions were obsolete as of #6908, which deleted these tests. These instructions should just be removed.

### Testing done

- Confirmed that build information could be edited when running Jenkins with `jetty:run` and `MAVEN_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED'`.
- Confirmed that I could run `yarn start` and `yarn lint` after setting the path as documented.

### Proposed changelog entries

Update the contributing guide to cover recent changes to the frontend and backend build system.

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
