### PR TITLE
Fix error message when creation of item by type is prohibited

### DIFF
--- a/core/src/main/java/hudson/security/ACL.java
+++ b/core/src/main/java/hudson/security/ACL.java
@@ -237,7 +237,7 @@ public abstract class ACL {
         }
         if (!hasCreatePermission2(a, c, d)) {
             throw new AccessDeniedException(Messages.AccessDeniedException2_MissingPermission(a.getName(),
-                    Item.CREATE.group.title + "/" + Item.CREATE.name + Item.CREATE + "/" + d.getDisplayName()));
+                    Item.CREATE.group.title + "/" + Item.CREATE.name + "/" + d.getDisplayName()));
         }
     }
     /**
@@ -290,7 +290,7 @@ public abstract class ACL {
         }
         if (!hasCreatePermission2(a, c, d)) {
             throw new AccessDeniedException(Messages.AccessDeniedException2_MissingPermission(a.getName(),
-                    View.CREATE.group.title + "/" + View.CREATE.name + View.CREATE + "/" + d.getDisplayName()));
+                    View.CREATE.group.title + "/" + View.CREATE.name + "/" + d.getDisplayName()));
         }
     }
 


### PR DESCRIPTION
Noticed this while looking at neighboring code for `matrix-auth` development and experimentally confirmed: The output here is weird.

<details><summary>Patch to matrix-auth since there seem to be no implementers</summary>

```diff
diff --git a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
index 14eae51..38eb9fc 100644
--- a/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
+++ b/src/main/java/hudson/security/GlobalMatrixAuthorizationStrategy.java
@@ -29,6 +29,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.PluginManager;
 import hudson.model.Descriptor;
+import hudson.model.FreeStyleProject;
+import hudson.model.ItemGroup;
+import hudson.model.TopLevelItemDescriptor;
 import hudson.model.User;
 import hudson.util.FormValidation;
 import java.io.IOException;
@@ -57,6 +60,7 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.springframework.security.core.Authentication;
 
 /**
  * Role-based authorization via a matrix.
@@ -121,6 +125,11 @@ public class GlobalMatrixAuthorizationStrategy extends AuthorizationStrategy imp
                     toString(p), permission, p instanceof PrincipalSid)) return true;
             return null;
         }
+
+        @Override
+        public boolean hasCreatePermission2(@NonNull Authentication a, @NonNull ItemGroup c, @NonNull TopLevelItemDescriptor d) {
+            return d.clazz != FreeStyleProject.class;
+        }
     }

```

</details>

### Testing done

Manual - before

<img width="980" alt="Screenshot 2024-08-26 at 17 58 24" src="https://github.com/user-attachments/assets/80e45977-4607-4949-9416-6a0c9e95733f">

Manual - after

<img width="641" alt="Screenshot 2024-08-26 at 18 06 36" src="https://github.com/user-attachments/assets/65a2acce-d7be-4291-9170-ae6f017f8e0c">

(I skipped a manual test of the `View` variant.)

Still not ideal, but that's more related to the localization message skipping quotation marks or other formatting than this message.

### Proposed changelog entries

- too minor

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
