### PR TITLE
Avoid saving `nextBuildNumber` while loading `Job`

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -221,29 +221,20 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
         TextFile f = getNextBuildNumberFile();
         if (f.exists()) {
-            // starting 1.28, we store nextBuildNumber in a separate file.
-            // but old Hudson didn't do it, so if the file doesn't exist,
-            // assume that nextBuildNumber was read from config.xml
             try {
                 synchronized (this) {
                     this.nextBuildNumber = Integer.parseInt(f.readTrim());
                 }
             } catch (NumberFormatException e) {
                 LOGGER.log(Level.WARNING, "Corruption in {0}: {1}", new Object[] {f, e});
-                //noinspection StatementWithEmptyBody
-                if (this instanceof LazyBuildMixIn.LazyLoadingJob) {
-                    // allow LazyBuildMixIn.onLoad to fix it
-                } else {
-                    RunT lB = getLastBuild();
-                    synchronized (this) {
-                        this.nextBuildNumber = lB != null ? lB.getNumber() + 1 : 1;
-                    }
-                    saveNextBuildNumber();
+                RunT lB = getLastBuild();
+                synchronized (this) {
+                    this.nextBuildNumber = lB != null ? lB.getNumber() + 1 : 1;
                 }
+                saveNextBuildNumber();
             }
-        } else {
-            // From the old Hudson, or doCreateItem. Create this file now.
-            saveNextBuildNumber();
+        } else if (nextBuildNumber == 0) {
+            nextBuildNumber = 1;
         }
 
         if (properties == null) // didn't exist < 1.72

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -109,8 +109,8 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
         int max = _builds.maxNumberOnDisk();
         int next = asJob().getNextBuildNumber();
         if (next <= max) {
-            LOGGER.log(Level.WARNING, "JENKINS-27530: improper nextBuildNumber {0} detected in {1} with highest build number {2}; adjusting", new Object[] {next, asJob(), max});
-            asJob().updateNextBuildNumber(max + 1);
+            LOGGER.log(Level.FINE, "nextBuildNumber {0} detected in {1} with highest build number {2}; adjusting", new Object[] {next, asJob(), max});
+            asJob().fastUpdateNextBuildNumber(max + 1);
         }
         RunMap<RunT> currentBuilds = this.builds;
         if (parent != null) {


### PR DESCRIPTION
I spent a while looking into a semi-reproducible test failure affecting CloudBees CI running in high availability mode. The scenario involves a job being created and then a build immediately being scheduled; `config.xml` is created and then `nextBuildNumber` is created shortly thereafter. If another process is loading the job in between, it can attempt to write out `nextBuildNumber` itself, despite not actually running any build of the job. The details are probably not relevant to OSS Jenkins users but the essential guideline is that you should not be writing files _to_ disk just because you are loading some configuration _from_ disk, at least not without a good reason. The file should be written only if and when a build is scheduled; its absence should be treated as an implicit value of 1. (`lastBuildNumber` with an implicit value of 0 would perhaps have been more intuitive.)

I did keep the clause which recomputes and writes out `nextBuildNumber` in case the file existed but was corrupt (not parsable as an integer), since otherwise you might be printing an error on every Jenkins startup, if the job is never built again.

### Testing done

Seems to resolve a timing-dependent test failure observed in CloudBees CI proprietary code.

### Proposed changelog entries

N/A, likely not interesting.

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
