### PR TITLE
 Override the outdated managed dependency on `asm` in `guice-parent`

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -352,6 +352,12 @@ THE SOFTWARE.
         <artifactId>stapler-groovy</artifactId>
         <version>${stapler.version}</version>
       </dependency>
+      <!-- Override the outdated managed dependency on asm in guice-parent -->
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.7</version>
+      </dependency>
       <dependency>
         <groupId>org.samba.jcifs</groupId>
         <artifactId>jcifs</artifactId>


### PR DESCRIPTION
Amends #9182 to reduce our exposure to jenkinsci/plugin-pom#1032. Today, `jenkins-bom` is delivering a managed dependency on `asm` 9.5, coming from Guice. While it is bad that we deliver any reference to ASM from `jenkins-bom`, it is even worse that we deliver an old one. This overrides the old version to a more recent one, which is a strict improvement over the status quo. It is not a complete long-term solution to the problem, but it will surely not make things any worse than they are today, and will make them better in some cases.

### Testing done

https://github.com/jenkinsci/workflow-job-plugin/pull/471 exhibits the problem before this PR and passes after this PR.

### Deployment plan

I plan to backport this to 2.479.1 LTS. Until that is generally available, I will re-introduce a workaround in `plugin-pom` (effectively reverting https://github.com/jenkinsci/plugin-pom/issues/918 for a few weeks).

### Proposed changelog entries

Developer: Prevent an old version of ASM from appearing as a managed dependency in plugin builds.

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
