### PR TITLE
Added test from CLIAction

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -492,6 +492,12 @@ THE SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness</artifactId>
+      <version>2353.ve3f890c6eea_f</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/core/src/test/java/hudson/cli/CLIActionTest.java
+++ b/core/src/test/java/hudson/cli/CLIActionTest.java
@@ -67,10 +67,8 @@ public class CLIActionTest {
         .when(rsp)
         .sendError(eq(HttpServletResponse.SC_NOT_FOUND), anyString());
 
-    // Вызов тестируемого метода
     cliAction.doCommand(req, rsp);
 
-    // Проверка, что sendError был вызван
     verify(rsp).sendError(HttpServletResponse.SC_NOT_FOUND, "No such command");
   }
 
@@ -124,7 +122,7 @@ public class CLIActionTest {
   @Test
   public void testWebSocketNotSupported() throws Exception {
     try (MockedStatic<WebSockets> webSocketsMock = Mockito.mockStatic(WebSockets.class)) {
-      StaplerRequest2 req = mock(StaplerRequest2.class);// Используем обычный StaplerRequest
+      StaplerRequest2 req = mock(StaplerRequest2.class);
 
       webSocketsMock.when(WebSockets::isSupported).thenReturn(false);
 
@@ -149,11 +147,11 @@ public class CLIActionTest {
 
       webSocketsMock.when(WebSockets::isSupported).thenReturn(true);
 
-      when(req.getHeader("Origin")).thenReturn("http://invalid-origin.com");
+      when(req.getHeader("Origin")).thenReturn("https://invalid-origin.com");
 
       Jenkins jenkins = mock(Jenkins.class);
       jenkinsMock.when(Jenkins::get).thenReturn(jenkins);
-      when(jenkins.getRootUrlFromRequest()).thenReturn("http://correct-origin.com/");
+      when(jenkins.getRootUrlFromRequest()).thenReturn("https://correct-origin.com/");
       when(req.getContextPath()).thenReturn("");
 
       Field allowWebSocketField = CLIAction.class.getDeclaredField("ALLOW_WEBSOCKET");
@@ -182,11 +180,11 @@ public class CLIActionTest {
 
       webSocketsMock.when(WebSockets::isSupported).thenReturn(true);
 
-      when(req.getHeader("Origin")).thenReturn("http://correct-origin.com");
+      when(req.getHeader("Origin")).thenReturn("https://correct-origin.com");
 
       Jenkins jenkins = mock(Jenkins.class);
       jenkinsMock.when(Jenkins::get).thenReturn(jenkins);
-      when(jenkins.getRootUrlFromRequest()).thenReturn("http://correct-origin.com/");
+      when(jenkins.getRootUrlFromRequest()).thenReturn("https://correct-origin.com/");
       when(req.getContextPath()).thenReturn("");
 
       Field allowWebSocketField = CLIAction.class.getDeclaredField("ALLOW_WEBSOCKET");
@@ -207,7 +205,6 @@ public class CLIActionTest {
 
       webSocketsMock.when(WebSockets::isSupported).thenReturn(true);
 
-      // Отключен WebSocket через флаг ALLOW_WEBSOCKET
       Field allowWebSocketField = CLIAction.class.getDeclaredField("ALLOW_WEBSOCKET");
       allowWebSocketField.setAccessible(true);
       allowWebSocketField.set(cliAction, false);

--- a/core/src/test/java/hudson/cli/CLIActionTest.java
+++ b/core/src/test/java/hudson/cli/CLIActionTest.java
@@ -1,0 +1,228 @@
+package hudson.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Optional;
+import javax.servlet.http.HttpServletResponse;
+import jenkins.model.Jenkins;
+import jenkins.websocket.WebSocketSession;
+import jenkins.websocket.WebSockets;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+public class CLIActionTest {
+
+  @Rule
+  public JenkinsRule jenkinsRule = new JenkinsRule();
+
+  private final CLIAction cliAction = new CLIAction();
+
+  @Test
+  public void testDoCommand() throws ServletException, IOException {
+    Jenkins jenkins = jenkinsRule.getInstance();
+    jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
+    jenkinsRule.jenkins.setAuthorizationStrategy(
+        new org.jvnet.hudson.test.MockAuthorizationStrategy()
+            .grant(Jenkins.READ)
+            .everywhere()
+            .to("user"));
+
+    StaplerRequest2 req = mock(StaplerRequest2.class);
+    StaplerResponse2 rsp = mock(StaplerResponse2.class);
+
+    when(req.getRestOfPath()).thenReturn("/testCommand");
+
+    doAnswer(
+        (Answer<Void>) invocation -> {
+          int statusCode = invocation.getArgument(0);
+          String message = invocation.getArgument(1);
+          assertEquals("Expected 404 error", HttpServletResponse.SC_NOT_FOUND, statusCode);
+          assertTrue("Expected 'No such command' message", message.contains("No such command"));
+          return null;
+        })
+        .when(rsp)
+        .sendError(eq(HttpServletResponse.SC_NOT_FOUND), anyString());
+
+    // Вызов тестируемого метода
+    cliAction.doCommand(req, rsp);
+
+    // Проверка, что sendError был вызван
+    verify(rsp).sendError(HttpServletResponse.SC_NOT_FOUND, "No such command");
+  }
+
+  @Test
+  public void testDoCommandWithParameter() throws ServletException, IOException {
+    Jenkins jenkins = jenkinsRule.getInstance();
+
+    jenkins.setSecurityRealm(jenkinsRule.createDummySecurityRealm());
+    jenkinsRule.jenkins.setAuthorizationStrategy(
+        new MockAuthorizationStrategy()
+            .grant(Jenkins.READ)
+            .everywhere()
+            .to("user"));
+
+    StaplerRequest2 req = mock(StaplerRequest2.class);
+    StaplerResponse2 rsp = mock(StaplerResponse2.class);
+    RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+
+    when(req.getRestOfPath()).thenReturn("/add-job-to-view");
+    when(req.getView(Optional.ofNullable(any()), anyString())).thenReturn(dispatcher);
+
+    doNothing().when(dispatcher).forward(any(), any());
+
+    cliAction.doCommand(req, rsp);
+
+    verify(req).getRestOfPath();
+    verify(req).getView(Optional.ofNullable(any()), anyString());
+    verify(dispatcher).forward(any(), any());
+  }
+
+  @Test
+  public void getIconFileName() {
+    assertNull(cliAction.getIconFileName());
+  }
+
+  @Test
+  public void getDisplayName() {
+    assertEquals("Jenkins CLI", cliAction.getDisplayName());
+  }
+
+  @Test
+  public void getUrlName() {
+    assertEquals("cli", cliAction.getUrlName());
+  }
+
+  @Test
+  public void isWebSocketSupported() {
+    assertFalse(cliAction.isWebSocketSupported());
+  }
+
+  @Test
+  public void testWebSocketNotSupported() throws Exception {
+    try (MockedStatic<WebSockets> webSocketsMock = Mockito.mockStatic(WebSockets.class)) {
+      StaplerRequest2 req = mock(StaplerRequest2.class);// Используем обычный StaplerRequest
+
+      webSocketsMock.when(WebSockets::isSupported).thenReturn(false);
+
+      HttpResponse response = cliAction.doWs(req);
+
+      assertNotNull("Response should not be null", response);
+
+      StaplerResponse2 resp = mock(StaplerResponse2.class);
+      response.generateResponse(req, resp, null);
+
+      verify(resp).setStatus(HttpServletResponse.SC_NOT_FOUND);
+    }
+  }
+
+  @Test
+  public void testInvalidOrigin() throws Exception {
+    try (MockedStatic<WebSockets> webSocketsMock = Mockito.mockStatic(WebSockets.class);
+        MockedStatic<Jenkins> jenkinsMock = Mockito.mockStatic(Jenkins.class)) {
+
+      StaplerRequest2 req = mock(StaplerRequest2.class);
+      StaplerResponse2 resp = mock(StaplerResponse2.class);
+
+      webSocketsMock.when(WebSockets::isSupported).thenReturn(true);
+
+      when(req.getHeader("Origin")).thenReturn("http://invalid-origin.com");
+
+      Jenkins jenkins = mock(Jenkins.class);
+      jenkinsMock.when(Jenkins::get).thenReturn(jenkins);
+      when(jenkins.getRootUrlFromRequest()).thenReturn("http://correct-origin.com/");
+      when(req.getContextPath()).thenReturn("");
+
+      Field allowWebSocketField = CLIAction.class.getDeclaredField("ALLOW_WEBSOCKET");
+      allowWebSocketField.setAccessible(true);
+      allowWebSocketField.set(cliAction, null);
+
+      HttpResponse response = cliAction.doWs(req);
+
+      assertNotNull("Response should not be null", response);
+
+      response.generateResponse(req, resp, null);
+
+      verify(resp).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+  }
+
+  @Test
+  public void testWebSocketSupportedAndAllowed() throws Exception {
+    try (MockedStatic<WebSockets> webSocketsMock = Mockito.mockStatic(WebSockets.class);
+        MockedStatic<Jenkins> jenkinsMock = Mockito.mockStatic(Jenkins.class)) {
+
+      webSocketsMock.when(() -> WebSockets.upgrade(any(WebSocketSession.class)))
+          .thenReturn(mock(HttpResponse.class));
+
+      StaplerRequest2 req = mock(StaplerRequest2.class);
+
+      webSocketsMock.when(WebSockets::isSupported).thenReturn(true);
+
+      when(req.getHeader("Origin")).thenReturn("http://correct-origin.com");
+
+      Jenkins jenkins = mock(Jenkins.class);
+      jenkinsMock.when(Jenkins::get).thenReturn(jenkins);
+      when(jenkins.getRootUrlFromRequest()).thenReturn("http://correct-origin.com/");
+      when(req.getContextPath()).thenReturn("");
+
+      Field allowWebSocketField = CLIAction.class.getDeclaredField("ALLOW_WEBSOCKET");
+      allowWebSocketField.setAccessible(true);
+      allowWebSocketField.set(cliAction, true);
+
+      HttpResponse response = cliAction.doWs(req);
+
+      assertNotNull("Response should not be null", response);
+    }
+  }
+
+  @Test
+  public void testWebSocketDisabled() throws Exception {
+    try (MockedStatic<WebSockets> webSocketsMock = Mockito.mockStatic(WebSockets.class)) {
+      StaplerRequest2 req = mock(StaplerRequest2.class);
+      StaplerResponse2 resp = mock(StaplerResponse2.class);
+
+      webSocketsMock.when(WebSockets::isSupported).thenReturn(true);
+
+      // Отключен WebSocket через флаг ALLOW_WEBSOCKET
+      Field allowWebSocketField = CLIAction.class.getDeclaredField("ALLOW_WEBSOCKET");
+      allowWebSocketField.setAccessible(true);
+      allowWebSocketField.set(cliAction, false);
+
+      HttpResponse response = cliAction.doWs(req);
+
+      assertNotNull("Response should not be null", response);
+
+      response.generateResponse(req, resp, null);
+
+      verify(resp).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+  }
+
+  @Test
+  public void getTarget() {
+  }
+}

--- a/core/src/test/java/hudson/cli/CLIActionTest.java
+++ b/core/src/test/java/hudson/cli/CLIActionTest.java
@@ -218,8 +218,4 @@ public class CLIActionTest {
       verify(resp).setStatus(HttpServletResponse.SC_FORBIDDEN);
     }
   }
-
-  @Test
-  public void getTarget() {
-  }
 }


### PR DESCRIPTION
## See [JENKINS-70464](https://issues.jenkins.io/browse/JENKINS-70464)

## Testing done

I added a comprehensive set of unit tests for the `CLIAction` class, which include the following scenarios:

- **Test for the `doCommand()` method**: Verifies that a 404 error is returned when an invalid command is requested.
- **Test for the `doCommand()` method with a valid parameter**: Checks that the correct view dispatcher is called and forwarded when a valid command is provided.
- **Tests for WebSocket-related behavior**:
  - Verifies that a WebSocket connection is not supported.
  - Checks the behavior when the origin header is invalid.
  - Ensures that WebSocket connections are allowed only if both conditions (WebSocket support and allowed origin) are met.
  - Verifies that a `Forbidden` response is returned when WebSocket connections are not allowed.

All tests were executed successfully on a local Jenkins instance.

## Proposed changelog entries

- Added unit tests for `CLIAction` class methods and WebSocket handling.
- Improved test coverage for CLI commands and WebSocket connection handling.

## Proposed upgrade guidelines

N/A

---

## Pull Request Template

```markdown
[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with @Restricted or have @since TODO Javadocs, as appropriate.
- [x] New deprecations are annotated with @Deprecated(since = "TODO") or @Deprecated(forRemoval = true, since = "TODO"), if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call eval to ease future introduction of Content Security Policy (CSP) directives.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
