### PR TITLE
[JENKINS-73302] Restore margins around setup wizard alert messages

### DIFF
--- a/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard.properties
@@ -66,7 +66,7 @@ installWizard_installIncomplete_message=Jenkins was restarted during installatio
 installWizard_installIncomplete_resumeInstallationButtonLabel=Resume
 installWizard_saveFirstUser=Save and Continue
 installWizard_skipFirstUser=Skip and continue as admin
-installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 You have skipped the <strong>setup of an admin user</strong>. <br /><br />\
 To log in, use the username: "admin" and the administrator password you used to access the setup wizard.\
 </div>
@@ -76,7 +76,7 @@ installWizard_addFirstUser_title=Getting Started
 installWizard_configureInstance_title=Instance Configuration
 installWizard_saveConfigureInstance=Save and Finish
 installWizard_skipConfigureInstance=Not now
-installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 You have skipped the configuration of the Jenkins URL. <br/><br/>\
 To configure the Jenkins URL, go to "Manage Jenkins" page.\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_fr.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_fr.properties
@@ -41,7 +41,7 @@ certains plugins n\'ont pas l\'air d\'avoir été installés.
 installWizard_installIncomplete_resumeInstallationButtonLabel=Reprendre
 installWizard_saveFirstUser=Sauver et continuer
 installWizard_skipFirstUser=Continuer en tant qu\'Administrateur
-installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 Vous avez passé la <strong>création d\'un utilisateur administrateur</strong>. <br /><br />\
 Pour vous connecter, utilisez le login : "admin" et le mot de passe administrateur que vous avez utilisé pour accéder au \
 wizard d\'installation.</div>
@@ -49,7 +49,7 @@ installWizard_addFirstUser_title=Démarrage
 
 # instance configuration page
 installWizard_configureInstance_title=Démarrage
-installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 Vous avez passé la <strong>configuration de l\'instance</strong>. <br /><br /> \
 Vous pouvez toujours vous rendre sur les pages de configuration pour remplir les informations qui pourraient manquer.\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_it.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_it.properties
@@ -23,7 +23,7 @@
 
 installWizard_addFirstUser_title=Attività iniziali
 installWizard_configureInstanceSkippedMessage=\
-  <div class="jenkins-alert jenkins-alert-warning fade in">La configurazione dell''URL di \
+  <div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">La configurazione dell''URL di \
   Jenkins è stata omessa.<br/><br/>Per configurare l''URL di Jenkins, aprire \
   la pagina "Gestisci Jenkins".</div>
 installWizard_configureInstance_title=Configurazione istanza
@@ -37,7 +37,7 @@ installWizard_error_restartNotSupported=Il riavvio non è supportato, \
   riavviare quest''istanza manualmente
 installWizard_error_title=Errore
 installWizard_firstUserSkippedMessage=\
-  <div class="jenkins-alert jenkins-alert-warning fade in">La <strong>configurazione di un \
+  <div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">La <strong>configurazione di un \
   utente amministratore</strong> è stata omessa.<br /><br />Per accedere, \
   utilizzare il nome utente "admin" e la password di amministrazione che si \
   è utilizzata per accedere alla configurazione guidata.</div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_lt.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_lt.properties
@@ -39,7 +39,7 @@ installWizard_installIncomplete_message=Jenkinsas buvo iš naujo paleistas diegi
 installWizard_installIncomplete_resumeInstallationButtonLabel=Tęsti
 installWizard_saveFirstUser=Įrašyti ir baigti
 installWizard_skipFirstUser=Tęsti kaip administratoriumi
-installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 Jūs praleidote administratoriaus naudotojo kūrimą. Norėdami prisijungti, naudokite vardą: „admin“ ir \
 administratoriaus slaptažodį, kurį naudojote prisijungimui prie nustatymo vedlio.\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_pl.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_pl.properties
@@ -31,7 +31,7 @@ installWizard_jenkinsVersionTitle=Jenkins
 installWizard_installComplete_banner=Jenkins jest gotowy!
 installWizard_installComplete_finishButtonLabel=Zacznij korzystać z Jenkinsa
 installWizard_installComplete_message=Konfiguracja Jenkinsa została zakończona.
-installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 Pominięto utworzenie konta administratora. Aby się zalogować, użyj loginu 'admin' i hasła użytego podczas konfigurowania Jenkinsa.\
 </div>
 installWizard_addFirstUser_title=Dodawanie pierwszego użytkownika
@@ -79,7 +79,7 @@ installWizard_installComplete_installComplete_restartRequiredNotSupportedMessage
 installWizard_gettingStarted_title=Zaczynamy
 installWizard_saveSecurity=Zapisz i kontynuuj
 installWizard_installIncomplete_dependenciesLabel=Zależności
-installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 Pominięto konfiguracje bazowego adresu URL Jenkinsa. <br/><br/>\
 Aby go skonfigurować, przejdź do strony "Zarządzaj Jenkinsem".\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_pt_BR.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_pt_BR.properties
@@ -38,7 +38,7 @@ installWizard_error_connection=Incapaz de conectar ao Jenkins
 installWizard_installing_detailsLink=Detalhes...
 installWizard_gettingStarted_title=Começando
 installWizard_installIncomplete_title=Prosseguir com a instalação
-installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">Você pulou a configuração da \
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">Você pulou a configuração da \
   URL do Jenkins. <br/><br/>Para configurá-la, vá para a página "Gerenciar o Jenkins".</div>
 installWizard_installIncomplete_banner=Prosseguir com a instalação
 installWizard_welcomePanel_recommendedActionTitle=Instalar as extensões sugeridas
@@ -82,7 +82,7 @@ installWizard_installComplete_finishButtonLabel=Começar a usar o Jenkins
 installWizard_goInstall=Instalar
 installWizard_installCustom_selectNone=Nenhum
 installWizard_installComplete_title=Começar
-installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">Você pulou a <strong>configuração do \
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">Você pulou a <strong>configuração do \
   usuário admin</strong>. <br /><br />Para entrar, use o nome de usuário "admin" e a senha de administrador que você \
   usou para acessar o assistente de configuração.</div>
 installWizard_configureProxy_save=Salvar e continuar

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_sr.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_sr.properties
@@ -40,7 +40,7 @@ installWizard_installIncomplete_banner=Настави са инсталациј�
 installWizard_installIncomplete_message=
 installWizard_saveFirstUser=Сачувај и настави
 installWizard_skipFirstUser=Настави са администраторским налогом
-installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 Прескочили сте креирањем административог корисника. Пријавите се како што ће те користити име: 'admin' и лозинку коју сте користили инсталацијом.\
 </div>
 installWizard_addFirstUser_title=Почетак

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_sv_SE.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_sv_SE.properties
@@ -66,7 +66,7 @@ installWizard_installIncomplete_message=Jenkins startades om under installatione
 installWizard_installIncomplete_resumeInstallationButtonLabel=Återuppta
 installWizard_saveFirstUser=Spara och fortsätt
 installWizard_skipFirstUser=Hoppa över och fortsätt som administratör
-installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 Du har hoppat över <strong>installationen av en administratörsanvändare</strong>. <br /><br />\
 Använd användarnamnet "admin" och administratörslösenordet du använde för att komma åt installationsguiden för att logga in.\
 </div>
@@ -76,7 +76,7 @@ installWizard_addFirstUser_title=Kom igång
 installWizard_configureInstance_title=Konfigurera instans
 installWizard_saveConfigureInstance=Spara och avsluta
 installWizard_skipConfigureInstance=Inte nu
-installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 Du har hoppat över konfigurationen av Jenkins-webbadressen. <br/><br/>\
 Gå till sidan "Hantera Jenkins" för att konfigurera Jenkins-webbadressen.\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_zh_CN.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_zh_CN.properties
@@ -64,7 +64,7 @@ installWizard_installIncomplete_message=Jenkins在安装过程已重启，部分
 installWizard_installIncomplete_resumeInstallationButtonLabel=恢复
 installWizard_saveFirstUser=保存并完成
 installWizard_skipFirstUser=使用admin账户继续
-installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_firstUserSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 你已跳过创建admin用户的步骤。要登录请使用用户名：'admin' \
 及用于访问安装向导的管理员密码。\
 </div> 
@@ -74,7 +74,7 @@ installWizard_addFirstUser_title=新手入门
 installWizard_configureInstance_title=实例配置
 installWizard_saveConfigureInstance=保存并完成
 installWizard_skipConfigureInstance=现在不要
-installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning fade in">\
+installWizard_configureInstanceSkippedMessage=<div class="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">\
 您已经跳过了 Jenkins URL的配置。 <br/><br/>\
 要配置 Jenkins URL的话，到“Jenkins管理”页面。\
 </div>

--- a/core/src/main/resources/jenkins/install/pluginSetupWizard_zh_TW.properties
+++ b/core/src/main/resources/jenkins/install/pluginSetupWizard_zh_TW.properties
@@ -61,14 +61,14 @@ installWizard_installIncomplete_message=Jenkins 在安裝期間重新啟動，�
 installWizard_installIncomplete_resumeInstallationButtonLabel=繼續
 installWizard_saveFirstUser=儲存並繼續
 installWizard_skipFirstUser=跳過並以 admin 繼續
-installWizard_firstUserSkippedMessage=<div class\="jenkins-alert jenkins-alert-warning fade in">您已略過<strong>設定管理員使用者</strong>。<br /><br />請使用帳號：「admin」和您進入安裝精靈的管理員密碼登入。</div>
+installWizard_firstUserSkippedMessage=<div class\="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">您已略過<strong>設定管理員使用者</strong>。<br /><br />請使用帳號：「admin」和您進入安裝精靈的管理員密碼登入。</div>
 installWizard_addFirstUser_title=開始使用
 
 # instance configuration page
 installWizard_configureInstance_title=執行個體組態
 installWizard_saveConfigureInstance=儲存並完成
 installWizard_skipConfigureInstance=暫時不要
-installWizard_configureInstanceSkippedMessage=<div class\="jenkins-alert jenkins-alert-warning fade in">您已略過設定 Jenkins URL。<br/><br/>您之後可以到「管理 Jenkins」頁面設定 Jenkins URL。</div>
+installWizard_configureInstanceSkippedMessage=<div class\="jenkins-alert jenkins-alert-warning jenkins-!-margin-top-1 jenkins-!-margin-bottom-0 fade in">您已略過設定 Jenkins URL。<br/><br/>您之後可以到「管理 Jenkins」頁面設定 Jenkins URL。</div>
 
 installWizard_configureProxy_label=設定代理伺服器
 installWizard_configureProxy_save=儲存並繼續


### PR DESCRIPTION
## [JENKINS-73302] Restore margins around setup wizard alert messages

[JENKINS-73302](https://issues.jenkins.io/browse/JENKINS-73302) reports that when a user of the setup wizard skips the creation of a user and skips the assignment of the Jenkins URL, the two alert messages no longer have a margin between them.

This adds a top margin to each of the messages so that when two messages are displayed, there will be a margin between them.  Follows the same pattern of margin definition that is used elsewhere in Jenkins core.

### Testing done

Checked the visual display with 2 messages and with each message alone.

Confirmed that margins were already included in the "Manage Jenkins" page when the old data admin monitor and the deprecated plugins admin monitor are both displayed.  This change is not needed for the "Manage Jenkins" page, only for the setup wizard.

### Before 2.459

<img width="1389" alt="two-warnings-before" src="https://github.com/user-attachments/assets/bf5e3fc2-3081-471f-89fd-6d21be5944b5">

## After 2.459 and before the change

<img width="1392" alt="two-warnings-after-2 459" src="https://github.com/user-attachments/assets/d4860e98-223e-4b91-9934-065fbc6e4ec4">


### After the change

![two-warnings-on-setup-wizard](https://github.com/user-attachments/assets/0d5b2739-fefb-47a7-9ceb-d623eada45db)

### Single warning alert (user creation skipped)

![admin-user-skipped-setup](https://github.com/user-attachments/assets/ae8f6d3e-6ff1-4b70-9976-a116652215a4)

### Single warning alert (Jenkins URL skipped)

![Jenkins-url-skipped](https://github.com/user-attachments/assets/86b3d410-8dcd-4953-a6f1-a8bda0fa955a)

### Proposed changelog entries

- Restore margins around setup wizard alert messages (regression in 2.459).

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mawinter69

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
