### PR TITLE
Create a tmp directory when such doesn't exist. In some cases the tmp…

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -436,6 +436,14 @@ public class Util {
         // https://github.com/jenkinsci/jenkins/pull/3161 )
         final Path tempPath;
         final String tempDirNamePrefix = "jenkins";
+
+        final Path systemTmpDirectoryPath = Path.of(System.getProperty("java.io.tmpdir"));
+        if (!systemTmpDirectoryPath.toFile().exists()){
+            // In some cases the tmp directory set in the java.io.tmpdir property will not exist and hence will have to
+            // be created here.
+            systemTmpDirectoryPath.toFile().mkdirs();
+        }
+
         if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
             tempPath = Files.createTempDirectory(tempDirNamePrefix,
                     PosixFilePermissions.asFileAttribute(EnumSet.allOf(PosixFilePermission.class)));

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -438,10 +438,10 @@ public class Util {
         final String tempDirNamePrefix = "jenkins";
 
         final Path systemTmpDirectoryPath = Path.of(System.getProperty("java.io.tmpdir"));
-        if (!systemTmpDirectoryPath.toFile().exists()){
+        if (!systemTmpDirectoryPath.toFile().exists()) {
             // In some cases the tmp directory set in the java.io.tmpdir property will not exist and hence will have to
             // be created here.
-            systemTmpDirectoryPath.toFile().mkdirs();
+            Files.createDirectory(systemTmpDirectoryPath);
         }
 
         if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {


### PR DESCRIPTION
# Description 
While writing Jenkins plugin tests and debugging them in IntelliJ I stumbled upon an issue when trying to create an instance of JenkinsRule, which was failing to instantiate due to the following exception:

```
java.lang.Error: java.nio.file.NoSuchFileException: .../plugin-dir/target/tmp/jenkins17059940806884222895
at org.jvnet.hudson.test.TestPluginManager.<clinit>(TestPluginManager.java:45)
at org.jvnet.hudson.test.JenkinsRule.<init>(JenkinsRule.java:345)
at com.appfire.jenkins.plugins.it.TestDeflakeBuild.<init>(TestDeflakeBuild.java:10)
at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
at java.base/java.util.Optional.orElseGet(Optional.java:364)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.nio.file.NoSuchFileException: .../plugin-dir/target/tmp/jenkins17059940806884222895
at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:397)
at java.base/java.nio.file.Files.createDirectory(Files.java:700)
at java.base/java.nio.file.TempFileHelper.create(TempFileHelper.java:134)
at java.base/java.nio.file.TempFileHelper.createTempDirectory(TempFileHelper.java:171)
at java.base/java.nio.file.Files.createTempDirectory(Files.java:1017)
at hudson.Util.createTempDir(Util.java:437)
at org.jvnet.hudson.test.TestPluginManager.<init>(TestPluginManager.java:50)
at org.jvnet.hudson.test.TestPluginManager.<clinit>(TestPluginManager.java:28)
... 7 more
```

I was debugging the test from within IntelliJ and what I noticed was that IntelliJ was setting the `java.io.tmpdir` property to be a `tmp` directory within the project target directory, which doesn't exist my default, hence why I am creating this PR. This issue could have been resolved with extra maven hackery in my plugin's pom.xml, but I thought that this issue might occur in different scenarios as well and why not handle it here. 