### PR TITLE
Backporting for 2.479.1 (part 3)

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1551,6 +1551,9 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      *      if we fail to delete.
      */
     public void delete() throws IOException {
+        if (isLogUpdated()) {
+            throw new IOException("Unable to delete " + this + " because it is still running");
+        }
         synchronized (this) {
             // Avoid concurrent delete. See https://issues.jenkins.io/browse/JENKINS-61687
             if (isPendingDelete) {
@@ -1882,12 +1885,6 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
                 } catch (IOException e) {
                     LOGGER.log(Level.SEVERE, "Failed to save build record", e);
                 }
-            }
-
-            try {
-                getParent().logRotate();
-            } catch (Exception e) {
-                LOGGER.log(Level.SEVERE, "Failed to rotate log", e);
             }
         } finally {
             onEndBuilding();

--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -250,7 +250,7 @@ public class LogRotator extends BuildDiscarder {
             LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s the last stable build", r);
             return true;
         }
-        if (r.isBuilding()) {
+        if (r.isLogUpdated()) {
             LOGGER.log(FINER, "{0} is not to be removed or purged of artifacts because it’s still building", r);
             return true;
         }

--- a/core/src/main/java/jenkins/model/BackgroundGlobalBuildDiscarder.java
+++ b/core/src/main/java/jenkins/model/BackgroundGlobalBuildDiscarder.java
@@ -31,6 +31,7 @@ import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -56,8 +57,18 @@ public class BackgroundGlobalBuildDiscarder extends AsyncPeriodicWork {
         }
     }
 
+    /**
+     * Runs all globally configured build discarders against a job.
+     */
     public static void processJob(TaskListener listener, Job job) {
-        GlobalBuildDiscarderConfiguration.get().getConfiguredBuildDiscarders().forEach(strategy -> {
+        processJob(listener, job, GlobalBuildDiscarderConfiguration.get().getConfiguredBuildDiscarders().stream());
+    }
+
+    /**
+     * Runs the specified build discarders against a job.
+     */
+    public static void processJob(TaskListener listener, Job job, Stream<GlobalBuildDiscarderStrategy> strategies) {
+        strategies.forEach(strategy -> {
             String displayName = strategy.getDescriptor().getDisplayName();
             if (strategy.isApplicable(job)) {
                 try {

--- a/core/src/main/java/jenkins/model/GlobalBuildDiscarderListener.java
+++ b/core/src/main/java/jenkins/model/GlobalBuildDiscarderListener.java
@@ -35,7 +35,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
- * Run background build discarders on an individual job once a build is finalized
+ * Run build discarders on an individual job once a build is finalized
  */
 @Extension
 @Restricted(NoExternalUse.class)
@@ -46,6 +46,15 @@ public class GlobalBuildDiscarderListener extends RunListener<Run> {
     @Override
     public void onFinalized(Run run) {
         Job job = run.getParent();
-        BackgroundGlobalBuildDiscarder.processJob(new LogTaskListener(LOGGER, Level.FINE), job);
+        try {
+            // Job-level build discarder execution is unconditional.
+            job.logRotate();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, e, () -> "Failed to rotate log for " + run);
+        }
+        // Avoid calling Job.logRotate twice in case JobGlobalBuildDiscarderStrategy is configured globally.
+        BackgroundGlobalBuildDiscarder.processJob(new LogTaskListener(LOGGER, Level.FINE), job,
+                GlobalBuildDiscarderConfiguration.get().getConfiguredBuildDiscarders().stream()
+                        .filter(s -> !(s instanceof JobGlobalBuildDiscarderStrategy)));
     }
 }

--- a/core/src/main/resources/hudson/model/Run/delete.jelly
+++ b/core/src/main/resources/hudson/model/Run/delete.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <j:if test="${!it.building and !it.keepLog}">
+  <j:if test="${!it.logUpdated and !it.keepLog}">
     <l:task href="${buildUrl.baseUrl}/confirmDelete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%delete.build(it.displayName)}"/>
   </j:if>
 </j:jelly>

--- a/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
 import hudson.model.ExecutorTest;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.labels.LabelAtom;
 import hudson.tasks.Shell;
@@ -139,7 +140,7 @@ public class DeleteBuildsCommandTest {
     @Issue("JENKINS-73835")
     @Test public void deleteBuildsShouldFailIfTheBuildIsRunning() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject("aProject");
-        ExecutorTest.startBlockingBuild(project);
+        var build = ExecutorTest.startBlockingBuild(project);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         final CLICommandInvoker.Result result = command
@@ -148,6 +149,9 @@ public class DeleteBuildsCommandTest {
         assertThat(result, failedWith(1));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("Unable to delete aProject #1 because it is still running"));
+
+        build.doStop();
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(build));
     }
 
     @Test public void deleteBuildsShouldSuccessEvenTheBuildIsStuckInTheQueue() throws Exception {

--- a/test/src/test/java/hudson/model/RunTest.java
+++ b/test/src/test/java/hudson/model/RunTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import hudson.FilePath;
@@ -59,6 +60,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SleepBuilder;
 import org.jvnet.hudson.test.SmokeTest;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -112,6 +114,18 @@ public class RunTest  {
         FreeStyleBuild b = j.buildAndAssertSuccess(p);
         b.delete();
         assertTrue(Mgr.deleted.get());
+    }
+
+    @Issue("JENKINS-73835")
+    @Test public void buildsMayNotBeDeletedWhileRunning() throws Exception {
+        var p = j.createFreeStyleProject();
+        p.getBuildersList().add(new SleepBuilder(999999));
+        var b = p.scheduleBuild2(0).waitForStart();
+        var ex = assertThrows(IOException.class, () -> b.delete());
+        assertThat(ex.getMessage(), containsString("Unable to delete " + b + " because it is still running"));
+        b.getExecutor().interrupt();
+        j.waitForCompletion(b);
+        b.delete(); // Works fine.
     }
 
     @Issue("SECURITY-1902")


### PR DESCRIPTION
## Backporting for 2.479.1 (part 3)

Latest core version: Jenkins 2.480

## Candidates included

```
JENKINS-73835           Minor                   2.481
        Builds can be deleted while they are still running
        https://issues.jenkins.io/browse/JENKINS-73835
```

Backported issues include:

- [JENKINS-73835](https://issues.jenkins.io/browse/JENKINS-73835) Builds can be deleted while they are still running

### Testing done

`mvn clean verify -DskipTests`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jglick, @dwnusbaum 

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
