### PR TITLE
Winstone 8.2: Upgrade Jetty from 12.0.13 to Jetty 12.0.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.30</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.1</winstone.version>
+    <winstone.version>8.2</winstone.version>
     <node.version>20.18.0</node.version>
   </properties>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -645,7 +645,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-maven-plugin</artifactId>
-        <version>12.0.13</version>
+        <version>12.0.14</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
Jetty: [changelog](https://github.com/eclipse/jetty.project/releases/jetty-12.0.14), [compare view](https://github.com/eclipse/jetty.project/compare/jetty-12.0.13...jetty-12.0.14)

Winstone: [8.2 changelog](https://github.com/jenkinsci/winstone/releases/winstone-8.2), [compare view](https://github.com/jenkinsci/winstone/compare/winstone-8.1...winstone-8.2)

### Testing done

Ran `java -jar jenkins.war` and verified that Jenkins was usable after the Jetty upgrade.

### Proposed changelog entries

- Winstone 8.2: Upgrade Jetty from 12.0.13 to 12.0.14 ([Jetty 12.0.14 changelog](https://github.com/eclipse/jetty.project/releases/jetty-12.0.14), [Winstone 8.2 changelog](https://github.com/jenkinsci/winstone/releases/winstone-8.2))

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
