### PR TITLE
[JENKINS-73613] refresh buildhistory widget in all cases

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -56,7 +56,7 @@ THE SOFTWARE.
         <div id="jenkins-build-history" class="app-builds-container__items">
         </div>
 
-        <div class="app-builds-container__controls" id="controls">
+        <div class="app-builds-container__controls jenkins-hidden" id="controls">
           <button class="jenkins-button jenkins-button--tertiary jenkins-card__unveil" id="up">
             <l:icon src="symbol-arrow-left" />
             <span class="jenkins-visually-hidden">${%Newer builds}</span>

--- a/war/src/main/js/pages/project/builds-card.js
+++ b/war/src/main/js/pages/project/builds-card.js
@@ -30,6 +30,9 @@ function load(options = {}) {
 
   // Avoid fetching if the page isn't active
   if (document.hidden) {
+    if (buildHistoryPage.dataset.pageHasUp === "false") {
+      createRefreshTimeout();
+    }
     return;
   }
 
@@ -101,6 +104,7 @@ function updateCardControls(parameters) {
 
   buildHistoryPage.dataset.pageEntryNewest = parameters.pageEntryNewest;
   buildHistoryPage.dataset.pageEntryOldest = parameters.pageEntryOldest;
+  buildHistoryPage.dataset.pageHasUp = parameters.pageHasUp;
 }
 
 paginationPrevious.addEventListener("click", () => {


### PR DESCRIPTION
refresh the buildHistory widget instantly when the window gets focus, e.g. after switching browser tabs but also when one was in another application and clicks in the browser window.
When the window is visible it will update even when it has no focus, when the window is hidden no calls to the controller will be done.

Additionally the buildHistory will be updated when it is not on the first page. So e.g. when someone deletes a build, changes the display name or the description or when a build is still running the page gets updated.

This replaces #9605

See [JENKINS-73613](https://issues.jenkins.io/browse/JENKINS-73613).
See [JENKINS-73592](https://issues.jenkins.io/browse/JENKINS-73592).

### Testing done
Manual testing
- Create a job and run it at least once
- From dashboard view open the job in a new tab
- switch to tab -> the history should load instantly

- make the job run for longer time and start it once (`sleep 300`)
- reconfigure the job to do nothing
- run the job over 30 times until the long running build is on the second page of the history
- go to second page of history and see that the still running build gets updated and finally finishes
- in another browser window delete a build from the second page -> build is removed
- in another browser window, change the display name and/or description of a build-> name/description changes

### Proposed changelog entries

- Refresh build history widget in all cases, including on background tabs or hidden tabs.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
