### PR TITLE
Consistent Jelly version for `commons-jelly-tags-fmt`

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -39,8 +39,9 @@ THE SOFTWARE.
 
   <properties>
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
-    <stapler.version>1928.v9115fe47607f</stapler.version>
     <groovy.version>2.4.21</groovy.version>
+    <jelly.version>1.1-jenkins-20250107</jelly.version>
+    <stapler.version>1940.v41211a_a_b_b_d8b_</stapler.version>
   </properties>
 
   <dependencyManagement>
@@ -130,11 +131,6 @@ THE SOFTWARE.
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.18.0</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-jelly</groupId>
-        <artifactId>commons-jelly-tags-fmt</artifactId>
-        <version>1.0</version>
       </dependency>
       <dependency>
         <groupId>commons-jelly</groupId>
@@ -249,6 +245,11 @@ THE SOFTWARE.
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci</groupId>
+        <artifactId>commons-jelly-tags-fmt</artifactId>
+        <version>${jelly.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci</groupId>
         <artifactId>commons-jexl</artifactId>
         <version>1.1-jenkins-20111212</version>
       </dependency>
@@ -290,7 +291,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.jvnet.hudson</groupId>
         <artifactId>commons-jelly-tags-define</artifactId>
-        <version>1.1-jenkins-20241115</version>
+        <version>${jelly.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jvnet.localizer</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -168,10 +168,6 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>commons-jelly</groupId>
-      <artifactId>commons-jelly-tags-fmt</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-jelly</groupId>
       <artifactId>commons-jelly-tags-xml</artifactId>
       <exclusions>
         <exclusion>
@@ -309,6 +305,10 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>commons-jelly-tags-fmt</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/licenseCompleter.groovy
+++ b/licenseCompleter.groovy
@@ -31,6 +31,7 @@ complete {
     "commons-net:*",
     "commons-cli:*",
     "*:commons-jelly",
+    "org.jenkins-ci:commons-jelly-tags-fmt",
     "org.jvnet.hudson:commons-jelly-tags-define",
     "slide:slide-webdavlib"
   ]) {

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -151,6 +151,7 @@ THE SOFTWARE.
                     <exclude>com.infradna.tool:bridge-method-annotation</exclude>
                     <exclude>org.jenkins-ci:annotation-indexer</exclude>
                     <exclude>org.jenkins-ci:commons-jelly</exclude>
+                    <exclude>org.jenkins-ci:commons-jelly-tags-fmt</exclude>
                     <exclude>org.jenkins-ci:crypto-util</exclude>
                     <exclude>org.jenkins-ci.main:cli</exclude>
                     <exclude>org.jenkins-ci.main:jenkins-core</exclude>


### PR DESCRIPTION
We currently ship `commons-jelly-tags-fmt` 1.0 from [19 years ago](https://repo1.maven.org/maven2/commons-jelly/commons-jelly-tags-fmt/1.0/). While the fact that it has not needed any changes in 19 years is a testament to the quality of that code, we were not so lucky in https://github.com/jenkinsci/jelly/pull/110 and https://github.com/jenkinsci/json-lib/commit/b1fe8a34f83b8d0b115f13224a9fabd8c0842d30, both of which required us to patch and deliver changes to unmaintained third-party libraries via our forks. We were able to do both easily because we had a pipeline for delivering changes, which we do not currently have for `commons-jelly-tags-fmt` because the project is dead upstream.

This PR solves this problem by switching our `commons-jelly-tags-fmt` JAR to the one built and deployed from our fork of Jelly. I compared the sources in our fork to that of https://repo1.maven.org/maven2/commons-jelly/commons-jelly-tags-fmt/1.0/commons-jelly-tags-fmt-1.0-sources.jar and, other than Javadoc updates for Java 11/17/21 compatibility, the sources were identical, so there is no risk here in terms of code change. The only difference in the JARs is that ours is now compiled with Java 17. More importantly, though, this allows us to deliver changes to this code in the future, should the need arise. Currently I do not anticipate such a need.

A similar problem exists for `commons-jelly-tags-xml`, which I am explicitly not tackling here. I could not easily find the source files for what we are shipping today in https://repo1.maven.org/maven2/commons-jelly/commons-jelly-tags-xml/1.1/ and it is not immediately obvious to me whether or not we are even using this functionality. Some more effort would be required (a) to confirm that we are using this functionality and (b) to dig up the source code for what we are shipping today (or decompile the JAR) to confirm that switching to the sources in our fork would not be introducing a regression.

### Testing done

As mentioned above, confirmed that the only source code changes were changes to Javadoc comments, which carry a minimal to zero risk of regression. Automated testing should take care of the rest.

Jelly versions after this change:

```
WEB-INF/lib/commons-jelly-1.1-jenkins-20250107.jar
WEB-INF/lib/commons-jelly-tags-define-1.1-jenkins-20250107.jar
WEB-INF/lib/commons-jelly-tags-fmt-1.1-jenkins-20250107.jar
WEB-INF/lib/commons-jelly-tags-xml-1.1.jar (see note above)
```

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
