### PR TITLE
Account for new Maven version requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This page provides information about contributing code to the Jenkins core codeb
 3. Install the necessary development tools. In order to develop Jenkins, you need the following:
    - Java Development Kit (JDK) 17 or 21.
      In the Jenkins project we usually use [Eclipse Temurin](https://adoptium.net/) or [OpenJDK](https://openjdk.java.net/), but you can use other JDKs as well.
-   - Apache Maven 3.8.1 or above. You can [download Maven here](https://maven.apache.org/download.cgi).
+   - Apache Maven 3.9.6 or above. You can [download Maven here](https://maven.apache.org/download.cgi).
      In the Jenkins project we usually use the most recent Maven release.
    - Any IDE which supports importing Maven projects.
 4. Set up your development environment as described in [Preparing for Plugin Development](https://www.jenkins.io/doc/developer/tutorial/prepare/)


### PR DESCRIPTION
Jenkins fails to build with Maven 3.8.1 now it seems - update the documentation to reflect that 3.9.6 is now required per a recent change in maven-hpi-plugin.

### Testing done

Tried building the project with `mvn -am -pl war,bom -Pquick-build clean install` using Maven 3.8.7 as packaged with Debian bookworm after creating a settings.xml as suggested in the documentation. Worked fine up until about a week ago, which seems to align with:
https://github.com/jenkinsci/maven-hpi-plugin/commit/a5f524a6dbb8738c3087ca7bc097a0e4cb89a0e3

Repeated previous build steps using Maven 3.9.9 with success.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Desired reviewers

N/A

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
