### PR TITLE
Pass branch name to launchable 'record build'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ stage('Record build') {
         /*
          * TODO Add the commits of the transitive closure of the Jenkins WAR under test to this build.
          */
-        sh 'launchable verify && launchable record build --name ${BUILD_TAG} --branch ${env.BRANCH_NAME} --source jenkinsci/jenkins=.'
+        sh 'launchable verify && launchable record build --name ${BUILD_TAG} --branch ${BRANCH_NAME} --source jenkinsci/jenkins=.'
         axes.values().combinations {
           def (platform, jdk) = it
           if (platform == 'windows' && jdk != 17) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ stage('Record build') {
         /*
          * TODO Add the commits of the transitive closure of the Jenkins WAR under test to this build.
          */
-        sh 'launchable verify && launchable record build --name ${BUILD_TAG} --source jenkinsci/jenkins=.'
+        sh 'launchable verify && launchable record build --name ${BUILD_TAG} --branch ${env.BRANCH_NAME} --source jenkinsci/jenkins=.'
         axes.values().combinations {
           def (platform, jdk) = it
           if (platform == 'windows' && jdk != 17) {


### PR DESCRIPTION
## Pass branch name to launchable 'record build'

The [launchable documentation](https://www.launchableinc.com/docs/resources/troubleshooting/#3500600-recording-branch-of-build) says:

> During record build, Launchable tries to automatically determine the Git branch being built. However, this can fail, depending on how you check out the code. When this happens, our webapp will ask you to configure this explicitly.

The [launchable unhealthy tests report](https://app.launchableinc.com/organizations/jenkins/workspaces/jenkins/insights/unhealthy-tests) is where 'We are unable to figure out your Git branch' was first reported.

### Testing done

I confirmed that `BRANCH_NAME` is an available key of the `env` map by opening the Pipeline syntax page for the Jenkins core build of the master branch on ci.jenkins.io.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
