### PR TITLE
Fix for CVE-2024-38827[Medium Severity]

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -70,7 +70,7 @@ THE SOFTWARE.
         <!-- https://docs.spring.io/spring-security/reference/6.3/getting-spring-security.html#getting-maven-no-boot -->
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-bom</artifactId>
-        <version>6.3.4</version>
+        <version>6.3.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This PR upgrades Spring Security from version **6.3.4** to **6.3.5** to address the recently reported vulnerability **CVE-2024-38827**.

For more details about the vulnerability, refer to the official Spring Security advisory: https://spring.io/security/cve-2024-38827.