### PR TITLE
Backporting for 2.479.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -352,6 +352,12 @@ THE SOFTWARE.
         <artifactId>stapler-groovy</artifactId>
         <version>${stapler.version}</version>
       </dependency>
+      <!-- Override the outdated managed dependency on asm in guice-parent -->
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.7</version>
+      </dependency>
       <dependency>
         <groupId>org.samba.jcifs</groupId>
         <artifactId>jcifs</artifactId>

--- a/core/src/main/java/hudson/model/UpdateSite.java
+++ b/core/src/main/java/hudson/model/UpdateSite.java
@@ -538,14 +538,17 @@ public class UpdateSite {
 
     /**
      * Is this the legacy default update center site?
-     * @deprecated
-     *      Will be removed, currently returns always false.
-     * @since 2.343
+     * @since 1.357
      */
-    @Deprecated
     @Restricted(NoExternalUse.class)
     public boolean isLegacyDefault() {
-        return false;
+        return isJenkinsCI();
+    }
+
+    private boolean isJenkinsCI() {
+        return url != null
+                && UpdateCenter.PREDEFINED_UPDATE_SITE_ID.equals(id)
+                && url.startsWith("http://updates.jenkins-ci.org/");
     }
 
     /**

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -949,9 +949,28 @@ public abstract class View extends AbstractModelObject implements AccessControll
 
     /**
      * Accepts {@code config.xml} submission, as well as serve it.
+     *
+     * @since 2.475
      */
     @WebMethod(name = "config.xml")
     public HttpResponse doConfigDotXml(StaplerRequest2 req) throws IOException {
+        if (Util.isOverridden(View.class, getClass(), "doConfigDotXml", StaplerRequest.class)) {
+            return doConfigDotXml(StaplerRequest.fromStaplerRequest2(req));
+        } else {
+            return doConfigDotXmlImpl(req);
+        }
+    }
+
+    /**
+     * @deprecated use {@link #doConfigDotXml(StaplerRequest2)}
+     */
+    @Deprecated
+    @StaplerNotDispatchable
+    public HttpResponse doConfigDotXml(StaplerRequest req) throws IOException {
+        return doConfigDotXmlImpl(StaplerRequest.toStaplerRequest2(req));
+    }
+
+    private HttpResponse doConfigDotXmlImpl(StaplerRequest2 req) throws IOException {
         if (req.getMethod().equals("GET")) {
             // read
             checkPermission(READ);

--- a/core/src/main/java/jenkins/cli/SafeRestartCommand.java
+++ b/core/src/main/java/jenkins/cli/SafeRestartCommand.java
@@ -32,6 +32,7 @@ import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.args4j.Option;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Safe Restart Jenkins - do not accept any new jobs and try to pause existing.
@@ -53,7 +54,7 @@ public class SafeRestartCommand extends CLICommand {
 
     @Override
     protected int run() throws Exception {
-        Jenkins.get().doSafeRestart(null, message);
+        Jenkins.get().doSafeRestart((StaplerRequest2) null, message);
         return 0;
     }
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4665,7 +4665,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Queues up a safe restart of Jenkins. Jobs have to finish or pause before it can proceed. No new jobs are accepted.
      *
-     * @since 2.414
+     * @since 2.475
      */
     public HttpResponse doSafeRestart(StaplerRequest2 req, @QueryParameter("message") String message) throws IOException, ServletException, RestartNotSupportedException {
         checkPermission(MANAGE);
@@ -4682,6 +4682,20 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         }
 
         return HttpResponses.redirectToDot();
+    }
+
+    /**
+     * @deprecated use {@link #doSafeRestart(StaplerRequest2, String)}
+     * @since 2.414
+     */
+    @Deprecated
+    @StaplerNotDispatchable
+    public HttpResponse doSafeRestart(StaplerRequest req, @QueryParameter("message") String message) throws IOException, javax.servlet.ServletException, RestartNotSupportedException {
+        try {
+            return doSafeRestart(StaplerRequest.toStaplerRequest2(req), message);
+        } catch (ServletException e) {
+            throw ServletExceptionWrapper.fromJakartaServletException(e);
+        }
     }
 
     private static Lifecycle restartableLifecycle() throws RestartNotSupportedException {

--- a/test/src/test/java/hudson/model/UpdateCenterMigrationTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterMigrationTest.java
@@ -1,0 +1,35 @@
+package hudson.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+public class UpdateCenterMigrationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule() {
+        @Override
+        protected void configureUpdateCenter() {
+            // Avoid reverse proxy
+            DownloadService.neverUpdate = true;
+            UpdateSite.neverUpdate = true;
+        }
+    };
+
+    @Issue("JENKINS-73760")
+    @LocalData
+    @Test
+    public void updateCenterMigration() {
+        UpdateSite site = j.jenkins.getUpdateCenter().getSites().stream()
+                .filter(s -> UpdateCenter.PREDEFINED_UPDATE_SITE_ID.equals(s.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertFalse(site.isLegacyDefault());
+        assertEquals(j.jenkins.getUpdateCenter().getDefaultBaseUrl() + "update-center.json", site.getUrl());
+    }
+}

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -72,6 +72,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class UpdateSiteTest {
@@ -203,6 +204,19 @@ public class UpdateSiteTest {
         overrideUpdateSite(site);
         assertEquals("number of warnings", 7, site.getData().getWarnings().size());
         assertNotEquals("plugin data is present", Collections.emptyMap(), site.getData().plugins);
+    }
+
+    @Issue("JENKINS-73760")
+    @Test
+    public void isLegacyDefault() {
+        assertFalse("isLegacyDefault should be false with null id", new UpdateSite(null, "url").isLegacyDefault());
+        assertFalse(
+                "isLegacyDefault should be false when id is not default and url is http://updates.jenkins-ci.org/",
+                new UpdateSite("dummy", "http://updates.jenkins-ci.org/").isLegacyDefault());
+        assertTrue(
+                "isLegacyDefault should be true when id is default and url is http://updates.jenkins-ci.org/",
+                new UpdateSite(UpdateCenter.PREDEFINED_UPDATE_SITE_ID, "http://updates.jenkins-ci.org/").isLegacyDefault());
+        assertFalse("isLegacyDefault should be false with null url", new UpdateSite(null, null).isLegacyDefault());
     }
 
     @Test public void getAvailables() throws Exception {

--- a/test/src/test/resources/hudson/model/UpdateCenterMigrationTest/updateCenterMigration/hudson.model.UpdateCenter.xml
+++ b/test/src/test/resources/hudson/model/UpdateCenterMigrationTest/updateCenterMigration/hudson.model.UpdateCenter.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sites>
+  <site>
+    <id>default</id>
+    <url>http://updates.jenkins-ci.org/update-center.json</url>
+  </site>
+</sites>

--- a/war/src/main/scss/pages/_job.scss
+++ b/war/src/main/scss/pages/_job.scss
@@ -129,9 +129,12 @@
       font-weight: 450;
       flex-grow: 1;
       padding: 0.45rem 0 0;
+      word-break: normal;
+      overflow-wrap: anywhere;
 
       .app-builds-container__item__time {
         color: var(--text-color-secondary);
+        white-space: nowrap;
       }
     }
 
@@ -168,6 +171,8 @@
     padding-left: 2.25rem;
     margin-top: -2px;
     grid-column: 1 / span 2;
+    word-break: normal;
+    overflow-wrap: anywhere;
 
     &::before {
       content: "";


### PR DESCRIPTION
## Backporting for 2.479.1

Latest core version: Jenkins 2.479

## Candidates included

```
JENKINS-73867           Minor                   2.480
        Backport the override of outdated managed dependency on asm
        https://issues.jenkins.io/browse/JENKINS-73867

JENKINS-73838           Minor                   2.480
        Compatibility for Jenkins#doSafeRestart(StaplerRequest, String)
        regression
        https://issues.jenkins.io/browse/JENKINS-73838

JENKINS-73801           Minor                   2.480
        Nested Views plugin overrides View#doConfigDotXml(StaplerRequest)
        regression
        https://issues.jenkins.io/browse/JENKINS-73801

JENKINS-73760           Major                   2.480
        Updates fail due to invalid JSON from HTTP updates.jenkins.io (HTTPS is ok)
        https://issues.jenkins.io/browse/JENKINS-73760

JENKINS-73437           Minor                   2.480
        the build history widget displaying a very long http link, it looks a bit bad
        https://issues.jenkins.io/browse/JENKINS-73437
```

Backported issues include:

* [JENKINS-73437](https://issues.jenkins.io/browse/JENKINS-73437) Backport the override of outdated managed dependency on asm
* [JENKINS-73760](https://issues.jenkins.io/browse/JENKINS-73760) Compatibility for Jenkins#doSafeRestart
* [JENKINS-73801](https://issues.jenkins.io/browse/JENKINS-73801) Nested Views plugin overrides View#doConfigDotXml
* [JENKINS-73838](https://issues.jenkins.io/browse/JENKINS-73838) Switch update center to https://updates.jenkins.io for older installs
* [JENKINS-73867](https://issues.jenkins.io/browse/JENKINS-73867) Wrap long build description text in the build history widget

### Testing done

* [JENKINS-73867](https://issues.jenkins.io/browse/JENKINS-73867) Wrap long build description text in the build history widget.
  Confirmed that long build description text is wrapped for freestyle and Pipeline jobs

Other backports rely on automated tests to confirm.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
