### PR TITLE
Re-enable Checkstyle

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -343,17 +343,20 @@ public class CLI {
 
         class Authenticator extends ClientEndpointConfig.Configurator {
             HandshakeResponse hr;
+
             @Override
             public void beforeRequest(Map<String, List<String>> headers) {
                 if (factory.authorization != null) {
                     headers.put("Authorization", List.of(factory.authorization));
                 }
             }
+
             @Override
             public void afterResponse(HandshakeResponse hr) {
                 this.hr = hr;
             }
         }
+
         var authenticator = new Authenticator();
 
         ClientManager client = ClientManager.createClient(JdkClientContainer.class.getName()); // ~ ContainerProvider.getWebSocketContainer()

--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -279,7 +279,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
     /**
      * @deprecated since 2.459 use {@link #createClassLoader(String, List, ClassLoader, Attributes)}
      */
-    @Deprecated(since="2.459")
+    @Deprecated(since = "2.459")
     protected ClassLoader createClassLoader(List<File> paths, ClassLoader parent, Attributes atts) throws IOException {
         // generate a legacy id so at least we can track to something
         return createClassLoader("unidentified-" + UUID.randomUUID(), paths, parent, atts);

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1115,7 +1115,21 @@ public abstract class Launcher {
             final String workDir = psPwd == null ? null : psPwd.getRemote();
 
             try {
-                RemoteLaunchCallable remote = new RemoteLaunchCallable(ps.commands, ps.masks, ps.envs, in, ps.reverseStdin, out, ps.reverseStdout, err, ps.reverseStderr, ps.quiet, workDir, listener, ps.stdoutListener, envVarsFilterRuleWrapper);
+                RemoteLaunchCallable remote = new RemoteLaunchCallable(
+                        ps.commands,
+                        ps.masks,
+                        ps.envs,
+                        in,
+                        ps.reverseStdin,
+                        out,
+                        ps.reverseStdout,
+                        err,
+                        ps.reverseStderr,
+                        ps.quiet,
+                        workDir,
+                        listener,
+                        ps.stdoutListener,
+                        envVarsFilterRuleWrapper);
                 // reset the rules to prevent build step without rules configuration to re-use those
                 envVarsFilterRuleWrapper = null;
                 return new ProcImpl(getChannel().call(remote));

--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -115,8 +115,8 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
     }
 
     /**
-     * @deprecated Use {@link #getComputers()} instead.
      * @return All {@link Computer} instances managed by this set.
+     * @deprecated Use {@link #getComputers()} instead.
      */
     @Deprecated(since = "2.480")
     public Computer[] get_all() {

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -354,10 +354,12 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
          * Implementation of {@link Job#assignBuildNumber}.
          */
         int assignBuildNumber(Job<?, ?> job, SaveNextBuildNumber saveNextBuildNumber) throws IOException;
+
         /**
          * Provides an externally accessible alias for {@link Job#saveNextBuildNumber}, which is {@code protected}.
          * ({@link #getNextBuildNumber} and {@link #fastUpdateNextBuildNumber} are already accessible.)
          */
+
         interface SaveNextBuildNumber {
             void call() throws IOException;
         }

--- a/core/src/main/java/hudson/model/UserPropertyDescriptor.java
+++ b/core/src/main/java/hudson/model/UserPropertyDescriptor.java
@@ -117,11 +117,9 @@ public abstract class UserPropertyDescriptor extends Descriptor<UserProperty> {
      * Method proposed to prevent plugins to rely on too recent core version
      * while keeping the possibility to use the categories.
      *
-     * @deprecated This should only be used when the core requirement is below the version this method was added
-     *
      * @return String name corresponding to the symbol of {@link #getUserPropertyCategory()}
-     *
      * @since 2.468
+     * @deprecated This should only be used when the core requirement is below the version this method was added
      */
     @Deprecated
     protected @CheckForNull String getUserPropertyCategoryAsString() {

--- a/core/src/main/java/hudson/model/userproperty/UserPropertyCategory.java
+++ b/core/src/main/java/hudson/model/userproperty/UserPropertyCategory.java
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package hudson.model.userproperty;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/core/src/main/java/hudson/model/userproperty/UserPropertyCategoryAccountAction.java
+++ b/core/src/main/java/hudson/model/userproperty/UserPropertyCategoryAccountAction.java
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package hudson.model.userproperty;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/core/src/main/java/hudson/model/userproperty/UserPropertyCategoryAppearanceAction.java
+++ b/core/src/main/java/hudson/model/userproperty/UserPropertyCategoryAppearanceAction.java
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package hudson.model.userproperty;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/core/src/main/java/hudson/model/userproperty/UserPropertyCategoryExperimentalAction.java
+++ b/core/src/main/java/hudson/model/userproperty/UserPropertyCategoryExperimentalAction.java
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package hudson.model.userproperty;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/core/src/main/java/hudson/model/userproperty/UserPropertyCategoryPreferencesAction.java
+++ b/core/src/main/java/hudson/model/userproperty/UserPropertyCategoryPreferencesAction.java
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package hudson.model.userproperty;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/core/src/main/java/hudson/model/userproperty/UserPropertyCategorySecurityAction.java
+++ b/core/src/main/java/hudson/model/userproperty/UserPropertyCategorySecurityAction.java
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package hudson.model.userproperty;
 
+package hudson.model.userproperty;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;

--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -464,7 +464,14 @@ public class RobustReflectionConverter implements Converter {
         return context.convertAnother(result, type, converter);
     }
 
-    private void writeValueToImplicitCollection(HierarchicalStreamReader reader, UnmarshallingContext context, Object value, Map<String, Collection<Object>> implicitCollections, Map<String, Class<?>> implicitCollectionElementTypes, Object result, String itemFieldName) {
+    private void writeValueToImplicitCollection(
+            HierarchicalStreamReader reader,
+            UnmarshallingContext context,
+            Object value,
+            Map<String, Collection<Object>> implicitCollections,
+            Map<String, Class<?>> implicitCollectionElementTypes,
+            Object result,
+            String itemFieldName) {
         String fieldName = mapper.getFieldNameForItemTypeAndName(context.getRequiredType(), value.getClass(), itemFieldName);
         if (fieldName != null) {
             Collection collection = implicitCollections.get(fieldName);

--- a/core/src/main/java/jenkins/agents/IOfflineCause.java
+++ b/core/src/main/java/jenkins/agents/IOfflineCause.java
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package jenkins.agents;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/core/src/main/java/jenkins/model/IComputer.java
+++ b/core/src/main/java/jenkins/model/IComputer.java
@@ -185,6 +185,7 @@ public interface IComputer extends AccessControlled, IconSpec {
      * Returns the number of {@link IExecutor}s that are doing some work right now.
      */
     int countBusy();
+
     /**
      * Returns the current size of the executor pool for this computer.
      */
@@ -194,6 +195,7 @@ public interface IComputer extends AccessControlled, IconSpec {
      * @return true if the computer is online.
      */
     boolean isOnline();
+
     /**
      * @return the number of {@link IExecutor}s that are idle right now.
      */

--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -113,7 +113,7 @@ public class Nodes implements PersistenceRoot {
      * @throws IOException if the new list of nodes could not be persisted.
      */
     public void setNodes(final @NonNull Collection<? extends Node> nodes) throws IOException {
-        Map<String,Node> toRemove = new HashMap<>();
+        Map<String, Node> toRemove = new HashMap<>();
         Queue.withLock(() -> {
             toRemove.putAll(Nodes.this.nodes);
             for (var node : nodes) {

--- a/core/src/main/java/jenkins/security/s2m/JarURLValidatorImpl.java
+++ b/core/src/main/java/jenkins/security/s2m/JarURLValidatorImpl.java
@@ -78,6 +78,7 @@ public class JarURLValidatorImpl extends ChannelConfigurator implements JarURLVa
             LOGGER.log(Level.FINE, () -> "Allowing URL: " + url);
         }
     }
+
     @SuppressFBWarnings(
             value = "DMI_COLLECTION_OF_URLS",
             justification = "All URLs point to local files, so no DNS lookup.")

--- a/core/src/test/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitorTest.java
+++ b/core/src/test/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitorTest.java
@@ -197,7 +197,7 @@ public class OperatingSystemEndOfLifeAdminMonitorTest {
      * name, and expected value for each of the resource files used by
      * the test.
      *
-     * @param simplifyExpectedValue if true, then the expected value
+     * @param simplify if true, then the expected value
      * is simplified by replacing ' ' with '-', by replacing '/' with
      * '-', and by removing '(' and ')'.
      * @return arguments for ParameterizedTest, resource file name,

--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,11 @@ THE SOFTWARE.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <!-- Version specified in parent POM -->
+      </plugin>
     </plugins>
   </build>
 

--- a/test/src/test/java/hudson/model/UserPropertyTest.java
+++ b/test/src/test/java/hudson/model/UserPropertyTest.java
@@ -37,7 +37,7 @@ public class UserPropertyTest {
     public JenkinsRule j = new JenkinsRule();
 
     public User configRoundtrip(User u) throws Exception {
-        submit(j.createWebClient().goTo(u.getUrl()+"/account/").getFormByName("config"));
+        submit(j.createWebClient().goTo(u.getUrl() + "/account/").getFormByName("config"));
         return u;
     }
 

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmFIPSTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmFIPSTest.java
@@ -164,7 +164,7 @@ public class HudsonPrivateSecurityRealmFIPSTest {
         User u1 =  securityRealm.createAccount("test", "aValidFipsPass");
 
         WebClient wc = j.createWebClient();
-        wc.login("test","aValidFipsPass");
+        wc.login("test", "aValidFipsPass");
 
         HtmlPage configurePage = wc.goTo(u1.getUrl() + "/security/");
         HtmlPasswordInput password1 = configurePage.getElementByName("user.password");
@@ -192,7 +192,7 @@ public class HudsonPrivateSecurityRealmFIPSTest {
 
 
         WebClient wc = j.createWebClient();
-        wc.login("test","aValidFipsPass");
+        wc.login("test", "aValidFipsPass");
 
         HtmlPage configurePage = wc.goTo(u1.getUrl() + "/security/");
         HtmlPasswordInput password1 = configurePage.getElementByName("user.password");
@@ -219,7 +219,7 @@ public class HudsonPrivateSecurityRealmFIPSTest {
         User u1 =  securityRealm.createAccount("test", "aValidFipsPass");
 
         WebClient wc = j.createWebClient();
-        wc.login("test","aValidFipsPass");
+        wc.login("test", "aValidFipsPass");
 
         HtmlPage configurePage = wc.goTo(u1.getUrl() + "/security/");
         HtmlPasswordInput password1 = configurePage.getElementByName("user.password");

--- a/test/src/test/java/hudson/util/FormFieldValidatorTest.java
+++ b/test/src/test/java/hudson/util/FormFieldValidatorTest.java
@@ -185,7 +185,7 @@ public class FormFieldValidatorTest {
         private Secret populatedPassword = Secret.fromString("secret!");
         private String textarea;
         private Secret emptySecretTextarea;
-        private Secret populatedSecretTextarea = Secret.fromString("sensitive!");;
+        private Secret populatedSecretTextarea = Secret.fromString("sensitive!");
 
         @DataBoundConstructor
         public ValidatingDescribable() {

--- a/test/src/test/java/jenkins/model/NodesTest.java
+++ b/test/src/test/java/jenkins/model/NodesTest.java
@@ -307,7 +307,7 @@ public class NodesTest {
     private static class DumbSlaveNameAndRemoteFSMatcher extends TypeSafeMatcher<DumbSlavePair> {
         private final DumbSlavePair expected;
 
-        public DumbSlaveNameAndRemoteFSMatcher(DumbSlavePair expected) {
+        DumbSlaveNameAndRemoteFSMatcher(DumbSlavePair expected) {
             this.expected = expected;
         }
 

--- a/test/src/test/java/jenkins/security/Security3430Test.java
+++ b/test/src/test/java/jenkins/security/Security3430Test.java
@@ -156,7 +156,8 @@ public class Security3430Test {
                 // outdated remoting.jar will fail, but up to date one passes
                 if (requestingJarFromAgent) {
                     final IOException ex = assertThrows(IOException.class, () -> channel.preloadJar(j.jenkins.getPluginManager().uberClassLoader, Stapler.class));
-                    assertThat(ex.getMessage(), containsString("No hudson.remoting.JarURLValidator has been set for this channel, so all #fetchJar calls are rejected. This is likely a bug in Jenkins. As a workaround, try updating the agent.jar file."));
+                    assertThat(ex.getMessage(), containsString(
+                            "No hudson.remoting.JarURLValidator has been set for this channel, so all #fetchJar calls are rejected. This is likely a bug in Jenkins. As a workaround, try updating the agent.jar file."));
                 } else {
                     assertTrue(channel.preloadJar(j.jenkins.getPluginManager().uberClassLoader, Stapler.class));
                     assertThat(logRecords.stream().map(LogRecord::getMessage).toList(), is(empty()));
@@ -227,7 +228,8 @@ public class Security3430Test {
                     assertThat(logRecords, not(hasItem(logMessageContainsString("Allowing URL"))));
                     assertThat(logRecords, hasItem(logMessageContainsString("Rejecting URL: ")));
                 } else {
-                    assertThat(itex.getCause().getMessage(), containsString("No hudson.remoting.JarURLValidator has been set for this channel, so all #fetchJar calls are rejected. This is likely a bug in Jenkins. As a workaround, try updating the agent.jar file."));
+                    assertThat(itex.getCause().getMessage(), containsString(
+                            "No hudson.remoting.JarURLValidator has been set for this channel, so all #fetchJar calls are rejected. This is likely a bug in Jenkins. As a workaround, try updating the agent.jar file."));
                 }
             }
 
@@ -264,10 +266,11 @@ public class Security3430Test {
         private final URL controllerFilePath;
         private final String expectedContent;
 
-        public Exploit(URL controllerFilePath, String expectedContent) {
+        Exploit(URL controllerFilePath, String expectedContent) {
             this.controllerFilePath = controllerFilePath;
             this.expectedContent = expectedContent;
         }
+
         @Override
         public Void call() throws Exception {
             final ClassLoader ccl = Thread.currentThread().getContextClassLoader();
@@ -290,7 +293,7 @@ public class Security3430Test {
     private static final class LogMessageContainsString extends TypeSafeMatcher<LogRecord> {
         private final Matcher<String> stringMatcher;
 
-        public LogMessageContainsString(Matcher<String> stringMatcher) {
+        LogMessageContainsString(Matcher<String> stringMatcher) {
             this.stringMatcher = stringMatcher;
         }
 


### PR DESCRIPTION
#9037 accidentally disabled enforcement of Checkstyle. This PR re-enables Checkstyle and fixes any violations that were introduced in the meantime.

### Testing done

`mvn clean verify -Dtest=hudson.AboutJenkinsTest`

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
