### PR TITLE
Use a variable for bold font weight

### DIFF
--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
@@ -29,7 +29,7 @@
 
   color: #fff;
   background-color: var(--warning-color);
-  font-weight: 500;
+  font-weight: var(--bold-weight);
   font-size: var(--font-size-xs);
 
   border-radius: 16px;

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsDecorator/resources.css
@@ -29,7 +29,7 @@
 
   color: #fff;
   background-color: var(--warning-color);
-  font-weight: var(--bold-weight);
+  font-weight: var(--font-bold-weight);
   font-size: var(--font-size-xs);
 
   border-radius: 16px;

--- a/src/main/js/widgets/add/addform.scss
+++ b/src/main/js/widgets/add/addform.scss
@@ -36,7 +36,7 @@
     .input-validation-message {
       color: var(--error-color);
       padding-top: 2px;
-      font-weight: 500;
+      font-weight: var(--font-bold-weight);
     }
 
     .input-message-disabled {
@@ -201,7 +201,7 @@
     label {
       display: block;
       font-size: var(--font-size-sm);
-      font-weight: 500;
+      font-weight: var(--font-bold-weight);
       color: var(--text-color);
       cursor: pointer;
 

--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -40,6 +40,7 @@ $semantics: (
   --font-size-sm: 0.875rem; // 14px
   --font-size-xs: 0.75rem; // 12px
   --font-size-monospace: 1em;
+  --font-bold-weight: 450;
 
   // Line height
   --line-height-base: 1.5;
@@ -152,7 +153,7 @@ $semantics: (
   --link-text-decoration: none;
   --link-text-decoration--hover: underline;
   --link-text-decoration--active: underline;
-  --link-font-weight: 450;
+  --link-font-weight: var(--font-bold-weight);
 
   // Command Palette
   --command-palette-results-backdrop-filter: contrast(0.7) brightness(1.5)
@@ -194,7 +195,7 @@ $semantics: (
   --link-dark-text-decoration: none;
   --link-dark-text-decoration--hover: underline;
   --link-dark-text-decoration--active: underline;
-  --link-dark-font-weight: 500;
+  --link-dark-font-weight: var(--font-bold-weight);
 
   // Pane
   --pane-border-width: 1px;
@@ -266,7 +267,7 @@ $semantics: (
     --form-item-max-width--small: 100%;
   }
 
-  --form-label-font-weight: 450;
+  --form-label-font-weight: var(--font-bold-weight);
   --form-input-padding: 0.625rem;
   --form-input-border-radius: 0.625rem;
   --form-input-glow: 0 0 0 10px transparent;

--- a/src/main/scss/base/_style.scss
+++ b/src/main/scss/base/_style.scss
@@ -188,7 +188,7 @@ pre.console {
 }
 
 .setting-name {
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
   margin-bottom: 0.5rem;
   white-space: nowrap;
 }
@@ -400,7 +400,7 @@ img.icon-help {
   position: relative;
   padding: 0.5rem 0.8rem;
   cursor: pointer;
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 
   &::before {
     content: "";

--- a/src/main/scss/components/_alert.scss
+++ b/src/main/scss/components/_alert.scss
@@ -7,7 +7,7 @@
   border-radius: 10px;
 
   strong {
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
   }
 
   a {

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -25,7 +25,7 @@
       align-items: center;
       justify-content: center;
       color: var(--text-color);
-      font-weight: 500;
+      font-weight: normal;
       font-size: 0.875rem;
       padding: 0.2rem 0.4rem;
 

--- a/src/main/scss/components/_buttons.scss
+++ b/src/main/scss/components/_buttons.scss
@@ -16,6 +16,7 @@
   margin: 0;
   padding: 0.5rem 0.9rem;
   font-size: 0.875rem;
+  font-weight: normal;
   text-decoration: none !important;
   background: transparent;
   color: var(--text-color) !important;

--- a/src/main/scss/components/_cards.scss
+++ b/src/main/scss/components/_cards.scss
@@ -13,7 +13,7 @@ $card-padding: 1rem;
     padding: 0 $card-padding;
     height: 50px;
     font-size: var(--font-size-sm) !important;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
     width: 100%;
     z-index: 1;
   }

--- a/src/main/scss/components/_command-palette.scss
+++ b/src/main/scss/components/_command-palette.scss
@@ -120,7 +120,7 @@
     padding: 0.5rem;
 
     &__heading {
-      font-weight: 500;
+      font-weight: var(--font-bold-weight);
       font-size: 0.875rem;
       margin: 0;
       padding: 0.75rem 0.75rem 0.625rem;

--- a/src/main/scss/components/_content-blocks.scss
+++ b/src/main/scss/components/_content-blocks.scss
@@ -8,7 +8,7 @@
   align-items: center;
   padding: 0.75rem 1.1rem;
   color: var(--text-color) !important;
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
   text-decoration: none !important;
 
   &::before {

--- a/src/main/scss/components/_dialogs.scss
+++ b/src/main/scss/components/_dialogs.scss
@@ -18,7 +18,7 @@ $jenkins-dialog-padding: 1.3rem;
 
   &__title {
     font-size: 1.125rem;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
     padding: 0 $jenkins-dialog-padding;
     color: var(--text-color);
   }
@@ -56,7 +56,7 @@ $jenkins-dialog-padding: 1.3rem;
 
   &__subtitle {
     font-size: 1rem;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
     color: var(--text-color-secondary);
     padding: 0;
     margin: 0 0 1rem;

--- a/src/main/scss/components/_dropdowns.scss
+++ b/src/main/scss/components/_dropdowns.scss
@@ -93,7 +93,7 @@ $dropdown-padding: 0.4rem;
     color: var(--text-color-secondary) !important;
     margin: $dropdown-padding 0.55rem;
     font-size: 0.8125rem;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
     opacity: 0.8;
 
     &:not(:first-of-type) {
@@ -134,7 +134,7 @@ $dropdown-padding: 0.4rem;
     margin: 0;
     padding: $dropdown-padding 1.75rem $dropdown-padding 0.6rem;
     font-size: 0.8125rem;
-    font-weight: 450;
+    font-weight: normal;
     text-decoration: none !important;
     background: transparent;
     color: var(--text-color) !important;

--- a/src/main/scss/components/_notice.scss
+++ b/src/main/scss/components/_notice.scss
@@ -9,7 +9,7 @@
   border-radius: 0.66rem;
   font-size: var(--font-size-base);
   margin-bottom: var(--section-padding);
-  font-weight: 450;
+  font-weight: var(--font-bold-weight);
   padding: calc(var(--section-padding) * 2);
   text-align: center;
 

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -12,7 +12,7 @@
   grid-gap: 1.5ch;
   padding: 0.8rem;
   border-radius: 10px;
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
   line-height: 1.66;
   color: var(--text-color);
   box-shadow:

--- a/src/main/scss/components/_section.scss
+++ b/src/main/scss/components/_section.scss
@@ -26,7 +26,7 @@
 .jenkins-section__title {
   margin: 0 0 var(--section-padding) 0;
   font-size: 1rem;
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 }
 
 .jenkins-section__description {
@@ -109,14 +109,14 @@
 
   dt {
     font-size: 0.9375rem;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
     margin: 0.1rem 0 0.2rem;
     color: var(--text-color);
   }
 
   dd {
     color: var(--text-color-secondary);
-    font-weight: 450;
+    font-weight: normal;
     line-height: 1.6;
     margin: 0 0.66rem 0 0;
     font-size: 0.9375rem;

--- a/src/main/scss/components/_side-panel-tasks.scss
+++ b/src/main/scss/components/_side-panel-tasks.scss
@@ -65,7 +65,7 @@ $background-outset: 0.7rem;
   gap: 0.65rem;
   width: 100%;
   cursor: pointer;
-  font-weight: 450 !important;
+  font-weight: normal !important;
   font-size: 0.875rem;
   color: var(--text-color) !important;
   background: transparent;

--- a/src/main/scss/components/_side-panel-widgets.scss
+++ b/src/main/scss/components/_side-panel-widgets.scss
@@ -28,7 +28,7 @@
 #side-panel .pane-header-title {
   display: inline-block;
   flex: 1;
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 
   & > div {
     font-weight: normal;

--- a/src/main/scss/components/_spinner.scss
+++ b/src/main/scss/components/_spinner.scss
@@ -3,7 +3,7 @@
   display: inline-flex;
   align-items: center;
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
   margin: 0;
 
   &::before,

--- a/src/main/scss/components/_table.scss
+++ b/src/main/scss/components/_table.scss
@@ -38,7 +38,7 @@
         padding-top: calc(var(--table-padding) * 0.9);
         padding-bottom: calc((var(--table-padding) * 0.9) + 2px);
         padding-left: 1.6rem;
-        font-weight: 500;
+        font-weight: var(--font-bold-weight);
         font-size: 0.875rem;
 
         &[align="center"] {

--- a/src/main/scss/components/_tabs.scss
+++ b/src/main/scss/components/_tabs.scss
@@ -38,7 +38,7 @@
   border-radius: 100px;
   background: var(--tabs-item-background);
   color: var(--tabs-item-foreground);
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
   font-size: 0.875rem;
   transition: var(--standard-transition);
   cursor: pointer;

--- a/src/main/scss/components/_tooltips.scss
+++ b/src/main/scss/components/_tooltips.scss
@@ -3,7 +3,6 @@
   padding: 0.45rem 0.8rem;
   border-radius: 0.66rem;
   box-shadow: var(--tooltip-box-shadow);
-  font-weight: 500;
   font-size: 0.75rem;
   line-height: 1.6;
   max-width: min(50vw, 1000px) !important;

--- a/src/main/scss/form/_file-upload.scss
+++ b/src/main/scss/form/_file-upload.scss
@@ -35,7 +35,7 @@
     }
 
     font-size: 0.8rem;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
     color: var(--text-color);
     border-radius: 0.66rem;
     cursor: pointer;

--- a/src/main/scss/form/_file-upload.scss
+++ b/src/main/scss/form/_file-upload.scss
@@ -35,7 +35,7 @@
     }
 
     font-size: 0.8rem;
-    font-weight: var(--font-bold-weight);
+    font-weight: normal;
     color: var(--text-color);
     border-radius: 0.66rem;
     cursor: pointer;

--- a/src/main/scss/form/_layout.scss
+++ b/src/main/scss/form/_layout.scss
@@ -170,7 +170,7 @@
   gap: 0.45rem;
   margin-left: 0.4rem;
   font-size: 0.8rem;
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
   cursor: default;
 
   svg {
@@ -198,7 +198,7 @@
     padding-top: 0.35rem;
 
     .jenkins-instructions__label {
-      font-weight: 450;
+      font-weight: var(--font-bold-weight);
       margin: 0;
     }
 
@@ -217,7 +217,7 @@
       color: var(--background);
       border-radius: 100px;
       text-align: center;
-      font-weight: 450;
+      font-weight: var(--font-bold-weight);
     }
   }
 }

--- a/src/main/scss/form/_search-bar.scss
+++ b/src/main/scss/form/_search-bar.scss
@@ -390,5 +390,5 @@
   margin: 2rem;
   padding: 0;
   color: var(--text-color-secondary);
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 }

--- a/src/main/scss/form/_validation.scss
+++ b/src/main/scss/form/_validation.scss
@@ -29,7 +29,7 @@
 .info {
   position: relative;
   padding-left: calc(22px + 0.4rem);
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 
   &::before {
     content: "";
@@ -60,7 +60,7 @@
 
 .error-inline {
   color: var(--red);
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 }
 
 .warning {
@@ -73,7 +73,7 @@
 
 .warning-inline {
   color: var(--orange);
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 }
 
 .info {

--- a/src/main/scss/pages/_about.scss
+++ b/src/main/scss/pages/_about.scss
@@ -119,18 +119,18 @@
 .app-about-heading {
   font-weight: 600;
   font-family: Georgia, serif;
-  font-size: 1.6rem;
+  font-size: 1.5rem;
   margin-bottom: 0.5rem !important;
 }
 
 .app-about-version {
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
   color: var(--text-color-secondary);
   margin: 0;
 }
 
 .app-about-paragraph {
-  font-size: 1.125rem;
+  font-size: 1rem;
   margin-bottom: var(--section-padding);
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 }

--- a/src/main/scss/pages/_dashboard.scss
+++ b/src/main/scss/pages/_dashboard.scss
@@ -121,7 +121,7 @@ $min-button-size: 36px;
 
     &__label {
       color: var(--link-color);
-      font-weight: 500;
+      font-weight: var(--font-bold-weight);
       margin: 0;
       font-size: 1rem;
     }

--- a/src/main/scss/pages/_icon-legend.scss
+++ b/src/main/scss/pages/_icon-legend.scss
@@ -24,7 +24,7 @@
     margin: 0;
     padding: 0;
     font-size: 0.9375rem;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
     line-height: 1.6;
   }
 }

--- a/src/main/scss/pages/_job.scss
+++ b/src/main/scss/pages/_job.scss
@@ -36,7 +36,7 @@
     font-size: 0.75rem;
     color: var(--text-color-secondary);
     margin-top: 10px;
-    font-weight: 450;
+    font-weight: var(--font-bold-weight);
     margin-bottom: 4px;
   }
 
@@ -126,7 +126,7 @@
       color: var(--text-color);
       gap: 0.5rem;
       text-decoration: none;
-      font-weight: 450;
+      font-weight: var(--font-bold-weight);
       flex-grow: 1;
       padding: 0.45rem 0 0;
       word-break: normal;

--- a/src/main/scss/pages/_sign-in-register.scss
+++ b/src/main/scss/pages/_sign-in-register.scss
@@ -148,7 +148,7 @@
     display: block;
     font-size: 0.95rem;
     margin-bottom: 0.5rem;
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
   }
 
   button {
@@ -180,7 +180,7 @@
 
       z-index: 1;
       padding: 0 0.2rem;
-      font-weight: 500;
+      font-weight: var(--font-bold-weight);
       font-size: 0.95rem;
       margin: 0;
       color: var(--link-color);
@@ -263,7 +263,7 @@
 .app-sign-in-register__error {
   font-size: 0.95rem;
   color: var(--error-color);
-  font-weight: 500;
+  font-weight: var(--font-bold-weight);
 
   &:empty {
     display: none;

--- a/src/main/scss/simple-page.scss
+++ b/src/main/scss/simple-page.scss
@@ -49,7 +49,7 @@
   }
 
   strong {
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
   }
 }
 
@@ -136,7 +136,7 @@
   margin: 1rem 0 0;
 
   p {
-    font-weight: 500;
+    font-weight: var(--font-bold-weight);
     font-size: 1.125rem;
   }
 }


### PR DESCRIPTION
Standardises bold fonts on Jenkins using a CSS variable, overall the UI should look the same - some elements are a little lighter/less heavy on the eye. Overall not very noticeable but a quality of life update - using a variable keeps it consistent and easy to change in the future.

### Testing done

* Works as expected, font weights are slightly less bold across Jenkins

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
