### PR TITLE
Restore trailing period on 'Jenkins is getting ready to work' screens

### DIFF
--- a/core/src/main/resources/hudson/util/HudsonIsLoading/index.properties
+++ b/core/src/main/resources/hudson/util/HudsonIsLoading/index.properties
@@ -1,4 +1,4 @@
 Please\ wait\ while\ Jenkins\ is\ getting\ ready\ to\ work=\
  Jenkins is getting ready to work
 Your\ browser\ will\ reload\ automatically\ when\ Jenkins\ is\ ready=\
- Your browser will reload automatically when Jenkins is ready
+ Your browser will reload automatically when Jenkins is ready.

--- a/core/src/main/resources/hudson/util/HudsonIsRestarting/index.properties
+++ b/core/src/main/resources/hudson/util/HudsonIsRestarting/index.properties
@@ -1,2 +1,3 @@
 Please\ wait\ while\ Jenkins\ is\ restarting=\
  Jenkins is restarting
+Your\ browser\ will\ reload\ automatically\ when\ Jenkins\ is\ ready=Your browser will reload automatically when Jenkins is ready.


### PR DESCRIPTION
Tiny one for consistency, restores trailing periods on the 'Jenkins is getting ready to work' screens.

**Before**
<img width="541" alt="image" src="https://github.com/user-attachments/assets/7155e9c0-7564-45b7-97d0-2bd4d22b62ff" />

**After**
<img width="538" alt="image" src="https://github.com/user-attachments/assets/af551e0a-9415-4ed6-90f0-d9afd1c8fef1" />

### Testing done

* Trailing period is visible

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
