### PR TITLE
Disable JnlpSlaveRestarterInstallerTest on Windows CI agents

### DIFF
--- a/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
+++ b/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
@@ -25,7 +25,9 @@
 package jenkins.slaves.restarter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
+import hudson.Functions;
 import hudson.model.Slave;
 import hudson.slaves.DumbSlave;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -49,15 +51,31 @@ public class JnlpSlaveRestarterInstallerTest {
     @Rule
     public LoggerRule logging = new LoggerRule().record(JnlpSlaveRestarterInstaller.class, Level.FINE).capture(10);
 
+    private static final String JENKINS_URL = System.getenv("JENKINS_URL") != null
+            ? System.getenv("JENKINS_URL")
+            : "http://localhost:8080/";
+
     @Issue("JENKINS-19055")
     @Test
     public void tcpReconnection() throws Throwable {
+        // TODO Enable when test is reliable on Windows
+        // When builds switched from ACI containers to virtual machines, this test consistently failed
+        // When the test is run on local Windows computers, it passes
+        // Disable the test on ci.jenkins.io and friends when running Windows
+        // Do not disable for Windows developers generally
+        assumeFalse(Functions.isWindows() && JENKINS_URL.contains("ci.jenkins.io"));
         reconnection(false);
     }
 
     @Issue("JENKINS-66446")
     @Test
     public void webSocketReconnection() throws Throwable {
+        // TODO Enable when test is reliable on Windows
+        // When builds switched from ACI containers to virtual machines, this test consistently failed
+        // When the test is run on local Windows computers, it passes
+        // Disable the test on ci.jenkins.io and friends when running Windows
+        // Do not disable for Windows developers generally
+        assumeFalse(Functions.isWindows() && JENKINS_URL.contains("ci.jenkins.io"));
         reconnection(true);
     }
 

--- a/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
+++ b/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
@@ -51,31 +51,27 @@ public class JnlpSlaveRestarterInstallerTest {
     @Rule
     public LoggerRule logging = new LoggerRule().record(JnlpSlaveRestarterInstaller.class, Level.FINE).capture(10);
 
-    private static final String JENKINS_URL = System.getenv("JENKINS_URL") != null
-            ? System.getenv("JENKINS_URL")
-            : "http://localhost:8080/";
-
     @Issue("JENKINS-19055")
     @Test
     public void tcpReconnection() throws Throwable {
-        // TODO Enable when test is reliable on Windows
+        // TODO Enable when test is reliable on Windows agents of ci.jenkins.io
         // When builds switched from ACI containers to virtual machines, this test consistently failed
         // When the test is run on local Windows computers, it passes
         // Disable the test on ci.jenkins.io and friends when running Windows
         // Do not disable for Windows developers generally
-        assumeFalse(Functions.isWindows() && JENKINS_URL.contains("ci.jenkins.io"));
+        assumeFalse("TODO: Test fails on Windows VM", Functions.isWindows() && System.getenv("CI") != null);
         reconnection(false);
     }
 
     @Issue("JENKINS-66446")
     @Test
     public void webSocketReconnection() throws Throwable {
-        // TODO Enable when test is reliable on Windows
+        // TODO Enable when test is reliable on Windows agents of ci.jenkins.io
         // When builds switched from ACI containers to virtual machines, this test consistently failed
         // When the test is run on local Windows computers, it passes
         // Disable the test on ci.jenkins.io and friends when running Windows
         // Do not disable for Windows developers generally
-        assumeFalse(Functions.isWindows() && JENKINS_URL.contains("ci.jenkins.io"));
+        assumeFalse("TODO: Test fails on Windows VM", Functions.isWindows() && System.getenv("CI") != null);
         reconnection(true);
     }
 


### PR DESCRIPTION
## Disable JnlpSlaveRestarterInstallerTest on Windows CI agents

The tests have failed consistently on Windows agents of ci.jenkins.io since we switched to virtual machines instead of containers.  The tests fail on the stable-2.479, stable-2.492, and master branches.  The tests do not fail when run on my Windows 10 and Windows 11 computers in my home lab.

Needs more investigation, but I would rather not block the 2.492.1 release candidate build for that investigation.

### Testing done

Ran the test with Jenkins on 5 different Windows computers (mix of Windows 10 and Windows 11) with i5 and i7 processors using local SSD drives.  No failures reported in the 45+ test runs spread across those computers.  One Windows computer would sometimes fail with a test timeout message when I ran the test from the Windows command prompt.

Tests fail on master branch, stable-2.479 branch, and stable-2.492 branch when running on ci.jenkins.io.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
