### PR TITLE
Skip `LogRotatorTest#ableToDeleteCurrentBuild` on Windows

### DIFF
--- a/test/src/test/java/hudson/tasks/LogRotatorTest.java
+++ b/test/src/test/java/hudson/tasks/LogRotatorTest.java
@@ -31,7 +31,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -103,6 +105,8 @@ public class LogRotatorTest {
 
     @Test
     public void ableToDeleteCurrentBuild() throws Exception {
+        assumeFalse("Deleting the current build while is is completing does not work consistently on Windows",
+                Functions.isWindows());
         var p = j.createFreeStyleProject();
         // Keep 0 builds, i.e. immediately delete builds as they complete.
         LogRotator logRotator = new LogRotator(-1, 0, -1, -1);

--- a/test/src/test/java/hudson/tasks/LogRotatorTest.java
+++ b/test/src/test/java/hudson/tasks/LogRotatorTest.java
@@ -52,10 +52,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -65,9 +63,6 @@ import org.jvnet.hudson.test.TestBuilder;
  * Verifies that the last successful and stable builds of a job will be kept if requested.
  */
 public class LogRotatorTest {
-
-    @ClassRule
-    public static BuildWatcher watcher = new BuildWatcher();
 
     @Rule
     public JenkinsRule j = new JenkinsRule();


### PR DESCRIPTION
Trying to fix another observed flake from https://github.com/jenkinsci/jenkins/pull/9810, see https://github.com/jenkinsci/jenkins/pull/9810/files/9aaa7ba3fe523c07a4ed8d63281dbe86db064465#r1819518792.

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

I ran these tests manually a little bit to check various things, but I do not have easy access to Windows to run the tests in a loop to check flakiness in a robust way. The observed failure is due to log rotation failing to delete a build with this exception:
```
Also:   java.nio.file.AccessDeniedException: C:\Jenkins\agent\workspace\Core_jenkins_PR-9921\test\target\j h17634935987546233869\jobs\test0\builds\1 -> C:\Jenkins\agent\workspace\Core_jenkins_PR-9921\test\target\j h17634935987546233869\jobs\test0\builds\.1
		at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:89)
		at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
		at java.base/sun.nio.fs.WindowsFileCopy.move(WindowsFileCopy.java:317)
		at java.base/sun.nio.fs.WindowsFileSystemProvider.move(WindowsFileSystemProvider.java:293)
		at java.base/java.nio.file.Files.move(Files.java:1432)
		at hudson.model.Run.delete(Run.java:1598)
		at hudson.tasks.LogRotator.perform(LogRotator.java:179)
jenkins.util.io.CompositeIOException: Failed to rotate logs for [test0 #1]
	at hudson.tasks.LogRotator.perform(LogRotator.java:236)
	at hudson.model.Job.logRotate(Job.java:490)
	at jenkins.model.GlobalBuildDiscarderListener.onFinalized(GlobalBuildDiscarderListener.java:51)
	at hudson.model.listeners.RunListener.lambda$fireFinalized$3(RunListener.java:260)
	at jenkins.util.Listeners.lambda$notify$0(Listeners.java:59)
	at jenkins.util.Listeners.notify(Listeners.java:67)
	at hudson.model.listeners.RunListener.fireFinalized(RunListener.java:258)
	at hudson.model.Run.onEndBuilding(Run.java:1985)
	at hudson.model.Run.execute(Run.java:1892)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:446)
``` 
My best hypothesis is that the move failed because something else was accessing the directory in question, but given the  `AccessDeniedException` that did not have the typical `The process cannot access the file because it is being used by another process` message, perhaps the problem was something else entirely.

### Proposed changelog entries

N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
