### PR TITLE
[JENKINS-75134] fix the Spanish translation of the description of 'Unprotected URLs'

### DIFF
--- a/core/src/main/resources/hudson/security/LegacySecurityRealm/config_es.properties
+++ b/core/src/main/resources/hudson/security/LegacySecurityRealm/config_es.properties
@@ -1,4 +1,6 @@
 # This file is under the MIT License by authors
 
 Unprotected\ URLs=URLs Desprotegidas
-blurb=Estas URLs (y las URLs que inician con el prefijo /) no requieren autenticación. Si es posible, configure su servidor para pasar esta solicitud a Jenkins si requerir autenticación.
+blurb=\
+    Estas URLs (y las URLs que inician con el prefijo /) no requieren autenticación. \
+    Si es posible, configure su servidor para pasar estas peticiones directamente a Jenkins sin requerir autenticación.


### PR DESCRIPTION
See [JENKINS-75134](https://issues.jenkins.io/browse/JENKINS-75134).

depends on https://github.com/jenkinsci/jenkins/pull/10151

### Testing done
![Screenshot from 2025-01-14 14-48-34](https://github.com/user-attachments/assets/ab03f37a-163d-4e7e-ac16-a18c0933fd89)

### Proposed changelog entries

- fix the Spanish translation of the description of 'Unprotected URLs'

### Proposed upgrade guidelines

N/A


```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention


Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
