### PR TITLE
[JENKINS-73330] Fix dropdowns and tooltips on HDR displays

### DIFF
--- a/war/src/main/scss/abstracts/_theme.scss
+++ b/war/src/main/scss/abstracts/_theme.scss
@@ -200,15 +200,13 @@ $semantics: (
   --link-font-weight: 450;
 
   // Tooltips
-  --tooltip-backdrop-filter: contrast(0.6) brightness(2.4) saturate(2)
-    blur(15px);
+  --tooltip-backdrop-filter: saturate(2) blur(20px);
   --tooltip-color: var(--text-color);
   --tooltip-box-shadow: 0 0 8px 2px rgba(0, 0, 30, 0.05),
     0 0 1px 1px rgba(0, 0, 20, 0.025), 0 10px 20px rgba(0, 0, 20, 0.15);
 
   // Dropdowns
-  --dropdown-backdrop-filter: contrast(0.6) brightness(2.5) saturate(1.5)
-    blur(20px);
+  --dropdown-backdrop-filter: saturate(1.5) blur(20px);
   --dropdown-box-shadow: 0 10px 30px rgba(0, 0, 20, 0.2),
     0 2px 10px rgba(0, 0, 20, 0.05), inset 0 -1px 2px rgba(255, 255, 255, 0.025);
 

--- a/war/src/main/scss/components/_dropdowns.scss
+++ b/war/src/main/scss/components/_dropdowns.scss
@@ -6,6 +6,7 @@ $dropdown-padding: 0.4rem;
   border-radius: 15px;
   box-shadow: var(--dropdown-box-shadow);
   outline: none !important;
+  background: color-mix(in sRGB, var(--background) 85%, transparent);
   backdrop-filter: var(--dropdown-backdrop-filter);
   max-width: unset !important;
   max-height: 75vh;

--- a/war/src/main/scss/components/_tooltips.scss
+++ b/war/src/main/scss/components/_tooltips.scss
@@ -9,6 +9,7 @@
   max-width: min(50vw, 1000px) !important;
   white-space: pre-line;
   z-index: 0;
+  background: color-mix(in sRGB, var(--background) 85%, transparent);
   backdrop-filter: var(--tooltip-backdrop-filter);
 
   .tippy-content {


### PR DESCRIPTION
See [JENKINS-73330](https://issues.jenkins.io/browse/JENKINS-73330).

Safari on macOS behaves a little differently to every other browser in that it turns on HDR when using the `brightness(...)` filter in CSS. This causes dropdowns, tooltips and dialogs to appear over exposed (and literally brighter) when working on a HDR display. It's pretty painful.

This PR fixes that, by removing the `brightness()` filter, and instead just setting the background on those elements to a semi translucent colour.

See https://github.com/jenkinsci/jenkins/pull/9649 for a fix to dialogs.

### Testing done

* Dropdowns and tooltips appear as expected, similar to how they did before, just not overblown 

### Proposed changelog entries

- Fix dropdown and tooltip brightness on HDR displays.

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
