### PR TITLE
Improve dialog appearance + tidy up SCSS

### DIFF
--- a/src/main/scss/components/_dialogs.scss
+++ b/src/main/scss/components/_dialogs.scss
@@ -1,8 +1,9 @@
 $jenkins-dialog-padding: 1.3rem;
 
 .jenkins-dialog {
-  border-radius: 0.6rem;
+  border-radius: var(--form-input-border-radius);
   border: none;
+  background-color: var(--card-background);
   box-shadow: var(--dialog-box-shadow);
   animation: jenkins-dialog-animate-in 0.25s cubic-bezier(0, 0.68, 0.5, 1.5);
   overflow: hidden;
@@ -10,6 +11,7 @@ $jenkins-dialog-padding: 1.3rem;
   display: flex;
   flex-direction: column;
   gap: $jenkins-dialog-padding;
+  outline: none;
 
   &::backdrop {
     background: var(--dialog-backdrop-background);
@@ -48,8 +50,6 @@ $jenkins-dialog-padding: 1.3rem;
     flex-direction: row-reverse;
 
     .jenkins-button {
-      font-size: 0.9rem;
-      padding: 0.7rem 0.6rem;
       min-width: 100px;
     }
   }
@@ -68,16 +68,7 @@ $jenkins-dialog-padding: 1.3rem;
     right: $jenkins-dialog-padding - 0.5rem;
     aspect-ratio: 1;
     padding: 0;
-
-    &::before,
-    &::after {
-      border-radius: 100%;
-      outline: none;
-    }
-
-    &::after {
-      backdrop-filter: contrast(0.9) blur(5px);
-    }
+    border-radius: 100%;
   }
 }
 


### PR DESCRIPTION
Small one to tidy up the dialog SCSS. It removes some unneeded SCSS, fixes an annoying outline bug and also ensures that the dialog appears correctly in dark mode.

I've left some comments explaining the changes ⬇️

### Testing done

* Dialog appears/works as expected 

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
