### PR TITLE
[JENKINS-73760] Updates fail due to invalid JSON from HTTP Update Center

### DIFF
--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -538,14 +538,17 @@ public class UpdateSite {
 
     /**
      * Is this the legacy default update center site?
-     * @deprecated
-     *      Will be removed, currently returns always false.
-     * @since 2.343
+     * @since 1.357
      */
-    @Deprecated
     @Restricted(NoExternalUse.class)
     public boolean isLegacyDefault() {
-        return false;
+        return isJenkinsCI();
+    }
+
+    private boolean isJenkinsCI() {
+        return url != null
+                && UpdateCenter.PREDEFINED_UPDATE_SITE_ID.equals(id)
+                && url.startsWith("http://updates.jenkins-ci.org/");
     }
 
     /**

--- a/test/src/test/java/hudson/model/UpdateCenterMigrationTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterMigrationTest.java
@@ -1,0 +1,35 @@
+package hudson.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+public class UpdateCenterMigrationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule() {
+        @Override
+        protected void configureUpdateCenter() {
+            // Avoid reverse proxy
+            DownloadService.neverUpdate = true;
+            UpdateSite.neverUpdate = true;
+        }
+    };
+
+    @Issue("JENKINS-73760")
+    @LocalData
+    @Test
+    public void updateCenterMigration() {
+        UpdateSite site = j.jenkins.getUpdateCenter().getSites().stream()
+                .filter(s -> UpdateCenter.PREDEFINED_UPDATE_SITE_ID.equals(s.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertFalse(site.isLegacyDefault());
+        assertEquals(j.jenkins.getUpdateCenter().getDefaultBaseUrl() + "update-center.json", site.getUrl());
+    }
+}

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -72,6 +72,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class UpdateSiteTest {
@@ -203,6 +204,19 @@ public class UpdateSiteTest {
         overrideUpdateSite(site);
         assertEquals("number of warnings", 7, site.getData().getWarnings().size());
         assertNotEquals("plugin data is present", Collections.emptyMap(), site.getData().plugins);
+    }
+
+    @Issue("JENKINS-73760")
+    @Test
+    public void isLegacyDefault() {
+        assertFalse("isLegacyDefault should be false with null id", new UpdateSite(null, "url").isLegacyDefault());
+        assertFalse(
+                "isLegacyDefault should be false when id is not default and url is http://updates.jenkins-ci.org/",
+                new UpdateSite("dummy", "http://updates.jenkins-ci.org/").isLegacyDefault());
+        assertTrue(
+                "isLegacyDefault should be true when id is default and url is http://updates.jenkins-ci.org/",
+                new UpdateSite(UpdateCenter.PREDEFINED_UPDATE_SITE_ID, "http://updates.jenkins-ci.org/").isLegacyDefault());
+        assertFalse("isLegacyDefault should be false with null url", new UpdateSite(null, null).isLegacyDefault());
     }
 
     @Test public void getAvailables() throws Exception {

--- a/test/src/test/resources/hudson/model/UpdateCenterMigrationTest/updateCenterMigration/hudson.model.UpdateCenter.xml
+++ b/test/src/test/resources/hudson/model/UpdateCenterMigrationTest/updateCenterMigration/hudson.model.UpdateCenter.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sites>
+  <site>
+    <id>default</id>
+    <url>http://updates.jenkins-ci.org/update-center.json</url>
+  </site>
+</sites>


### PR DESCRIPTION
See [JENKINS-73760](https://issues.jenkins.io/browse/JENKINS-73760). Partial revert of #6116, which deprecated/removed useful functionality (the ability to migrate old update sites to new ones). #2996 should have used this subsystem but did not, resulting in [JENKINS-73760](https://issues.jenkins.io/browse/JENKINS-73760). This PR restores the subsystem and correctly applies it to #2996 to complete the migration from http://updates.jenkins-ci.org to https://updates.jenkins.io which was begun in 2017.

### Testing done

New unit tests.

### Proposed changelog entries

Migrate from http://updates.jenkins-ci.org to https://updates.jenkins.io when the initial installation version was 2.76 or older.

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
