### PR TITLE
Update @since javadoc comments for recent API additions

### DIFF
--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -329,7 +329,7 @@ public abstract class Lifecycle implements ExtensionPoint {
     /**
      * Called when Jenkins has failed to boot.
      * @param problem a boot failure (could be {@link JenkinsReloadFailed})
-     * @since TODO
+     * @since 2.469
      */
     public void onBootFailure(BootFailure problem) {
     }

--- a/core/src/main/java/hudson/model/listeners/ItemListener.java
+++ b/core/src/main/java/hudson/model/listeners/ItemListener.java
@@ -101,7 +101,7 @@ public class ItemListener implements ExtensionPoint {
      * @param item the item being deleted
      * @throws Failure to veto the operation.
      * @throws InterruptedException If a blocking condition was interrupted, also vetoing the operation.
-     * @since TODO
+     * @since 2.470
      */
     public void onCheckDelete(Item item) throws Failure, InterruptedException {
     }

--- a/core/src/main/java/jenkins/model/queue/ItemDeletion.java
+++ b/core/src/main/java/jenkins/model/queue/ItemDeletion.java
@@ -198,7 +198,7 @@ public class ItemDeletion extends Queue.QueueDecisionHandler {
      * Cancels any builds in progress of this item (if a job) or descendants (if a folder).
      * Also cancels any associated queue items.
      * @param initiatingItem an item being deleted
-     * @since TODO
+     * @since 2.470
      */
     public static void cancelBuildsInProgress(@NonNull Item initiatingItem) throws Failure, InterruptedException {
         Queue queue = Queue.getInstance();


### PR DESCRIPTION
## Update since javadoc comments for recent API additions

List of commits introducing new API and the first release they went in:
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.469
  - https://github.com/jenkinsci/jenkins/commit/7680da0cef93fa7edd5b4eb2faf6cf9c04374f68
* https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.470
  - https://github.com/jenkinsci/jenkins/commit/220165fd27f776e0e3155fd077d6f212a4824a1b

### Testing done

None.  Rely on ci.jenkins.io checks.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
