### PR TITLE
[JENKINS-74814] `java.lang.UnsupportedOperationException`: This stack walker does not have `RETAIN_CLASS_REFERENCE` access

### DIFF
--- a/core/src/main/java/jenkins/util/SetContextClassLoader.java
+++ b/core/src/main/java/jenkins/util/SetContextClassLoader.java
@@ -62,7 +62,7 @@ public final class SetContextClassLoader implements AutoCloseable {
      * @since 2.362
      */
     public SetContextClassLoader() {
-        this(StackWalker.getInstance().getCallerClass());
+        this(StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass());
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-74814](https://issues.jenkins.io/browse/JENKINS-74814). When attempting to use the zero-argument version of `jenkins.util.SetContextClassLoader` from #6575 in `ldap-plugin`, I got this exception:

```
java.lang.UnsupportedOperationException: This stack walker does not have RETAIN_CLASS_REFERENCE access
	at java.base/java.lang.StackWalker.getCallerClass(StackWalker.java:687)
	at jenkins.util.SetContextClassLoader.<init>(SetContextClassLoader.java:65)
	at PluginClassLoader for ldap//hudson.security.LDAPSecurityRealm$LDAPAuthenticationManager.authenticate(LDAPSecurityRealm.java:989)
	at org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.attemptAuthentication(UsernamePasswordAuthenticationFilter.java:85)
	at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:231)
	at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:221)
	at hudson.security.ChainedServletFilter2$1.doFilter(ChainedServletFilter2.java:99)
```

This apparently has never worked, but the bug was easy to fix by configuring the stack walker with the `StackWalker.Option.RETAIN_CLASS_REFERENCE` option (which instructs the stack walker to retain class information in each stack frame).

### Testing done

Reproduced the problem in context in a draft `ldap-plugin` change and verified that after this PR the problem was resolved.

### Proposed changelog entries

- Developer: Allow context classloaders to be defined without making explicit reference to the calling class.

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
