### PR TITLE
Be more explicit about not being logged in on 404 error page

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/_404.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_404.jelly
@@ -44,6 +44,9 @@ THE SOFTWARE.
 	                    <j:choose>
 	                        <j:when test="${app.useSecurity}">
                                 ${%noAccess}
+                                <j:if test="${h.isAnonymous()}">
+                                    ${%tryLoggingIn}
+                                </j:if>
 		                    </j:when>
 		                    <j:otherwise>
 		                        ${%notFound}

--- a/core/src/main/resources/jenkins/model/Jenkins/_404.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/_404.properties
@@ -1,3 +1,4 @@
 title = {0}
 noAccess = This page may not exist, or you may not have permission to see it.
+tryLoggingIn = If you have an account, try logging in.
 notFound = This page does not exist.


### PR DESCRIPTION
A recent comment in https://issues.jenkins.io/browse/JENKINS-21813 (which IMO was taken care of by https://github.com/jenkinsci/jenkins/pull/8250) brought up that it's not really easy to tell you're not logged in, just a difference in the header.

So this makes that more obvious. Suggestions for wording welcome.

### Testing done


####  Before

https://ci.jenkins.io/lol

#### After

> <img width="1054" alt="Screenshot 2024-09-20 at 20 09 15" src="https://github.com/user-attachments/assets/5bdd4d18-c198-4c5c-9873-616394a85f88">

### Proposed changelog entries

Too minor?

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
