### PR TITLE
Include trailing slash in `/computer/xxx/` links

### DIFF
--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -56,7 +56,7 @@ public class ModelHyperlinkNote extends HyperlinkNote {
             return encodeTo("/" + c.getUrl(), node.getDisplayName());
         }
         String nodePath = node == Jenkins.get() ? "(built-in)" : node.getNodeName();
-        return encodeTo("/computer/" + nodePath, node.getDisplayName());
+        return encodeTo("/computer/" + nodePath + "/", node.getDisplayName());
     }
 
     /**

--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -488,7 +488,7 @@ public abstract class AbstractBuild<P extends AbstractProject<P, R>, R extends A
                     if (node instanceof Jenkins) {
                         listener.getLogger().print(Messages.AbstractBuild_BuildingOnMaster());
                     } else {
-                        listener.getLogger().print(Messages.AbstractBuild_BuildingRemotely(ModelHyperlinkNote.encodeTo("/computer/" + builtOn, node.getDisplayName())));
+                        listener.getLogger().print(Messages.AbstractBuild_BuildingRemotely(ModelHyperlinkNote.encodeTo("/computer/" + builtOn + "/", node.getDisplayName())));
                         Set<LabelAtom> assignedLabels = new HashSet<>(node.getAssignedLabels());
                         assignedLabels.remove(node.getSelfLabel());
                         if (!assignedLabels.isEmpty()) {

--- a/core/src/main/java/hudson/slaves/NodeProperty.java
+++ b/core/src/main/java/hudson/slaves/NodeProperty.java
@@ -59,7 +59,7 @@ import org.kohsuke.stapler.StaplerRequest2;
  * {@link NodeProperty}s show up in the configuration screen of a node, and they are persisted with the {@link Node} object.
  *
  * <p>
- * To add UI action to {@link Node}s, i.e. a new link shown in the left side menu on a node page ({@code ./computer/<a node>}), see instead {@link hudson.model.TransientComputerActionFactory}.
+ * To add UI action to {@link Node}s, i.e. a new link shown in the left side menu on a node page ({@code ./computer/<a node>/}), see instead {@link hudson.model.TransientComputerActionFactory}.
  *
  *
  * <h2>Views</h2>

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5479,7 +5479,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         @Override
         public boolean hasPermission(Permission permission) {
             // no one should be allowed to delete the master.
-            // this hides the "delete" link from the /computer/(master) page.
+            // this hides the "delete" link from the /computer/(built-in)/ page.
             if (permission == Computer.DELETE)
                 return false;
             // Configuration of master node requires ADMINISTER permission

--- a/core/src/main/resources/hudson/model/Job/buildTimeTrend_resources.js
+++ b/core/src/main/resources/hudson/model/Job/buildTimeTrend_resources.js
@@ -50,7 +50,7 @@ window.buildTimeTrend_displayBuilds = function (data) {
       let buildInfoStr = escapeHTML(e.builtOnStr || "");
       if (e.builtOn) {
         buildInfo = document.createElement("a");
-        buildInfo.href = rootURL + "/computer/" + e.builtOn;
+        buildInfo.href = rootURL + "/computer/" + e.builtOn + "/";
         buildInfo.classList.add("model-link", "inside");
         buildInfo.innerText = buildInfoStr;
       } else {

--- a/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/threadDump.jelly
@@ -47,7 +47,7 @@ THE SOFTWARE.
         </j:if>
         <j:if test="${e.key != null and e.key.length() > 0}">
           <h1 id="id${e.key.hashCode()}">
-            <l:icon class="symbol-computer icon-lg"/> <a class="model-link inside" href="${rootURL}/computer/${e.key}">${e.key}</a>
+            <l:icon class="symbol-computer icon-lg"/> <a class="model-link inside" href="${rootURL}/computer/${e.key}/">${e.key}</a>
           </h1>
         </j:if>
         <j:forEach var="t" items="${e.value.entrySet()}">

--- a/core/src/main/resources/lib/hudson/node.jelly
+++ b/core/src/main/resources/lib/hudson/node.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
   </st:documentation>
   <j:choose>
     <j:when test="${value!=null and value!=app}">
-      <a href="${rootURL}/computer/${value.nodeName}" class="model-link inside">${value.nodeName}</a>
+      <a href="${rootURL}/computer/${value.nodeName}/" class="model-link inside">${value.nodeName}</a>
     </j:when>
     <j:when test="${valueStr != null and valueStr != ''}">
       ${valueStr}


### PR DESCRIPTION
Otherwise `org.kohsuke.stapler.DirectoryishDispatcher` has to serve a 302 to the correct URL, which is wasteful.

### Testing done

Interactive testing with `mock-agent` used from both freestyle and Pipeline jobs in various views.

### Proposed changelog entries

N/A (too minor?)

### Proposed upgrade guidelines

N/A

### Desired reviewers

@Vlatombe

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
