### PR TITLE
[JENKINS-73785] Restore `ContextMenu#from` with `StaplerRequest`/`Response` args

### DIFF
--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -299,6 +299,10 @@ public interface ModelObjectWithContextMenu extends ModelObject {
             return from(self, request, response, "sidepanel");
         }
 
+        public ContextMenu from(ModelObjectWithContextMenu self, StaplerRequest request, StaplerResponse response) throws JellyException, IOException {
+            return from(self, StaplerRequest.toStaplerRequest2(request), StaplerResponse.toStaplerResponse2(response), "sidepanel");
+        }
+
         public ContextMenu from(ModelObjectWithContextMenu self, StaplerRequest2 request, StaplerResponse2 response, String view) throws JellyException, IOException {
             WebApp webApp = WebApp.getCurrent();
             final Script s = webApp.getMetaClass(self).getTearOff(JellyClassTearOff.class).findScript(view);


### PR DESCRIPTION
See [JENKINS-73785](https://issues.jenkins.io/browse/JENKINS-73785).

### Testing done

Manual. Before, log message from the JENKINS issue, and:

<img width="180" alt="Screenshot 2024-09-16 at 18 47 10" src="https://github.com/user-attachments/assets/5be170f1-c906-4fb0-be87-9d2661ed2922">

After: No log message, and:

<img width="379" alt="Screenshot 2024-09-16 at 18 43 40" src="https://github.com/user-attachments/assets/07afa86c-7823-4022-a278-720e759a53c5">

### Usage

usage-in-plugins with

```
jenkins.model.ModelObjectWithContextMenu$ContextMenu#from
jenkins.model.ModelObjectWithContextMenu.ContextMenu#from
```

find these plugins:

* https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/blob/8cdf04c9998d8d6bfcdefb0fea7ef94c6522167e/src/main/java/com/atlassian/bitbucket/jenkins/internal/jenkins/oauth/consumer/OAuthConsumerUpdateAction.java#L53
* https://github.com/jenkinsci/design-library-plugin/blob/61719374986ba42d8b47a0be0d2f37b447671b9f/src/main/java/io/jenkins/plugins/designlibrary/Links.java#L26
* https://github.com/jenkinsci/nested-view-plugin/blob/78604f54b610dba7f831da4cf650ae6e12f62c1f/src/main/java/hudson/plugins/nested_view/NestedView.java#L130

So it seems safe to not provide a compatibility overload for the 4-arg method.

### Proposed changelog entries

Restore compatibility with plugins contributing new objects with context menus, like Nested Views plugin. (regression in 2.475)

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
