### PR TITLE
Require a changelog label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,6 +42,34 @@ You may add multiple changelog entries if applicable by adding a new entry to th
 - Second changelog entry
 -->
 
+### Proposed changelog category
+
+/label <update-this-with-category>
+
+<!-- 
+The changelog entry needs to have a category which is selected based on the label.
+If there's no changelog then the label should be `skip-changelog`.
+
+The available categories are:
+* bug - Minor bug. Will be listed after features
+* developer - Changes which impact plugin developers
+* dependencies - Pull requests that update a dependency 
+* internal - Internal only change, not user facing
+* localization - Updates localization files
+* major-bug - Major bug. Will be highlighted on the top of the changelog
+* major-rfe - Major enhancement. Will be highlighted on the top
+* rfe - Minor enhancement
+* regression-fix - Fixes a regression in one of the previous Jenkins releases
+* removed - Removes a feature or a public API
+* skip-changelog - Should not be shown in the changelog
+
+Non-changelog categories:
+* web-ui - Changes in the web UI
+
+Non-changelog categories require a changelog category but should be used if applicable,
+comma separate to provide multiple categories in the label command.
+-->
+
 ### Proposed upgrade guidelines
 
 N/A

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -55,6 +55,7 @@ The available categories are:
 * developer - Changes which impact plugin developers
 * dependencies - Pull requests that update a dependency
 * internal - Internal only change, not user facing
+* into-lts - Changes that are backported to the LTS baseline
 * localization - Updates localization files
 * major-bug - Major bug. Will be highlighted on the top of the changelog
 * major-rfe - Major enhancement. Will be highlighted on the top

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,14 +46,14 @@ You may add multiple changelog entries if applicable by adding a new entry to th
 
 /label <update-this-with-category>
 
-<!-- 
+<!--
 The changelog entry needs to have a category which is selected based on the label.
 If there's no changelog then the label should be `skip-changelog`.
 
 The available categories are:
 * bug - Minor bug. Will be listed after features
 * developer - Changes which impact plugin developers
-* dependencies - Pull requests that update a dependency 
+* dependencies - Pull requests that update a dependency
 * internal - Internal only change, not user facing
 * localization - Updates localization files
 * major-bug - Major bug. Will be highlighted on the top of the changelog

--- a/.github/workflows/require-changelog-label.yml
+++ b/.github/workflows/require-changelog-label.yml
@@ -1,0 +1,29 @@
+name: Require Changelog Label
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5
+        with:
+          mode: minimum
+          count: 1
+          add_comment: true
+          message: "Missing required label for changelog. Requires {{errorString}} {{count}} of: {{ provided }}. Found: {{ applied }}.\n\nYou can add the required label by adding a comment with the following text: `/label <category>`"
+          labels: |
+            bug
+            developer
+            dependencies
+            internal
+            localization
+            major-bug
+            major-rfe
+            rfe
+            regression-fix
+            removed
+            skip-changelog

--- a/.github/workflows/require-changelog-label.yml
+++ b/.github/workflows/require-changelog-label.yml
@@ -20,6 +20,7 @@ jobs:
             developer
             dependencies
             internal
+            into-lts
             localization
             major-bug
             major-rfe

--- a/.github/workflows/require-changelog-label.yml
+++ b/.github/workflows/require-changelog-label.yml
@@ -1,6 +1,6 @@
 name: Require Changelog Label
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 jobs:
   label:

--- a/.github/workflows/require-changelog-label.yml
+++ b/.github/workflows/require-changelog-label.yml
@@ -2,6 +2,8 @@ name: Require Changelog Label
 on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
+    branches:
+      - 'master'
 jobs:
   label:
     runs-on: ubuntu-latest
@@ -20,7 +22,6 @@ jobs:
             developer
             dependencies
             internal
-            into-lts
             localization
             major-bug
             major-rfe


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

Closes https://github.com/jenkins-infra/jenkins.io/pull/7881

See https://github.com/jenkins-infra/jenkins.io/pull/7881 for more information

Tested in https://github.com/timja/jenkins/pull/138

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- human-readable text (none)
- 

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label skip-changelog

<!-- 
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency 
* internal - Internal only change, not user facing
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->


### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
