### PR TITLE
Backporting for 2.479.1 (part 2)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -356,7 +356,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>9.7</version>
+        <version>9.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.samba.jcifs</groupId>

--- a/core/src/main/java/jenkins/model/queue/ItemDeletion.java
+++ b/core/src/main/java/jenkins/model/queue/ItemDeletion.java
@@ -266,12 +266,10 @@ public class ItemDeletion extends Queue.QueueDecisionHandler {
                     // comparison with executor.getCurrentExecutable() == executable currently should always be
                     // true as we no longer recycle Executors, but safer to future-proof in case we ever
                     // revisit recycling.
-                    if (!entry.getKey().isAlive()
+                    if (!entry.getKey().isActive()
                             || entry.getValue() != entry.getKey().getCurrentExecutable()) {
                         iterator.remove();
                     }
-                    // I don't know why, but we have to keep interrupting
-                    entry.getKey().interrupt(Result.ABORTED);
                 }
                 Thread.sleep(50L);
             }

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -494,7 +494,7 @@ THE SOFTWARE.
                   <!-- dependency of scm-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>asm-api</artifactId>
-                  <version>9.7-33.v4d23ef79fcc8</version>
+                  <version>9.7.1-95.v9f552033802a_</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>


### PR DESCRIPTION
## Backporting for 2.479.1 (part 2)

Latest core version: Jenkins 2.480

## Candidates included

```
JENKINS-73917           Minor                   2.480
        Backport the ASM 9.7.1 update to 2.479.1
        https://issues.jenkins.io/browse/JENKINS-73917

JENKINS-73824           Major                   2.480
        Deletion of Pipeline jobs does not wait for ongoing builds to fully complete
        https://issues.jenkins.io/browse/JENKINS-73824
```

Backported issues include:

- [JENKINS-73917](https://issues.jenkins.io/browse/JENKINS-73917) Backport the ASM 9.7.1 update to 2.479.1
- [JENKINS-73824](https://issues.jenkins.io/browse/JENKINS-73824) Deletion of Pipeline jobs does not wait for ongoing builds to fully complete

### Testing done

Ran automated tests locally to confirm success.  Confirmed that Jenkins 2.480 in [weekly plugin BOM 3482.x](https://github.com/jenkinsci/bom/releases/tag/3482.vc10d4f6da_28a_) is able to use most recent versions of warnings-ng and analysis-model-api plugins.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

- @basil
- @jglick
- @dwnusbaum

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
