### PR TITLE
Display Console Output on the build page (behind an experimental flag)

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -54,7 +54,6 @@ import hudson.model.PaneStatusProperties;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterDefinition.ParameterDescriptor;
 import hudson.model.PasswordParameterDefinition;
-import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.Slave;
 import hudson.model.TimeZoneProperty;
@@ -144,6 +143,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TimeZone;
@@ -159,6 +159,7 @@ import java.util.logging.SimpleFormatter;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import jenkins.console.ConsoleUrlProvider;
+import jenkins.console.DefaultConsoleUrlProvider;
 import jenkins.console.WithConsoleUrl;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
@@ -1994,15 +1995,12 @@ public class Functions {
         return consoleUrl != null ? Stapler.getCurrentRequest().getContextPath() + '/' + consoleUrl : null;
     }
 
-    public static @CheckForNull ConsoleUrlProvider getConsoleProvider(Queue.Executable executable) {
-        if (executable == null) {
-            return null;
-        } else if (executable instanceof Run) {
-            return ConsoleUrlProvider.getProvider((Run<?, ?>) executable);
-        } else {
-            // Handles cases such as PlaceholderExecutable for Pipeline node steps.
-            return getConsoleProvider(executable.getParentExecutable());
-        }
+    /**
+     * @param run the run
+     * @return the Console Provider for the given run, if null, the default Console Provider
+     */
+    public static ConsoleUrlProvider getConsoleProviderFor(Run<?, ?> run) {
+        return Optional.ofNullable(ConsoleUrlProvider.getProvider(run)).orElse(new DefaultConsoleUrlProvider());
     }
 
     /**

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -54,6 +54,7 @@ import hudson.model.PaneStatusProperties;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterDefinition.ParameterDescriptor;
 import hudson.model.PasswordParameterDefinition;
+import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.Slave;
 import hudson.model.TimeZoneProperty;
@@ -1991,6 +1992,17 @@ public class Functions {
     public static @CheckForNull String getConsoleUrl(WithConsoleUrl withConsoleUrl) {
         String consoleUrl = withConsoleUrl.getConsoleUrl();
         return consoleUrl != null ? Stapler.getCurrentRequest().getContextPath() + '/' + consoleUrl : null;
+    }
+
+    public static @CheckForNull ConsoleUrlProvider getConsoleProvider(Queue.Executable executable) {
+        if (executable == null) {
+            return null;
+        } else if (executable instanceof Run) {
+            return ConsoleUrlProvider.getProvider((Run<?, ?>) executable);
+        } else {
+            // Handles cases such as PlaceholderExecutable for Pipeline node steps.
+            return getConsoleProvider(executable.getParentExecutable());
+        }
     }
 
     /**

--- a/core/src/main/java/jenkins/console/ConsoleUrlProvider.java
+++ b/core/src/main/java/jenkins/console/ConsoleUrlProvider.java
@@ -83,11 +83,7 @@ public interface ConsoleUrlProvider extends Describable<ConsoleUrlProvider> {
         return Stapler.getCurrentRequest().getContextPath() + '/' + run.getConsoleUrl();
     }
 
-    /**
-     * Looks up the {@link #getConsoleUrl} value from the first provider to offer one.
-     * @since 2.476
-     */
-    static @NonNull String consoleUrlOf(Run<?, ?> run) {
+    static List<ConsoleUrlProvider> all() {
         final List<ConsoleUrlProvider> providers = new ArrayList<>();
         User currentUser = User.current();
         if (currentUser != null) {
@@ -105,8 +101,20 @@ public interface ConsoleUrlProvider extends Describable<ConsoleUrlProvider> {
         if (globalProviders != null) {
             providers.addAll(globalProviders);
         }
+        return providers;
+    }
+
+    static ConsoleUrlProvider getProvider(Run<?, ?> run) {
+        return all().stream().filter(provider -> provider.getConsoleUrl(run) != null).findFirst().orElse(null);
+    }
+
+    /**
+     * Looks up the {@link #getConsoleUrl} value from the first provider to offer one.
+     * @since 2.476
+     */
+    static @NonNull String consoleUrlOf(Run<?, ?> run) {
         String url = null;
-        for (ConsoleUrlProvider provider : providers) {
+        for (ConsoleUrlProvider provider : all()) {
             try {
                 String tempUrl = provider.getConsoleUrl(run);
                 if (tempUrl != null) {

--- a/core/src/main/java/jenkins/model/experimentalflags/ConsoleWidgetUserExperimentalFlag.java
+++ b/core/src/main/java/jenkins/model/experimentalflags/ConsoleWidgetUserExperimentalFlag.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Jan Faracik
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model.experimentalflags;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class ConsoleWidgetUserExperimentalFlag extends BooleanUserExperimentalFlag {
+    public ConsoleWidgetUserExperimentalFlag() {
+        super("console-widget.flag");
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Show Console Output on build pages";
+    }
+
+    @Nullable
+    @Override
+    public String getShortDescription() {
+        return "Shows the Console Output as a widget on build pages.";
+    }
+}

--- a/core/src/main/java/jenkins/model/experimentalflags/NewBuildPageUserExperimentalFlag.java
+++ b/core/src/main/java/jenkins/model/experimentalflags/NewBuildPageUserExperimentalFlag.java
@@ -44,6 +44,6 @@ public class NewBuildPageUserExperimentalFlag extends BooleanUserExperimentalFla
     @Nullable
     @Override
     public String getShortDescription() {
-        return "Enables a revamped build page. This is a work in progress.";
+        return "Enables a revamped build page. This feature is still a work in progress, so some things might not work perfectly yet.";
     }
 }

--- a/core/src/main/java/jenkins/model/experimentalflags/NewBuildPageUserExperimentalFlag.java
+++ b/core/src/main/java/jenkins/model/experimentalflags/NewBuildPageUserExperimentalFlag.java
@@ -31,19 +31,19 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 @Extension
 @Restricted(NoExternalUse.class)
-public class ConsoleWidgetUserExperimentalFlag extends BooleanUserExperimentalFlag {
-    public ConsoleWidgetUserExperimentalFlag() {
-        super("console-widget.flag");
+public class NewBuildPageUserExperimentalFlag extends BooleanUserExperimentalFlag {
+    public NewBuildPageUserExperimentalFlag() {
+        super("new-build-page.flag");
     }
 
     @Override
     public String getDisplayName() {
-        return "Show Console Output on build pages";
+        return "New build page";
     }
 
     @Nullable
     @Override
     public String getShortDescription() {
-        return "Shows the Console Output as a widget on build pages.";
+        return "Enables a revamped build page. This is a work in progress.";
     }
 }

--- a/core/src/main/resources/hudson/model/Run/console-log.jelly
+++ b/core/src/main/resources/hudson/model/Run/console-log.jelly
@@ -1,0 +1,38 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
+  <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
+  <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->
+  <j:set var="offset" value="${empty(consoleFull) ? it.logText.length()-threshold*1024 : 0}" />
+  <j:choose>
+    <j:when test="${offset > 0}">
+      <a class="jenkins-button jenkins-!-accent-color jenkins-!-padding-2 jenkins-!-margin-bottom-2" style="width: 100%; justify-content: start" href="consoleFull">
+        <l:icon src="symbol-help-circle" />
+        ${%skipSome(offset / 1024)}
+      </a>
+    </j:when>
+    <j:otherwise>
+      <j:set var="offset" value="${0}" />
+    </j:otherwise>
+  </j:choose>
+
+  <j:out value="${h.generateConsoleAnnotationScriptAndStylesheet()}"/>
+
+  <j:choose>
+    <!-- Do progressive console output -->
+    <j:when test="${it.isLogUpdated()}">
+      <pre id="out" class="console-output" />
+      <div id="spinner">
+        <l:progressAnimation/>
+      </div>
+      <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
+                 startOffset="${offset}" onFinishEvent="jenkins:consoleFinished"/>
+    </j:when>
+    <!-- output is completed now. -->
+    <j:otherwise>
+      <pre class="console-output">
+        <st:getOutput var="output" />
+        <j:whitespace>${it.writeLogTo(offset,output)}</j:whitespace>
+      </pre>
+    </j:otherwise>
+  </j:choose>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/Run/console-log.properties
+++ b/core/src/main/resources/hudson/model/Run/console-log.properties
@@ -1,0 +1,1 @@
+skipSome=This log is too long to show here, {0,number,integer} KB has been skipped — click to see the complete log

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -50,38 +50,7 @@ THE SOFTWARE.
         ${%Console Output}
       </t:buildCaption>
 
-      <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
-      <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->
-      <j:set var="offset" value="${empty(consoleFull) ? it.logText.length()-threshold*1024 : 0}" />
-      <j:choose>
-        <j:when test="${offset > 0}">
-          ${%skipSome(offset/1024,"consoleFull")}
-        </j:when>
-        <j:otherwise>
-          <j:set var="offset" value="${0}" />
-        </j:otherwise>
-      </j:choose>
-
-      <j:out value="${h.generateConsoleAnnotationScriptAndStylesheet()}"/>
-
-      <j:choose>
-        <!-- Do progressive console output -->
-        <j:when test="${it.isLogUpdated()}">
-          <pre id="out" class="console-output" />
-            <div id="spinner">
-              <l:progressAnimation/>
-            </div>
-          <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
-               startOffset="${offset}" onFinishEvent="jenkins:consoleFinished"/>
-        </j:when>
-        <!-- output is completed now. -->
-        <j:otherwise>
-          <pre class="console-output" id="out">
-            <st:getOutput var="output" />
-            <j:whitespace>${it.writeLogTo(offset,output)}</j:whitespace>
-          </pre>
-        </j:otherwise>
-      </j:choose>
+      <st:include page="console-log.jelly" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Run/index.jelly
+++ b/core/src/main/resources/hudson/model/Run/index.jelly
@@ -25,58 +25,62 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:i="jelly:fmt">
-  <l:layout title="${it.fullDisplayName}">
-    <st:include page="sidepanel.jelly" />
+  <l:userExperimentalFlag var="newBuildPage" flagClassName="jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag" />
 
-    <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
-    <l:main-panel>
-      <j:set var="controls">
-        <t:editDescriptionButton permission="${it.UPDATE}"/>
-        <l:hasPermission permission="${it.UPDATE}">
-          <st:include page="logKeep.jelly" />
-        </l:hasPermission>
-      </j:set>
+  <j:choose>
+    <j:when test="${newBuildPage}">
+      <st:include page="new-build-page.jelly" />
+    </j:when>
+    <j:otherwise>
+      <l:layout title="${it.fullDisplayName}">
+        <st:include page="sidepanel.jelly" />
 
-      <t:buildCaption controls="${controls}">${it.displayName} (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</t:buildCaption>
+        <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
+        <l:main-panel>
+          <j:set var="controls">
+            <t:editDescriptionButton permission="${it.UPDATE}"/>
+            <l:hasPermission permission="${it.UPDATE}">
+              <st:include page="logKeep.jelly" />
+            </l:hasPermission>
+          </j:set>
 
-      <div>
-        <t:editableDescription permission="${it.UPDATE}" hideButton="true"/>
-      </div>
+          <t:buildCaption controls="${controls}">${it.displayName} (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</t:buildCaption>
 
-      <l:userExperimentalFlag var="newBuildPage" flagClassName="jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag" />
-      <j:if test="${newBuildPage}">
-        <st:include page="console.jelly" from="${h.getConsoleProviderFor(it)}" optional="true" />
-      </j:if>
+          <div>
+            <t:editableDescription permission="${it.UPDATE}" hideButton="true"/>
+          </div>
 
-      <div style="float:right; z-index: 1; position:relative; margin-left: 1em">
-        <div style="margin-top:1em">
-          ${%startedAgo(it.timestampString)}
-        </div>
-        <div>
-          <j:if test="${it.building}">
-            ${%beingExecuted(it.executor.timestampString)}
-          </j:if>
-          <j:if test="${!it.building}">
-            ${%Took} <a href="${rootURL}/${it.parent.url}buildTimeTrend">${it.durationString}</a>
-          </j:if>
-          <st:include page="details.jelly" optional="true" />
-        </div>
-      </div>
+          <div style="float:right; z-index: 1; position:relative; margin-left: 1em">
+            <div style="margin-top:1em">
+              ${%startedAgo(it.timestampString)}
+            </div>
+            <div>
+              <j:if test="${it.building}">
+                ${%beingExecuted(it.executor.timestampString)}
+              </j:if>
+              <j:if test="${!it.building}">
+                ${%Took} <a href="${rootURL}/${it.parent.url}buildTimeTrend">${it.durationString}</a>
+              </j:if>
+              <st:include page="details.jelly" optional="true" />
+            </div>
+          </div>
 
 
-      <table>
-        <t:artifactList build="${it}" caption="${%Build Artifacts}"
-          permission="${it.ARTIFACTS}" />
+          <table>
+            <t:artifactList build="${it}" caption="${%Build Artifacts}"
+                            permission="${it.ARTIFACTS}" />
 
-        <!-- give actions a chance to contribute summary item -->
-        <j:forEach var="a" items="${it.allActions}">
-          <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
-        </j:forEach>
+            <!-- give actions a chance to contribute summary item -->
+            <j:forEach var="a" items="${it.allActions}">
+              <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
+            </j:forEach>
 
-        <st:include page="summary.jelly" optional="true" />
-      </table>
+            <st:include page="summary.jelly" optional="true" />
+          </table>
 
-      <st:include page="main.jelly" optional="true" />
-    </l:main-panel>
-  </l:layout>
+          <st:include page="main.jelly" optional="true" />
+        </l:main-panel>
+      </l:layout>
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Run/index.jelly
+++ b/core/src/main/resources/hudson/model/Run/index.jelly
@@ -43,8 +43,8 @@ THE SOFTWARE.
         <t:editableDescription permission="${it.UPDATE}" hideButton="true"/>
       </div>
 
-      <l:userExperimentalFlag var="showConsoleWidget" flagClassName="jenkins.model.experimentalflags.ConsoleWidgetUserExperimentalFlag" />
-      <j:if test="${showConsoleWidget}">
+      <l:userExperimentalFlag var="newBuildPage" flagClassName="jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag" />
+      <j:if test="${newBuildPage}">
         <st:include page="console.jelly" from="${h.getConsoleProviderFor(it)}" optional="true" />
       </j:if>
 

--- a/core/src/main/resources/hudson/model/Run/index.jelly
+++ b/core/src/main/resources/hudson/model/Run/index.jelly
@@ -43,6 +43,11 @@ THE SOFTWARE.
         <t:editableDescription permission="${it.UPDATE}" hideButton="true"/>
       </div>
 
+      <l:userExperimentalFlag var="showConsoleWidget" flagClassName="jenkins.model.experimentalflags.ConsoleWidgetUserExperimentalFlag" />
+      <j:if test="${showConsoleWidget}">
+        <st:include page="console.jelly" from="${h.getConsoleProvider(it)}" optional="true" />
+      </j:if>
+
       <div style="float:right; z-index: 1; position:relative; margin-left: 1em">
         <div style="margin-top:1em">
           ${%startedAgo(it.timestampString)}

--- a/core/src/main/resources/hudson/model/Run/index.jelly
+++ b/core/src/main/resources/hudson/model/Run/index.jelly
@@ -45,7 +45,7 @@ THE SOFTWARE.
 
       <l:userExperimentalFlag var="showConsoleWidget" flagClassName="jenkins.model.experimentalflags.ConsoleWidgetUserExperimentalFlag" />
       <j:if test="${showConsoleWidget}">
-        <st:include page="console.jelly" from="${h.getConsoleProvider(it)}" optional="true" />
+        <st:include page="console.jelly" from="${h.getConsoleProviderFor(it)}" optional="true" />
       </j:if>
 
       <div style="float:right; z-index: 1; position:relative; margin-left: 1em">

--- a/core/src/main/resources/hudson/model/Run/new-build-page.jelly
+++ b/core/src/main/resources/hudson/model/Run/new-build-page.jelly
@@ -1,0 +1,78 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Matthew R. Harrah,
+Tom Huybrechts, id:cactusman, Romain Seguy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:i="jelly:fmt">
+  <l:layout title="${it.fullDisplayName}">
+    <st:include page="sidepanel.jelly" />
+
+    <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
+    <l:main-panel>
+      <j:set var="controls">
+        <t:editDescriptionButton permission="${it.UPDATE}"/>
+        <l:hasPermission permission="${it.UPDATE}">
+          <st:include page="logKeep.jelly" />
+        </l:hasPermission>
+      </j:set>
+
+      <t:buildCaption controls="${controls}">${it.displayName} (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</t:buildCaption>
+
+      <div>
+        <t:editableDescription permission="${it.UPDATE}" hideButton="true"/>
+      </div>
+
+      <st:include page="console.jelly" from="${h.getConsoleProviderFor(it)}" optional="true" />
+
+      <div style="float:right; z-index: 1; position:relative; margin-left: 1em">
+        <div style="margin-top:1em">
+          ${%startedAgo(it.timestampString)}
+        </div>
+        <div>
+          <j:if test="${it.building}">
+            ${%beingExecuted(it.executor.timestampString)}
+          </j:if>
+          <j:if test="${!it.building}">
+            ${%Took} <a href="${rootURL}/${it.parent.url}buildTimeTrend">${it.durationString}</a>
+          </j:if>
+          <st:include page="details.jelly" optional="true" />
+        </div>
+      </div>
+
+      <table>
+        <t:artifactList build="${it}" caption="${%Build Artifacts}"
+                        permission="${it.ARTIFACTS}" />
+
+        <!-- give actions a chance to contribute summary item -->
+        <j:forEach var="a" items="${it.allActions}">
+          <st:include page="summary.jelly" from="${a}" optional="true" it="${a}" />
+        </j:forEach>
+
+        <st:include page="summary.jelly" optional="true" />
+      </table>
+
+      <st:include page="main.jelly" optional="true" />
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/Run/new-build-page.properties
+++ b/core/src/main/resources/hudson/model/Run/new-build-page.properties
@@ -1,0 +1,2 @@
+startedAgo=Started {0} ago
+beingExecuted=Build has been executing for {0}

--- a/core/src/main/resources/jenkins/console/DefaultConsoleUrlProvider/console.jelly
+++ b/core/src/main/resources/jenkins/console/DefaultConsoleUrlProvider/console.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <j:set var="controls">
+    <a href="consoleText" download="${it.displayName}.txt" tooltip="${%Download}" class="jenkins-card__reveal">
+      <l:icon src="symbol-download" />
+    </a>
+  </j:set>
+
+  <l:card title="${%Console Output}" expandable="console" controls="${controls}">
+    <div class="app-console-output-widget progressive-text-container">
+      <st:include page="console-log.jelly" />
+    </div>
+  </l:card>
+</j:jelly>

--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -10,7 +10,9 @@ Behaviour.specify(
     let onFinishEvent = holder.getAttribute("data-on-finish-event");
     let errorMessage = holder.getAttribute("data-error-message");
 
-    var scroller = new AutoScroller(holder.closest(".progressive-text-container") || document.body);
+    var scroller = new AutoScroller(
+      holder.closest(".progressive-text-container") || document.body,
+    );
     /*
   fetches the latest update from the server
   @param e

--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -10,7 +10,7 @@ Behaviour.specify(
     let onFinishEvent = holder.getAttribute("data-on-finish-event");
     let errorMessage = holder.getAttribute("data-error-message");
 
-    var scroller = new AutoScroller(document.body);
+    var scroller = new AutoScroller(holder.closest(".progressive-text-container") || document.body);
     /*
   fetches the latest update from the server
   @param e

--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -5,3 +5,19 @@
   flex-wrap: nowrap;
   gap: 10px;
 }
+
+.app-console-output-widget {
+  min-height: 340px;
+  max-height: 340px;
+  overflow-y: auto;
+  margin: 0 -1rem -1rem;
+  padding: 0 1rem 1rem;
+
+  pre {
+    background: transparent;
+    margin: 0;
+    padding: 0;
+    line-height: 1.75;
+    font-size: var(--font-size-sm);
+  }
+}

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2030,10 +2030,14 @@ function AutoScroller(scrollContainer) {
     scrollToBottom: function () {
       var scrollDiv = this.scrollContainer;
       var currentHeight = this.getCurrentHeight();
-      if (document.documentElement) {
-        document.documentElement.scrollTop = currentHeight;
+
+      if (scrollDiv === document.body) {
+        window.scrollTo({
+          top: currentHeight,
+        });
+      } else {
+        scrollDiv.scrollTop = currentHeight;
       }
-      scrollDiv.scrollTop = currentHeight;
     },
   };
 }


### PR DESCRIPTION
This PR adds the Console Output to the build page (behind an experimental flag). This reduces the amount of clicks it takes to get to the console, making it easy to see build output.

The implementation allows for console providers (such as Pipeline Graph View) to override what displays on the build page.

Why the `new-build-page.flag` flag? Modifying the build pages is pretty fiddly due to the sidebar and summary items, so I've put this behind a flag to not disrupt existing users layouts unless they explicitly want to. Keen to make more use of this flag going forward to avoid disruption/allow for more iterative work on things like this.

**Freestyle**
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a2ec1663-66ca-439b-85e5-8358f85fdf67" />

**Pipeline**
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/bc42bb7e-6a2d-4448-ac94-1159cc533cf7" />

**Flag**
![image](https://github.com/user-attachments/assets/80bb665b-3619-4845-83d3-4931c8d2d289)

### Testing done

* Widget hides if the flag is disabled
* Widget shows if the flag is enabled
* Existing console works as expected

### Proposed changelog entries

- Add the option to display the Console Output on the build page (behind an experimental flag)

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
