### PR TITLE
Revert `oklch` usage in core

### DIFF
--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -2,20 +2,20 @@
 @use "../base/breakpoints";
 
 $colors: (
-  "blue": oklch(55% 0.2308 256.91),
-  "brown": oklch(60% 0.0941 72.67),
-  "cyan": oklch(60% 0.1497 234.48),
-  "green": oklch(70% 0.2155 150),
-  "indigo": oklch(60% 0.191 278.34),
-  "orange": oklch(70% 0.2001 50.74),
-  "pink": oklch(60% 0.2601 12.28),
-  "purple": oklch(60% 0.2308 314.6),
-  "red": oklch(60% 0.2671 30),
-  "yellow": oklch(80% 0.17 76),
-  "teal": oklch(60% 0.1122 216.72),
+  "blue": #006fe6,
+  "brown": #a2845e,
+  "cyan": #32ade6,
+  "green": #1ea64b,
+  "indigo": #5856d6,
+  "orange": #fe820a,
+  "pink": #fb0f45,
+  "purple": #af52de,
+  "red": #e6001f,
+  "yellow": #ffb31a,
   "white": #fff,
-  "black": oklch(from var(--accent-color) 2% 0.075 h),
+  "black": #14141f,
 );
+
 $semantics: (
   "accent": var(--blue),
   "text": var(--black),
@@ -31,17 +31,15 @@ $semantics: (
 :root,
 .app-theme-picker__picker[data-theme="none"] {
   // Font related properties
-  --font-family-sans:
-    system-ui, "Segoe UI", roboto, "Noto Sans", oxygen, ubuntu, cantarell,
-    "Fira Sans", "Droid Sans", "Helvetica Neue", arial, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  --font-family-mono:
-    ui-monospace, sfmono-regular, sf mono, jetbrainsmono, consolas, monospace;
+  --font-family-sans: system-ui, "Segoe UI", roboto, "Noto Sans", oxygen,
+    ubuntu, cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", arial,
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --font-family-mono: ui-monospace, sfmono-regular, sf mono, jetbrainsmono,
+    consolas, monospace;
   --font-size-base: 1rem; // 16px
   --font-size-sm: 0.875rem; // 14px
   --font-size-xs: 0.75rem; // 12px
   --font-size-monospace: 1em;
-  --font-bold-weight: 450;
 
   // Line height
   --line-height-base: 1.5;
@@ -54,13 +52,20 @@ $semantics: (
   --dark-grey: #4d545d;
 
   // branding
-  --secondary: oklch(from var(--black) 60% c h);
+  --secondary: rgb(96 125 159);
   --focus-input-border: var(--accent-color);
   --focus-input-glow: color-mix(in sRGB, var(--accent-color) 15%, transparent);
 
+  // Deprecated
+  --focus-btn-primary: #{color.change(#0b6aa2, $alpha: 0.5)};
+  --focus-btn-secondary: #{color.change(#0b6aa2, $alpha: 0.5)};
+  --focus-btn-danger: #{color.change(#cc0003, $alpha: 0.5)};
+
   // State colors
-  --primary-hover: var(--accent-color);
-  --primary-active: var(--accent-color);
+  --primary-hover: #0587d4;
+  --primary-active: #095683;
+  --danger-hover: #eb383b;
+  --danger-active: #b50003;
 
   // Status icon colors
   --weather-icon-color: var(--accent-color);
@@ -72,21 +77,19 @@ $semantics: (
   // Header
   --brand-link-color: var(--secondary);
   --header-link-color: var(--white);
-  --header-bg-classic: var(--black);
+  --header-link-color-active: #f5f5f5;
+  --header-search-border: var(--white);
+  --search-input-color: var(--brand-link-color);
+  --search-bg: var(--white);
+  --search-box-completion-bg: var(--primary-hover);
+  --search-box-shadow: 0 1px 7px 0 rgb(0 0 0 / 0.3);
+  --header-bg-classic: #000;
   --header-link-bg-classic-hover: #404040;
   --header-link-bg-classic-active: #404040;
+  --header-item-border-radius: 4px;
 
   // Breadcrumbs bar
-  --breadcrumbs-bar-background: oklch(
-    from var(--text-color) 96.8% 0.005 h / 0.8
-  );
-
-  // App bar
-  --bottom-app-bar-shadow: color-mix(
-    in sRGB,
-    var(--text-color-secondary) 7.5%,
-    transparent
-  );
+  --breadcrumbs-bar-background: hsl(240 20% 96.5% / 0.8);
 
   // Alert call outs
   --alert-success-text-color: var(--success-color);
@@ -133,41 +136,41 @@ $semantics: (
   // Typography
   --text-color-secondary: var(--secondary);
 
-  // Borders
-  --jenkins-border-width: 1.5px;
-  --jenkins-border-color: color-mix(
-    in sRGB,
-    var(--text-color-secondary) 12%,
-    var(--card-background)
-  );
-  --jenkins-border-color--subtle: color-mix(
-    in sRGB,
-    currentColor 1.5%,
-    transparent
-  );
-
-  /* This is a harsher border - for dividers, content blocks and more */
-  --jenkins-border: var(--jenkins-border-width) solid
-    var(--jenkins-border-color);
-
-  /* This is a subtle border - for increasing contrast on elements, such as buttons, menu and more */
-  --jenkins-border--subtle: var(--jenkins-border-width) solid
-    var(--jenkins-border-color--subtle);
-  --jenkins-border--subtle-shadow: 0 0 0 1.5px
-    var(--jenkins-border-color--subtle);
-
-  @media (resolution <= 1x) {
-    --jenkins-border-width: 2px;
-  }
-
-  @media (prefers-contrast: more) {
-    --focus-input-border: var(--text-color);
-    --jenkins-border-color: var(--text-color);
-    --jenkins-border-color--subtle: var(--text-color);
-  }
+  // Deprecated - Button generic
+  --btn-font-weight: bold;
+  --btn-text-color: var(--white);
+  --btn-font-size: var(--font-size-xs);
+  --btn-line-height: 1rem;
+  --btn-large-font-size: var(--font-size-sm);
+  --btn-large-line-height: 1.25rem;
+  // Deprecated - Button primary
+  --button-color--primary: var(--background);
+  --btn-primary-bg: #063f61;
+  --btn-primary-bg-hover: #{lighten(#063f61, 7.5%)};
+  --btn-primary-bg-active: #{lighten(#063f61, 12%)};
+  // Deprecated - Button primary
+  --btn-secondary-color: var(--secondary);
+  --btn-secondary-bg: var(--btn-text-color);
+  --btn-secondary-border: var(--medium-grey);
+  --btn-secondary-color--hover: var(--accent-color);
+  --btn-secondary-bg--hover: var(--btn-secondary-bg);
+  --btn-secondary-border--hover: var(--accent-color);
+  --btn-secondary-color--focus: var(--accent-color);
+  --btn-secondary-bg--focus: var(--btn-secondary-bg);
+  --btn-secondary-border--focus: var(--accent-color);
+  --btn-secondary-color--active: var(--primary-active);
+  --btn-secondary-bg--active: var(--btn-secondary-bg);
+  --btn-secondary-border--active: var(--primary-active);
+  // Deprecated - Button link
+  --btn-link-color: var(--accent-color);
+  --btn-link-font-weight: var(--link-font-weight);
+  --btn-link-color--hover: var(--primary-hover);
+  --btn-link-bg--hover: var(--very-light-grey);
+  --btn-link-color--active: var(--primary-active);
+  --btn-link-bg--active: var(--light-grey);
 
   // Table
-  --table-background: oklch(from var(--text-color-secondary) l c h / 0.075);
+  --table-background: var(--panel-header-bg-color);
   --table-header-foreground: var(--text-color);
   --table-body-background: var(--background);
   --table-body-foreground: var(--text-color);
@@ -194,14 +197,12 @@ $semantics: (
   --link-text-decoration: none;
   --link-text-decoration--hover: underline;
   --link-text-decoration--active: underline;
-  --link-font-weight: var(--font-bold-weight);
+  --link-font-weight: 450;
 
   // Command Palette
   --command-palette-results-backdrop-filter: contrast(0.7) brightness(1.5)
     saturate(1.4) blur(20px);
-  --command-palette-inset-shadow:
-    inset 0 0 2px 2px rgb(255 255 255 / 0.1),
-    var(--jenkins-border--subtle-shadow);
+  --command-palette-inset-shadow: inset 0 0 2px 2px rgb(255 255 255 / 0.1);
 
   ::backdrop {
     --command-palette-backdrop-background: radial-gradient(
@@ -214,14 +215,12 @@ $semantics: (
   // Tooltips
   --tooltip-backdrop-filter: saturate(2) blur(20px);
   --tooltip-color: var(--text-color);
-  --tooltip-box-shadow:
-    0 0 8px 2px rgb(0 0 50 / 0.05), var(--jenkins-border--subtle-shadow),
-    0 10px 50px rgb(0 0 20 / 0.1);
+  --tooltip-box-shadow: 0 0 8px 2px rgb(0 0 30 / 0.05),
+    0 0 1px 1px rgb(0 0 20 / 0.025), 0 10px 20px rgb(0 0 20 / 0.15);
 
   // Dropdowns
   --dropdown-backdrop-filter: saturate(1.5) blur(20px);
-  --dropdown-box-shadow:
-    var(--jenkins-border--subtle-shadow), 0 10px 30px rgb(0 0 20 / 0.1),
+  --dropdown-box-shadow: 0 10px 30px rgb(0 0 20 / 0.2),
     0 2px 10px rgb(0 0 20 / 0.05), inset 0 -1px 2px rgb(255 255 255 / 0.025);
 
   // Dialogs
@@ -229,8 +228,7 @@ $semantics: (
     --dialog-backdrop-background: hsl(240 10% 20% / 0.8);
   }
 
-  --dialog-box-shadow:
-    var(--jenkins-border--subtle-shadow), 0 10px 40px rgb(0 0 20 / 0.15),
+  --dialog-box-shadow: 0 10px 40px rgb(0 0 20 / 0.15),
     0 2px 15px rgb(0 0 20 / 0.05), inset 0 0 2px 2px rgb(255 255 255 / 0.025);
 
   // Dark link
@@ -241,7 +239,7 @@ $semantics: (
   --link-dark-text-decoration: none;
   --link-dark-text-decoration--hover: underline;
   --link-dark-text-decoration--active: underline;
-  --link-dark-font-weight: var(--font-bold-weight);
+  --link-dark-font-weight: 500;
 
   // Pane
   --pane-border-width: 1px;
@@ -258,27 +256,15 @@ $semantics: (
   --card-background: var(--background);
   --card-background--hover: transparent;
   --card-background--active: transparent;
-  --card-border-color: oklch(from var(--text-color-secondary) l c h / 0.15);
-  --card-border-color--hover: oklch(
-    from var(--text-color-secondary) l c h / 0.3
-  );
-  --card-border-color--active: oklch(
-    from var(--text-color-secondary) l c h / 0.5
-  );
-  --card-border-width: var(--jenkins-border-width);
-
-  @media (prefers-contrast: more) {
-    --card-border-color: var(--text-color);
-  }
+  --card-border-color: hsl(240 25% 75% / 0.25);
+  --card-border-color--hover: hsl(240 25% 75% / 0.5);
+  --card-border-color--active: hsl(240 25% 75% / 0.75);
+  --card-border-width: 2px;
 
   // Tab bar
-  --tabs-background: oklch(from var(--text-color-secondary) l c h / 0.1);
+  --tabs-background: var(--panel-header-bg-color);
   --tabs-item-background: transparent;
-  --tabs-item-foreground: color-mix(
-    in sRGB,
-    var(--text-color-secondary),
-    var(--text-color)
-  );
+  --tabs-item-foreground: var(--text-color);
   --tabs-item-background--hover: rgb(0 0 0 / 0.05);
   --tabs-item-foreground--hover: var(--text-color);
   --tabs-item-background--active: rgb(0 0 0 / 0.1);
@@ -287,10 +273,18 @@ $semantics: (
   --tabs-item-foreground--selected: var(--link-color);
   --tabs-border-radius: calc((10px + 34px) / 2);
 
+  // Deprecated - Tabbar baseline
+  --tab-baseline-width: 2px;
+  --tab-baseline-color: var(--light-grey);
+  --tab-baseline-default-display: none;
+
   // Side panel
   --side-panel-width: 340px;
   --panel-header-bg-color: var(--light-grey);
   --panel-border-color: var(--light-grey);
+  --side-panel-hover-color: var(--panel-border-color);
+  --task-link-bg-color--active: var(--panel-border-color);
+  --task-link-bg-color--hover: var(--very-light-grey);
 
   // Form
   --section-padding: 1.625rem;
@@ -314,6 +308,7 @@ $semantics: (
   --form-item-max-width--medium: min(50vw, 1400px);
   --form-item-max-width--small: min(35vw, 1200px);
 
+  /* stylelint-disable-next-line media-query-no-invalid */
   @media screen and (max-width: breakpoints.$tablet-breakpoint) {
     --section-padding: 1.25rem;
     --form-item-max-width: 100%;
@@ -321,48 +316,47 @@ $semantics: (
     --form-item-max-width--small: 100%;
   }
 
-  --form-label-font-weight: var(--font-bold-weight);
-  --form-input-padding: 0.5rem 0.625rem;
+  --form-label-font-weight: 450;
+  --form-input-padding: 0.625rem;
   --form-input-border-radius: 0.625rem;
-  --form-input-glow: 0 0 0 0.5rem transparent;
-  --form-input-glow--focus: 0 0 0 0.25rem var(--focus-input-glow);
-  --pre-background: var(--button-background);
+  --form-input-glow: 0 0 0 10px transparent;
+  --form-input-glow--focus: 0 0 0 5px var(--focus-input-glow);
+  --pre-background: rgb(0 0 0 / 0.05);
   --pre-color: var(--text-color);
-  --selection-color: oklch(from var(--accent-color) l c h / 0.2);
-
-  @media (prefers-contrast: more) {
-    --input-border: var(--text-color) !important;
-    --input-border-hover: var(--text-color) !important;
-    --form-input-glow--focus: 0 0 0 4px
-      color-mix(in sRGB, var(--text-color), transparent);
-  }
+  --selection-color: rgb(2 76 182 / 0.3);
 
   // Animations
   --standard-transition: 0.3s ease;
   --elastic-transition: 0.3s cubic-bezier(0, 0.68, 0.5, 1.5);
 
+  // Deprecated - Pop out menus
+  --menu-text-color: black;
+  --menu-bg-color: var(--white);
+  --menu-selected-color: #b3d4ff;
+  --menu-box-shadow: 0 3px 10px rgb(0 0 0 / 0.3);
+
+  // Deprecated - Add form widget / configure job
+  --light-bg-color: #eee;
+  --light-bg-color--hover: rgb(255 255 255 / 0.65);
+  --add-item-btn-decorator-border-color: #acb;
+  --add-item-btn-decorator-bg-color: rgb(245 249 239 / 0.75);
+
   // Plugin manager
   --plugin-manager-bg-color-already-upgraded: var(--light-grey);
 
+  // Auto complete
+  --auto-complete-bg-color--prehighlight: #b3d4ff;
+
   // Default button
-  --button-background: oklch(from var(--text-color-secondary) l c h / 0.075);
-  --button-background--hover: oklch(
-    from var(--text-color-secondary) l c h / 0.125
-  );
-  --button-background--active: oklch(
-    from var(--text-color-secondary) l c h / 0.175
-  );
-  --button-box-shadow--focus: oklch(
-    from var(--text-color-secondary) l c h / 0.1
-  );
-  --button-color--primary: var(--background);
+  --button-background: hsl(240 25% 75% / 0.1);
+  --button-background--hover: hsl(240 25% 75% / 0.175);
+  --button-background--active: hsl(240 25% 75% / 0.25);
+  --button-box-shadow--focus: hsl(240 25% 75% / 0.1);
 
   // Variables for sidebar items, card items
-  --item-background--hover: oklch(from var(--text-color-secondary) l c h / 0.1);
-  --item-background--active: oklch(
-    from var(--text-color-secondary) l c h / 0.15
-  );
-  --item-box-shadow--focus: oklch(from var(--text-color-secondary) l c h / 0.1);
+  --item-background--hover: hsl(240 25% 75% / 0.15);
+  --item-background--active: hsl(240 25% 75% / 0.225);
+  --item-box-shadow--focus: hsl(240 25% 75% / 0.105);
 
   // Deprecated
   --primary: var(--accent-color); // Use var(--accent-color) instead
@@ -375,8 +369,8 @@ $semantics: (
     --#{$key}: #{$value};
 
     @if $key != "black" and $key != "white" {
-      --light-#{$key}: #{color.adjust($value, $lightness: 20%)};
-      --dark-#{$key}: #{color.adjust($value, $lightness: -20%)};
+      --light-#{$key}: #{lighten($value, 20%)};
+      --dark-#{$key}: #{darken($value, 20%)};
     }
   }
 


### PR DESCRIPTION
#10078 introduces `oklch` usage in Jenkins core. This PR caused a major regression, see  [JENKINS-75242](https://issues.jenkins.io/browse/JENKINS-75242) that affects all plugins that use trend charts that are based on the echarts plugin. Some examples are the popular junit, warnings, and coverage plugins. 

Since nobody corresponded on the JENKINS-75242 yet, it makes sense to revert the original change until a solution has been found in core or the affected plugins. 

### Testing done

Manual testing of the charts in my instance. Now all colors are working again when hovering over the chart. 


### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A


### Submitter checklist
- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @janfaracik


Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
