### PR TITLE
Add -webSocket option by default when creating an inbound agent

### DIFF
--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -213,9 +213,7 @@ public class JNLPLauncher extends ComputerLauncher {
         sb.append("-name ");
         sb.append(computerName);
         sb.append(' ');
-        if (isWebSocket()) {
-            sb.append("-webSocket ");
-        }
+        sb.append("-webSocket ");
         if (tunnel != null) {
             sb.append(" -tunnel ");
             sb.append(tunnel);

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.properties
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.properties
@@ -26,7 +26,7 @@ slaveAgent.cli.run=Run from agent command line:
 slaveAgent.cli.run.secret=Or run from agent command line, with the secret stored in a file:
 powerShell.cli.curl=Note: PowerShell users must use curl.exe instead of curl because curl is a default PowerShell cmdlet alias for Invoke-WebRequest.
 commonOptions=\
-  The most commonly used option is <code>-webSocket</code>. \
+  If you want to use inbound TCP instead of websockets, remove <code>-webSocket</code> option. \
   Run <code>java -jar agent.jar -help</code> for more.
 tcp-port-disabled=\
   The TCP port is disabled so TCP agents may not be connected. \

--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.properties
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.properties
@@ -26,7 +26,7 @@ slaveAgent.cli.run=Run from agent command line:
 slaveAgent.cli.run.secret=Or run from agent command line, with the secret stored in a file:
 powerShell.cli.curl=Note: PowerShell users must use curl.exe instead of curl because curl is a default PowerShell cmdlet alias for Invoke-WebRequest.
 commonOptions=\
-  If you want to use inbound TCP instead of websockets, remove <code>-webSocket</code> option. \
+  If you prefer to use TCP instead of WebSockets, remove the <code>-webSocket</code> option. \
   Run <code>java -jar agent.jar -help</code> for more.
 tcp-port-disabled=\
   The TCP port is disabled so TCP agents may not be connected. \


### PR DESCRIPTION
This amends https://github.com/jenkinsci/jenkins/pull/8762 by making the webSocket connection method part of the connect string by default.

In case the inbound tcp support is disabled, the current default command doesn't work. So it makes more sense to make the websockets option part of the default command that is generated.

### Testing done

Ran a quick build, executed the war file, and confirmed that the new default command correctly connects the agent.

### Proposed changelog entries

- Use websocket in the inbound agent command line sample.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
