### PR TITLE
Fix attributes leaking in the toggle switch component

### DIFF
--- a/core/src/main/resources/lib/form/toggleSwitch.jelly
+++ b/core/src/main/resources/lib/form/toggleSwitch.jelly
@@ -76,19 +76,19 @@ THE SOFTWARE.
            disabled="${readOnlyMode ? 'true' : null}"
            checked="${value ? 'true' : null}"/>
     <label class="jenkins-toggle-switch__label ${id != null ? '' : 'attach-previous'}"
-           for="${id}" data-title="${title}" data-checked-title="${checkedTitle}">
+           for="${attrs.id}" data-title="${attrs.title}" data-checked-title="${attrs.checkedTitle}">
       <j:choose>
-        <j:when test="${checkedTitle == null}">
-          ${title}
+        <j:when test="${attrs.checkedTitle == null}">
+          ${attrs.title}
         </j:when>
         <j:otherwise>
-          <span class="jenkins-toggle-switch__label__unchecked-title">${title}</span>
-          <span class="jenkins-toggle-switch__label__checked-title">${checkedTitle}</span>
+          <span class="jenkins-toggle-switch__label__unchecked-title">${attrs.title}</span>
+          <span class="jenkins-toggle-switch__label__checked-title">${attrs.checkedTitle}</span>
         </j:otherwise>
       </j:choose>
     </label>
-    <j:if test="${description != null and !description.trim().isEmpty()}">
-      <span class="jenkins-toggle-switch__description">${description}</span>
+    <j:if test="${attrs.description != null and !attrs.description.trim().isEmpty()}">
+      <span class="jenkins-toggle-switch__description">${attrs.description}</span>
     </j:if>
   </span>
 </j:jelly>


### PR DESCRIPTION
Small one to fix the attributes leaking in the `<f:toggleSwitch />` component. It was missing `attrs.` which caused some properties to inherit prior set values.

### Testing done

* Toggle switch works as expected in project views/Design Library

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
