### PR TITLE
Turn down log level of `StaplerFilteredActionListener`

### DIFF
--- a/core/src/main/java/jenkins/security/stapler/StaplerFilteredActionListener.java
+++ b/core/src/main/java/jenkins/security/stapler/StaplerFilteredActionListener.java
@@ -50,7 +50,7 @@ public class StaplerFilteredActionListener implements FilteredDoActionTriggerLis
 
     @Override
     public boolean onDoActionTrigger(Function f, StaplerRequest req, StaplerResponse rsp, Object node) {
-        LOGGER.log(Level.WARNING, LOG_MESSAGE, new Object[]{
+        LOGGER.log(Level.FINER, LOG_MESSAGE, new Object[]{
                 req.getPathInfo(),
                 f.getSignature(),
         });
@@ -59,7 +59,7 @@ public class StaplerFilteredActionListener implements FilteredDoActionTriggerLis
 
     @Override
     public boolean onGetterTrigger(Function f, StaplerRequest req, StaplerResponse rsp, Object node, String expression) {
-        LOGGER.log(Level.WARNING, LOG_MESSAGE, new Object[]{
+        LOGGER.log(Level.FINER, LOG_MESSAGE, new Object[]{
                 req.getPathInfo(),
                 f.getSignature(),
         });
@@ -68,7 +68,7 @@ public class StaplerFilteredActionListener implements FilteredDoActionTriggerLis
 
     @Override
     public boolean onFieldTrigger(FieldRef f, StaplerRequest req, StaplerResponse staplerResponse, Object node, String expression) {
-        LOGGER.log(Level.WARNING, LOG_MESSAGE, new Object[]{
+        LOGGER.log(Level.FINER, LOG_MESSAGE, new Object[]{
                 req.getPathInfo(),
                 f.getSignature(),
         });
@@ -77,7 +77,7 @@ public class StaplerFilteredActionListener implements FilteredDoActionTriggerLis
 
     @Override
     public boolean onDispatchTrigger(StaplerRequest req, StaplerResponse rsp, Object node, String viewName) {
-        LOGGER.warning(() -> "New Stapler dispatch rules result in the URL \"" + req.getPathInfo() + "\" no longer being allowed. " +
+        LOGGER.finer(() -> "New Stapler dispatch rules result in the URL \"" + req.getPathInfo() + "\" no longer being allowed. " +
                 "If you consider it safe to use, add the following to the whitelist: \"" + node.getClass().getName() + " " + viewName + "\". " +
                 "Learn more: https://www.jenkins.io/redirect/stapler-facet-restrictions");
         return false;


### PR DESCRIPTION
The warnings in `StaplerFilteredActionListener` were added in commit 47f38d714c99e1841fb737ad1005618eb26ed852 in 2018 as part of a transition to a more strict set of semantics for Stapler. Since these semantics have now been the default for many years, there is no need to log these warnings at such a high level. In fact, this high level of logging creates an unnecessary amount of spam when using the `@StaplerNotDispatchable` annotation, so turn down the level to `FINER` by default.

### Testing done

`mvn clean verify -Dtest=hudson.cli.BuildCommandTest,hudson.cli.CLITest,hudson.console.AnnotatedLargeTextTest,hudson.core.PluginManagerOverrideTest,hudson.diagnosis.OldDataMonitorTest,hudson.ExceptionTest,hudson.FunctionsTest,hudson.markup.MarkupFormatterTest,hudson.model.ApiTest,hudson.model.ComputerConfigDotXmlTest,hudson.model.DescriptorTest,hudson.model.DirectoryBrowserSupportTest,hudson.model.FingerprintTest,hudson.model.FreeStyleProjectTest,hudson.model.JobPropertyTest,hudson.model.JobTest,hudson.model.labels.LabelAtomPropertyTest,hudson.model.ListViewTest,hudson.model.ParametersDefinitionPropertyTest,hudson.model.QueueTest,hudson.model.RunTest,hudson.model.UserPropertyTest,hudson.model.UserTest,hudson.model.ViewDescriptorTest,hudson.model.ViewPropertyTest,hudson.model.ViewTest,hudson.pages.SystemConfigurationTestCase,hudson.PluginManagerCheckUpdateCenterTest,hudson.PluginManagerTest,hudson.RelativePathTest,hudson.security.AccessDeniedException3Test,hudson.security.ACLTest,hudson.security.csrf.CrumbExclusionTest,hudson.security.SecurityRealmTest,hudson.security.TokenBasedRememberMeServices2Test,hudson.security.WhoAmITest,hudson.slaves.CloudTest,hudson.slaves.NodePropertyTest,hudson.tasks.CommandInterpreterTest,hudson.tasks.MavenTest,hudson.triggers.TriggerStartTest,hudson.triggers.TriggerTest,hudson.util.BootFailureTest,hudson.util.FormFieldValidatorTest,hudson.util.RobustReflectionConverterTest,hudson.util.XStream2Security383Test,hudson.views.GlobalDefaultViewConfigurationTest,jenkins.bugs.Jenkins19124Test,jenkins.diagnostics.URICheckEncodingMonitorTest,jenkins.model.ContextMenuTest,jenkins.model.GlobalSCMRetryCountConfigurationTest,jenkins.model.JenkinsGetRootUrlTest,jenkins.model.JenkinsSystemReadAndManagePermissionTest,jenkins.model.JenkinsTest,jenkins.scm.SCMCheckoutStrategyTest,jenkins.security.ApiCrumbExclusionTest,jenkins.security.BasicHeaderProcessorTest,jenkins.security.RedactSecretJsonInErrorMessageSanitizerHtmlTest,jenkins.security.ResourceDomainTest,jenkins.security.Security3030Test,jenkins.security.Security380Test,jenkins.security.seed.UserSeedSecurityListenerTest,jenkins.security.StackTraceSuppressionTest,jenkins.security.stapler.CustomRoutingDecisionProviderTest,jenkins.security.stapler.DoActionFilterTest,jenkins.security.stapler.DynamicTest,jenkins.security.stapler.GetterMethodFilterTest,jenkins.security.stapler.JenkinsSupportAnnotationsTest,jenkins.security.stapler.PreventRoutingTest,jenkins.security.stapler.Security400Test,jenkins.security.stapler.Security867Test,jenkins.security.stapler.Security914Test,jenkins.security.stapler.StaplerAbstractTest,jenkins.security.stapler.StaplerDispatchValidatorTest,jenkins.security.stapler.StaplerRoutableActionTest,jenkins.security.stapler.StaplerRoutableFieldTest,jenkins.security.stapler.StaplerRoutableGetterTest,jenkins.security.stapler.StaplerSignaturesTest,jenkins.security.stapler.StaticRoutingDecisionProvider2Test,jenkins.security.stapler.StaticRoutingDecisionProviderTest,jenkins.security.stapler.TypedFilterTest,jenkins.security.SuspiciousRequestFilterTest,jenkins.telemetry.TelemetryTest,jenkins.util.FullDuplexHttpServiceTest,lib.form.AdvancedButtonTest,lib.form.BooleanRadioTest,lib.form.ComboBoxTest,lib.form.DropdownListTest,lib.form.EnumSetTest,lib.form.EnumTest,lib.form.ExpandableTextboxTest,lib.form.NameRefTest,lib.form.NumberTest,lib.form.PasswordTest,lib.form.RepeatablePropertyTest,lib.form.RepeatableTest,lib.form.RowSetTest,lib.form.RowVisibilityGroupTest,lib.form.SecretTextareaTest,lib.form.TextAreaTest,lib.form.ValidateButtonTest,lib.layout.AjaxTest,lib.layout.ConfirmationLinkTest,lib.layout.RenderOnDemandTest,lib.layout.StopButtonTest,lib.layout.TaskTest,org.kohsuke.stapler.beanutils.BasicTagWithObjectProperty,org.kohsuke.stapler.beanutils.BeanUtilsTagLibrary,org.kohsuke.stapler.beanutils.DynaTagWithStringProperty,org.kohsuke.stapler.beanutils.TagTest,org.kohsuke.stapler.MockStaplerRequestBuilder,org.kohsuke.stapler.Security1097Test,scripts.BehaviorTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
