### PR TITLE
Backporting for 2.492.2 LTS

### DIFF
--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -35,6 +35,7 @@ import java.lang.ref.Cleaner;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -246,11 +247,11 @@ public class AtomicFileWriter extends Writer {
                 // Both files are on the same filesystem, so this should not happen.
                 LOGGER.log(Level.WARNING, e, () -> "Atomic move " + source + " → " + destination + " not supported. Falling back to non-atomic move.");
                 atomicMoveSupported = false;
+            } catch (AccessDeniedException e) {
+                LOGGER.log(Level.INFO, e, () -> "Move " + source + " → " + destination + " failed, perhaps due to a temporary file lock. Falling back to non-atomic move.");
             }
         }
-        if (!atomicMoveSupported) {
-            Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
-        }
+        Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
     }
 
     private static final class CleanupChecker implements Runnable {

--- a/core/src/main/resources/hudson/widgets/HistoryWidget/entries.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/entries.jelly
@@ -28,7 +28,11 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:i="jelly:fmt">
   <j:set target="${it}" property="nextBuildNumberToFetch" value="${it.nextBuildNumber}" />
-  <j:invokeStatic className="java.time.LocalDate" method="now" var="now" />
+  <j:if test="${h.isUserTimeZoneOverride()}">
+    <i:setTimeZone value="${h.getUserTimeZone()}" />
+  </j:if>
+  <j:new var="dateNow" className="java.util.Date"/>
+  <i:formatDate value="${dateNow}" var="now" type="date" pattern="YYYY-MM-dd"/>
 
   <j:forEach var="pageEntry" items="${it.runs}">
     <i:formatDate value="${pageEntry.entry.timestamp.time}" var="date" type="date" dateStyle="long" />

--- a/core/src/main/resources/lib/hudson/executors.jelly
+++ b/core/src/main/resources/lib/hudson/executors.jelly
@@ -81,7 +81,7 @@ THE SOFTWARE.
                     <td class="pane">
                       <div style="white-space: normal">
                         <j:choose>
-                          <j:when test="${exeparent != null}">
+                          <j:when test="${exe == null and exeparent != null }">
                             <j:choose>
                               <j:when test="${exeparentcanread}">
                                 <a href="${rootURL}/${exeparent.url}"><l:breakable value="${exeparent.fullDisplayName}"/></a>

--- a/core/src/main/resources/lib/layout/task/task.js
+++ b/core/src/main/resources/lib/layout/task/task.js
@@ -23,9 +23,9 @@ Behaviour.specify("a.task-link-no-confirm", "task-link", 0, function (el) {
         headers: crumb.wrap({}),
       }).then((rsp) => {
         if (rsp.ok) {
-          notificationBar(success, notificationBar.SUCCESS);
+          notificationBar.show(success, notificationBar.SUCCESS);
         } else {
-          notificationBar(failure, notificationBar.ERROR);
+          notificationBar.show(failure, notificationBar.ERROR);
         }
       });
       ev.preventDefault();


### PR DESCRIPTION
```console
Latest core version: jenkins-2.497

Postponed
---------

JENKINS-75224           Minor                   1948.v0f99403fe86a_
        Remove support for ?jsonp parameter from Flavor.JSON in Stapler
        https://issues.jenkins.io/browse/JENKINS-75224

Fixed
-----

JENKINS-75265           Minor                   Sun, 16 Feb 2025 06:36:32 +0000
        l:task notifications not working
        regression
        https://issues.jenkins.io/browse/JENKINS-75265

JENKINS-75259           Minor                   Sun, 16 Feb 2025 06:35:59 +0000
        Job start time and remaining time gone from root build history widget for freestyle jobs
        regression
        https://issues.jenkins.io/browse/JENKINS-75259

JENKINS-75255           Major                   Sun, 16 Feb 2025 06:35:39 +0000
        AccessDeniedException from AtomicFileWriter.move (e.g., while fingerprinting) on Windows
        regression
        https://issues.jenkins.io/browse/JENKINS-75255

JENKINS-75163           Minor                   2.494
        Yesterday's builds are shown to be today in build history widget
        https://issues.jenkins.io/browse/JENKINS-75163

```

<!-- ### Testing done -->

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

<!-- ### Proposed changelog entries

- human-readable text -->

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

<!-- ### Proposed upgrade guidelines

N/A -->

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

```[tasklist]
### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.
```

### Desired reviewers

@timja @basil @MarkEWaite @NotMyFault @mawinter69 @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

```[tasklist]
### Maintainer checklist
- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
```
