### PR TITLE
Compatibility for `ChainedServletFilter`

### DIFF
--- a/core/src/main/java/hudson/security/ChainedServletFilter2.java
+++ b/core/src/main/java/hudson/security/ChainedServletFilter2.java
@@ -24,41 +24,39 @@
 
 package hudson.security;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * Servlet {@link Filter} that chains multiple {@link Filter}s.
  *
  * @author Kohsuke Kawaguchi
- * @deprecated use {@link ChainedServletFilter2}
  */
-@Deprecated
-public class ChainedServletFilter implements Filter {
+public class ChainedServletFilter2 implements Filter {
     // array is assumed to be immutable once set
     protected volatile Filter[] filters;
 
-    public ChainedServletFilter() {
+    public ChainedServletFilter2() {
         filters = new Filter[0];
     }
 
-    public ChainedServletFilter(Filter... filters) {
+    public ChainedServletFilter2(Filter... filters) {
         this(Arrays.asList(filters));
     }
 
-    public ChainedServletFilter(Collection<? extends Filter> filters) {
+    public ChainedServletFilter2(Collection<? extends Filter> filters) {
         setFilters(filters);
     }
 
@@ -70,7 +68,7 @@ public class ChainedServletFilter implements Filter {
     public void init(FilterConfig filterConfig) throws ServletException {
         if (LOGGER.isLoggable(Level.FINEST))
             for (Filter f : filters)
-                LOGGER.finest("ChainedServletFilter contains: " + f);
+                LOGGER.finest("ChainedServletFilter2 contains: " + f);
 
         for (Filter f : filters)
             f.init(filterConfig);
@@ -87,7 +85,7 @@ public class ChainedServletFilter implements Filter {
         new FilterChain() {
             private int position = 0;
             // capture the array for thread-safety
-            private final Filter[] filters = ChainedServletFilter.this.filters;
+            private final Filter[] filters = ChainedServletFilter2.this.filters;
 
             @Override
             public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
@@ -120,5 +118,5 @@ public class ChainedServletFilter implements Filter {
             f.destroy();
     }
 
-    private static final Logger LOGGER = Logger.getLogger(ChainedServletFilter.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(ChainedServletFilter2.class.getName());
 }

--- a/core/src/main/java/hudson/security/LegacySecurityRealm.java
+++ b/core/src/main/java/hudson/security/LegacySecurityRealm.java
@@ -89,7 +89,7 @@ public final class LegacySecurityRealm extends SecurityRealm implements Authenti
         // when using container-authentication we can't hit /login directly.
         // we first have to hit protected /loginEntry, then let the container
         // trap that into /login.
-        return new ChainedServletFilter(filters);
+        return new ChainedServletFilter2(filters);
     }
 
     /**

--- a/core/src/main/java/hudson/security/SecurityRealm.java
+++ b/core/src/main/java/hudson/security/SecurityRealm.java
@@ -678,7 +678,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
         }
         filters.add(new RememberMeAuthenticationFilter(sc.manager2, sc.rememberMe2));
         filters.addAll(commonFilters());
-        return new ChainedServletFilter(filters);
+        return new ChainedServletFilter2(filters);
     }
 
     protected final List<Filter> commonFilters() {
@@ -781,7 +781,7 @@ public abstract class SecurityRealm extends AbstractDescribableImpl<SecurityReal
          */
         @Override
         public Filter createFilter(FilterConfig filterConfig) {
-            return new ChainedServletFilter();
+            return new ChainedServletFilter2();
         }
 
         /**


### PR DESCRIPTION
### Problem

As of #9672, `oic-auth` started failing with e.g.

```
java.lang.NoSuchMethodError: 'void hudson.security.ChainedServletFilter.<init>(javax.servlet.Filter[])'
        at org.jenkinsci.plugins.oic.OicSecurityRealm.createFilter(OicSecurityRealm.java:828)
        at hudson.security.SecurityRealm.createFilter(SecurityRealm.java:626)
        at hudson.security.HudsonFilter.reset(HudsonFilter.java:145)
        at jenkins.model.Jenkins.resetFilter(Jenkins.java:2820)
        at jenkins.model.Jenkins.setSecurityRealm(Jenkins.java:2802)
        at org.jenkinsci.plugins.oic.PluginTest.testLoginWithMissingIdTokenShouldBeRefused(PluginTest.java:911)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:706)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

I verified that Reverse Proxy Authentication is also affected:

```
java.lang.NoSuchMethodError: 'void hudson.security.ChainedServletFilter.<init>(javax.servlet.Filter[])'
	at org.jenkinsci.plugins.reverse_proxy_auth.ReverseProxySecurityRealm.createFilter(ReverseProxySecurityRealm.java:579)
	at hudson.security.SecurityRealm.createFilter(SecurityRealm.java:626)
	at hudson.security.HudsonFilter.reset(HudsonFilter.java:145)
	at jenkins.model.Jenkins.resetFilter(Jenkins.java:2820)
	at jenkins.model.Jenkins.setSecurityRealm(Jenkins.java:2802)
	at org.jenkinsci.plugins.reverse_proxy_auth.ReverseProxySecurityRealmTest.basicAuthenticate(ReverseProxySecurityRealmTest.java:52)
```

### Evaluation

`ChainedServletFilter` broke binary compatibility.

### Solution

Restore the original `ChainedServletFilter` (perfectly binary compatible) and add a new `ChainedServletFilter2` for Jakarta.

### Testing done

- CI build of this repository
- PCT: https://github.com/jenkinsci/bom/pull/3544 (reproduced issue before this PR, fixed after this PR). `build-user-vars` will need to be recompiled after this PR to pass PCT again, but I can take care of that easily once this is released.
- ATH: https://github.com/jenkinsci/acceptance-test-harness/pull/1701 (reproduced issue before this PR, fixed after this PR)

I also tested `reverse-proxy-auth-plugin` in PCT with 2.475, saw the failure mentioned above, and confirmed it was fixed with this PR. I will add `reverse-proxy-auth` to `jenkinsci/bom` once I finish adding `oic-auth`.

### Proposed changelog entries

Restore compatibility with the OpenId Connect Authentication and Reverse Proxy Authentication plugins (regression in 2.475).

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```

Fixes jenkinsci/oic-auth-plugin#387