### PR TITLE
`CronTab.floor` / `.ceil` should return times at minute granularity

### DIFF
--- a/core/src/main/java/hudson/scheduler/CronTab.java
+++ b/core/src/main/java/hudson/scheduler/CronTab.java
@@ -371,6 +371,11 @@ public final class CronTab {
      * (e.g. Jun 31) date, or at least a date too rare to be useful. This addresses JENKINS-41864 and was added in 2.49
      */
     public Calendar ceil(Calendar cal) {
+        if (cal.get(Calendar.SECOND) > 0 || cal.get(Calendar.MILLISECOND) > 0) {
+            cal.set(Calendar.SECOND, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+            cal.add(Calendar.MINUTE, 1);
+        }
         Calendar twoYearsFuture = (Calendar) cal.clone();
         twoYearsFuture.add(Calendar.YEAR, 2);
         OUTER:
@@ -440,6 +445,8 @@ public final class CronTab {
      * (e.g. Jun 31) date, or at least a date too rare to be useful. This addresses JENKINS-41864 and was added in 2.49
      */
     public Calendar floor(Calendar cal) {
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
         Calendar twoYearsAgo = (Calendar) cal.clone();
         twoYearsAgo.add(Calendar.YEAR, -2);
 

--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -27,6 +27,7 @@ package hudson.scheduler;
 import static java.util.Calendar.MONDAY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -338,6 +339,24 @@ public class CronTabTest {
             }
         }
         assertEquals("[35, 56]", times.toString());
+    }
+
+    @Test public void floorCeilMinuteGranularity() throws Exception {
+        var tab = new CronTab("*/5 * * * *");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 15, 23), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:20:00 PM");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 19, 23), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:20:00 PM");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 16,  0), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:20:00 PM");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 19,  0), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:20:00 PM");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 15,  0), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:15:00 PM");
+    }
+
+    private static void assertFloorCeil(CronTab tab, Calendar now, String expectedFloor, String expectedCeil) {
+        var fmt = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM);
+        var nowFormatted = fmt.format(now.getTime());
+        var nowClone = (Calendar) now.clone();
+        assertThat("floor of " + nowFormatted, fmt.format(tab.floor(nowClone).getTime()), is(expectedFloor));
+        nowClone = (Calendar) now.clone();
+        assertThat("ceil of " + nowFormatted, fmt.format(tab.ceil(nowClone).getTime()), is(expectedCeil));
     }
 
     @Issue("SECURITY-790")

--- a/core/src/test/java/hudson/scheduler/CronTabTest.java
+++ b/core/src/test/java/hudson/scheduler/CronTabTest.java
@@ -34,12 +34,15 @@ import static org.junit.Assert.assertThrows;
 
 import antlr.ANTLRException;
 import java.text.DateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.function.Function;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -343,20 +346,20 @@ public class CronTabTest {
 
     @Test public void floorCeilMinuteGranularity() throws Exception {
         var tab = new CronTab("*/5 * * * *");
-        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 15, 23), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:20:00 PM");
-        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 19, 23), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:20:00 PM");
-        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 16,  0), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:20:00 PM");
-        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 19,  0), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:20:00 PM");
-        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 15,  0), "Mar 4, 2025, 2:15:00 PM", "Mar 4, 2025, 2:15:00 PM");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 15, 23), "2025-03-04T14:15:00", "2025-03-04T14:20:00");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 19, 23), "2025-03-04T14:15:00", "2025-03-04T14:20:00");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 16,  0), "2025-03-04T14:15:00", "2025-03-04T14:20:00");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 19,  0), "2025-03-04T14:15:00", "2025-03-04T14:20:00");
+        assertFloorCeil(tab, new GregorianCalendar(2025, 2, 4, 14, 15,  0), "2025-03-04T14:15:00", "2025-03-04T14:15:00");
     }
 
     private static void assertFloorCeil(CronTab tab, Calendar now, String expectedFloor, String expectedCeil) {
-        var fmt = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM);
-        var nowFormatted = fmt.format(now.getTime());
+        Function<Calendar, String> fmt = c -> ZonedDateTime.ofInstant(c.toInstant(), c.getTimeZone().toZoneId()).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        var nowFormatted = fmt.apply(now);
         var nowClone = (Calendar) now.clone();
-        assertThat("floor of " + nowFormatted, fmt.format(tab.floor(nowClone).getTime()), is(expectedFloor));
+        assertThat("floor of " + nowFormatted, fmt.apply(tab.floor(nowClone)), is(expectedFloor));
         nowClone = (Calendar) now.clone();
-        assertThat("ceil of " + nowFormatted, fmt.format(tab.ceil(nowClone).getTime()), is(expectedCeil));
+        assertThat("ceil of " + nowFormatted, fmt.apply(tab.ceil(nowClone)), is(expectedCeil));
     }
 
     @Issue("SECURITY-790")


### PR DESCRIPTION
f97b5b33b0754532b945340cdee4b6ea1d2f6ba4 seems to have been calling previously unused utility methods. https://github.com/jenkinsci/jenkins/blob/630b6b63abcf30959c7b1457a19e155e5f18a436/core/src/main/java/hudson/triggers/Trigger.java#L223-L224 (#1216) shows how the actual trigger is checked at precise one-minute intervals, and https://github.com/jenkinsci/jenkins/blob/630b6b63abcf30959c7b1457a19e155e5f18a436/core/src/main/java/hudson/scheduler/CronTab.java#L160-L169 does not even consider seconds or microseconds, so the form validation rendered at 2:17:23 would claim that `*/5 * * * *` would next run at 2:20:23, which is not really true: it would run at 2:20:00, or very shortly thereafter, and at any rate not specifically at 23 seconds past the minute.

### Testing done

Unit tests, and then some interactive sanity checks of form validation including of `@hourly` etc.

### Proposed changelog entries

- Form validation for cron schedules included seconds based on the current time, when in fact the trigger fires at minute-granularity slots.

### Proposed upgrade guidelines

N/A

### Desired reviewers

@Vlatombe

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
