### PR TITLE
[JENKINS-75321] Clarify the message displayed when loading the content of the build history widget

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -49,7 +49,10 @@ THE SOFTWARE.
                     clazz="${page.runs.isEmpty() and page.queueItems.isEmpty() ? 'jenkins-hidden' : ''}"/>
 
       <div class="app-builds-container">
-        <div id="no-builds" class="app-builds-container__placeholder">
+        <div id="loading-builds" class="app-builds-container__placeholder">
+          <l:spinner text="${%Loading builds...}"/>
+        </div>
+        <div id="no-builds" style="display:none" class="app-builds-container__placeholder">
           ${%No builds}
         </div>
 

--- a/src/main/js/pages/project/builds-card.js
+++ b/src/main/js/pages/project/builds-card.js
@@ -9,6 +9,7 @@ const ajaxUrl = buildHistoryPage.getAttribute("page-ajax");
 const card = document.querySelector("#jenkins-builds");
 const contents = card.querySelector("#jenkins-build-history");
 const container = card.querySelector(".app-builds-container");
+const loadingBuilds = card.querySelector("#loading-builds");
 const noBuilds = card.querySelector("#no-builds");
 
 // Pagination controls
@@ -58,6 +59,7 @@ function load(options = {}) {
         if (responseText.trim() === "") {
           contents.innerHTML = "";
           noBuilds.style.display = "block";
+          loadingBuilds.style.display = "none";
           updateCardControls({
             pageHasUp: false,
             pageHasDown: false,
@@ -69,7 +71,7 @@ function load(options = {}) {
 
         // Show the refreshed builds list
         contents.innerHTML = responseText;
-        noBuilds.style.display = "none";
+        loadingBuilds.style.display = "none";
         behaviorShim.applySubtree(contents);
 
         // Show the card controls
@@ -146,6 +148,7 @@ document.addEventListener("DOMContentLoaded", function () {
     debouncedLoad();
   });
 
+  container.classList.add("app-builds-container--loading");
   load();
 
   window.addEventListener("focus", function () {


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-75321](https://issues.jenkins.io/browse/JENKINS-75321).

This displays an explicit message about loading builds data instead of displaying "no builds".

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

Recordings using a local patch increasing the delay by 2 seconds to make it more visible.

<details>
<summary>Details</summary>

```patch
Index: src/main/js/pages/project/builds-card.js
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/main/js/pages/project/builds-card.js b/src/main/js/pages/project/builds-card.js
--- a/src/main/js/pages/project/builds-card.js	(revision 5d65d117a52ce8494923f71c9a090c859812ec27)
+++ b/src/main/js/pages/project/builds-card.js	(date 1740144645635)
@@ -141,7 +141,7 @@
   load();
 }, 150);
 
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("DOMContentLoaded", async function () {
   pageSearchInput.addEventListener("input", function () {
     container.classList.add("app-builds-container--loading");
     pageSearch.classList.add("jenkins-search--loading");
@@ -149,6 +149,7 @@
   });
 
   container.classList.add("app-builds-container--loading");
+  await new Promise(r => setTimeout(r, 2000));
   load();
 
   window.addEventListener("focus", function () {
```

</details>

A project without any build

https://github.com/user-attachments/assets/3f90103d-9896-4377-9f2e-29d2056d40b2

A project with 2 builds

https://github.com/user-attachments/assets/f4e33e2d-4502-41d0-b10a-82146e8cdd1c

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Clarify the displayed message while the build history widget initializes.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
