### PR TITLE
Correcting API documentation of `builds` vs. `allBuilds`

### DIFF
--- a/core/src/main/resources/hudson/model/Job/_api.jelly
+++ b/core/src/main/resources/hudson/model/Job/_api.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
   <h2>Retrieving all builds</h2>
   <p>
     To prevent Jenkins from having to load all builds from disk when someone accesses the job API, the <code>builds</code>
-    tree only contains the 50 newest builds. If you really need to get all builds, access the <code>allBuilds</code> tree,
+    tree only contains the 100 newest builds. If you really need to get all builds, access the <code>allBuilds</code> tree,
     e.g. by fetching <code>…/api/xml?tree=allBuilds[…]</code>. Note that this may result in significant performance degradation
     if you have a lot of builds in this job.
   </p>


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/1817#discussion_r1889095592.

### Testing done

https://github.com/jenkinsci/jenkins/blob/75410bc607e9f59de1d7f2ebb7e0d8573eddf141/core/src/main/java/hudson/model/Job.java#L784-L787 remains the current value. Not tested other than that.

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

### Desired reviewers

@daniel-beck

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
