### PR TITLE
[JENKINS-75003] Zip-based tool installer configuration incorrectly rejects non-HTTP(S) URLs (regression in 2.379)

### DIFF
--- a/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
+++ b/core/src/main/java/hudson/tools/ZipExtractionInstaller.java
@@ -43,6 +43,8 @@ import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Path;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
@@ -116,6 +118,14 @@ public class ZipExtractionInstaller extends ToolInstaller {
                 uri = new URI(value);
             } catch (URISyntaxException e) {
                 return FormValidation.error(e, Messages.ZipExtractionInstaller_malformed_url());
+            }
+            if (uri.getScheme() != null && !uri.getScheme().startsWith("http")) {
+                try {
+                    Path.of(uri);
+                    return FormValidation.ok();
+                } catch (FileSystemNotFoundException | IllegalArgumentException e) {
+                    return FormValidation.error(e, Messages.ZipExtractionInstaller_malformed_url());
+                }
             }
             HttpClient httpClient = ProxyConfiguration.newHttpClient();
             HttpRequest httpRequest;


### PR DESCRIPTION
See [JENKINS-75003](https://issues.jenkins.io/browse/JENKINS-75003). Amends #7398 to restore form validation support for non-HTTP(S) URLs.

### Testing done

As described in the bug report, created a Maven tool with the "Extract `*.zip`/`*.tar.gz`" installer, using a download URL of `file:///path/to/apache-maven-3.9.9-bin.tar.gz` and a subdirectory of `apache-maven-3.9.9`. Verified that form validation failed before this PR and passed after this PR. Verified that a Pipeline job succeeded using this tool. Verified that a download URL of `fil://path/to/invalid` (invalid scheme) still reported a form validation error.

### Proposed changelog entries

Allow non-HTTP(S) URLs in zip-based tool installer configuration (regression in 2.379).

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
