### PR TITLE
[JENKINS-73768] Handle base=derived case in Util#isOverridden

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1526,7 +1526,7 @@ public class Util {
      */
     public static boolean isOverridden(@NonNull Class<?> base, @NonNull Class<?> derived, @NonNull String methodName, @NonNull Class<?>... types) {
         if (base == derived) {
-            // If base and derived are the same time, the method is not overridden by definition
+            // If base and derived are the same type, the method is not overridden by definition
             return false;
         }
         // If derived is not a subclass or implementor of base, it can't override any method

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1525,6 +1525,10 @@ public class Util {
      *                                  does not contain the specified method.
      */
     public static boolean isOverridden(@NonNull Class<?> base, @NonNull Class<?> derived, @NonNull String methodName, @NonNull Class<?>... types) {
+        if (base == derived) {
+            // If base and derived are the same time, the method is not overridden by definition
+            return false;
+        }
         // If derived is not a subclass or implementor of base, it can't override any method
         // Technically this should also be triggered when base == derived, because it can't override its own method, but
         // the unit tests explicitly test for that as working.

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import hudson.Util;
+import java.io.PrintWriter;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
@@ -52,6 +53,8 @@ public class IsOverriddenTest {
         assertTrue(Util.isOverridden(Base.class, Derived.class, "method"));
         assertTrue(Util.isOverridden(Base.class, Intermediate.class, "method"));
         assertFalse(Util.isOverridden(Base.class, Base.class, "method"));
+        assertFalse(Util.isOverridden(Throwable.class, Throwable.class, "printStackTrace", PrintWriter.class));
+        assertFalse(Util.isOverridden(Throwable.class, Exception.class, "printStackTrace", PrintWriter.class));
         assertTrue(Util.isOverridden(Base.class, Intermediate.class, "setX", Object.class));
         assertTrue(Util.isOverridden(Base.class, Intermediate.class, "getX"));
     }


### PR DESCRIPTION
See [JENKINS-73768](https://issues.jenkins.io/browse/JENKINS-73768).

It looks like https://github.com/jenkinsci/jenkins/pull/4833 does not properly consider the case where base == derived. Somehow the existing test coverage is insufficient, did not dig further into this yet.

I encountered this when looking at the system log and being surprised about exception output using "Caused by" rather than "Causes" when [what was thrown was a raw `Throwable`](https://github.com/jenkinsci/jenkins/blob/d5271c8d2f38a2ba8b1f9d8fcbb66070e5e5333d/core/src/main/java/hudson/Functions.java#L1813-L1818) in test code -- hence the choice of types in the test.

An alternative solution could be to change the last line to use `equals` instead of `!=`, but that seems more likely to have unintended consequences.

CC @Zastai in case you're still around/interested.

### Testing done

None.

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
