### PR TITLE
[JENKINS-73908] Do not show button to upgrade to SystemRead users

### DIFF
--- a/core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/message.jelly
+++ b/core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/message.jelly
@@ -53,11 +53,13 @@ THE SOFTWARE.
       <j:otherwise>
         <j:set var="changelog_url" value="${app.CHANGELOG_URL}"/>
         ${%NewVersionAvailable(ucData.core.version,ucData.core.url,changelog_url)}
-        <j:if test="${ucData.canUpgrade()}">
-        <form method="post" action="${rootURL}/updateCenter/upgrade">
-          <f:submit value="${%Or Upgrade Automatically}"/>
-        </form>
-        </j:if>
+        <l:isAdmin>
+          <j:if test="${ucData.canUpgrade()}">
+            <form method="post" action="${rootURL}/updateCenter/upgrade">
+              <f:submit value="${%Or Upgrade Automatically}"/>
+            </form>
+          </j:if>
+        </l:isAdmin>
       </j:otherwise>
     </j:choose>
   </div>


### PR DESCRIPTION
See [JENKINS-73908](https://issues.jenkins.io/browse/JENKINS-73908). Amends https://github.com/jenkinsci/jenkins/pull/4685.


### Testing done

For ease of testing I commented out the `<j:if>`, then compared based on permissions:

<img width="984" alt="Screenshot 2024-11-15 at 20 09 09" src="https://github.com/user-attachments/assets/3323e706-6a67-42a2-8628-524a9f77b63a">
<img width="987" alt="Screenshot 2024-11-15 at 20 09 03" src="https://github.com/user-attachments/assets/5aa99606-aeae-4015-9118-d126f6d01a3b">


### Proposed changelog entries

Too minor

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
