### PR TITLE
[JENKINS-73907] Fix double-escaped tooltips in "Help for feature"

### DIFF
--- a/core/src/main/resources/lib/form/helpLink.jelly
+++ b/core/src/main/resources/lib/form/helpLink.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
   </st:documentation>
   <j:choose>
     <j:when test="${attrs.url!=null}">
-      <j:set var="altText" value="${attrs.featureName != null ? '%Help for feature:' + ' ' + h.escape(attrs.featureName) : '%Help'}" />
+      <j:set var="altText" value="${attrs.featureName != null ? '%Help for feature:' + ' ' + attrs.featureName : '%Help'}" />
       <a href="#" class="jenkins-help-button" tooltip="${altText}" helpURL="${rootURL}${attrs.url}">
         <!-- .jenkins-help-button span element is required as it's restyled in CSS -->
         <span>?</span>

--- a/test/src/test/java/jenkins/security/Security2779Test.java
+++ b/test/src/test/java/jenkins/security/Security2779Test.java
@@ -49,7 +49,7 @@ public class Security2779Test {
 
         // assert leading space to identify unintentional double-escaping (&amp;lt;) as test failure
         assertThat("tooltip does not contain dangerous HTML", jsResultString, not(containsString(" <img src=x")));
-        assertThat("tooltip contains safe text", jsResultString, containsString("lt;img src=x"));
+        assertThat("tooltip contains safe text", jsResultString, containsString(" &lt;img src=x"));
     }
 
     @TestExtension


### PR DESCRIPTION
See [JENKINS-73907](https://issues.jenkins.io/browse/JENKINS-73907).

### Testing done
![CleanShot 2024-11-21 at 11 14 20](https://github.com/user-attachments/assets/1485046f-25f7-4131-9d49-0296db121877)

### Proposed changelog entries

- Fix double-escaped tooltips in "Help for feature".

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
