### PR TITLE
`PeepholePermalink.Cache`

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -853,7 +853,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     /**
-     * Gets the youngest build #m that satisfies {@code n&lt;=m}.
+     * Gets the oldest build #m that satisfies {@code m ≥ n}.
      *
      * This is useful when you'd like to fetch a build but the exact build might
      * be already gone (deleted, rotated, etc.)
@@ -868,7 +868,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     /**
-     * Gets the latest build #m that satisfies {@code m&lt;=n}.
+     * Gets the newest build #m that satisfies {@code m ≤ n}.
      *
      * This is useful when you'd like to fetch a build but the exact build might
      * be already gone (deleted, rotated, etc.)
@@ -977,7 +977,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     protected abstract void removeRun(RunT run);
 
     /**
-     * Returns the last build.
+     * Returns the newest build.
      * @see LazyBuildMixIn#getLastBuild
      */
     @Exported

--- a/core/src/main/java/jenkins/model/PeepholePermalink.java
+++ b/core/src/main/java/jenkins/model/PeepholePermalink.java
@@ -4,6 +4,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
 import hudson.Util;
 import hudson.model.Job;
 import hudson.model.PermalinkProjectAction.Permalink;
@@ -14,6 +16,7 @@ import hudson.model.listeners.RunListener;
 import hudson.util.AtomicFileWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
@@ -24,6 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
@@ -64,14 +68,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public abstract class PeepholePermalink extends Permalink implements Predicate<Run<?, ?>> {
 
     /**
-     * JENKINS-22822: avoids rereading caches.
-     * Top map keys are {@code builds} directories.
-     * Inner maps are from permalink name to build number.
-     * Synchronization is first on the outer map, then on the inner.
-     */
-    private static final Map<File, Map<String, Integer>> caches = new HashMap<>();
-
-    /**
      * Checks if the given build satisfies the peep-hole criteria.
      *
      * This is the "G(B)" as described in the class javadoc.
@@ -94,115 +90,216 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
      */
     @Override
     public Run<?, ?> resolve(Job<?, ?> job) {
-        Map<String, Integer> cache = cacheFor(job.getBuildDir());
-        int n;
-        synchronized (cache) {
-            n = cache.getOrDefault(getId(), 0);
-        }
-        if (n == RESOLVES_TO_NONE) {
-            return null;
-        }
-        Run<?, ?> b;
-        if (n > 0) {
-            b = job.getBuildByNumber(n);
-            if (b != null && apply(b)) {
-                return b; // found it (in the most efficient way possible)
-            }
-        } else {
-            b = null;
-        }
-
-        // the cache is stale. start the search
-        if (b == null) {
-            b = job.getNearestOldBuild(n);
-        }
-
-        if (b == null) {
-            // no cache
-            b = job.getLastBuild();
-        }
-
-        // start from the build 'b' and locate the build that matches the criteria going back in time
-        b = find(b);
-
-        updateCache(job, b);
-        return b;
+        return ExtensionList.lookupFirst(Cache.class).get(job, getId()).resolve(this, job, getId());
     }
 
     /**
      * Start from the build 'b' and locate the build that matches the criteria going back in time
      */
-    private Run<?, ?> find(Run<?, ?> b) {
-        //noinspection StatementWithEmptyBody
-        for ( ; b != null && !apply(b); b = b.getPreviousBuild())
-            ;
+    @CheckForNull
+    private Run<?, ?> find(@CheckForNull Run<?, ?> b) {
+        while (b != null && !apply(b)) {
+            b = b.getPreviousBuild();
+        }
         return b;
-    }
-
-    private static @NonNull Map<String, Integer> cacheFor(@NonNull File buildDir) {
-        synchronized (caches) {
-            Map<String, Integer> cache = caches.get(buildDir);
-            if (cache == null) {
-                cache = load(buildDir);
-                caches.put(buildDir, cache);
-            }
-            return cache;
-        }
-    }
-
-    private static @NonNull Map<String, Integer> load(@NonNull File buildDir) {
-        Map<String, Integer> cache = new TreeMap<>();
-        File storage = storageFor(buildDir);
-        if (storage.isFile()) {
-            try (Stream<String> lines = Files.lines(storage.toPath(), StandardCharsets.UTF_8)) {
-                lines.forEach(line -> {
-                    int idx = line.indexOf(' ');
-                    if (idx == -1) {
-                        return;
-                    }
-                    try {
-                        cache.put(line.substring(0, idx), Integer.parseInt(line.substring(idx + 1)));
-                    } catch (NumberFormatException x) {
-                        LOGGER.log(Level.WARNING, "failed to read " + storage, x);
-                    }
-                });
-            } catch (IOException x) {
-                LOGGER.log(Level.WARNING, "failed to read " + storage, x);
-            }
-            LOGGER.fine(() -> "loading from " + storage + ": " + cache);
-        }
-        return cache;
-    }
-
-    static @NonNull File storageFor(@NonNull File buildDir) {
-        return new File(buildDir, "permalinks");
     }
 
     /**
      * Remembers the value 'n' in the cache for future {@link #resolve(Job)}.
      */
     protected void updateCache(@NonNull Job<?, ?> job, @CheckForNull Run<?, ?> b) {
-        File buildDir = job.getBuildDir();
-        Map<String, Integer> cache = cacheFor(buildDir);
-        synchronized (cache) {
-            cache.put(getId(), b == null ? RESOLVES_TO_NONE : b.getNumber());
-            File storage = storageFor(buildDir);
-            LOGGER.fine(() -> "saving to " + storage + ": " + cache);
-            try (AtomicFileWriter cw = new AtomicFileWriter(storage)) {
-                try {
-                    for (Map.Entry<String, Integer> entry : cache.entrySet()) {
-                        cw.write(entry.getKey());
-                        cw.write(' ');
-                        cw.write(Integer.toString(entry.getValue()));
-                        cw.write('\n');
-                    }
-                    cw.commit();
-                } finally {
-                    cw.abort();
+        ExtensionList.lookupFirst(Cache.class).put(job, getId(), b != null ? new Cache.Some(b.getNumber()) : Cache.NONE);
+    }
+
+    /**
+     * Persistable cache of peephole permalink targets.
+     */
+    @Restricted(Beta.class)
+    public interface Cache extends ExtensionPoint {
+
+        /** Cacheable target of a permalink. */
+        sealed interface PermalinkTarget extends Serializable {
+
+            /**
+             * Implementation of {@link #resolve(Job)}.
+             * This may update the cache if it was missing or found to be invalid.
+             */
+            @Restricted(NoExternalUse.class)
+            @CheckForNull
+            Run<?, ?> resolve(@NonNull PeepholePermalink pp, @NonNull Job<?, ?> job, @NonNull String id);
+
+            /**
+             * Partial implementation of {@link #resolve(PeepholePermalink, Job, String)} when searching.
+             * @param b if set, the newest build to even consider when searching
+             */
+            @Restricted(NoExternalUse.class)
+            @CheckForNull
+            default Run<?, ?> search(@NonNull PeepholePermalink pp, @NonNull Job<?, ?> job, @NonNull String id, @CheckForNull Run<?, ?> b) {
+                if (b == null) {
+                    // no cache
+                    b = job.getLastBuild();
                 }
-            } catch (IOException x) {
-                LOGGER.log(Level.WARNING, "failed to update " + storage, x);
+                // start from the build 'b' and locate the build that matches the criteria going back in time
+                b = pp.find(b);
+                pp.updateCache(job, b);
+                return b;
             }
+
+        }
+
+        /**
+         * The cache entry for this target is missing.
+         */
+        record Unknown() implements PermalinkTarget {
+            @Override
+            public Run<?, ?> resolve(PeepholePermalink pp, Job<?, ?> job, String id) {
+                return search(pp, job, id, null);
+            }
+        }
+
+        Unknown UNKNOWN = new Unknown();
+
+        /**
+         * The cache entry for this target is present.
+         */
+        sealed interface Known extends PermalinkTarget {}
+
+        /** There is known to be no matching build. */
+        record None() implements Known {
+            @Override
+            public Run<?, ?> resolve(PeepholePermalink pp, Job<?, ?> job, String id) {
+                return null;
+            }
+        }
+
+        /** Singleton of {@link None}. */
+        None NONE = new None();
+
+        /** A matching build, indicated by {@link Run#getNumber}. */
+        record Some(int number) implements Known {
+            @Override
+            public Run<?, ?> resolve(PeepholePermalink pp, Job<?, ?> job, String id) {
+                Run<?, ?> b = job.getBuildByNumber(number);
+                if (b != null && pp.apply(b)) {
+                    return b; // found it (in the most efficient way possible)
+                }
+                // the cache is stale. start the search
+                if (b == null) {
+                    b = job.getNearestOldBuild(number);
+                }
+                return search(pp, job, id, b);
+            }
+        }
+
+        /**
+         * Looks for any existing cache hit.
+         * @param id {@link #getId}
+         * @return {@link Some} or {@link #NONE} or {@link #UNKNOWN}
+         */
+        @NonNull PermalinkTarget get(@NonNull Job<?, ?> job, @NonNull String id);
+
+        /**
+         * Updates the cache.
+         * Note that this may be called not just when a build completes or is deleted
+         * (meaning that the logical value of the cache has changed),
+         * but also when {@link #resolve} has failed to find a cached value
+         * (or determined that a previously cached value is in fact invalid).
+         * @param id {@link #getId}
+         * @param target {@link Some} or {@link #NONE}
+         */
+        void put(@NonNull Job<?, ?> job, @NonNull String id, @NonNull Known target);
+    }
+
+    /**
+     * Default cache based on a {@code permalinks} file in the build directory.
+     * There is one line per cached permalink, in the format {@code lastStableBuild 123}
+     * or (for a negative cache) {@code lastFailedBuild -1}.
+     */
+    @Restricted(NoExternalUse.class)
+    @Extension(ordinal = -1000)
+    public static final class DefaultCache implements Cache {
+
+        /**
+         * JENKINS-22822: avoids rereading caches.
+         * Top map keys are {@code builds} directories.
+         * Inner maps are from permalink name to target.
+         * Synchronization is first on the outer map, then on the inner.
+         */
+        private final Map<File, Map<String, Known>> caches = new HashMap<>();
+
+        @Override
+        public PermalinkTarget get(Job<?, ?> job, String id) {
+            var cache = cacheFor(job.getBuildDir());
+            synchronized (cache) {
+                var cached = cache.get(id);
+                return cached != null ? cached : UNKNOWN;
+            }
+        }
+
+        @Override
+        public void put(Job<?, ?> job, String id, Known target) {
+            File buildDir = job.getBuildDir();
+            var cache = cacheFor(buildDir);
+            synchronized (cache) {
+                cache.put(id, target);
+                File storage = storageFor(buildDir);
+                LOGGER.fine(() -> "saving to " + storage + ": " + cache);
+                try (AtomicFileWriter cw = new AtomicFileWriter(storage)) {
+                    try {
+                        for (var entry : cache.entrySet()) {
+                            cw.write(entry.getKey());
+                            cw.write(' ');
+                            cw.write(Integer.toString(entry.getValue() instanceof Cache.Some some ? some.number : -1));
+                            cw.write('\n');
+                        }
+                        cw.commit();
+                    } finally {
+                        cw.abort();
+                    }
+                } catch (IOException x) {
+                    LOGGER.log(Level.WARNING, "failed to update " + storage, x);
+                }
+            }
+        }
+
+        private @NonNull Map<String, Known> cacheFor(@NonNull File buildDir) {
+            synchronized (caches) {
+                var cache = caches.get(buildDir);
+                if (cache == null) {
+                    cache = load(buildDir);
+                    caches.put(buildDir, cache);
+                }
+                return cache;
+            }
+        }
+
+        private static @NonNull Map<String, Known> load(@NonNull File buildDir) {
+            Map<String, Known> cache = new TreeMap<>();
+            File storage = storageFor(buildDir);
+            if (storage.isFile()) {
+                try (Stream<String> lines = Files.lines(storage.toPath(), StandardCharsets.UTF_8)) {
+                    lines.forEach(line -> {
+                        int idx = line.indexOf(' ');
+                        if (idx == -1) {
+                            return;
+                        }
+                        try {
+                            int number = Integer.parseInt(line.substring(idx + 1));
+                            cache.put(line.substring(0, idx), number == -1 ? Cache.NONE : new Cache.Some(number));
+                        } catch (NumberFormatException x) {
+                            LOGGER.log(Level.WARNING, "failed to read " + storage, x);
+                        }
+                    });
+                } catch (IOException x) {
+                    LOGGER.log(Level.WARNING, "failed to read " + storage, x);
+                }
+                LOGGER.fine(() -> "loading from " + storage + ": " + cache);
+            }
+            return cache;
+        }
+
+        static @NonNull File storageFor(@NonNull File buildDir) {
+            return new File(buildDir, "permalinks");
         }
     }
 
@@ -379,8 +476,6 @@ public abstract class PeepholePermalink extends Permalink implements Predicate<R
 
     @Restricted(NoExternalUse.class)
     public static void initialized() {}
-
-    private static final int RESOLVES_TO_NONE = -1;
 
     private static final Logger LOGGER = Logger.getLogger(PeepholePermalink.class.getName());
 }

--- a/test/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/test/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -82,7 +82,7 @@ public class PeepholePermalinkTest {
     }
 
     private void assertStorage(String id, Job<?, ?> job, Run<?, ?> build) throws Exception {
-        assertThat(Files.readAllLines(PeepholePermalink.storageFor(job.getBuildDir()).toPath(), StandardCharsets.UTF_8),
+        assertThat(Files.readAllLines(PeepholePermalink.DefaultCache.storageFor(job.getBuildDir()).toPath(), StandardCharsets.UTF_8),
             hasItem(id + " " + (build == null ? -1 : build.getNumber())));
     }
 

--- a/test/src/test/java/jenkins/model/lazy/LazyBuildMixInTest.java
+++ b/test/src/test/java/jenkins/model/lazy/LazyBuildMixInTest.java
@@ -24,6 +24,9 @@
 
 package jenkins.model.lazy;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -85,6 +88,40 @@ public class LazyBuildMixInTest {
         assertNotSame(b1, b1a);
         assertEquals(1, b1a.getNumber());
         assertEquals(b3, b1a.getNextBuild());
+    }
+
+    @Test public void numericLookups() throws Exception {
+        var p = r.createFreeStyleProject();
+        var b1 = r.buildAndAssertSuccess(p);
+        var b2 = r.buildAndAssertSuccess(p);
+        var b3 = r.buildAndAssertSuccess(p);
+        var b4 = r.buildAndAssertSuccess(p);
+        var b5 = r.buildAndAssertSuccess(p);
+        var b6 = r.buildAndAssertSuccess(p);
+        b1.delete();
+        b3.delete();
+        b6.delete();
+        // leaving 2, 4, 5
+        assertThat(p.getFirstBuild(), is(b2));
+        assertThat(p.getLastBuild(), is(b5));
+        assertThat(p.getNearestBuild(-1), is(b2));
+        assertThat(p.getNearestBuild(0), is(b2));
+        assertThat(p.getNearestBuild(1), is(b2));
+        assertThat(p.getNearestBuild(2), is(b2));
+        assertThat(p.getNearestBuild(3), is(b4));
+        assertThat(p.getNearestBuild(4), is(b4));
+        assertThat(p.getNearestBuild(5), is(b5));
+        assertThat(p.getNearestBuild(6), nullValue());
+        assertThat(p.getNearestBuild(7), nullValue());
+        assertThat(p.getNearestOldBuild(-1), nullValue());
+        assertThat(p.getNearestOldBuild(0), nullValue());
+        assertThat(p.getNearestOldBuild(1), nullValue());
+        assertThat(p.getNearestOldBuild(2), is(b2));
+        assertThat(p.getNearestOldBuild(3), is(b2));
+        assertThat(p.getNearestOldBuild(4), is(b4));
+        assertThat(p.getNearestOldBuild(5), is(b5));
+        assertThat(p.getNearestOldBuild(6), is(b5));
+        assertThat(p.getNearestOldBuild(7), is(b5));
     }
 
     @Issue("JENKINS-20662")


### PR DESCRIPTION
Jenkins persistently caches permalink values such as `lastUnstableBuild` to a text file `$JENKINS_HOME/job/$name/builds/permalinks`, with the format

```
lastUnstableBuild 123
lastFailedBuild -1
```

where `-1` indicates a negative cache. This was implemented because lazy loading of builds means we wish to avoid loading too many historical build records into memory. If you are so lucky as to have had thousands of builds without a single failure, without a cache the controller would need to search them all after every startup just to find that there has never been an unstable build. So the cache is read into memory at most once per job, and written whenever some permalink changes (typically after a build completes).

In CloudBees CI running in high availability mode this cache implementation was problematic and needed to be replaced with something appropriate for concurrent access. Originally I had tried invalidating the in-memory cache and letting it be reread from disk, but this was a bit inefficient and still vulnerable to race conditions. A more satisfactory solution is to extract the singleton implementation into a beta extension point, similarly to #9846.

The behavior for Jenkins should be identical, but there may be an ancillary benefit that (in my opinion) the refactored logic is easier to read and reason about. In the original code, an `int` variable was overloaded to mean a build number (when >0), a negative cache result when -1, or no cache result when 0. There actually appears to have been a mistake in the logic (albeit a harmless one) caused by treating 0 as if it were a legitimate build number. This seemed like a great opportunity to practice using `sealed` types as unions to catch such mistakes in the compiler. Additionally, all code relating to the file format (and the rather arbitrary choice of `-1` to mean a negative cache, rather than say `-` or `null`) is encapsulated in the default cache implementation.

### Testing done

The existing `PeepholePermalinkTest` (in the `test` module) should cover the existing logic. The viability of an alternate extension point implementation is covered by a test in CloudBees CI.

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

### Desired reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
