### PR TITLE
[JENKINS-74795] createItem API should not assign new jobs to default view

### DIFF
--- a/core/src/main/java/hudson/model/ListView.java
+++ b/core/src/main/java/hudson/model/ListView.java
@@ -366,8 +366,8 @@ public class ListView extends View implements DirectlyModifiableView {
             JSONObject form = req.getSubmittedForm();
             return form.has("addToCurrentView") && form.getBoolean("addToCurrentView");
         } else {
-            // Submitted via API
-            return true;
+            // Submitted via API - JENKINS-74975
+            return false;
         }
     }
 

--- a/test/src/test/java/hudson/jobs/CreateItemTest.java
+++ b/test/src/test/java/hudson/jobs/CreateItemTest.java
@@ -38,12 +38,10 @@ import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.ListView;
 import hudson.model.listeners.ItemListener;
-import hudson.util.VersionNumber;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.text.MessageFormat;
-import jenkins.model.Jenkins;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
 import org.htmlunit.WebRequest;
@@ -114,14 +112,7 @@ public class CreateItemTest {
 
         // Confirm new job is not visible in default view
         assertTrue(aView.isDefault()); // a-view is still the default view
-        VersionNumber jenkinsVersion = Jenkins.getVersion();
-        if (jenkinsVersion == null || jenkinsVersion.isOlderThan(new VersionNumber("2.475"))) {
-            // TODO: When JENKINS-74795 is fixed, this assertion will pass
-            assertThat(aView.getItems(), containsInAnyOrder(aJob));
-        } else {
-            // TODO: Until JENKINS-74795 is fixed, this assertion passes (a bug)
-            assertThat(aView.getItems(), containsInAnyOrder(aJob, b2Job));
-        }
+        assertThat(aView.getItems(), containsInAnyOrder(aJob));
     }
 
     @Issue("JENKINS-31235")

--- a/test/src/test/java/hudson/jobs/CreateItemTest.java
+++ b/test/src/test/java/hudson/jobs/CreateItemTest.java
@@ -38,10 +38,12 @@ import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.ListView;
 import hudson.model.listeners.ItemListener;
+import hudson.util.VersionNumber;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.text.MessageFormat;
+import jenkins.model.Jenkins;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
 import org.htmlunit.WebRequest;
@@ -112,10 +114,14 @@ public class CreateItemTest {
 
         // Confirm new job is not visible in default view
         assertTrue(aView.isDefault()); // a-view is still the default view
-        // TODO: When JENKINS-74795 is fixed, this assertion will pass
-        // assertThat(aView.getItems(), containsInAnyOrder(aJob));
-        // TODO: Until JENKINS-74795 is fixed, this assertion passes (a bug)
-        assertThat(aView.getItems(), containsInAnyOrder(aJob, b2Job));
+        VersionNumber jenkinsVersion = Jenkins.getVersion();
+        if (jenkinsVersion == null || jenkinsVersion.isOlderThan(new VersionNumber("2.475"))) {
+            // TODO: When JENKINS-74795 is fixed, this assertion will pass
+            assertThat(aView.getItems(), containsInAnyOrder(aJob));
+        } else {
+            // TODO: Until JENKINS-74795 is fixed, this assertion passes (a bug)
+            assertThat(aView.getItems(), containsInAnyOrder(aJob, b2Job));
+        }
     }
 
     @Issue("JENKINS-31235")

--- a/test/src/test/java/hudson/model/ItemsTest.java
+++ b/test/src/test/java/hudson/model/ItemsTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -41,7 +40,6 @@ import hudson.cli.CLICommandInvoker;
 import hudson.cli.CopyJobCommand;
 import hudson.cli.CreateJobCommand;
 import hudson.security.ACL;
-import hudson.util.VersionNumber;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.net.HttpURLConnection;
@@ -210,7 +208,7 @@ public class ItemsTest {
     }
 
     /* JENKINS-74795 notes that new items created through the REST API
-     * are made visible in the default view with 2.475 and newer.
+     * are made visible in the default view with 2.475-2.483.
      * They were not made visible in the default view with 2.474 and
      * earlier.
      */


### PR DESCRIPTION
## [JENKINS-74795] createItem API should not assign new jobs to default view

Prior to Jenkins 2.475, jobs that were created with the `createItem` API were not automatically assigned to the default view.  Jenkins 2.475 changed that behavior so that newly created jobs are always assigned to the default view.

This test checks that behavior.  The test will need to be adapted when the fix is applied.  Fix is intended to be included in this pull request as a later change.

See [JENKINS-74795](https://issues.jenkins.io/browse/JENKINS-74795).

[JENKINS-9264](https://issues.jenkins.io/browse/JENKINS-9264) shows that it is intentional that a user can create a new job using the `createItem` API call under a view and [JENKINS-41128](https://issues.jenkins.io/browse/JENKINS-41128) indicates that users expect the `createItem` API call to work within a view.  Those two issues don't make the expected behavior clear when the `createItem` API call is used to create a new item from the Jenkins base URL but the default view ("primary view") is configured to not show that newly created job.  In that case, 2.474 would create the job and not show it in the view, while 2.475 would create the job and add it to the view.

In the table below, the job being created has a name that will not cause it to be shown in the view "b-list-view".

| URL that created the job | Primary (default) view | Jenkins version | Job added to primary view |
| --------------------------------- | ---------------------------- | -------------------- | ------------------------ |
| `/createItem`                    | All                               | 2.474               | Yes                        |
| `/createItem`                    | All                               | 2.475               | Yes                        |
| `/createItem`                    | b-list-view                   | 2.474               | No                         |
| `/createItem`                    | b-list-view                   | 2.475               | Yes                        |
| `/view/b-list-view/createItem` | All                         | 2.474               | Yes                         |
| `/view/b-list-view/createItem` | All                         | 2.475               | Yes                        |
| `/view/b-list-view/createItem` | b-list-view             | 2.474               | Yes                         |
| `/view/b-list-view/createItem` | b-list-view             | 2.475               | Yes                        |

### Testing done

Confirmed with interactive testing and bisect that the createItem behavior changed for 2.475.  The command line interface behavior did not change, only the createItem API.

### Proposed changelog entries

- Do not assign new jobs to the default view when using the `createItem` API from the root URL.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
