### PR TITLE
Fix PathRemoverTest timeout in RISC-V devices.

### DIFF
--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -69,7 +69,7 @@ import org.jvnet.hudson.test.Issue;
 public class PathRemoverTest {
 
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
-    @Rule public Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
+    @Rule public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
     @Rule public FileLockerRule locker = new FileLockerRule();
 
     @Test


### PR DESCRIPTION
I am working in Arch Linux RISC-V port.  
RISC-V devices have extremely low performance, 10 seconds timeout in `PathRemoverTest` is too short to pass in these devices.  
After my test, changing it to 30 seconds can pass tests.  
That is a minor change, so I haven't created an issue in Jira.  

### Testing done

It simply increases the timeout and is tested in our compile machines.  

### Proposed changelog entries

- Increase timeout in `PathRemoverTest` for RISC-V devices.  

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

Sorry, I don't know which team should be mentioned.  

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
