### PR TITLE
Stop build in `DeleteBuildsCommandTest.deleteBuildsShouldFailIfTheBuildIsRunning` so test can be cleaned up on Windows consistently

### DIFF
--- a/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
+++ b/test/src/test/java/hudson/cli/DeleteBuildsCommandTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
 import hudson.model.ExecutorTest;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.labels.LabelAtom;
 import hudson.tasks.Shell;
@@ -139,7 +140,7 @@ public class DeleteBuildsCommandTest {
     @Issue("JENKINS-73835")
     @Test public void deleteBuildsShouldFailIfTheBuildIsRunning() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject("aProject");
-        ExecutorTest.startBlockingBuild(project);
+        var build = ExecutorTest.startBlockingBuild(project);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
 
         final CLICommandInvoker.Result result = command
@@ -148,6 +149,9 @@ public class DeleteBuildsCommandTest {
         assertThat(result, failedWith(1));
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("Unable to delete aProject #1 because it is still running"));
+
+        build.doStop();
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(build));
     }
 
     @Test public void deleteBuildsShouldSuccessEvenTheBuildIsStuckInTheQueue() throws Exception {


### PR DESCRIPTION
Followup to https://github.com/jenkinsci/jenkins/pull/9810 to fix a test on Windows, see specifically https://github.com/jenkinsci/jenkins/pull/9810#issuecomment-2415043295.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
