### PR TITLE
Add Resource Root URL test for permissions assigned to groups

### DIFF
--- a/test/src/test/java/jenkins/security/ResourceDomainTest.java
+++ b/test/src/test/java/jenkins/security/ResourceDomainTest.java
@@ -56,6 +56,34 @@ public class ResourceDomainTest {
     }
 
     @Test
+    public void groupPermissionsWork() throws Exception {
+        final JenkinsRule.DummySecurityRealm securityRealm = j.createDummySecurityRealm();
+        securityRealm.addGroups("alice", "admins");
+        j.jenkins.setSecurityRealm(securityRealm);
+        MockAuthorizationStrategy a = new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to("admins");
+        j.jenkins.setAuthorizationStrategy(a);
+
+        JenkinsRule.WebClient webClient = j.createWebClient().login("alice");
+
+        { // DBS directory listing is shown as always
+            Page page = webClient.goTo("userContent");
+            Assert.assertEquals("successful request", 200, page.getWebResponse().getStatusCode());
+            Assert.assertTrue("still on the original URL", page.getUrl().toString().contains("/userContent"));
+            Assert.assertTrue("web page", page.isHtmlPage());
+            Assert.assertTrue("complex web page", page.getWebResponse().getContentAsString().contains("javascript"));
+        }
+        { // DBS on primary domain forwards to second domain when trying to access a file URL
+            webClient.setRedirectEnabled(true);
+            Page page = webClient.goTo("userContent/readme.txt", "text/plain");
+            final String resourceResponseUrl = page.getUrl().toString();
+            Assert.assertEquals("resource response success", 200, page.getWebResponse().getStatusCode());
+            Assert.assertNull("no CSP headers", page.getWebResponse().getResponseHeaderValue("Content-Security-Policy"));
+            Assert.assertTrue("Served from resource domain", resourceResponseUrl.contains(RESOURCE_DOMAIN));
+            Assert.assertTrue("Served from resource action", resourceResponseUrl.contains("static-files"));
+        }
+    }
+
+    @Test
     public void secondDomainBasics() throws Exception {
         JenkinsRule.WebClient webClient = j.createWebClient();
 


### PR DESCRIPTION
Vaguely motivated by [JENKINS-73720](https://issues.jenkins.io/browse/JENKINS-73720): Confirm Resource Root URL works in principle when permissions are assigned to groups.

### Testing done

n/a

### Proposed changelog entries

n/a

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
