### PR TITLE
[JENKINS - 73837] Changing DirScanner to allow empty directories in TARArchiver

### DIFF
--- a/core/src/main/java/hudson/util/DirScanner.java
+++ b/core/src/main/java/hudson/util/DirScanner.java
@@ -146,6 +146,12 @@ public abstract class DirScanner implements Serializable {
                     File file = new File(dir, f);
                     scanSingle(file, f, visitor);
                 }
+                for (String d : ds.getIncludedDirectories()) {
+                    if (!d.isEmpty()) {
+                        File directory = new File(dir, d);
+                        scanSingle(directory, d, visitor);
+                    }
+                }
             }
         }
 

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -327,9 +327,8 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
         private static void collectFiles(VirtualFile d, Collection<String> names, String prefix) throws IOException {
             for (VirtualFile child : d.list()) {
-                if (child.isFile()) {
-                    names.add(prefix + child.getName());
-                } else if (child.isDirectory()) {
+                names.add(prefix + child.getName());
+                if (child.isDirectory()) {
                     collectFiles(child, names, prefix + child.getName() + "/");
                 }
             }

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -806,7 +806,7 @@ public class FilePathTest {
         // Compress archive
         final FilePath tmpDirPath = new FilePath(srcFolder);
         int tarred = tmpDirPath.tar(Files.newOutputStream(archive.toPath()), "**");
-        assertEquals("One file should have been compressed", 3, tarred);
+        assertEquals("One file should have been compressed", 4, tarred);
 
         // Decompress
         final File dstFolder = temp.newFolder("dst");

--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -129,7 +129,7 @@ public class TarArchiverTest {
         }
     }
 
-    @Ignore("TODO fails to add empty directories to archive")
+    //@Ignore("TODO fails to add empty directories to archive")
     @Issue("JENKINS-73837")
     @Test
     public void emptyDirectory() throws Exception {

--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -81,7 +81,7 @@ public class ZipArchiverTest {
         }
     }
 
-    @Ignore("TODO fails to add empty directories to archive")
+    //@Ignore("TODO fails to add empty directories to archive")
     @Issue("JENKINS-49296")
     @Test
     public void emptyDirectory() throws Exception {

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -132,16 +132,16 @@ public class VirtualFileTest {
             System.err.println("testing " + vf.getClass().getName());
             assertEquals("[.hg/config.txt, sub/mid.txt, sub/subsub/lowest.txt, top.txt]", new TreeSet<>(vf.list("**/*.txt", null, false)).toString());
             assertEquals("[sub/mid.txt, sub/subsub/lowest.txt, top.txt]", new TreeSet<>(vf.list("**/*.txt", null, true)).toString());
-            assertEquals("[.hg/config.txt, sub/mid.txt, sub/subsub/lowest.txt, top.txt, very/deep/path/here]", new TreeSet<>(vf.list("**", null, false)).toString());
+            assertEquals("[.hg, .hg/config.txt, sub, sub/mid.txt, sub/subsub, sub/subsub/lowest.txt, top.txt, very, very/deep, very/deep/path, very/deep/path/here]", new TreeSet<>(vf.list("**", null, false)).toString());
             assertEquals("[]", new TreeSet<>(vf.list("", null, false)).toString());
-            assertEquals("[sub/mid.txt, sub/subsub/lowest.txt]", new TreeSet<>(vf.list("sub/", null, false)).toString());
-            assertEquals("[sub/mid.txt]", new TreeSet<>(vf.list("sub/", "sub/subsub/", false)).toString());
-            assertEquals("[sub/mid.txt]", new TreeSet<>(vf.list("sub/", "sub/subsub/**", false)).toString());
-            assertEquals("[sub/mid.txt]", new TreeSet<>(vf.list("sub/", "**/subsub/", false)).toString());
+            assertEquals("[sub, sub/mid.txt, sub/subsub, sub/subsub/lowest.txt]", new TreeSet<>(vf.list("sub/", null, false)).toString());
+            assertEquals("[sub, sub/mid.txt]", new TreeSet<>(vf.list("sub/", "sub/subsub/", false)).toString());
+            assertEquals("[sub, sub/mid.txt]", new TreeSet<>(vf.list("sub/", "sub/subsub/**", false)).toString());
+            assertEquals("[sub, sub/mid.txt]", new TreeSet<>(vf.list("sub/", "**/subsub/", false)).toString());
             assertEquals("[.hg/config.txt, sub/mid.txt]", new TreeSet<>(vf.list("**/mid*,**/conf*", null, false)).toString());
-            assertEquals("[sub/mid.txt, sub/subsub/lowest.txt]", new TreeSet<>(vf.list("sub/", "**/notthere/", false)).toString());
+            assertEquals("[sub, sub/mid.txt, sub/subsub, sub/subsub/lowest.txt]", new TreeSet<>(vf.list("sub/", "**/notthere/", false)).toString());
             assertEquals("[top.txt]", new TreeSet<>(vf.list("*.txt", null, false)).toString());
-            assertEquals("[sub/subsub/lowest.txt, top.txt, very/deep/path/here]", new TreeSet<>(vf.list("**", "**/mid*,**/conf*", false)).toString());
+            assertEquals("[.hg, sub, sub/subsub, sub/subsub/lowest.txt, top.txt, very, very/deep, very/deep/path, very/deep/path/here]", new TreeSet<>(vf.list("**", "**/mid*,**/conf*", false)).toString());
         }
     }
     /** Roughly analogous to {@code org.jenkinsci.plugins.compress_artifacts.ZipStorage}. */
@@ -240,7 +240,13 @@ public class VirtualFileTest {
         assertThat(children, containsInAnyOrder(
                 "a/aa/aa.txt",
                 "a/ab/ab.txt",
-                "b/ba/ba.txt"
+                "b/ba/ba.txt",
+                "a",
+                "a/aa",
+                "a/aa/aaa",
+                "a/ab",
+                "b",
+                "b/ba"
         ));
     }
 
@@ -256,7 +262,13 @@ public class VirtualFileTest {
         assertThat(children, containsInAnyOrder(
                 "a/aa/aa.txt",
                 "a/ab/ab.txt",
-                "b/ba/ba.txt"
+                "b/ba/ba.txt",
+                "a",
+                "a/aa",
+                "a/aa/aaa",
+                "a/ab",
+                "b",
+                "b/ba"
         ));
     }
 
@@ -281,7 +293,7 @@ public class VirtualFileTest {
         assertTrue(unzipPath.isDirectory());
         assertTrue(unzipPath.child("a").child("aa").child("aa.txt").exists());
         assertTrue(unzipPath.child("a").child("ab").child("ab.txt").exists());
-        assertFalse(unzipPath.child("a").child("aa").child("aaa").exists());
+        assertTrue(unzipPath.child("a").child("aa").child("aaa").exists());
         assertFalse(unzipPath.child("a").child("_b").exists());
         assertTrue(unzipPath.child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child("b").child("_a").exists());
@@ -311,7 +323,7 @@ public class VirtualFileTest {
         assertTrue(unzipPath.child(prefix).isDirectory());
         assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aa.txt").exists());
         assertTrue(unzipPath.child(prefix).child("a").child("ab").child("ab.txt").exists());
-        assertFalse(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
+        assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
         assertFalse(unzipPath.child(prefix).child("a").child("_b").exists());
         assertTrue(unzipPath.child(prefix).child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child(prefix).child("b").child("_a").exists());
@@ -339,7 +351,7 @@ public class VirtualFileTest {
         assertTrue(unzipPath.isDirectory());
         assertTrue(unzipPath.child("a").child("aa").child("aa.txt").exists());
         assertTrue(unzipPath.child("a").child("ab").child("ab.txt").exists());
-        assertFalse(unzipPath.child("a").child("aa").child("aaa").exists());
+        assertTrue(unzipPath.child("a").child("aa").child("aaa").exists());
         assertFalse(unzipPath.child("a").child("_b").exists());
         assertTrue(unzipPath.child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child("b").child("_a").exists());
@@ -369,7 +381,7 @@ public class VirtualFileTest {
         assertTrue(unzipPath.child(prefix).isDirectory());
         assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aa.txt").exists());
         assertTrue(unzipPath.child(prefix).child("a").child("ab").child("ab.txt").exists());
-        assertFalse(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
+        assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
         assertFalse(unzipPath.child(prefix).child("a").child("_b").exists());
         assertTrue(unzipPath.child(prefix).child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child(prefix).child("b").child("_a").exists());
@@ -504,7 +516,7 @@ public class VirtualFileTest {
         VirtualFile symlinkVirtualPath = VirtualFile.forFilePath(symlinkPath);
         VirtualFile symlinkChildVirtualPath = symlinkVirtualPath.child("aa");
         Collection<String> children = symlinkChildVirtualPath.list("**", null, true, LinkOption.NOFOLLOW_LINKS);
-        assertThat(children, contains("aa.txt"));
+        assertThat(children, containsInAnyOrder("aa.txt", "aaa"));
     }
 
     @Test
@@ -519,7 +531,7 @@ public class VirtualFileTest {
         VirtualFile symlinkVirtualFile = VirtualFile.forFile(symlinkFile);
         VirtualFile symlinkChildVirtualFile = symlinkVirtualFile.child("aa");
         Collection<String> children = symlinkChildVirtualFile.list("**", null, true, LinkOption.NOFOLLOW_LINKS);
-        assertThat(children, contains("aa.txt"));
+        assertThat(children, containsInAnyOrder("aa.txt", "aaa"));
     }
 
     @Test


### PR DESCRIPTION
Regarding [JENKINS - 73837](https://issues.jenkins.io/browse/JENKINS-73837?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20core%20AND%20labels%20in%20(newbie-friendly))

Testing done
![image](https://github.com/user-attachments/assets/897b471b-fdcf-47ac-a0b4-4d8f143c96a4)

Changes
1. Changed DirScanner to accommodate empty directories as they weren't being passed to visit() function in TarArchiver
2. Changed VirtualFile so that it adds empty directories to vf object while testing
3. Made changes to tests which uses the DirScanner object.