### PR TITLE
[JENKINS-74868] Use new build status symbols in multi branch projects

### DIFF
--- a/core/src/main/resources/lib/hudson/ballColorTd.jelly
+++ b/core/src/main/resources/lib/hudson/ballColorTd.jelly
@@ -24,9 +24,9 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
-    Display the ball in a TD.
-    <st:attribute name="it" type="hudson.model.BallColor">
-      Color of the ball or null to skip drawing.
+    Display the build status icon in a table cell.
+    <st:attribute name="it" type="hudson.model.StatusIcon">
+      Icon to be displayed.
     </st:attribute>
     <st:attribute name="iconSizeClass">
       Specifies the size of the icon. If unspecified, it inherits from
@@ -56,33 +56,42 @@ THE SOFTWARE.
           </j:choose>
         </j:if>
 
-        <j:choose>
-          <j:when test="${iconClassName != null}">
-            <l:icon class="${iconClassName} ${subIconSizeClass}" alt="${it.description}" tooltip="${it.description}" />
-          </j:when>
-          <j:otherwise>
-            <!-- "it" is not a hudson.model.BallColor.  Let's try figure out the icon from its URL.  -->
-            <j:set var="iconUrl" value="${it.getImageOf(iconSize)}"/>
-            <j:if test="${iconUrl.startsWith(imagesURL)}">
-              <!-- Normalize the icon URL  -->
-              <j:set var="iconUrl" value="${iconUrl.substring(imagesURL.length() + 1)}"/>
-            </j:if>
+        <!-- if its actually a BallColor then use the appropriate build symbol -->
+        <j:if test="${attrs.it.baseColor != null}">
+          <l:icon src="symbol-status-${attrs.it.iconName}" class="${subIconSizeClass}" alt="${it.description}" tooltip="${it.description}" />
+        </j:if>
 
-            <!-- See if we can get an Icon def from the URL  -->
-            <j:set var="icon" value="${icons.getIconByUrl(iconUrl)}"/>
-            <j:choose>
-              <j:when test="${icon != null}">
-                <!-- We found the Icon def -->
-                <l:icon class="${icon.classSpec}" alt="${it.description}" tooltip="${it.description}" style="${attrs.style}" />
-              </j:when>
-              <j:otherwise>
-                <!-- We don't seem to have this icon in the IconSet... fallback again... -->
-                <j:set var="iconUrl" value="${it.getImageOf(iconSize)}"/>
-                <l:icon src="${iconUrl}" class="${iconSizeClass}" alt="${it.description}" tooltip="${it.description}" style="${attrs.style}" />
-              </j:otherwise>
-            </j:choose>
-          </j:otherwise>
-        </j:choose>
+        <j:if test="${attrs.it.baseColor == null}">
+          <j:choose>
+            <j:when test="${iconClassName != null}">
+              <l:icon class="${iconClassName} ${subIconSizeClass}" alt="${it.description}" tooltip="${it.description}"/>
+            </j:when>
+            <j:otherwise>
+              <!-- "it" is not a hudson.model.BallColor.  Let's try figure out the icon from its URL.  -->
+              <j:set var="iconUrl" value="${it.getImageOf(iconSize)}"/>
+              <j:if test="${iconUrl.startsWith(imagesURL)}">
+                <!-- Normalize the icon URL  -->
+                <j:set var="iconUrl" value="${iconUrl.substring(imagesURL.length() + 1)}"/>
+              </j:if>
+
+              <!-- See if we can get an Icon def from the URL  -->
+              <j:set var="icon" value="${icons.getIconByUrl(iconUrl)}"/>
+              <j:choose>
+                <j:when test="${icon != null}">
+                  <!-- We found the Icon def -->
+                  <l:icon class="${icon.classSpec}" alt="${it.description}" tooltip="${it.description}"
+                          style="${attrs.style}"/>
+                </j:when>
+                <j:otherwise>
+                  <!-- We don't seem to have this icon in the IconSet... fallback again... -->
+                  <j:set var="iconUrl" value="${it.getImageOf(iconSize)}"/>
+                  <l:icon src="${iconUrl}" class="${iconSizeClass}" alt="${it.description}" tooltip="${it.description}"
+                          style="${attrs.style}"/>
+                </j:otherwise>
+              </j:choose>
+            </j:otherwise>
+          </j:choose>
+        </j:if>
       </j:if>
     </div>
   </td>

--- a/test/src/test/java/lib/layout/IconTest.java
+++ b/test/src/test/java/lib/layout/IconTest.java
@@ -93,11 +93,14 @@ public class IconTest  {
         HtmlPage p = j.createWebClient().goTo("testBallColorTd");
 
         DomElement ballColorAborted = p.getElementById("ballColorAborted");
-        List<DomElement> ballIcons = StreamSupport.stream(ballColorAborted.getChildElements().spliterator(), false).collect(Collectors.toList());
-        assertIconToSvgIconOkay(ballIcons.get(0).getFirstElementChild(), "icon-aborted icon-md");
+        assertThat("Aborted", is(ballColorAborted.getTextContent()));
+        HtmlElement symbol = ballColorAborted.getElementsByTagName("svg").get(0);
+        assertThat("icon-md", is(symbol.getAttribute("class")));
+
+        assertIconToSymbolOkay(symbol);
 
         DomElement statusIcons = p.getElementById("statusIcons");
-        List<DomElement> statusIconsList = StreamSupport.stream(statusIcons.getChildElements().spliterator(), false).collect(Collectors.toList());
+        List<DomElement> statusIconsList = StreamSupport.stream(statusIcons.getChildElements().spliterator(), false).toList();
 
         assertIconToSvgOkay(statusIconsList.get(0).getFirstElementChild().getNextElementSibling(), "icon-user icon-xlg");
 
@@ -177,13 +180,6 @@ public class IconTest  {
     private void assertIconToSvgOkay(DomElement icon, String classSpec) {
         assertThat(icon.getTagName(), is("svg"));
 
-        if (classSpec != null) {
-            assertThat(icon.getAttribute("class"), endsWith(classSpec));
-        }
-    }
-
-    private void assertIconToSvgIconOkay(DomElement icon, String classSpec) {
-        assertThat(icon.getTagName(), is("span"));
         if (classSpec != null) {
             assertThat(icon.getAttribute("class"), endsWith(classSpec));
         }


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See JENKINS-74868

Fixes https://github.com/jenkinsci/dark-theme-plugin/issues/550
Closes https://github.com/jenkinsci/dark-theme-plugin/pull/552
Closes https://github.com/jenkinsci/jenkins/pull/10032

Review with whitespace disabled: https://github.com/jenkinsci/jenkins/pull/10106/files?w=1

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

Created a multi branch project
Configured with single repository and branch using https://github.com/timja-org/junit-attachments-test
Ran a build and aborted it before it got anywhere

Before it was using the old symbol which looked bad in dark theme and was inconsistent

After:

<img width="319" alt="image" src="https://github.com/user-attachments/assets/383b1e91-ccd0-49f5-baae-49d6862ff59c" />

I've also tested with custom-job-folder-icon and a variety of folder and non folder jobs I have in my setup.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Use refined build status icons in multi-branch projects

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
