### PR TITLE
[JENKINS-73422] Add escape hatch for Authenticated user access to Resource URL

### DIFF
--- a/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
@@ -117,7 +117,7 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
             return null;
         }
 
-        if (!ACL.isAnonymous2(Jenkins.getAuthentication2())) {
+        if (!ALLOW_AUTHENTICATED_USER && !ACL.isAnonymous2(Jenkins.getAuthentication2())) {
             rsp.sendError(400);
             return null;
         }
@@ -327,4 +327,8 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
     // Not @Restricted because the entire class is
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static /* not final for Groovy */ int VALID_FOR_MINUTES = SystemProperties.getInteger(ResourceDomainRootAction.class.getName() + ".validForMinutes", 30);
+
+    /* Escape hatch for a fix part of SECURITY-3314 / CVE-2024-23897 (Variant 2) */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
+    public static /* not final for Groovy */ boolean ALLOW_AUTHENTICATED_USER = SystemProperties.getBoolean(ResourceDomainRootAction.class.getName() + ".allowAuthenticatedUser", false);
 }

--- a/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
+++ b/core/src/main/java/jenkins/security/ResourceDomainRootAction.java
@@ -328,7 +328,7 @@ public class ResourceDomainRootAction implements UnprotectedRootAction {
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static /* not final for Groovy */ int VALID_FOR_MINUTES = SystemProperties.getInteger(ResourceDomainRootAction.class.getName() + ".validForMinutes", 30);
 
-    /* Escape hatch for a fix part of SECURITY-3314 / CVE-2024-23897 (Variant 2) */
+    /* Escape hatch for a security hardening preventing one of the known ways to elevate arbitrary file read to RCE */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static /* not final for Groovy */ boolean ALLOW_AUTHENTICATED_USER = SystemProperties.getBoolean(ResourceDomainRootAction.class.getName() + ".allowAuthenticatedUser", false);
 }


### PR DESCRIPTION
See [JENKINS-73422](https://issues.jenkins.io/browse/JENKINS-73422) caused by https://github.com/jenkinsci/jenkins/pull/8922. Proposing an escape hatch to re-allow access to Resource URL. Many users seem impacted due to client automatically sending Authorization on redirect.. The escape hatch can help transitioning to the correct behavior while still upgrading Jenkins.

### Testing done

Unit test.

### Proposed changelog entries

- Add escape hatch for Authenticated user access to Resource URL

### Proposed upgrade guidelines

To allow authenticated user to access Resource URL, add the system property `jenkins.security.ResourceDomainRootAction.allowAuthenticatedUser=false` on startup. This can also be done live by executing the groovy script `jenkins.security.ResourceDomainRootAction.ALLOW_AUTHENTICATED_USER = true`.

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@daniel-beck 

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
