### PR TITLE
Introducing Jenkins Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3538/badge)](https://bestpractices.coreinfrastructure.org/projects/3538)
 [![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-green)](https://maven.apache.org/guides/mini/guide-reproducible-builds.html)
 [![Gitter](https://img.shields.io/gitter/room/jenkinsci/jenkins)](https://app.gitter.im/#/room/#jenkinsci_jenkins:gitter.im)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Jenkins%20Guru-006BFF)](https://gurubase.io/g/jenkins)
 
 In a nutshell, Jenkins is the leading open-source automation server.
 Built with Java, it provides over 1,800 [plugins](https://plugins.jenkins.io/) to support automating virtually anything,


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Jenkins Guru](https://gurubase.io/g/jenkins) has been manually added to Gurubase. Jenkins Guru uses the data from this repo and data from the [docs](https://www.jenkins.io) to answer questions by leveraging the LLM.

This PR introduces the "Jenkins Guru", showcasing that Jenkins now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Jenkins Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Jenkins documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Jenkins Guru in Gurubase, just let us know that's totally fine.
