### PR TITLE
[JENKINS-75136] Show 'Unprotected URLs' description

### DIFF
--- a/core/src/main/resources/hudson/security/LegacySecurityRealm/config.groovy
+++ b/core/src/main/resources/hudson/security/LegacySecurityRealm/config.groovy
@@ -7,9 +7,7 @@ import jenkins.model.Jenkins
 def f = namespace(lib.FormTagLib)
 
 f.entry(title: _('Unprotected URLs')) {
-    p(class: "jenkins-form-description") {
-        _('blurb')
-    }
+    f.description(_('blurb'))
     ul {
         for (def action : Jenkins.get().getActions().sort { x, y -> x.getUrlName() <=> y.getUrlName() }) {
             if (action instanceof UnprotectedRootAction) {


### PR DESCRIPTION
See [JENKINS-75136](https://issues.jenkins.io/browse/JENKINS-75136).

### Testing done
![Screenshot from 2025-01-14 14-53-11](https://github.com/user-attachments/assets/36684011-8914-4535-80d8-03d6549788e3)

```html
<div class="jenkins-form-description">These URLs (and URLs starting with these prefixes plus a /) should require no authentication. If possible, configure your container to pass these requests straight to Jenkins without requiring login.</div>
```

### Proposed changelog entries

- Show 'Unprotected URLs' description


### Proposed upgrade guidelines

N/A


```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
