### PR TITLE
Stop ignoring updates to `softprops/action-gh-release`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,6 @@
   "postUpdateOptions": [
     "yarnDedupeHighest"
   ],
-  "ignoreDeps": ["softprops/action-gh-release"],
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
https://github.com/softprops/action-gh-release/pull/562 has been released.