### PR TITLE
[JENKINS-73713] Do not filter params for completed run

### DIFF
--- a/core/src/main/java/hudson/model/ParametersAction.java
+++ b/core/src/main/java/hudson/model/ParametersAction.java
@@ -320,6 +320,10 @@ public class ParametersAction implements RunAction2, Iterable<ParameterValue>, Q
             return parameters;
         }
 
+        if (!this.run.isBuilding()) {
+            return parameters;
+        }
+
         if (this.parameterDefinitionNames == null) {
             return parameters;
         }


### PR DESCRIPTION
If the Run has already completed there is no need to filter the parameters. This avoids unnecessary warnings about skipped parameters when getting environment for runs that have already finished.

Fixes #16534

### Testing done

Tested manually and regression run.

### Proposed changelog entries

- Remove unnecessary warnings about skipped parameters

### Proposed upgrade guidelines

N/A