### PR TITLE
Replace tasklist with checklist in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -80,8 +80,8 @@ Leave the proposed upgrade guidelines in the pull request with the "N/A" value i
 The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
 -->
 
-```
 ### Submitter checklist
+
 - [ ] The Jira issue, if it exists, is well-described.
 - [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
 - [ ] There is automated testing or an explanation as to why this change has no tests.
@@ -90,7 +90,6 @@ The changelog generator relies on the presence of the upgrade guidelines section
 - [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
 - [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
 - [ ] For new APIs and extension points, there is a link to at least one consumer.
-```
 
 ### Desired reviewers
 
@@ -102,12 +101,11 @@ If you need an accelerated review process by the community (e.g., for critical b
 
 Before the changes are marked as `ready-for-merge`:
 
-```
 ### Maintainer checklist
+
 - [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
 - [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
 - [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
 - [ ] Proper changelog labels are set so that the changelog can be generated automatically.
 - [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
 - [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
-```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -80,7 +80,7 @@ Leave the proposed upgrade guidelines in the pull request with the "N/A" value i
 The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
 -->
 
-```[tasklist]
+```
 ### Submitter checklist
 - [ ] The Jira issue, if it exists, is well-described.
 - [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
@@ -102,7 +102,7 @@ If you need an accelerated review process by the community (e.g., for critical b
 
 Before the changes are marked as `ready-for-merge`:
 
-```[tasklist]
+```
 ### Maintainer checklist
 - [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
 - [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.


### PR DESCRIPTION
## Replace tasklist with checklist in PR template

GitHub [announced](https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#tasklist-blocks-will-be-retired-and-replaced-with-sub-issues) that they are retiring task lists as of 30 Apr 2025.

They recommend a transition to sub-issues.  We don't use GitHub issues for the Jenkins core repository, so let's switch from tasklist to a simple checklist like we use for the Jenkins LTS release checklist.

### Testing done

Confirmed that simple checklists are still supported by GitHub and work well.

No automated testing required because this is changing a GitHub pull request template.

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
