### PR TITLE
[JENKINS-75255] Tolerate `AccessDeniedException` in `AtomicFileWriter`

### DIFF
--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -35,6 +35,7 @@ import java.lang.ref.Cleaner;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -246,11 +247,11 @@ public class AtomicFileWriter extends Writer {
                 // Both files are on the same filesystem, so this should not happen.
                 LOGGER.log(Level.WARNING, e, () -> "Atomic move " + source + " → " + destination + " not supported. Falling back to non-atomic move.");
                 atomicMoveSupported = false;
+            } catch (AccessDeniedException e) {
+                LOGGER.log(Level.INFO, e, () -> "Move " + source + " → " + destination + " failed, perhaps due to a temporary file lock. Falling back to non-atomic move.");
             }
         }
-        if (!atomicMoveSupported) {
-            Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
-        }
+        Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
     }
 
     private static final class CleanupChecker implements Runnable {


### PR DESCRIPTION
Amending #10058. See [JENKINS-75255](https://issues.jenkins.io/browse/JENKINS-75255), following suggested fix by @Vlatombe as I understand it.

### Testing done

**None whatsoever**, hoping that @mawinter69 or someone else will test an incremental build in a real Windows Server environment.

### Proposed changelog entries

- Occasional failures to write files to Jenkins home directory on Windows servers due perhaps to virus scanners.

### Proposed upgrade guidelines

N/A

### Desired reviewers

@Vlatombe

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
