### PR TITLE
Expose `User.reload` as beta API

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -77,6 +77,7 @@ import jenkins.security.UserDetailsCache;
 import jenkins.util.SystemProperties;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -673,9 +674,9 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     }
 
     /**
-     * To be called from {@link Jenkins#reload} only.
+     * Called from {@link Jenkins#reload}.
      */
-    @Restricted(NoExternalUse.class)
+    @Restricted(Beta.class)
     public static void reload() throws IOException {
         UserIdMapper.getInstance().reload();
         AllUsers.reload();


### PR DESCRIPTION
CloudBees CI in HA mode sometimes needs to reload the list of `User`s in response to changes on disk. #8544 suffices when there is merely a configuration change to a loaded `User` object (e.g., saving email address) but not in all cases, such as a new `User` being defined. Calling `Jenkins.reload` is much too heavyweight.

### Testing done

Covered by an automated test in CloudBees CI.

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
