### PR TITLE
Reduce default size of diagnostic buffer for `FlightRecorderInputStream` from 1MiB to 1KiB

### DIFF
--- a/cli/src/main/java/hudson/cli/FlightRecorderInputStream.java
+++ b/cli/src/main/java/hudson/cli/FlightRecorderInputStream.java
@@ -21,7 +21,7 @@ class FlightRecorderInputStream extends InputStream {
      * Size (in bytes) of the flight recorder ring buffer used for debugging remoting issues.
      * @since 2.41
      */
-    static final int BUFFER_SIZE = Integer.getInteger("hudson.remoting.FlightRecorderInputStream.BUFFER_SIZE", 1024 * 1024);
+    static final int BUFFER_SIZE = Integer.getInteger("hudson.remoting.FlightRecorderInputStream.BUFFER_SIZE", 1024);
 
     private final InputStream source;
     private ByteArrayRingBuffer recorder = new ByteArrayRingBuffer(BUFFER_SIZE);

--- a/test/src/test/java/hudson/cli/PlainCLIProtocolTest.java
+++ b/test/src/test/java/hudson/cli/PlainCLIProtocolTest.java
@@ -1,0 +1,61 @@
+package hudson.cli;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.logging.Level;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.LoggerRule;
+
+public class PlainCLIProtocolTest {
+
+    @Rule public LoggerRule logger = new LoggerRule().record(PlainCLIProtocol.class, Level.FINE).capture(50);
+
+    @Test
+    public void streamCorruption() throws Exception {
+        final PipedOutputStream upload = new PipedOutputStream();
+        final PipedOutputStream download = new PipedOutputStream();
+
+        class Server extends PlainCLIProtocol.ServerSide {
+            Server() throws IOException {
+                super(new PlainCLIProtocol.FramedOutput(download));
+            }
+
+            @Override
+            protected void onArg(String text) {}
+
+            @Override
+            protected void onLocale(String text) {}
+
+            @Override
+            protected void onEncoding(String text) {}
+
+            @Override
+            protected synchronized void onStart() {}
+
+            @Override
+            protected void onStdin(byte[] chunk) throws IOException {}
+
+            @Override
+            protected void onEndStdin() throws IOException {}
+
+            @Override
+            protected void handleClose() {}
+        }
+
+        Server server = new Server();
+        new PlainCLIProtocol.FramedReader(server, new PipedInputStream(upload)).start();
+        // Trigger corruption
+        upload.write(0xFF);
+        upload.write(0xFF);
+        upload.write(0xFF);
+        upload.write(0xFF);
+        upload.flush();
+        await().until(logger::getMessages, hasItem(containsString("Read back: 0xff 0xff 0xff 0xff")));
+    }
+}


### PR DESCRIPTION
Refiling https://github.com/jenkinsci/remoting/pull/770 against the duplicated class here.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

I added a new test to cover the `FlightRecorderInputStream` diagnostics for the CLI.

### Proposed changelog entries

N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
