### PR TITLE
[JENKINS-73845] Fix OperatingSystemEndOfLifeAdminMonitor endOfLifeDate displayed on first warning day

### DIFF
--- a/core/src/main/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor.java
@@ -145,7 +145,7 @@ public class OperatingSystemEndOfLifeAdminMonitor extends AdministrativeMonitor 
             }
 
             LOGGER.log(Level.FINE, "Matched operating system {0}", name);
-            if (startDate.isBefore(LocalDate.now())) {
+            if (!startDate.isAfter(LocalDate.now())) {
                 this.operatingSystemName = name;
                 this.documentationUrl = buildDocumentationUrl(this.operatingSystemName);
                 this.endOfLifeDate = endOfLife.toString();

--- a/core/src/test/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitorTest.java
+++ b/core/src/test/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitorTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -35,8 +36,11 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.time.LocalDate;
 import java.util.Random;
 import java.util.stream.Stream;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -208,6 +212,18 @@ public class OperatingSystemEndOfLifeAdminMonitorTest {
         assertTrue("Resource file '" + fileName + "' not found", fileUrl != null);
         File releaseFile = new File(fileUrl.toURI());
         assertThat(monitor.readOperatingSystemName(releaseFile, pattern), is(job));
+    }
+
+    @Test
+    public void testReadOperatingSystemListOnWarningDate() throws Exception {
+        JSONObject eolIn6Months = new JSONObject();
+        eolIn6Months.put("pattern", ".*");
+        eolIn6Months.put("endOfLife", LocalDate.now().plusMonths(6).toString());
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add(eolIn6Months);
+        monitor.readOperatingSystemList(jsonArray.toString());
+        assertTrue(monitor.isActivated());
+        assertEquals(LocalDate.now().plusMonths(6).toString(), monitor.getEndOfLifeDate());
     }
 
     @Test

--- a/core/src/test/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitorTest.java
+++ b/core/src/test/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitorTest.java
@@ -36,17 +36,23 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.time.LocalDate;
 import java.util.Random;
 import java.util.stream.Stream;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.rules.TemporaryFolder;
 
 public class OperatingSystemEndOfLifeAdminMonitorTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
     private final OperatingSystemEndOfLifeAdminMonitor monitor;
     private final Random random = new Random();
@@ -216,9 +222,12 @@ public class OperatingSystemEndOfLifeAdminMonitorTest {
 
     @Test
     public void testReadOperatingSystemListOnWarningDate() throws Exception {
+        File dataFile = tmp.newFile();
+        Files.writeString(dataFile.toPath(), "PRETTY_NAME=\"Test OS\"");
         JSONObject eolIn6Months = new JSONObject();
-        eolIn6Months.put("pattern", ".*");
+        eolIn6Months.put("pattern", "Test OS");
         eolIn6Months.put("endOfLife", LocalDate.now().plusMonths(6).toString());
+        eolIn6Months.put("file", dataFile.getAbsolutePath());
         JSONArray jsonArray = new JSONArray();
         jsonArray.add(eolIn6Months);
         monitor.readOperatingSystemList(jsonArray.toString());


### PR DESCRIPTION
See [JENKINS-73845](https://issues.jenkins.io/browse/JENKINS-73845). On the first day the warning should be displayed, the EOL date displayed was the default `2099-12-31`.

### Testing done

* Change the `end-of-life-data.json` with:

```
  {
    "pattern": "Ubuntu.* 20.04.*",
    "endOfLife": "2025-04-24"
  },
```

* Build Jenkins WAR
* Validate that it shows the monitor and the correct EOL date

### Proposed changelog entries

- Fix End of Life Operating System monitor that shows 2099-12-31 on the first day a warning should be displayed.

### Proposed upgrade guidelines

N/A


```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
