### PR TITLE
Rename '[Jenkins]' in tab title to '- Jenkins'

### DIFF
--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
     <j:set var="simpleDecorators" value="${h.simplePageDecorators}"/>
     <html lang="${request.getLocale().toLanguageTag()}">
       <head data-rooturl="${rootURL}" data-resurl="${resURL}" data-imagesurl="${imagesURL}" resURL="${resURL}">
-        <title>${%Register} [Jenkins]</title>
+        <title>${%Register} - Jenkins</title>
         <!-- we do not want bots on this page -->
         <meta name="ROBOTS" content="NOFOLLOW"/>
         <!-- mobile friendly layout -->

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup_it.properties
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup_it.properties
@@ -27,7 +27,7 @@ A\ strong\ password\ is\ a\ long\ password\ that''s\ unique\ for\ every\ site.\ 
   massimo di sicurezza.
 Create\ account=Crea account
 Create\ an\ account!=Crea un account!
-Create\ an\ account!\ [Jenkins]=Crea un account! [Jenkins]
+Create\ an\ account!\ -\ Jenkins=Crea un account! - Jenkins
 Email=Indirizzo di posta elettronica
 Enter\ text\ as\ shown=Immettere il testo così come viene visualizzato
 Full\ name=Nome completo

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup_pt_BR.properties
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup_pt_BR.properties
@@ -24,7 +24,7 @@
 Enter\ text\ as\ shown=Entre\ com\ texto\ conforme\ mostrado
 Create\ account=Criar\ conta
 Weak=Fraca
-Create\ an\ account!\ [Jenkins]=Criar\ uma\ conta!\ [Jenkins]
+Create\ an\ account!\ -\ Jenkins=Criar uma conta! - Jenkins
 Strength=Força
 Strong=Forte
 please\ sign\ in.=Por\ favor\ dê\ entrada.

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup_zh_TW.properties
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup_zh_TW.properties
@@ -22,7 +22,7 @@
 
 A\ strong\ password\ is\ a\ long\ password\ that's\ unique\ for\ every\ site.\ Try\ using\ a\ phrase\ with\ 5-6\ words\ for\ the\ best\ security.=強健的密碼擁有較多字元且在不同系統使用獨特的密碼。請試著使用包含 5~6 個單字的句子以獲得最佳安全性。
 If\ you\ already\ have\ a\ Jenkins\ account,=如果您有 Jenkins 帳戶了，
-Create\ an\ account\!\ [Jenkins]=建立新帳戶\! [Jenkins]
+Create\ an\ account\!\ -\ Jenkins=建立新帳戶\! - Jenkins
 Strength=強度
 please\ sign\ in.=請登入。
 Show=顯示

--- a/core/src/main/resources/jenkins/model/Jenkins/login.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/login.jelly
@@ -53,7 +53,7 @@ THE SOFTWARE.
     <!-- real deal starting here -->
     <html lang="${request.getLocale().toLanguageTag()}">
       <head data-rooturl="${rootURL}" data-resurl="${resURL}" data-imagesurl="${imagesURL}" resURL="${resURL}">
-        <title>${%signIn} [Jenkins]</title>
+        <title>${%signIn} - Jenkins</title>
         <!-- we do not want bots on this page -->
         <meta name="ROBOTS" content="NOFOLLOW" />
         <!-- mobile friendly layout -->

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -109,7 +109,7 @@ THE SOFTWARE.
     ${h.checkPermission(it,permission)}
     ${h.checkAnyPermission(it, permissions)}
 
-    <title>${h.appendIfNotNull(title, ' [Jenkins]', 'Jenkins')}</title>
+    <title>${h.appendIfNotNull(title, ' - Jenkins', 'Jenkins')}</title>
 
     <link rel="stylesheet" href="${resURL}/jsbundles/styles.css" type="text/css" />
     <j:if test="${attrs.nogrid==null or attrs.nogrid.equals(false)}">

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -190,7 +190,7 @@ public class SearchTest {
 
         // make sure we've fetched the testSearchByDisplayName project page
         String contents = result.getWebResponse().getContentAsString();
-        assertTrue(contents.contains(String.format("<title>%s [Jenkins]</title>", displayName)));
+        assertTrue(contents.contains(String.format("<title>%s - Jenkins</title>", displayName)));
         assertFalse(contents.contains(otherDisplayName));
     }
 

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -115,7 +115,7 @@ public class SearchTest {
 
         // make sure we've fetched the testSearchByDisplayName project page
         String contents = result.getWebResponse().getContentAsString();
-        assertTrue(contents.contains(String.format("<title>%s [Jenkins]</title>", projectName)));
+        assertTrue(contents.contains(String.format("<title>%s - Jenkins</title>", projectName)));
     }
 
     @Issue("JENKINS-24433")
@@ -162,7 +162,7 @@ public class SearchTest {
 
         // make sure we've fetched the testSearchByDisplayName project page
         String contents = result.getWebResponse().getContentAsString();
-        assertTrue(contents.contains(String.format("<title>%s [Jenkins]</title>", displayName)));
+        assertTrue(contents.contains(String.format("<title>%s - Jenkins</title>", displayName)));
     }
 
     @Test


### PR DESCRIPTION
A _hopefully_ small PR to rename `[Jenkins]` in the tab title to `- Jenkins`. Using a hyphen is more common across the web and feels a little more polished IMV compared to the square brackets.

### Testing done

* Pages feature '- Jenkins' in their tab title now

### Proposed changelog entries

- N/A

### Proposed developer changelog entries

- Rename '[Jenkins]' in tab title to '- Jenkins'

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
