### PR TITLE
Fail CI build on `prettier` errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "yarn prod",
     "start": "yarn dev --watch",
     "lint:js": "eslint . && prettier --check .",
-    "lint:js-ci": "eslint . -f checkstyle -o target/eslint-warnings.xml && prettier --check .",
+    "lint:js-ci": "eslint . -f checkstyle -o target/eslint-warnings.xml",
     "lint:css": "stylelint src/main/scss",
     "lint:css-ci": "stylelint src/main/scss --custom-formatter stylelint-checkstyle-reporter -o target/stylelint-warnings.xml",
     "lint:ci": "yarn lint:js-ci && yarn lint:css-ci",

--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,18 @@ THE SOFTWARE.
                   <skip>${yarn.lint.skip}</skip>
                 </configuration>
               </execution>
+              <execution>
+                <id>prettier</id>
+                <goals>
+                  <goal>corepack</goal>
+                </goals>
+                <phase>test</phase>
+                <configuration>
+                  <arguments>yarn exec prettier --check .</arguments>
+                  <skip>${yarn.lint.skip}</skip>
+                  <testFailureIgnore>false</testFailureIgnore>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
         </plugins>


### PR DESCRIPTION
A recent PR introduced Prettier errors without failing the CI build. This PR makes Prettier errors fail CI builds so that such errors are not introduced in the future.