### PR TITLE
Remove trailing backslash from 'Keep this build forever' hover text

### DIFF
--- a/core/src/main/resources/hudson/model/Run/KeepLogBuildBadge/badge.jelly
+++ b/core/src/main/resources/hudson/model/Run/KeepLogBuildBadge/badge.jelly
@@ -23,4 +23,4 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<l:icon src="symbol-lock-closed" class="icon-sm" tooltip="${%Keep this build forever}:\\n${build.whyKeepLog}" xmlns:l="/lib/layout"/>
+<l:icon src="symbol-lock-closed" class="icon-sm" tooltip="${%Keep this build forever}:\n${build.whyKeepLog}" xmlns:l="/lib/layout"/>


### PR DESCRIPTION
##  Remove trailing backslash from 'Keep this build forever' hover text

See the before and after pictures in the "Testing done" section.

### Testing done

Before:

![Keep-this-build-forever-hover-text-has-a-trailing-backslash](https://github.com/user-attachments/assets/e033e4f6-4891-46d9-8a2e-c74c9f8a11d5)

After:

![no-trailing-backslash](https://github.com/user-attachments/assets/ddda1b3b-c321-4c83-bb2d-746d15a98efd)

### Proposed changelog entries

- Remove trailing backslash from 'Keep this build forever' hover text.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described. (No Jira issue, too trivial a change)
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
