### PR TITLE
Remove `robust-http-client`

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -298,11 +298,6 @@ THE SOFTWARE.
         <version>1.31</version>
       </dependency>
       <dependency>
-        <groupId>org.jvnet.robust-http-client</groupId>
-        <artifactId>robust-http-client</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.jvnet.winp</groupId>
         <artifactId>winp</artifactId>
         <version>1.31</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -334,10 +334,6 @@ THE SOFTWARE.
       <artifactId>localizer</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.robust-http-client</groupId>
-      <artifactId>robust-http-client</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jvnet.winp</groupId>
       <artifactId>winp</artifactId>
     </dependency>

--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -70,7 +70,6 @@ import jenkins.security.stapler.StaplerAccessibleType;
 import jenkins.util.JenkinsJVM;
 import jenkins.util.SystemProperties;
 import org.jenkinsci.Symbol;
-import org.jvnet.robust_http_client.RetryableHttpStream;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -346,10 +345,10 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
     public static InputStream getInputStream(URL url) throws IOException {
         final ProxyConfiguration p = get();
         if (p == null)
-            return new RetryableHttpStream(url);
+            return ((HttpURLConnection) url.openConnection()).getInputStream();
 
         Proxy proxy = p.createProxy(url.getHost());
-        InputStream is = new RetryableHttpStream(url, proxy);
+        InputStream is = ((HttpURLConnection) url.openConnection(proxy)).getInputStream();
         if (p.getUserName() != null) {
             // Add an authenticator which provides the credentials for proxy authentication
             Authenticator.setDefault(p.authenticator);


### PR DESCRIPTION
This tiny library by Kohsuke was not being consumed directly by any Jenkins or CloudBees plugins whose binaries I searched. It was only used internally by `ProxyConfiguration#getInputStream`, a method no longer called by anything relevant besides https://github.com/jenkinsci/xunit-plugin/blob/4bf589c23c09a1988cf3e641e48d3251563814ac/src/main/java/org/jenkinsci/plugins/xunit/util/DownloadableResourceUtil.java#L66 and https://github.com/jenkinsci/xunit-plugin/blob/4bf589c23c09a1988cf3e641e48d3251563814ac/src/main/java/org/jenkinsci/plugins/xunit/util/DownloadableResourceUtil.java#L66, both of which seem like they could work just fine without a 5-try retry loop.

### Testing done

`mvn clean verify -Dtest=hudson.ProxyConfigurationManagerGUITest,hudson.ProxyConfigurationManagerTest,hudson.ProxyConfigurationTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
