### PR TITLE
[JENKINS-74795] Job created via REST API attaches to default view

### DIFF
--- a/core/src/main/java/hudson/model/ModifiableItemGroup.java
+++ b/core/src/main/java/hudson/model/ModifiableItemGroup.java
@@ -33,6 +33,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
  * {@link ItemGroup} that is a general purpose container, which allows users and the rest of the program
@@ -50,7 +51,7 @@ public interface ModifiableItemGroup<T extends Item> extends ItemGroup<T> {
      * The request format follows that of {@code &lt;n:form xmlns:n="/lib/form">}.
      *
      */
-    @StaplerNotDispatchable
+    @RequirePOST
     default T doCreateItem(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         if (ReflectionUtils.isOverridden(
                 ModifiableItemGroup.class,

--- a/test/src/test/java/hudson/jobs/CreateItemTest.java
+++ b/test/src/test/java/hudson/jobs/CreateItemTest.java
@@ -194,9 +194,5 @@ public class CreateItemTest {
         // Confirm new job is not visible in default view
         assertTrue(aView.isDefault()); // a-view is still the default view
         assertThat(aView.getItems(), containsInAnyOrder(aJob));
-
-        // Confirm new job is visible in non-default view
-        assertFalse(bView.isDefault()); // b-view is not the default view
-        assertThat(bView.getItems(), containsInAnyOrder(bJob, b2Job));
     }
 }


### PR DESCRIPTION
### Problem

See [JENKINS-74795](https://issues.jenkins.io/browse/JENKINS-74795). Creating jobs via the `createItem` REST API erroneously attaches those items to the default view after #9672.

### Evaluation

In the working scenario prior to #9672, the `Jenkins#doCreateItem` method is invoked by Stapler via its routable interface method `ModifiableItemGroup#doCreateItem`. In the failing scenario after #9672, the (incorrect) `ListView#doCreateItem` method is invoked by Stapler via its routable superclass method `View#doCreateItem`. This (mostly) works by accident, since `View#doCreateItem` happens to delegate to `Jenkins#doCreateItem`, but the incorrect behavior is still apparent when the item is incorrectly added to the default view. `View#doCreateItem` should never be invoked in this scenario, and the only reason it is was a regression in routing in #9672.

### Solution

Make the `Jenkins#doCreateItem(StaplerRequest2, StaplerResponse2)` default method routable, as the equivalent interface method was prior to #9672. For consistency with `View#doCreateItem(StaplerRequest2, StaplerResponse2)`, add a `@RequirePOST` annotation as well. The deprecated compatibility methods remain non-routable as before.

### Testing done

- Functional testing: new integration test passes before #9672, fails after #9672, and passes with this PR.
- Regression testing: CI build of Jenkins core, ATH, and BOM/PCT

### Proposed changelog entries

- Do not add jobs created via the REST API to the default view.

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```

Closes #9933