### PR TITLE
Improve Command Palette on mobile

### DIFF
--- a/src/main/scss/base/_typography.scss
+++ b/src/main/scss/base/_typography.scss
@@ -1,4 +1,5 @@
 @use "../abstracts/mixins";
+@use "../base/breakpoints";
 
 body,
 p {
@@ -16,11 +17,19 @@ button {
 table,
 td,
 th,
-form,
+form {
+  font-size: var(--font-size-sm);
+}
+
 input,
 textarea,
 select {
   font-size: var(--font-size-sm);
+
+  /* stylelint-disable-next-line media-query-no-invalid */
+  @media (max-width: breakpoints.$tablet-breakpoint) {
+    font-size: var(--font-size-base);
+  }
 }
 
 // Reset monospaced font-size, because browsers reduce it by default to ~81%

--- a/src/main/scss/components/_command-palette.scss
+++ b/src/main/scss/components/_command-palette.scss
@@ -1,10 +1,11 @@
 @use "../abstracts/mixins";
+@use "../base/breakpoints";
 
 .jenkins-command-palette__dialog {
   background: none;
   border: none;
-  height: 100vw !important;
-  max-height: 100vh !important;
+  height: 100dvh !important;
+  max-height: 100dvh !important;
   width: 100vw !important;
   max-width: 100vw !important;
   margin: 0 !important;
@@ -12,7 +13,8 @@
   user-select: none;
 
   &::backdrop {
-    background: var(--command-palette-backdrop-background);
+    //background: var(--command-palette-backdrop-background);
+    background: red;
     backdrop-filter: contrast(0.7) brightness(0.9) saturate(1.25) blur(3px);
     animation: jenkins-dialog-backdrop-animate-in 0.1s linear;
   }
@@ -47,28 +49,38 @@
 }
 
 .jenkins-command-palette__wrapper {
+  --inset: 15vh;
+
   width: 100%;
   height: 100%;
-  max-height: 100vh;
+  max-height: 100dvh;
   overflow: scroll;
-  padding-top: 20vh;
+  padding-top: var(--inset);
+
+  /* stylelint-disable-next-line media-query-no-invalid */
+  @media (max-width: breakpoints.$tablet-breakpoint) {
+    --inset: 10vh;
+  }
 }
 
 .jenkins-command-palette {
   position: relative;
   width: 50vw;
-  min-width: 400px;
   max-width: 650px;
   color: var(--text-color);
   pointer-events: auto;
-  margin: 0 auto 20vh;
+  margin: 0 auto var(--inset);
+
+  @media (max-width: breakpoints.$tablet-breakpoint) {
+    width: calc(100% - (var(--section-padding) * 2));
+  }
 
   &__search {
     --search-bar-height: 3rem !important;
 
     background: transparent;
     box-shadow: var(--command-palette-inset-shadow);
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--section-padding);
     border-radius: 1rem;
     transition: var(--standard-transition);
     z-index: 10;

--- a/src/main/scss/components/_command-palette.scss
+++ b/src/main/scss/components/_command-palette.scss
@@ -13,8 +13,7 @@
   user-select: none;
 
   &::backdrop {
-    //background: var(--command-palette-backdrop-background);
-    background: red;
+    background: var(--command-palette-backdrop-background);
     backdrop-filter: contrast(0.7) brightness(0.9) saturate(1.25) blur(3px);
     animation: jenkins-dialog-backdrop-animate-in 0.1s linear;
   }

--- a/src/main/scss/components/_command-palette.scss
+++ b/src/main/scss/components/_command-palette.scss
@@ -70,6 +70,7 @@
   pointer-events: auto;
   margin: 0 auto var(--inset);
 
+  /* stylelint-disable-next-line media-query-no-invalid */
   @media (max-width: breakpoints.$tablet-breakpoint) {
     width: calc(100% - (var(--section-padding) * 2));
   }


### PR DESCRIPTION
Some issues with Command Palette (and other inputs) on mobile (especially iOS...)

* If an inputs font size is smaller than 16px the browser zooms in automatically
* Accidentally had `vw` instead of `vh` for a `max-height` and that caused the dialog to be cut off on portrait devices
* Width issues (didn't take up the full width of the phone)
* Command Palette could look a little odd due to how `vh` is handled, changing to `dvh` fixes this

**Before**

[Large image](https://github.com/user-attachments/assets/d688a987-92e5-4b78-9d6b-cb297af76af8)

**After**

[Large image](https://github.com/user-attachments/assets/e7db8338-cd91-4c77-b7a9-1e6ac18a7ba6)

### Testing done

* Tried in a simulator
* Desktop works as before

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
