### PR TITLE
Fix typo in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
   "postUpdateOptions": [
     "yarnDedupeHighest"
   ],
-  "ignoreDeps": ["softprops/actions-gh-release"],
+  "ignoreDeps": ["softprops/action-gh-release"],
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
see https://github.com/jenkinsci/jenkins/pull/10092, PR shouldn't have been opened ref https://github.com/jenkinsci/jenkins/pull/10086