### PR TITLE
Update progressiveText.jelly with documentation tag

### DIFF
--- a/core/src/main/resources/lib/hudson/buildHealth.jelly
+++ b/core/src/main/resources/lib/hudson/buildHealth.jelly
@@ -22,15 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!--
-  <%@ attribute name="job" use="required" type="hudson.model.Job" %>
-  <%@ attribute name="iconSizeClass" type="java.lang.String" %>
-  <%@ attribute name="iconSize" type="java.lang.String" %>
-  <%@ attribute name="td" required="false" type="java.lang.String" %>
-  <%@ attribute name="link" required="false" type="java.lang.String" %>
--->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    <st:attribute name="job" use="required" type="hudson.model.Job">Job to display the health report.</st:attribute>
+    <st:attribute name="td" type="java.lang.Boolean">If `td` should be used instead of `div` to wrap the health reports.</st:attribute>
+    <st:attribute name="link" type="java.lang.String">href of the link.</st:attribute>
+    <st:attribute name="style" type="java.lang.String">link style.</st:attribute>
+  </st:documentation>
   <j:set var="healthReports" value="${job.buildHealthReports}"/>
   <j:new var="emptyHealthReport" className="hudson.model.HealthReport"/>
   <j:set var="buildHealth" value="${empty(healthReports) ? emptyHealthReport : healthReports[0]}"/>

--- a/core/src/main/resources/lib/hudson/buildRangeLink.jelly
+++ b/core/src/main/resources/lib/hudson/buildRangeLink.jelly
@@ -22,15 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!--
-  Link to a range of build. Used by fingerprint/index.jsp
-
-	<%@ attribute name="range" type="java.lang.Object" use="required" %>
-	<%@ attribute name="job" type="hudson.model.Job" use="required" %>
--->
 <!-- it's hudson.model.Fingerprint.RangeSet but Tomcat can't seem to handler inner classes -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+	<st:documentation>
+		Link to a range of build. Used by fingerprint/index.jelly
+		<st:attribute name="range" type="hudson.model.Fingerprint.RangeSet" use="required">A range set of builds</st:attribute>
+		<st:attribute name="job" type="hudson.model.Job" use="required">The owner of the builds</st:attribute>
+	</st:documentation>
 	<j:forEach var="r" items="${range.ranges}">
 	  <j:choose>
 	    <j:when test="${r.start==r.end-1}">

--- a/core/src/main/resources/lib/hudson/progressiveText.jelly
+++ b/core/src/main/resources/lib/hudson/progressiveText.jelly
@@ -22,17 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
-<!--
-  Use AJAX to load text data progressively.
-  This is used to achieve the effect of "tail -f"
-  without relying on full page reload.
-
-	<%@attribute name="href" use="required" description="URL that returns text data" %>
-	<%@attribute name="idref" use="required" description="ID of the HTML element in which the result is displayed" %>
-	<%@attribute name="spinner" required="false" description="ID of the HTML element in which the spinner is displayed" %>
-	<%@attribute name="startOffset" required="false" description="Skip this many bytes rather than showing from start of data" %>
-	<%@attribute name="onFinishEvent" required="false" description="JS custom event to be fired when progress is finished" %>
--->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
@@ -40,10 +29,10 @@ THE SOFTWARE.
     This is used to achieve the effect of "tail -f"
     without relying on full page reload.
     <st:attribute name="href" use="required">URL that returns text data</st:attribute>
-	  <st:attribute name="idref" use="required">ID of the HTML element in which the result is displayed</st:attribute>
-	  <st:attribute name="spinner" required="false">ID of the HTML element in which the spinner is displayed</st:attribute>
-	  <st:attribute name="startOffset" required="false">Skip this many bytes rather than showing from start of data</st:attribute>
-	  <st:attribute name="onFinishEvent" required="false">JS custom event to be fired when progress is finished</st:attribute>
+    <st:attribute name="idref" use="required">ID of the HTML element in which the result is displayed</st:attribute>
+    <st:attribute name="spinner">ID of the HTML element in which the spinner is displayed</st:attribute>
+    <st:attribute name="startOffset">Skip this many bytes rather than showing from start of data</st:attribute>
+    <st:attribute name="onFinishEvent">JS custom event to be fired when progress is finished</st:attribute>
   </st:documentation>
   <div class="progressiveText-holder" data-href="${href}" data-idref="${idref}" data-spinner="${spinner}" data-start-offset="${startOffset}"
        data-on-finish-event="${empty(onFinishEvent) ? '' : onFinishEvent}"

--- a/core/src/main/resources/lib/hudson/progressiveText.jelly
+++ b/core/src/main/resources/lib/hudson/progressiveText.jelly
@@ -35,6 +35,16 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <st:documentation>
+    Use AJAX to load text data progressively.
+    This is used to achieve the effect of "tail -f"
+    without relying on full page reload.
+    <st:attribute name="href" use="required">URL that returns text data</st:attribute>
+	  <st:attribute name="idref" use="required">ID of the HTML element in which the result is displayed</st:attribute>
+	  <st:attribute name="spinner" required="false">ID of the HTML element in which the spinner is displayed</st:attribute>
+	  <st:attribute name="startOffset" required="false">Skip this many bytes rather than showing from start of data</st:attribute>
+	  <st:attribute name="onFinishEvent" required="false">JS custom event to be fired when progress is finished</st:attribute>
+  </st:documentation>
   <div class="progressiveText-holder" data-href="${href}" data-idref="${idref}" data-spinner="${spinner}" data-start-offset="${startOffset}"
        data-on-finish-event="${empty(onFinishEvent) ? '' : onFinishEvent}"
        data-error-message="${%errorMessage}"/>


### PR DESCRIPTION
The `st:documentation` and `st:attribute` tags are used by [Jenkins Development Support plugin](https://github.com/jenkinsci/idea-stapler-plugin/) for autocomplete and documentation lookup.

I did this quick change in the GitHub editor as much as a conversation starter as the suggestion. There more instances like this, so there is likely more work required.  Tags documented like this get a benefit of autocompletion and documentation and deprecated attribute validation from the IntelliJ plugin. The more tags are update with unsupported documentation format the less helpful IntelliJ plugin becomes.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
