### PR TITLE
[JENKINS-73539] Disable YUI by default

### DIFF
--- a/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
+++ b/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
@@ -27,6 +27,7 @@ package jenkins.model.experimentalflags;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
+import jenkins.util.SystemProperties;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -51,6 +52,6 @@ public class RemoveYuiUserExperimentalFlag extends BooleanUserExperimentalFlag {
     @NonNull
     @Override
     public Boolean getDefaultValue() {
-        return true;
+        return SystemProperties.getBoolean(RemoveYuiUserExperimentalFlag.class.getName() + ".defaultValue", true);
     }
 }

--- a/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
+++ b/core/src/main/java/jenkins/model/experimentalflags/RemoveYuiUserExperimentalFlag.java
@@ -24,6 +24,7 @@
 
 package jenkins.model.experimentalflags;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import org.kohsuke.accmod.Restricted;
@@ -45,5 +46,11 @@ public class RemoveYuiUserExperimentalFlag extends BooleanUserExperimentalFlag {
     @Override
     public String getShortDescription() {
         return "Remove YUI from all Jenkins UI pages. This will break anything that depends on YUI";
+    }
+
+    @NonNull
+    @Override
+    public Boolean getDefaultValue() {
+        return true;
     }
 }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -194,16 +194,6 @@ var resURL = "not-defined-yet"; // eslint-disable-line no-unused-vars
   }
 })();
 
-(function initializeYUIDebugLogReader() {
-  Behaviour.addLoadEvent(function () {
-    var logReaderElement = document.getElementById("yui-logreader");
-    if (logReaderElement !== null) {
-      var logReader = new YAHOO.widget.LogReader("yui-logreader");
-      logReader.collapse();
-    }
-  });
-})();
-
 // Form check code
 //========================================================
 var FormChecker = {


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-73539](https://issues.jenkins.io/browse/JENKINS-73539).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

This is the culmination of a lot of work over the years to slowly replace existing components that were built with YUI to alternatives.
A few examples:
* https://github.com/jenkinsci/jenkins/pull/6408
* https://github.com/jenkinsci/jenkins/pull/9453
* https://github.com/jenkinsci/jenkins/pull/9395
* https://github.com/jenkinsci/jenkins/pull/6084
* https://github.com/jenkinsci/jenkins/pull/5177

A number of plugins and core changes have been prepared to make this possible.
See the tracking spreadsheet: https://docs.google.com/spreadsheets/d/1UjvtFmNmEdjMN5DUoFxJfBryA8q-E5_HwOzVKbVG9b0/edit?gid=969462704#gid=969462704

We aren't removing YUI at this time as @MarkEWaite requested that we wait till after the next LTS cutoff so-as vendors can change the default back if they still require YUI in their commercial products.

### Testing done

Checked elements in the browser tools, by default no yui is there.

Disabled the flag in user settings and yui appears

Ran `System.setProperty("jenkins.model.experimentalflags.RemoveYuiUserExperimentalFlag.defaultValue", "false")` in the script console and yui appears without having to set a flag.

Clicked around and no issues found.
ATH is successful: https://github.com/jenkinsci/acceptance-test-harness/pull/1861

PCT is successful: https://github.com/jenkinsci/bom/pull/4084.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Disable the Yahoo! User Interface library by default

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
