### PR TITLE
Backporting for 2.479.3 LTS - part 2

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -46,7 +46,7 @@ THE SOFTWARE.
     <host>localhost</host>
     <!-- HTTP listener port -->
     <port>8080</port>
-    <mina-sshd-api.version>2.13.2-125.v200281b_61d59</mina-sshd-api.version>
+    <mina-sshd-api.version>2.14.0-138.v6341ee58e1df</mina-sshd-api.version>
     <!-- Minimum Remoting version, which is tested for API compatibility, duplicated so that renovate only updates the latest remoting version property -->
     <remoting.minimum.supported.version>3107.v665000b_51092</remoting.minimum.supported.version>
 


### PR DESCRIPTION
## Backporting for 2.479.3 LTS (part 2)

Latest core version: `jenkins-2.492` (unreleased)

```console
Fixed
-----

JENKINS-75077           Minor                   2.492 (unreleased)
        Upgrade Apache MINA core from 2.0.26 to 2.0.27
        https://issues.jenkins.io/browse/JENKINS-75077

```

The pull request to the master branch has been merged for inclusion in the 7 Jan 2025 release of Jenkins 2.492.

* https://github.com/jenkinsci/jenkins/pull/10096 

The Apache MINA core library has reported [CVE-2024-52046](https://github.com/advisories/GHSA-76h9-2vwh-w278), an issue for MINA users that use `ioBuffer.getObject()`. Jenkins is not affected by the issue, but software composition analysis tools will report it as a vulnerability and we'll spend time explaining that Jenkins is not vulnerable.

Let's backport the change to the stable-2.479 line so that it can be part of Jenkins 2.479.3

This is an exception to the policy that we only backport to an LTS after a change has been merged to the Jenkins weekly release. I think this exception should be approved so that we reduce the amount of time that the Jenkins security team must spend explaining that Jenkins is not vulnerable to this issue. It is simpler to include the updated library plugin than to spend time explaining why this is not an issue.  

Changes included in this upgrade are:

* [2.14.0-127.v40e03d37b_308](https://github.com/jenkinsci/mina-sshd-api-plugin/releases/tag/2.14.0-127.v40e03d37b_308) - Upgrade mina-sshd from 2.13.2 to 2.14.0
* [2.14.0-131.v04e9b_6b_e0362](https://github.com/jenkinsci/mina-sshd-api-plugin/releases/tag/2.14.0-131.v04e9b_6b_e0362) - Fix support for BCFIPS Security
* [2.14.0-133.vcc091215a_358](https://github.com/jenkinsci/mina-sshd-api-plugin/releases/tag/2.14.0-133.vcc091215a_358) - fips-bundle-test should be test scope and no need of commons-io in dptMngt
* [2.14.0-136.v4d2b_0853615e](https://github.com/jenkinsci/mina-sshd-api-plugin/releases/tag/2.14.0-136.v4d2b_0853615e) - Use Apache Mina NIO2 framework instead of jdk provided NIO2 framework
* [2.14.0-138.v6341ee58e1df](https://github.com/jenkinsci/mina-sshd-api-plugin/releases/tag/2.14.0-138.v6341ee58e1df) - MINA core 2.0.26 to 2.0.27

### Testing done

I've been using the updated API plugin in my Jenkins controller since shortly after it was released.  I've used the preceding releases in Jenkins LTS and in Jenkins weekly releases.  No issues detected in any of those cases.

### Proposed changelog entries

- Upgrade Apache MINA core from 2.0.26 to 2.0.27, includes a fix for CVE-2024-52046

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@olamy, @timja, @wadeck, @daniel-beck

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
