### PR TITLE
Remove Commons Discovery

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,8 +41,7 @@ THE SOFTWARE.
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
     <groovy.version>2.4.21</groovy.version>
     <jelly.version>1.1-jenkins-20250108</jelly.version>
-    <!-- TODO https://github.com/jenkinsci/stapler/pull/622 -->
-    <stapler.version>1941.va_0b_2934ecb_68</stapler.version>
+    <stapler.version>1942.v708e07325402</stapler.version>
   </properties>
 
   <dependencyManagement>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -39,7 +39,8 @@ THE SOFTWARE.
 
   <properties>
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
-    <stapler.version>1928.v9115fe47607f</stapler.version>
+    <!-- TODO https://github.com/jenkinsci/stapler/pull/622/checks -->
+    <stapler.version>1939.v0750b_2e6f5b_d</stapler.version>
     <groovy.version>2.4.21</groovy.version>
   </properties>
 

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -53,11 +53,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
-import org.apache.commons.discovery.ResourceClassIterator;
-import org.apache.commons.discovery.ResourceNameIterator;
-import org.apache.commons.discovery.resource.ClassLoaders;
-import org.apache.commons.discovery.resource.classes.DiscoverClasses;
-import org.apache.commons.discovery.resource.names.DiscoverServiceNames;
 import org.jvnet.hudson.annotation_indexer.Index;
 import org.jvnet.tiger_types.Types;
 import org.kohsuke.accmod.Restricted;
@@ -572,20 +567,6 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
                 }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
-            }
-
-            // Register OptionHandlers through META-INF/services and Commons Discovery
-            ClassLoaders cls = new ClassLoaders();
-            cls.put(j.getPluginManager().uberClassLoader);
-            ResourceNameIterator servicesIter =
-                new DiscoverServiceNames(cls).findResourceNames(OptionHandler.class.getName());
-            final ResourceClassIterator itr =
-                new DiscoverClasses(cls).findResourceClasses(servicesIter);
-
-            while (itr.hasNext()) {
-                Class h = itr.nextResourceClass().loadClass();
-                Class c = Types.erasure(Types.getTypeArgument(Types.getBaseClass(h, OptionHandler.class), 0));
-                CmdLineParser.registerHandler(c, h);
             }
         }
     }

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -561,7 +561,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
         if (j != null) { // only when running on the controller
             // Register OptionHandlers through META-INF/services/annotations and Annotation Indexer
             try {
-                for (Class c : Index.list(OptionHandlerExtension.class, Jenkins.get().pluginManager.uberClassLoader, Class.class)) {
+                for (Class c : Index.list(OptionHandlerExtension.class, j.getPluginManager().uberClassLoader, Class.class)) {
                     Type t = Types.getBaseClass(c, OptionHandler.class);
                     CmdLineParser.registerHandler(Types.erasure(Types.getTypeArgument(t, 0)), c);
                 }

--- a/core/src/main/java/hudson/cli/handlers/GenericItemOptionHandler.java
+++ b/core/src/main/java/hudson/cli/handlers/GenericItemOptionHandler.java
@@ -42,7 +42,7 @@ import org.springframework.security.core.Authentication;
 /**
  * Refers to an {@link Item} by its name.
  * May be subclassed to handle specific kinds of items.
- * (Use {@code @MetaInfServices(OptionHandler.class)} to register the subclass.)
+ * (Use {@code @OptionHandlerExtension} to register the subclass.)
  * @param <T> the kind of item being handled
  * @since 1.538
  */


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/stapler/issues/414

From #10121:

> Once all usages of the second code path in core and plugins have been converted to the first code path, and once those releases have been sufficiently deployed, then the second code path can be deleted.

This PR deletes the second code path and removes Commons Discovery from the WAR.

### Testing done

```
mvn clean verify -Dtest=hudson.cli.AddJobToViewCommandTest,hudson.cli.BuildCommandTest,hudson.cli.CancelQuietDownCommandTest,hudson.cli.ClearQueueCommandTest,hudson.cli.ComputerStateTest,hudson.cli.ConnectNodeCommandTest,hudson.cli.ConsoleCommandTest,hudson.cli.CopyJobCommandTest,hudson.cli.CreateJobCommandTest,hudson.cli.CreateNodeCommandTest,hudson.cli.CreateViewCommandTest,hudson.cli.DeleteBuildsCommandTest,hudson.cli.DeleteJobCommandTest,hudson.cli.DeleteNodeCommandTest,hudson.cli.DeleteViewCommandTest,hudson.cli.DisablePluginCommandTest,hudson.cli.DisconnectNodeCommandTest,hudson.cli.EnableJobCommandTest,hudson.cli.EnablePluginCommandTest,hudson.cli.GetJobCommandTest,hudson.cli.GetNodeCommandTest,hudson.cli.GetViewCommandTest,hudson.cli.GroovyshCommandTest,hudson.cli.HelpCommandTest,hudson.cli.InstallPluginCommandTest,hudson.cli.ListJobsCommandTest,hudson.cli.ListPluginsCommandTest,hudson.cli.OfflineNodeCommandTest,hudson.cli.OnlineNodeCommandTest,hudson.cli.QuietDownCommandTest,hudson.cli.ReloadConfigurationCommandTest,hudson.cli.ReloadJobCommandTest,hudson.cli.RemoveJobFromViewCommandTest,hudson.cli.RunRangeCommand2Test,hudson.cli.RunRangeCommandTest,hudson.cli.SetBuildDescriptionCommandTest,hudson.cli.SetBuildDisplayNameCommandTest,hudson.cli.UpdateNodeCommandTest,hudson.cli.UpdateViewCommandTest,hudson.cli.ViewManipulationTestBase,hudson.cli.WaitNodeOfflineCommandTest,hudson.cli.WaitNodeOnlineCommandTest,hudson.model.ComputerSetTest,hudson.model.ItemsTest,hudson.model.listeners.ItemListenerTest,hudson.util.RobustReflectionConverterTest,jenkins.cli.StopBuildsCommandTest,jenkins.model.JenkinsManagePermissionTest,jenkins.model.NodeListenerTest,jenkins.model.RunIdMigratorTest,jenkins.model.ScriptListenerTest,jenkins.security.Security3314Test,jenkins.security.Security3448Test,lib.form.PasswordTest
```

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
