### PR TITLE
[JENKINS-58743] Allow to provide a custom path for master key

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -974,6 +974,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
             ClassFilterImpl.register();
             LOGGER.info("Starting version " + getVersion());
 
+            // Sanity check that we can load the confidential store. Fail fast if we can't.
+            ConfidentialStore.get();
+
             // initialization consists of ...
             executeReactor(is,
                     pluginManager.initTasks(is),    // loading and preparing plugins

--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -26,16 +26,16 @@ import jenkins.util.SystemProperties;
  * Default portable implementation of {@link ConfidentialStore} that uses
  * a directory inside $JENKINS_HOME.
  * <p>
- * The master key is stored by default in <code>$JENKINS_HOME/secrets/master.key</code> but another location can be provided using the system property <code>master.key.file</code>.
+ * The master key is stored by default in <code>$JENKINS_HOME/secrets/master.key</code> but another location can be provided using the system property <code>jenkins.master.key.file</code>.
  * <p>
- * It is also possible to prevent the generation of the master key file using the system property <code>-Dmaster.key.readOnly</code>. In this case, the master key file must be provided or startup will fail.
+ * It is also possible to prevent the generation of the master key file using the system property <code>-Djenkins.master.key.readOnly</code>. In this case, the master key file must be provided or startup will fail.
  *
  * @author Kohsuke Kawaguchi
  */
 // @MetaInfServices --- not annotated because this is the fallback implementation
 public class DefaultConfidentialStore extends ConfidentialStore {
-    static final String MASTER_KEY_FILE_SYSTEM_PROPERTY = "master.key.file";
-    static final String MASTER_KEY_READONLY_SYSTEM_PROPERTY_NAME = "master.key.readOnly";
+    static final String MASTER_KEY_FILE_SYSTEM_PROPERTY = "jenkins.master.key.file";
+    static final String MASTER_KEY_READONLY_SYSTEM_PROPERTY_NAME = "jenkins.master.key.readOnly";
 
     private final SecureRandom sr = new SecureRandom();
 

--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -34,8 +34,8 @@ import jenkins.util.SystemProperties;
  */
 // @MetaInfServices --- not annotated because this is the fallback implementation
 public class DefaultConfidentialStore extends ConfidentialStore {
-    static final String MASTER_KEY_FILE_SYSTEM_PROPERTY = "jenkins.master.key.file";
-    static final String MASTER_KEY_READONLY_SYSTEM_PROPERTY_NAME = "jenkins.master.key.readOnly";
+    static final String MASTER_KEY_FILE_SYSTEM_PROPERTY = DefaultConfidentialStore.class.getName() + ".file";
+    static final String MASTER_KEY_READONLY_SYSTEM_PROPERTY_NAME = DefaultConfidentialStore.class.getName() + ".readOnly";
 
     private final SecureRandom sr = new SecureRandom();
 

--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -1,5 +1,6 @@
 package jenkins.security;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.util.Secret;
@@ -19,18 +20,34 @@ import javax.crypto.CipherInputStream;
 import javax.crypto.CipherOutputStream;
 import javax.crypto.SecretKey;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 
 /**
  * Default portable implementation of {@link ConfidentialStore} that uses
  * a directory inside $JENKINS_HOME.
- *
- * The master key is also stored in this same directory.
+ * <p>
+ * The master key is stored by default in <code>$JENKINS_HOME/secrets/master.key</code> but another location can be provided using the system property <code>master.key.file</code>.
+ * <p>
+ * It is also possible to prevent the generation of the master key file using the system property <code>-Dmaster.key.readOnly</code>. In this case, the master key file must be provided or startup will fail.
  *
  * @author Kohsuke Kawaguchi
  */
 // @MetaInfServices --- not annotated because this is the fallback implementation
 public class DefaultConfidentialStore extends ConfidentialStore {
+    static final String MASTER_KEY_FILE_SYSTEM_PROPERTY = "master.key.file";
+    static final String MASTER_KEY_READONLY_SYSTEM_PROPERTY_NAME = "master.key.readOnly";
+
     private final SecureRandom sr = new SecureRandom();
+
+    @NonNull
+    private static File getMasterKeyFile(File rootDir) {
+        var jenkinsMasterKey = SystemProperties.getString(MASTER_KEY_FILE_SYSTEM_PROPERTY);
+        if (jenkinsMasterKey != null) {
+            return new File(jenkinsMasterKey);
+        } else {
+            return new File(rootDir, "master.key");
+        }
+    }
 
     /**
      * Directory that stores individual keys.
@@ -51,6 +68,10 @@ public class DefaultConfidentialStore extends ConfidentialStore {
     }
 
     public DefaultConfidentialStore(File rootDir) throws IOException, InterruptedException {
+        this(rootDir, getMasterKeyFile(rootDir));
+    }
+
+    protected DefaultConfidentialStore(File rootDir, File keyFile) throws IOException, InterruptedException {
         this.rootDir = rootDir;
         if (rootDir.mkdirs()) {
             // protect this directory. but don't change the permission of the existing directory
@@ -58,11 +79,15 @@ public class DefaultConfidentialStore extends ConfidentialStore {
             new FilePath(rootDir).chmod(0700);
         }
 
-        TextFile masterSecret = new TextFile(new File(rootDir, "master.key"));
+        TextFile masterSecret = new TextFile(keyFile);
         if (!masterSecret.exists()) {
-            // we are only going to use small number of bits (since export control limits AES key length)
-            // but let's generate a long enough key anyway
-            masterSecret.write(Util.toHexString(randomBytes(128)));
+            if (SystemProperties.getBoolean(MASTER_KEY_READONLY_SYSTEM_PROPERTY_NAME)) {
+                throw new IOException(masterSecret + " does not exist and system property " + MASTER_KEY_READONLY_SYSTEM_PROPERTY_NAME + " is set. You must provide a valid master key file.");
+            } else {
+                // we are only going to use small number of bits (since export control limits AES key length)
+                // but let's generate a long enough key anyway
+                masterSecret.write(Util.toHexString(randomBytes(128)));
+            }
         }
         this.masterKey = Util.toAes128Key(masterSecret.readTrim());
     }

--- a/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
+++ b/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
@@ -7,10 +7,15 @@ import static org.junit.Assert.assertTrue;
 
 import hudson.FilePath;
 import hudson.Functions;
+import hudson.Util;
+import hudson.util.TextFile;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.security.SecureRandom;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -20,6 +25,8 @@ public class DefaultConfidentialStoreTest {
     @Rule
     public TemporaryFolder tmpRule = new TemporaryFolder();
 
+    private final SecureRandom sr = new SecureRandom();
+
     @Test
     public void roundtrip() throws Exception {
         File tmp = new File(tmpRule.getRoot(), "tmp"); // let ConfidentialStore create a directory
@@ -27,6 +34,17 @@ public class DefaultConfidentialStoreTest {
         DefaultConfidentialStore store = new DefaultConfidentialStore(tmp);
         ConfidentialKey key = new ConfidentialKey("test") {};
 
+        assertTrue(new File(tmp, "master.key").exists());
+        roundTrip(store, key, tmp);
+
+        // if the master key changes, we should gracefully fail to load the store
+        new File(tmp, "master.key").delete();
+        DefaultConfidentialStore store2 = new DefaultConfidentialStore(tmp);
+        assertTrue(new File(tmp, "master.key").exists()); // we should have a new key now
+        assertNull(store2.load(key));
+    }
+
+    private static void roundTrip(DefaultConfidentialStore store, ConfidentialKey key, File tmp) throws IOException, InterruptedException {
         // basic roundtrip
         String str = "Hello world!";
         store.store(key, str.getBytes(StandardCharsets.UTF_8));
@@ -34,19 +52,34 @@ public class DefaultConfidentialStoreTest {
 
         // data storage should have some stuff
         assertTrue(new File(tmp, "test").exists());
-        assertTrue(new File(tmp, "master.key").exists());
 
         assertThrows(MalformedInputException.class, () -> Files.readString(tmp.toPath().resolve("test"), StandardCharsets.UTF_8)); // the data shouldn't be a plain text, obviously
 
         if (!Functions.isWindows()) {
             assertEquals(0700, new FilePath(tmp).mode() & 0777); // should be read only
         }
+    }
 
-        // if the master key changes, we should gracefully fail to load the store
-        new File(tmp, "master.key").delete();
-        DefaultConfidentialStore store2 = new DefaultConfidentialStore(tmp);
-        assertTrue(new File(tmp, "master.key").exists()); // we should have a new key now
-        assertNull(store2.load(key));
+    @Test
+    public void masterKeyGeneratedBeforehand() throws IOException, InterruptedException {
+        File external = new File(tmpRule.getRoot(), "external");
+        File tmp = new File(tmpRule.getRoot(), "tmp");
+        var masterKeyFile = new File(external, "master.key");
+        new TextFile(masterKeyFile).write(Util.toHexString(randomBytes(128)));
+        System.setProperty(DefaultConfidentialStore.MASTER_KEY_FILE_SYSTEM_PROPERTY, masterKeyFile.getAbsolutePath());
+        System.setProperty(DefaultConfidentialStore.MASTER_KEY_READONLY_SYSTEM_PROPERTY_NAME, "true");
+        DefaultConfidentialStore store = new DefaultConfidentialStore(tmp);
+        ConfidentialKey key = new ConfidentialKey("test") {};
+        roundTrip(store, key, tmp);
+        // With this configuration, the master key file deletion is fatal
+        masterKeyFile.delete();
+        assertThrows(IOException.class, () -> new DefaultConfidentialStore(tmp));
+    }
+
+    private byte[] randomBytes(int size) {
+        byte[] random = new byte[size];
+        sr.nextBytes(random);
+        return random;
     }
 
 }

--- a/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
+++ b/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
@@ -15,7 +15,6 @@ import java.nio.charset.MalformedInputException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.SecureRandom;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-58743](https://issues.jenkins.io/browse/JENKINS-58743).

The following system properties can be used to control the behaviour

* `jenkins.security.DefaultConfidentialStore.file` allows to provide an alternative path to load/store the master key (when unset, defaults to `$JENKINS_HOME/secrets/master.key` as previously)
* `jenkins.security.DefaultConfidentialStore.readOnly` when `true`, prevents Jenkins from generating a master key. If the master key file doesn't exist, Jenkins fails to start.

User-facing doc https://github.com/jenkins-infra/jenkins.io/pull/7859

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<details>
<summary>Create master.key beforehand in standard path</summary>

```
export JENKINS_HOME=/tmp/cc
mkdir -p $JENKINS_HOME/secrets
openssl rand -hex 128 >$JENKINS_HOME/secrets/master.key
java -Djenkins.master.key.readOnly=true -jar war/target/jenkins.war
```

✅ Normal startup sequence

Content of `$JENKINS_HOME/secrets` after startup

```
initialAdminPassword  jenkins.model.Jenkins.crumbSalt  master.key
```
</details>

<details>
<summary>Create master.key beforehand in custom path</summary>

```
export JENKINS_HOME=/tmp/cc
masterkey=$(mktemp)
openssl rand -hex 128 >$masterkey
java -Djenkins.master.key.readOnly=true -Djenkins.master.key.file=$masterkey -jar war/target/jenkins.war
```

✅ Normal startup sequence

Content of `$JENKINS_HOME/secrets` after startup

```
initialAdminPassword  jenkins.model.Jenkins.crumbSalt
```
</details>

<details>
<summary>Readonly missing master key</summary>

Starting with `-Djenkins.master.key.readOnly=true` and missing `master.key`.

Jenkins fails to start

```
[...]
2025-02-05 11:28:05.541+0000 [id=40]    INFO    hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
Exception in thread "Jenkins initialization thread" java.lang.Error: java.io.IOException: /tmp/cc/secrets/master.key does not exist and system property jenkins.security.DefaultConfidentialStore.readOnly is set. You must provide a valid master key file.
        at jenkins.security.ConfidentialStore.get(ConfidentialStore.java:93)
        at jenkins.model.Jenkins.<init>(Jenkins.java:977)
        at hudson.model.Hudson.<init>(Hudson.java:102)
        at hudson.model.Hudson.<init>(Hudson.java:87)
        at hudson.WebAppMain$3.run(WebAppMain.java:249)
Caused by: java.io.IOException: /tmp/cc/secrets/master.key does not exist and system property jenkins.security.DefaultConfidentialStore.readOnly is set. You must provide a valid master key file.
        at jenkins.security.DefaultConfidentialStore.<init>(DefaultConfidentialStore.java:85)
        at jenkins.security.DefaultConfidentialStore.<init>(DefaultConfidentialStore.java:71)
        at jenkins.security.DefaultConfidentialStore.<init>(DefaultConfidentialStore.java:67)
        at jenkins.security.ConfidentialStore.get(ConfidentialStore.java:90)
        ... 4 more
```

</details>

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Allow the master key to be stored in a separate location.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
