### PR TITLE
Trim the environment variables keys and values

### DIFF
--- a/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
+++ b/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
@@ -119,16 +119,20 @@ public class EnvironmentVariablesNodeProperty extends NodeProperty<Node> {
 
         @DataBoundConstructor
         public Entry(String key, String value) {
-            this.key = Util.fixNull(Util.fixEmptyAndTrim(key));
-            this.value = Util.fixNull(Util.fixEmptyAndTrim(value));
+            this.key = Util.fixEmptyAndTrim(key);
+            this.value = Util.fixEmptyAndTrim(value);
         }
     }
 
     private static EnvVars toMap(List<Entry> entries) {
         EnvVars map = new EnvVars();
-        if (entries != null)
-            for (Entry entry : entries)
-                map.put(entry.key, entry.value);
+        if (entries != null) {
+            for (Entry entry : entries) {
+                if(entry.key != null && entry.value != null) {
+                    map.put(entry.key, entry.value);
+                }
+            }
+        }
         return map;
     }
 

--- a/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
+++ b/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
@@ -119,8 +119,8 @@ public class EnvironmentVariablesNodeProperty extends NodeProperty<Node> {
 
         @DataBoundConstructor
         public Entry(String key, String value) {
-            this.key = Util.fixEmptyAndTrim(key);
-            this.value = Util.fixEmptyAndTrim(value);
+            this.key = Util.fixNull(Util.fixEmptyAndTrim(key));
+            this.value = Util.fixNull(Util.fixEmptyAndTrim(value));
         }
     }
 

--- a/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
+++ b/core/src/main/java/hudson/slaves/EnvironmentVariablesNodeProperty.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.ComputerSet;
@@ -118,8 +119,8 @@ public class EnvironmentVariablesNodeProperty extends NodeProperty<Node> {
 
         @DataBoundConstructor
         public Entry(String key, String value) {
-            this.key = key;
-            this.value = value;
+            this.key = Util.fixEmptyAndTrim(key);
+            this.value = Util.fixEmptyAndTrim(value);
         }
     }
 

--- a/test/src/test/java/hudson/slaves/EnvironmentVariableNodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/EnvironmentVariableNodePropertyTest.java
@@ -1,6 +1,7 @@
 package hudson.slaves;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -167,14 +168,14 @@ public class EnvironmentVariableNodePropertyTest {
 
         Map<String, String> envVars = executeBuild(j.jenkins);
 
-        assertEquals("", envVars.get("KEY"));
+        assertNull(envVars.get("KEY"));
     }
 
     @Test
     public void testEmptyForAgent() throws Exception {
         setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("KEY", ""));
         Map<String, String> envVars = executeBuild(agent);
-        assertEquals("", envVars.get("KEY"));
+        assertNull(envVars.get("KEY"));
     }
 
     @Test
@@ -185,14 +186,142 @@ public class EnvironmentVariableNodePropertyTest {
 
         Map<String, String> envVars = executeBuild(j.jenkins);
 
-        assertEquals("", envVars.get("KEY"));
+        assertNull(envVars.get("KEY"));
     }
 
     @Test
     public void testOnlySpacesForAgent() throws Exception {
         setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("KEY", "                "));
         Map<String, String> envVars = executeBuild(agent);
-        assertEquals("", envVars.get("KEY"));
+        assertNull(envVars.get("KEY"));
+    }
+
+    @Test
+    public void testFormRoundTripForControllerWithEmpty() throws Exception {
+        j.jenkins.getGlobalNodeProperties().replaceBy(
+                Set.of(new EnvironmentVariablesNodeProperty(
+                        new EnvironmentVariablesNodeProperty.Entry("", ""))));
+
+        WebClient webClient = j.createWebClient();
+        HtmlPage page = webClient.getPage(j.jenkins, "configure");
+        HtmlForm form = page.getFormByName("config");
+        j.submit(form);
+
+        assertEquals(1, j.jenkins.getGlobalNodeProperties().toList().size());
+
+        EnvironmentVariablesNodeProperty prop = j.jenkins.getGlobalNodeProperties().get(EnvironmentVariablesNodeProperty.class);
+        assertEquals(0, prop.getEnvVars().size());
+    }
+
+    @Test
+    public void testFormRoundTripForAgentWithEmpty() throws Exception {
+        setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("", ""));
+
+        WebClient webClient = j.createWebClient();
+        HtmlPage page = webClient.getPage(agent, "configure");
+        HtmlForm form = page.getFormByName("config");
+        j.submit(form);
+
+        assertEquals(1, agent.getNodeProperties().toList().size());
+
+        EnvironmentVariablesNodeProperty prop = agent.getNodeProperties().get(EnvironmentVariablesNodeProperty.class);
+        assertEquals(0, prop.getEnvVars().size());
+    }
+
+    @Test
+    public void testFormRoundTripForControllerWithSpaces() throws Exception {
+        j.jenkins.getGlobalNodeProperties().replaceBy(
+                Set.of(new EnvironmentVariablesNodeProperty(
+                        new EnvironmentVariablesNodeProperty.Entry("   ", "   "))));
+
+        WebClient webClient = j.createWebClient();
+        HtmlPage page = webClient.getPage(j.jenkins, "configure");
+        HtmlForm form = page.getFormByName("config");
+        j.submit(form);
+
+        assertEquals(1, j.jenkins.getGlobalNodeProperties().toList().size());
+
+        EnvironmentVariablesNodeProperty prop = j.jenkins.getGlobalNodeProperties().get(EnvironmentVariablesNodeProperty.class);
+        assertEquals(0, prop.getEnvVars().size());
+    }
+
+    @Test
+    public void testFormRoundTripForAgentWithSpaces() throws Exception {
+        setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("   ", "   "));
+
+        WebClient webClient = j.createWebClient();
+        HtmlPage page = webClient.getPage(agent, "configure");
+        HtmlForm form = page.getFormByName("config");
+        j.submit(form);
+
+        assertEquals(1, agent.getNodeProperties().toList().size());
+
+        EnvironmentVariablesNodeProperty prop = agent.getNodeProperties().get(EnvironmentVariablesNodeProperty.class);
+        assertEquals(0, prop.getEnvVars().size());
+    }
+
+    @Test
+    public void testFormRoundTripForControllerWithSpacesAndKey() throws Exception {
+        j.jenkins.getGlobalNodeProperties().replaceBy(
+                Set.of(new EnvironmentVariablesNodeProperty(
+                        new EnvironmentVariablesNodeProperty.Entry("KEY", "   "))));
+
+        WebClient webClient = j.createWebClient();
+        HtmlPage page = webClient.getPage(j.jenkins, "configure");
+        HtmlForm form = page.getFormByName("config");
+        j.submit(form);
+
+        assertEquals(1, j.jenkins.getGlobalNodeProperties().toList().size());
+
+        EnvironmentVariablesNodeProperty prop = j.jenkins.getGlobalNodeProperties().get(EnvironmentVariablesNodeProperty.class);
+        assertEquals(0, prop.getEnvVars().size());
+    }
+
+    @Test
+    public void testFormRoundTripForAgentWithSpacesAndKey() throws Exception {
+        setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("KEY", "   "));
+
+        WebClient webClient = j.createWebClient();
+        HtmlPage page = webClient.getPage(agent, "configure");
+        HtmlForm form = page.getFormByName("config");
+        j.submit(form);
+
+        assertEquals(1, agent.getNodeProperties().toList().size());
+
+        EnvironmentVariablesNodeProperty prop = agent.getNodeProperties().get(EnvironmentVariablesNodeProperty.class);
+        assertEquals(0, prop.getEnvVars().size());
+    }
+
+    @Test
+    public void testFormRoundTripForControllerWithEmptyAndKey() throws Exception {
+        j.jenkins.getGlobalNodeProperties().replaceBy(
+                Set.of(new EnvironmentVariablesNodeProperty(
+                        new EnvironmentVariablesNodeProperty.Entry("KEY", ""))));
+
+        WebClient webClient = j.createWebClient();
+        HtmlPage page = webClient.getPage(j.jenkins, "configure");
+        HtmlForm form = page.getFormByName("config");
+        j.submit(form);
+
+        assertEquals(1, j.jenkins.getGlobalNodeProperties().toList().size());
+
+        EnvironmentVariablesNodeProperty prop = j.jenkins.getGlobalNodeProperties().get(EnvironmentVariablesNodeProperty.class);
+        assertEquals(0, prop.getEnvVars().size());
+    }
+
+    @Test
+    public void testFormRoundTripForAgentWithEmptyAndKey() throws Exception {
+        setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("KEY", ""));
+
+        WebClient webClient = j.createWebClient();
+        HtmlPage page = webClient.getPage(agent, "configure");
+        HtmlForm form = page.getFormByName("config");
+        j.submit(form);
+
+        assertEquals(1, agent.getNodeProperties().toList().size());
+
+        EnvironmentVariablesNodeProperty prop = agent.getNodeProperties().get(EnvironmentVariablesNodeProperty.class);
+        assertEquals(0, prop.getEnvVars().size());
     }
 
     // //////////////////////// setup //////////////////////////////////////////

--- a/test/src/test/java/hudson/slaves/EnvironmentVariableNodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/EnvironmentVariableNodePropertyTest.java
@@ -141,6 +141,24 @@ public class EnvironmentVariableNodePropertyTest {
         assertEquals("value", prop.getEnvVars().get("KEY"));
     }
 
+    @Test
+    public void testExtraSpacesForController() throws Exception {
+        j.jenkins.getGlobalNodeProperties().replaceBy(
+                Set.of(new EnvironmentVariablesNodeProperty(
+                        new EnvironmentVariablesNodeProperty.Entry("      KEY       ", "         globalValue        "))));
+
+        Map<String, String> envVars = executeBuild(j.jenkins);
+
+        assertEquals("globalValue", envVars.get("KEY"));
+    }
+
+    @Test
+    public void testExtraSpacesForAgent() throws Exception {
+        setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("      KEY      ", "        agentValue      "));
+        Map<String, String> envVars = executeBuild(agent);
+        assertEquals("agentValue", envVars.get("KEY"));
+    }
+
     // //////////////////////// setup //////////////////////////////////////////
 
     @Before

--- a/test/src/test/java/hudson/slaves/EnvironmentVariableNodePropertyTest.java
+++ b/test/src/test/java/hudson/slaves/EnvironmentVariableNodePropertyTest.java
@@ -159,6 +159,42 @@ public class EnvironmentVariableNodePropertyTest {
         assertEquals("agentValue", envVars.get("KEY"));
     }
 
+    @Test
+    public void testEmptyForController() throws Exception {
+        j.jenkins.getGlobalNodeProperties().replaceBy(
+                Set.of(new EnvironmentVariablesNodeProperty(
+                        new EnvironmentVariablesNodeProperty.Entry("KEY", ""))));
+
+        Map<String, String> envVars = executeBuild(j.jenkins);
+
+        assertEquals("", envVars.get("KEY"));
+    }
+
+    @Test
+    public void testEmptyForAgent() throws Exception {
+        setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("KEY", ""));
+        Map<String, String> envVars = executeBuild(agent);
+        assertEquals("", envVars.get("KEY"));
+    }
+
+    @Test
+    public void testOnlySpacesForController() throws Exception {
+        j.jenkins.getGlobalNodeProperties().replaceBy(
+                Set.of(new EnvironmentVariablesNodeProperty(
+                        new EnvironmentVariablesNodeProperty.Entry("KEY", "                  "))));
+
+        Map<String, String> envVars = executeBuild(j.jenkins);
+
+        assertEquals("", envVars.get("KEY"));
+    }
+
+    @Test
+    public void testOnlySpacesForAgent() throws Exception {
+        setVariables(agent, new EnvironmentVariablesNodeProperty.Entry("KEY", "                "));
+        Map<String, String> envVars = executeBuild(agent);
+        assertEquals("", envVars.get("KEY"));
+    }
+
     // //////////////////////// setup //////////////////////////////////////////
 
     @Before


### PR DESCRIPTION
Add in trimming of the node environment variables key and value values. If you enter values in either fields with leading spaces, trailing spaces or leading and trailing spaces, those spaces would stay and the environment variables would not load. This becomes a real problem when adding `BASE+EXTRA` values, such as `PATH+LOCAL_BIN`.

This change trims the `key` and `value` values.

### Testing done

* `mvn -am -pl war,bom -Pquick-build clean install`
* `mvn -Dtest=EnvironmentVariableNodePropertyTest verify -Dskip.yarn -Dskip.corepack`

### Proposed changelog entries

- Trim the `key` and `value` values for Node environment variables.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
