### PR TITLE
Backporting for 2.492.1 LTS (part 2)

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entries.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entries.jelly
@@ -28,7 +28,11 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:i="jelly:fmt">
   <j:set target="${it}" property="nextBuildNumberToFetch" value="${it.nextBuildNumber}" />
-  <j:invokeStatic className="java.time.LocalDate" method="now" var="now" />
+  <j:if test="${h.isUserTimeZoneOverride()}">
+    <i:setTimeZone value="${h.getUserTimeZone()}" />
+  </j:if>
+  <j:new var="dateNow" className="java.util.Date"/>
+  <i:formatDate value="${dateNow}" var="now" type="date" pattern="YYYY-MM-dd"/>
 
   <j:forEach var="pageEntry" items="${it.runs}">
     <i:formatDate value="${pageEntry.entry.timestamp.time}" var="date" type="date" dateStyle="long" />

--- a/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
+++ b/test/src/test/java/jenkins/slaves/restarter/JnlpSlaveRestarterInstallerTest.java
@@ -58,24 +58,24 @@ public class JnlpSlaveRestarterInstallerTest {
     @Issue("JENKINS-19055")
     @Test
     public void tcpReconnection() throws Throwable {
-        // TODO Enable when test is reliable on Windows
+        // TODO Enable when test is reliable on Windows agents of ci.jenkins.io
         // When builds switched from ACI containers to virtual machines, this test consistently failed
         // When the test is run on local Windows computers, it passes
         // Disable the test on ci.jenkins.io and friends when running Windows
         // Do not disable for Windows developers generally
-        assumeFalse(Functions.isWindows() && JENKINS_URL.contains("ci.jenkins.io"));
+        assumeFalse("TODO: Test fails on Windows VM", Functions.isWindows() && System.getenv("CI") != null);
         reconnection(false);
     }
 
     @Issue("JENKINS-66446")
     @Test
     public void webSocketReconnection() throws Throwable {
-        // TODO Enable when test is reliable on Windows
+        // TODO Enable when test is reliable on Windows agents of ci.jenkins.io
         // When builds switched from ACI containers to virtual machines, this test consistently failed
         // When the test is run on local Windows computers, it passes
         // Disable the test on ci.jenkins.io and friends when running Windows
         // Do not disable for Windows developers generally
-        assumeFalse(Functions.isWindows() && JENKINS_URL.contains("ci.jenkins.io"));
+        assumeFalse("TODO: Test fails on Windows VM", Functions.isWindows() && System.getenv("CI") != null);
         reconnection(true);
     }
 


### PR DESCRIPTION
## 

Backport [JENKINS-75163](https://issues.jenkins.io/browse/JENKINS-75163) "Respect user timezone in history widget" to Jenkins 2.492 stable branch for inclusion in 2.492.1.

Also updates the [previous backport](https://github.com/jenkinsci/jenkins/pull/10195) to be consistent with the test exclusion that was merged and released from the master branch.

### Candidates

```
JENKINS-75163           Minor                   2.494
        Respect user timezone in history widget
        https://issues.jenkins.io/browse/JENKINS-75163
```

### Testing done

Confirmed that automated tests pass with the changes in this pull request.

Interactive testing confirmed that the build history widget displays as expected for freestyle and Pipeline jobs.  Rab jobs builds with multiple JDK versions and Maven versions.

Did not confirm that the [timezone issue](https://issues.jenkins.io/browse/JENKINS-75163) is fixed by the original change.  Relying on the results reported in pull request:

* https://github.com/jenkinsci/jenkins/pull/10177

### Proposed changelog entries

- Use the correct date in the History widget when a user has configured a dedicated time zone.

### Proposed upgrade guidelines

N/A

```[tasklist]
### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
