### PR TITLE
Clean up a few plain `e.printStackTrace()` calls

### DIFF
--- a/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsInstallerLink.java
@@ -226,7 +226,7 @@ public class WindowsInstallerLink extends ManagementLink {
                                         new File(installationDir, "jenkins.exe"), "start", task, installationDir);
                                 task.getLogger().println(r == 0 ? "Successfully started" : "start service failed. Exit code=" + r);
                             } catch (IOException | InterruptedException e) {
-                                e.printStackTrace();
+                                LOGGER.log(Level.WARNING, null, e);
                             }
                         }
 
@@ -241,7 +241,7 @@ public class WindowsInstallerLink extends ManagementLink {
                     Jenkins.get().cleanUp();
                     System.exit(0);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    LOGGER.log(Level.SEVERE, null, e);
                 }
             }
         }.start();

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -434,7 +434,7 @@ public abstract class AbstractItem extends Actionable implements Loadable, Item,
                             Util.deleteRecursive(oldRoot);
                         } catch (IOException e) {
                             // but ignore the error, since we expect that
-                            LOGGER.log(Level.FINEST, "Ignoring IOException while deleting", e);
+                            LOGGER.log(Level.WARNING, "Ignoring IOException while deleting", e);
                         }
                     }
 

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -434,7 +434,7 @@ public abstract class AbstractItem extends Actionable implements Loadable, Item,
                             Util.deleteRecursive(oldRoot);
                         } catch (IOException e) {
                             // but ignore the error, since we expect that
-                            e.printStackTrace();
+                            LOGGER.log(Level.FINEST, "Ignoring IOException while deleting", e);
                         }
                     }
 

--- a/core/src/main/java/hudson/model/ViewJob.java
+++ b/core/src/main/java/hudson/model/ViewJob.java
@@ -236,14 +236,23 @@ public abstract class ViewJob<JobT extends ViewJob<JobT, RunT>, RunT extends Run
         @Override
         public void run() {
             while (!terminating()) {
+                String jobName = null;
                 try {
-                    getNext()._reload();
+                    var next = getNext();
+                    jobName = next.getFullName();
+                    next._reload();
+                    jobName = null;
                 } catch (InterruptedException e) {
                     // treat this as a death signal
                     return;
-                } catch (Throwable t) {
+                } catch (Exception e) {
                     // otherwise ignore any error
-                    t.printStackTrace();
+                    if (jobName != null) {
+                        var finalJobName = jobName;
+                        LOGGER.log(Level.FINEST, e, () -> "Failed to reload job " + finalJobName);
+                    } else {
+                        LOGGER.log(Level.FINEST, e, () -> "Failed to obtain next job in the reload queue");
+                    }
                 }
             }
         }

--- a/core/src/main/java/hudson/model/ViewJob.java
+++ b/core/src/main/java/hudson/model/ViewJob.java
@@ -249,9 +249,9 @@ public abstract class ViewJob<JobT extends ViewJob<JobT, RunT>, RunT extends Run
                     // otherwise ignore any error
                     if (jobName != null) {
                         var finalJobName = jobName;
-                        LOGGER.log(Level.FINEST, e, () -> "Failed to reload job " + finalJobName);
+                        LOGGER.log(Level.WARNING, e, () -> "Failed to reload job " + finalJobName);
                     } else {
-                        LOGGER.log(Level.FINEST, e, () -> "Failed to obtain next job in the reload queue");
+                        LOGGER.log(Level.WARNING, e, () -> "Failed to obtain next job in the reload queue");
                     }
                 }
             }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5631,7 +5631,8 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if (is != null)
                 props.load(is);
         } catch (IOException e) {
-            e.printStackTrace(); // if the version properties is missing, that's OK.
+            // if the version properties is missing, that's OK.
+            LOGGER.log(Level.FINEST, e, () -> "Failed to load jenkins-version.properties");
         }
         String ver = props.getProperty("version");
         if (ver == null)   ver = UNCOMPUTED_VERSION;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5631,8 +5631,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             if (is != null)
                 props.load(is);
         } catch (IOException e) {
-            // if the version properties is missing, that's OK.
-            LOGGER.log(Level.FINEST, e, () -> "Failed to load jenkins-version.properties");
+            LOGGER.log(Level.WARNING, e, () -> "Failed to load jenkins-version.properties");
         }
         String ver = props.getProperty("version");
         if (ver == null)   ver = UNCOMPUTED_VERSION;


### PR DESCRIPTION
And use logger with appropriate severity instead.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
