### PR TITLE
[JENKINS-73487] Fix Stapler exception with multiple security warnings

### DIFF
--- a/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
+++ b/core/src/main/resources/jenkins/security/UpdateSiteWarningsMonitor/message.groovy
@@ -42,7 +42,7 @@ def listWarnings(warnings, boolean core) {
             }
         }
     }
-    if (fixables == warnings.size) {
+    if (fixables == warnings.size()) {
         dd {
             if (fixables == 1) {
                 raw(_(core ? "allFixable1Core" : "allFixable1", rootURL))


### PR DESCRIPTION
See [JENKINS-73487](https://issues.jenkins.io/browse/JENKINS-73487). Amends https://github.com/jenkinsci/jenkins/pull/7046.

### Testing done

I found this issue to be reproducible with Script Security 1.78 on 2.462.x (as well as latest master). My guess is it might happen once you collect multiple security warnings for an installed component, but looking at the code I'm unsure why that would be. Did not investigate further once I had the reproduction.

Adding this change / reverting it switches between the good and bad behaviors:

<img width="1035" alt="bad without fix" src="https://github.com/user-attachments/assets/b6f87a95-e456-404d-8b3c-7ca9cb07d74c">
<img width="1105" alt="good with fix" src="https://github.com/user-attachments/assets/dd905abe-845f-4bc9-ae61-637298be7342">

### Proposed changelog entries

- Fix exception error message about `hudson.model.UpdateSite$Warning` on Manage Jenkins that may be shown when plugins with known security issues are installed.

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
