### PR TITLE
Add form validation warnings for parameter names matching known env vars

### DIFF
--- a/core/src/main/java/hudson/model/BooleanParameterDefinition.java
+++ b/core/src/main/java/hudson/model/BooleanParameterDefinition.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import java.util.Objects;
+import jenkins.model.EnvironmentVariableParameterNameFormValidation;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -125,7 +126,7 @@ public class BooleanParameterDefinition extends SimpleParameterDefinition {
     // unlike all the other ParameterDescriptors, using 'booleanParam' as the primary
     // to avoid picking the Java reserved word "boolean" as the primary identifier
     @Extension @Symbol("booleanParam")
-    public static class DescriptorImpl extends ParameterDescriptor {
+    public static class DescriptorImpl extends ParameterDescriptor implements EnvironmentVariableParameterNameFormValidation {
         @NonNull
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
+++ b/core/src/main/java/hudson/model/ChoiceParameterDefinition.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import jenkins.model.EnvironmentVariableParameterNameFormValidation;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -202,7 +203,7 @@ public class ChoiceParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Extension @Symbol({"choice", "choiceParam"})
-    public static class DescriptorImpl extends ParameterDescriptor {
+    public static class DescriptorImpl extends ParameterDescriptor implements EnvironmentVariableParameterNameFormValidation {
         @NonNull
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/FileParameterDefinition.java
+++ b/core/src/main/java/hudson/model/FileParameterDefinition.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Objects;
+import jenkins.model.EnvironmentVariableParameterNameFormValidation;
 import net.sf.json.JSONObject;
 import org.apache.commons.fileupload2.core.FileItem;
 import org.apache.commons.io.FileUtils;
@@ -73,7 +74,7 @@ public class FileParameterDefinition extends ParameterDefinition {
     }
 
     @Extension @Symbol({"file", "fileParam"})
-    public static class DescriptorImpl extends ParameterDescriptor {
+    public static class DescriptorImpl extends ParameterDescriptor implements EnvironmentVariableParameterNameFormValidation {
         @NonNull
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/PasswordParameterDefinition.java
+++ b/core/src/main/java/hudson/model/PasswordParameterDefinition.java
@@ -30,6 +30,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.util.Secret;
 import java.util.Objects;
+import jenkins.model.EnvironmentVariableParameterNameFormValidation;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -137,7 +138,7 @@ public class PasswordParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Extension @Symbol("password")
-    public static final class ParameterDescriptorImpl extends ParameterDescriptor {
+    public static final class ParameterDescriptorImpl extends ParameterDescriptor implements EnvironmentVariableParameterNameFormValidation {
         @NonNull
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -32,6 +32,7 @@ import hudson.util.EnumConverter;
 import hudson.util.RunList;
 import java.util.Objects;
 import java.util.logging.Logger;
+import jenkins.model.EnvironmentVariableParameterNameFormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
@@ -142,7 +143,7 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Extension @Symbol({"run", "runParam"})
-    public static class DescriptorImpl extends ParameterDescriptor {
+    public static class DescriptorImpl extends ParameterDescriptor implements EnvironmentVariableParameterNameFormValidation {
         @NonNull
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/StringParameterDefinition.java
+++ b/core/src/main/java/hudson/model/StringParameterDefinition.java
@@ -30,6 +30,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import java.util.Objects;
+import jenkins.model.EnvironmentVariableParameterNameFormValidation;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -133,7 +134,7 @@ public class StringParameterDefinition extends SimpleParameterDefinition {
     }
 
     @Extension @Symbol({"string", "stringParam"})
-    public static class DescriptorImpl extends ParameterDescriptor {
+    public static class DescriptorImpl extends ParameterDescriptor implements EnvironmentVariableParameterNameFormValidation {
         @Override
         @NonNull
         public String getDisplayName() {

--- a/core/src/main/java/hudson/model/TextParameterDefinition.java
+++ b/core/src/main/java/hudson/model/TextParameterDefinition.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import java.util.Objects;
+import jenkins.model.EnvironmentVariableParameterNameFormValidation;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -54,7 +55,7 @@ public class TextParameterDefinition extends StringParameterDefinition {
     }
 
     @Extension @Symbol({"text", "textParam"})
-    public static class DescriptorImpl extends ParameterDescriptor {
+    public static class DescriptorImpl extends ParameterDescriptor implements EnvironmentVariableParameterNameFormValidation {
         @NonNull
         @Override
         public String getDisplayName() {

--- a/core/src/main/java/jenkins/model/EnvironmentVariableParameterNameFormValidation.java
+++ b/core/src/main/java/jenkins/model/EnvironmentVariableParameterNameFormValidation.java
@@ -1,0 +1,46 @@
+package jenkins.model;
+
+import hudson.util.FormValidation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.util.SystemProperties;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * Convenient interface adding form validation for parameter 'name' fields, emitting a warning if it case-insensitively matches a known environment variable causing trouble during the build.
+ * <p>
+ *     This is intended to check for accidental name matches (in particular given Jenkins's case insensitive behavior), rather than intentional matches.
+ *     Someone who wants to set LD_PRELOAD or DYLD_LIBRARY_PATH does so intentionally.
+ * </p>
+ *
+ * @since TODO
+ */
+public interface EnvironmentVariableParameterNameFormValidation {
+    default FormValidation doCheckName(@QueryParameter String value) {
+        if (Configuration.DISCOURAGED_NAMES.contains(value)) {
+            return FormValidation.warning(Messages.ParameterNameFormValidation_Warning(value));
+        }
+        return FormValidation.ok();
+    }
+
+    @Restricted(NoExternalUse.class)
+    class Configuration {
+        private static final Logger LOGGER = Logger.getLogger(EnvironmentVariableParameterNameFormValidation.class.getName());
+        private static final String NAMES = SystemProperties.getString(EnvironmentVariableParameterNameFormValidation.class.getName() + ".NAMES", "HOME,PATH,USER");
+
+        private static final Collection<String> DISCOURAGED_NAMES = new TreeSet<>(String::compareToIgnoreCase);
+
+        static {
+            final List<String> names = new ArrayList<>(Arrays.stream(NAMES.split(",")).map(String::trim).toList());
+            LOGGER.log(Level.CONFIG, () -> "Setting environment variable names causing form validation warnings: " + names);
+            DISCOURAGED_NAMES.addAll(names);
+        }
+    }
+}

--- a/core/src/main/resources/hudson/model/BooleanParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/BooleanParameterDefinition/config.jelly
@@ -26,8 +26,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:entry title="${%Name}" help="/help/parameter/name.html">
-		<f:textbox name="parameter.name" value="${instance.name}" />
+    <f:entry field="name" title="${%Name}" help="/help/parameter/name.html">
+		<f:textbox />
 	</f:entry>
     <f:entry field="boolean-default">
 	    <f:checkbox title="${%Set by Default}" name="parameter.defaultValue" checked="${instance.defaultValue}" />

--- a/core/src/main/resources/hudson/model/ChoiceParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/ChoiceParameterDefinition/config.jelly
@@ -26,8 +26,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:entry title="${%Name}" help="/help/parameter/name.html">
-		<f:textbox name="parameter.name" value="${instance.name}" />
+    <f:entry field="name" title="${%Name}" help="/help/parameter/name.html">
+		<f:textbox />
 	</f:entry>
 	<f:entry title="${%Choices}" help="/help/parameter/choice-choices.html">
 		<f:textarea checkUrl="${rootURL}/descriptorByName/hudson.model.ChoiceParameterDefinition/checkChoices" checkDependsOn="" name="parameter.choices" value="${instance.choicesText}" />

--- a/core/src/main/resources/hudson/model/FileParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/FileParameterDefinition/config.jelly
@@ -26,8 +26,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${%File location}" help="/help/parameter/file-name.html">
-		<f:textbox name="parameter.name" value="${instance.name}" />
+	<f:entry field="name" title="${%File location}" help="/help/parameter/file-name.html">
+		<f:textbox />
 	</f:entry>
 	<!--f:entry>
                <f:checkbox title="Optional" name="parameter.optional" value="${instance.optional}" />

--- a/core/src/main/resources/hudson/model/PasswordParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/PasswordParameterDefinition/config.jelly
@@ -26,8 +26,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:entry title="${%Name}" help="/help/parameter/name.html">
-		<f:textbox name="parameter.name" value="${instance.name}" />
+    <f:entry field="name" title="${%Name}" help="/help/parameter/name.html">
+		<f:textbox />
 	</f:entry>
 	<f:entry field="defaultValueAsSecret" title="${%Default Value}" help="/help/parameter/string-default.html">
 		<f:password />

--- a/core/src/main/resources/hudson/model/RunParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/RunParameterDefinition/config.jelly
@@ -26,8 +26,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${%Name}" help="/help/parameter/name.html">
-		<f:textbox name="parameter.name" value="${instance.name}" />
+	<f:entry field="name" title="${%Name}" help="/help/parameter/name.html">
+		<f:textbox />
 	</f:entry>
 	<f:entry title="${%Project}" help="/help/parameter/run-project.html">
             <f:textbox name="parameter.projectName" value="${instance.projectName}" autoCompleteField="projectName"/>

--- a/core/src/main/resources/hudson/model/StringParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/StringParameterDefinition/config.jelly
@@ -26,8 +26,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:entry title="${%Name}" help="/help/parameter/name.html">
-		<f:textbox name="parameter.name" value="${instance.name}" />
+    <f:entry field="name" title="${%Name}" help="/help/parameter/name.html">
+		<f:textbox />
 	</f:entry>
 	<f:entry title="${%Default Value}" help="/help/parameter/string-default.html">
 		<f:textbox name="parameter.defaultValue" value="${instance.defaultValue}" />

--- a/core/src/main/resources/hudson/model/TextParameterDefinition/config.jelly
+++ b/core/src/main/resources/hudson/model/TextParameterDefinition/config.jelly
@@ -26,8 +26,8 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${%Name}" help="/help/parameter/name.html">
-		<f:textbox name="parameter.name" value="${instance.name}" />
+	<f:entry field="name" title="${%Name}" help="/help/parameter/name.html">
+		<f:textbox />
 	</f:entry>
 	<f:entry title="${%Default Value}" help="/help/parameter/string-default.html">
 		<f:textarea name="parameter.defaultValue" value="${instance.defaultValue}" />

--- a/core/src/main/resources/jenkins/model/Messages.properties
+++ b/core/src/main/resources/jenkins/model/Messages.properties
@@ -80,3 +80,6 @@ BuiltInNodeMigration.DisplayName=Built-In Node Name and Label Migration
 
 SimpleGlobalBuildDiscarderStrategy.displayName=Specific Build Discarder
 JobGlobalBuildDiscarderStrategy.displayName=Project Build Discarder
+
+ParameterNameFormValidation.Warning=Use of the parameter name "{0}" is discouraged. \
+  This parameter creates or replaces an environment variable of the same name, and changing that environment variable is likely to result in unexpected behavior.


### PR DESCRIPTION
> <img width="1314" alt="Screenshot 2024-09-23 at 10 12 02" src="https://github.com/user-attachments/assets/7df17bd0-7122-4110-b144-71d56dd79376">

I considered putting this directly in `ParameterDescriptor`, but I think that parameters don't have to create env vars matching their name, so making this opt in is pragmatic IMO.

### Testing done

Manual only so far, PR build to see whether the Jelly changes work.

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
