### PR TITLE
[JENKINS-30101][JENKINS-30175] Simplify persistence design for temporarily offline status

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -704,6 +704,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      *
      * @param temporaryOfflineCause The reason why the node is being put offline.
      *                                If null, this cancels the status
+     * @since TODO
      */
     public void setTemporaryOfflineCause(@CheckForNull OfflineCause temporaryOfflineCause) {
         var node = getNode();
@@ -713,6 +714,10 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         node.setTemporaryOfflineCause(temporaryOfflineCause);
     }
 
+    /**
+     * @since TODO
+     * @return If the node is temporarily offline, the reason why.
+     */
     @SuppressWarnings("unused") // used by setOfflineCause.jelly
     public String getTemporaryOfflineCauseReason() {
         var node = getNode();

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -373,6 +373,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     @Exported
     @Override
     public String getOfflineCauseReason() {
+        var offlineCause = getOfflineCause();
         if (offlineCause == null) {
             return "";
         }

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -712,6 +712,20 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         node.setTemporaryOfflineCause(temporaryOfflineCause);
     }
 
+    @SuppressWarnings("unused") // used by setOfflineCause.jelly
+    public String getTemporaryOfflineCauseReason() {
+        var node = getNode();
+        if (node == null) {
+            // Node was deleted; computer still exists
+            return null;
+        }
+        var cause = node.getTemporaryOfflineCause();
+        if (cause instanceof OfflineCause.UserCause userCause) {
+            return userCause.getMessage();
+        }
+        return cause != null ? cause.toString() : "";
+    }
+
     @Exported
     @Override
     public String getIcon() {

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -622,8 +622,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     @Exported
     @Override
     public boolean isOffline() {
-        var node = getNode();
-        return node == null || node.isTemporarilyOffline() || getChannel() == null;
+        return isTemporarilyOffline() || getChannel() == null;
     }
 
     public final boolean isOnline() {

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -688,7 +688,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      */
     @Deprecated
     public void setTemporarilyOffline(boolean temporarilyOffline, OfflineCause cause) {
-        offlineCause = temporarilyOffline ? cause : null;
+        if (cause == null) {
+            setTemporarilyOffline(temporarilyOffline);
+        } else {
+            setTemporarilyOfflineCause(cause);
+        }
     }
 
     /**
@@ -698,13 +702,8 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
      * @param temporarilyOfflineCause The reason why the node is being put offline.
      *                                If null, this cancels the status
      */
-    public void setTemporarilyOfflineCause(OfflineCause temporarilyOfflineCause) {
+    public void setTemporarilyOfflineCause(@CheckForNull OfflineCause temporarilyOfflineCause) {
         getNodeOrDie().setTemporaryOfflineCause(temporarilyOfflineCause);
-        if (temporarilyOfflineCause != null) {
-            Listeners.notify(ComputerListener.class, false, l -> l.onTemporarilyOffline(this, temporarilyOfflineCause));
-        } else {
-            Listeners.notify(ComputerListener.class, false, l -> l.onTemporarilyOnline(this));
-        }
     }
 
     public OfflineCause getTemporarilyOfflineCause() {

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -686,10 +686,10 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     /**
-     * @deprecated as of TODO.
+     * @deprecated
      *      Use {@link #setTemporaryOfflineCause(OfflineCause)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "TODO")
     public void setTemporarilyOffline(boolean temporarilyOffline, OfflineCause cause) {
         if (cause == null) {
             setTemporarilyOffline(temporarilyOffline);

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -604,7 +604,11 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
 
     @NonNull
     private Node getNodeOrDie() {
-        return nodeName == null ? Jenkins.get() : Jenkins.get().getNode(nodeName);
+        var node = nodeName == null ? Jenkins.get() : Jenkins.get().getNode(nodeName);
+        if (node == null) {
+            throw new IllegalStateException("Can't set a temporary offline cause if the node has been removed");
+        }
+        return node;
     }
 
     @Exported

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -694,7 +694,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         if (cause == null) {
             setTemporarilyOffline(temporarilyOffline);
         } else {
-            setTemporaryOfflineCause(cause);
+            setTemporaryOfflineCause(temporarilyOffline ? cause : null);
         }
     }
 

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -264,6 +264,9 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         setNodeName(name);
     }
 
+    /**
+     * @return true if this node has a temporary offline cause set.
+     */
     boolean isTemporarilyOffline() {
         return temporaryOfflineCause != null;
     }

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -46,6 +46,7 @@ import hudson.remoting.VirtualChannel;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.slaves.Cloud;
+import hudson.slaves.ComputerListener;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.NodeDescriptor;
 import hudson.slaves.NodeProperty;
@@ -67,6 +68,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.model.Nodes;
+import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
 import jenkins.util.io.OnMaster;
 import net.sf.json.JSONObject;
@@ -277,6 +279,11 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
             if (temporaryOfflineCause != cause) {
                 temporaryOfflineCause = cause;
                 save();
+            }
+            if (temporaryOfflineCause != null) {
+                Listeners.notify(ComputerListener.class, false, l -> l.onTemporarilyOffline(toComputer(), temporaryOfflineCause));
+            } else {
+                Listeners.notify(ComputerListener.class, false, l -> l.onTemporarilyOnline(toComputer()));
             }
         } catch (java.io.IOException e) {
             LOGGER.warning("Unable to complete save, temporary offline status will not be persisted: " + e.getMessage());

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -264,7 +264,7 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         setNodeName(name);
     }
 
-    public boolean isTemporarilyOffline() {
+    boolean isTemporarilyOffline() {
         return temporaryOfflineCause != null;
     }
 

--- a/core/src/main/java/hudson/model/Node.java
+++ b/core/src/main/java/hudson/model/Node.java
@@ -30,7 +30,6 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
-import hudson.Extension;
 import hudson.ExtensionPoint;
 import hudson.FilePath;
 import hudson.FileSystemProvisioner;
@@ -47,7 +46,6 @@ import hudson.remoting.VirtualChannel;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
 import hudson.slaves.Cloud;
-import hudson.slaves.ComputerListener;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.NodeDescriptor;
 import hudson.slaves.NodeProperty;
@@ -264,25 +262,11 @@ public abstract class Node extends AbstractModelObject implements Reconfigurable
         setNodeName(name);
     }
 
-    /**
-     * Let Nodes be aware of the lifecycle of their own {@link Computer}.
-     */
-    @Extension
-    public static class InternalComputerListener extends ComputerListener {
-        @Override
-        public void onOnline(Computer c, TaskListener listener) {
-            Node node = c.getNode();
-
-            // At startup, we need to restore any previously in-effect temp offline cause.
-            // We wait until the computer is started rather than getting the data to it sooner
-            // so that the normal computer start up processing works as expected.
-            if (node != null && node.temporaryOfflineCause != null && node.temporaryOfflineCause != c.getOfflineCause()) {
-                c.setTemporarilyOffline(true, node.temporaryOfflineCause);
-            }
-        }
+    public boolean isTemporarilyOffline() {
+        return temporaryOfflineCause != null;
     }
 
-    private OfflineCause temporaryOfflineCause;
+    private volatile OfflineCause temporaryOfflineCause;
 
     /**
      * Enable a {@link Computer} to inform its node when it is taken

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -233,7 +233,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      */
     protected boolean markOnline(Computer c) {
         if (isIgnored() || c.isOnline()) return false; // noop
-        c.setTemporarilyOffline(false, null);
+        c.setTemporarilyOfflineCause(null);
         return true;
     }
 
@@ -247,7 +247,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
     protected boolean markOffline(Computer c, OfflineCause oc) {
         if (isIgnored() || c.isTemporarilyOffline()) return false; // noop
 
-        c.setTemporarilyOffline(true, oc);
+        c.setTemporarilyOfflineCause(oc);
 
         // notify the admin
         MonitorMarkedNodeOffline no = AdministrativeMonitor.all().get(MonitorMarkedNodeOffline.class);

--- a/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractNodeMonitorDescriptor.java
@@ -233,7 +233,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
      */
     protected boolean markOnline(Computer c) {
         if (isIgnored() || c.isOnline()) return false; // noop
-        c.setTemporarilyOfflineCause(null);
+        c.setTemporaryOfflineCause(null);
         return true;
     }
 
@@ -247,7 +247,7 @@ public abstract class AbstractNodeMonitorDescriptor<T> extends Descriptor<NodeMo
     protected boolean markOffline(Computer c, OfflineCause oc) {
         if (isIgnored() || c.isTemporarilyOffline()) return false; // noop
 
-        c.setTemporarilyOfflineCause(oc);
+        c.setTemporaryOfflineCause(oc);
 
         // notify the admin
         MonitorMarkedNodeOffline no = AdministrativeMonitor.all().get(MonitorMarkedNodeOffline.class);

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -151,15 +151,15 @@ public abstract class OfflineCause {
         // null when unknown
         private /*final*/ @CheckForNull String userId;
 
+        private final String message;
+
         public UserCause(@CheckForNull User user, @CheckForNull String message) {
-            this(
-                    user != null ? user.getId() : null,
-                    message != null ? " : " + message : ""
-            );
+            this(user != null ? user.getId() : null, message);
         }
 
         private UserCause(String userId, String message) {
-            super(hudson.slaves.Messages._SlaveComputer_DisconnectedBy(userId != null ? userId : Jenkins.ANONYMOUS2.getName(), message));
+            super(hudson.slaves.Messages._SlaveComputer_DisconnectedBy(userId != null ? userId : Jenkins.ANONYMOUS2.getName(), message != null ? " : " + message : ""));
+            this.message = message;
             this.userId = userId;
         }
 
@@ -168,6 +168,10 @@ public abstract class OfflineCause {
                     ? User.getUnknown()
                     : User.getById(userId, true)
             ;
+        }
+
+        public String getMessage() {
+            return message;
         }
 
         // Storing the User in a filed was a mistake, switch to userId

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -170,6 +170,9 @@ public abstract class OfflineCause {
             ;
         }
 
+        /**
+         * @return the message that was provided when the computer was taken offline
+         */
         public String getMessage() {
             return message;
         }

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -33,6 +33,8 @@ import java.util.Collections;
 import java.util.Date;
 import jenkins.model.Jenkins;
 import org.jvnet.localizer.Localizable;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -69,6 +71,19 @@ public abstract class OfflineCause {
      */
     public final @NonNull Date getTime() {
         return new Date(timestamp);
+    }
+
+    /**
+     * @deprecated Only exists for backward compatibility.
+     * @see Computer#setTemporarilyOffline(boolean).
+     */
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    public static class LegacyOfflineCause extends OfflineCause {
+        @Exported(name = "description") @Override
+        public String toString() {
+            return "";
+        }
     }
 
     /**

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -75,7 +75,7 @@ public abstract class OfflineCause {
 
     /**
      * @deprecated Only exists for backward compatibility.
-     * @see Computer#setTemporarilyOffline(boolean).
+     * @see Computer#setTemporarilyOffline(boolean)
      */
     @Deprecated
     @Restricted(NoExternalUse.class)

--- a/core/src/main/resources/hudson/model/Computer/setOfflineCause.jelly
+++ b/core/src/main/resources/hudson/model/Computer/setOfflineCause.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
           ${%blurb}
         </p>
         <form method="post" action="changeOfflineCause">
-          <f:textarea name="offlineMessage" value="${it.getOfflineCauseReason()}"/>
+          <f:textarea name="offlineMessage" value="${it.temporaryOfflineCauseReason}"/>
           <p>
             <f:submit value="${%submit}"  />
           </p>

--- a/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/OfflineNodeCommandTest.java
@@ -118,7 +118,7 @@ public class OfflineNodeCommandTest {
         slave.toComputer().setTemporarilyOffline(true, null);
         assertThat(slave.toComputer().isOffline(), equalTo(true));
         assertThat(slave.toComputer().isTemporarilyOffline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), equalTo(null));
+        assertThat(slave.toComputer().getOfflineCause(), instanceOf(OfflineCause.LegacyOfflineCause.class));
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
@@ -177,7 +177,7 @@ public class OfflineNodeCommandTest {
         slave.toComputer().setTemporarilyOffline(true, null);
         assertThat(slave.toComputer().isOffline(), equalTo(true));
         assertThat(slave.toComputer().isTemporarilyOffline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), equalTo(null));
+        assertThat(slave.toComputer().getOfflineCause(), instanceOf(OfflineCause.LegacyOfflineCause.class));
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -116,6 +116,7 @@ public class NodeTest {
         try (ACLContext ignored = ACL.as2(someone.impersonate2())) {
             computer.doToggleOffline("original message");
             cause = (OfflineCause.UserCause) computer.getOfflineCause();
+            assertThat(computer.getOfflineCauseReason(), is("original message"));
             assertThat(computer.getTemporaryOfflineCauseReason(), is("original message"));
             assertTrue(cause.toString(), cause.toString().matches("^.*?Disconnected by someone@somewhere.com : original message"));
             assertEquals(someone, cause.getUser());

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -104,6 +105,9 @@ public class NodeTest {
         OfflineCause cause2 = new OfflineCause.ByCLI("another message");
         node.setTemporaryOfflineCause(cause2);
         assertEquals("Node should have the new offline cause.", cause2, node.toComputer().getOfflineCause());
+        // Exists in some plugins
+        node.toComputer().setTemporarilyOffline(false, new OfflineCause.ByCLI("A third message"));
+        assertThat(node.getTemporaryOfflineCause(), nullValue());
     }
 
     @Test

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -27,6 +27,7 @@ package hudson.model;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -115,6 +116,7 @@ public class NodeTest {
         try (ACLContext ignored = ACL.as2(someone.impersonate2())) {
             computer.doToggleOffline("original message");
             cause = (OfflineCause.UserCause) computer.getOfflineCause();
+            assertThat(computer.getTemporaryOfflineCauseReason(), is("original message"));
             assertTrue(cause.toString(), cause.toString().matches("^.*?Disconnected by someone@somewhere.com : original message"));
             assertEquals(someone, cause.getUser());
         }
@@ -122,6 +124,7 @@ public class NodeTest {
         try (ACLContext ignored = ACL.as2(root.impersonate2())) {
             computer.doChangeOfflineCause("new message");
             cause = (OfflineCause.UserCause) computer.getOfflineCause();
+            assertThat(computer.getTemporaryOfflineCauseReason(), is("new message"));
             assertTrue(cause.toString(), cause.toString().matches("^.*?Disconnected by root@localhost : new message"));
             assertEquals(root, cause.getUser());
 

--- a/test/src/test/java/hudson/model/NodeTest.java
+++ b/test/src/test/java/hudson/model/NodeTest.java
@@ -102,7 +102,7 @@ public class NodeTest {
         assertEquals("Node should have offline cause which was set.", cause, node.toComputer().getOfflineCause());
         OfflineCause cause2 = new OfflineCause.ByCLI("another message");
         node.setTemporaryOfflineCause(cause2);
-        assertEquals("Node should have original offline cause after setting another.", cause, node.toComputer().getOfflineCause());
+        assertEquals("Node should have the new offline cause.", cause2, node.toComputer().getOfflineCause());
     }
 
     @Test


### PR DESCRIPTION
There were complex code to synchronize transient state of `Computer` from `Node` and vice versa.
But since any temporarily offline cause is being set by a user and should be persisted in a `Node`, the `Computer` should actually delegate to `Node` instead of trying to synchronize its state.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

Fixes [JENKINS-30101](https://issues.jenkins-ci.org/browse/JENKINS-30101) and [JENKINS-30175](https://issues.jenkins-ci.org/browse/JENKINS-30175)

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Keep user offline reason when agent connects or disconnects for technical reasons.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
