### PR TITLE
[JENKINS-75278] User pages for users with '\' in the user name fail after upgrading to 2.479.1

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -35,15 +35,5 @@
     <file url="file://$PROJECT_DIR$/websocket/spi/src/filter/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/spi/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/spi/src/main/resources" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/core/src/main/java" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/core/src/main/resources" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/groovy/src/main/java" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/groovy/src/main/resources" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/jelly/src/main/java" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/jelly/src/main/resources" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/jsp/src/main/java" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/jsp/src/main/resources" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/src/main/java" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/../stapler/src/main/resources" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -35,5 +35,15 @@
     <file url="file://$PROJECT_DIR$/websocket/spi/src/filter/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/spi/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/spi/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/core/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/core/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/groovy/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/groovy/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/jelly/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/jelly/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/jsp/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/jsp/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/../stapler/src/main/resources" charset="UTF-8" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.30</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.4</winstone.version>
+    <winstone.version>8.5-rc958.5290a_d1ea_6d2</winstone.version>
     <node.version>20.18.3</node.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.30</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.5-rc960.cdb_25ca_e2a_71</winstone.version>
+    <winstone.version>8.5</winstone.version>
     <node.version>20.18.3</node.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.30</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.5-rc958.5290a_d1ea_6d2</winstone.version>
+    <winstone.version>8.5-rc960.cdb_25ca_e2a_71</winstone.version>
     <node.version>20.18.3</node.version>
   </properties>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -178,7 +178,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2416.va_b_341a_592b_c7</version>
+      <version>2414.v185474555e66</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -178,7 +178,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2411.v1e79b_0dc94b_7</version>
+      <version>2416.va_b_341a_592b_c7</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/src/test/java/hudson/PluginTest.java
+++ b/test/src/test/java/hudson/PluginTest.java
@@ -54,7 +54,7 @@ public class PluginTest {
         r.createWebClient().assertFails("plugin/matrix-auth/images/%2e%2e%2fWEB-INF/licenses.xml", HttpServletResponse.SC_BAD_REQUEST);
         r.createWebClient().assertFails("plugin/matrix-auth/images/%2e.%2fWEB-INF/licenses.xml", HttpServletResponse.SC_BAD_REQUEST);
         r.createWebClient().assertFails("plugin/matrix-auth/images/..%2f..%2f..%2f" + r.jenkins.getRootDir().getName() + "%2fsecrets%2fmaster.key", HttpServletResponse.SC_BAD_REQUEST);
-        r.createWebClient().assertFails("plugin/matrix-auth/" + r.jenkins.getRootDir() + "/secrets/master.key", /* ./ prepended anyway */ Functions.isWindows() ? HttpServletResponse.SC_BAD_REQUEST : HttpServletResponse.SC_NOT_FOUND);
+        r.createWebClient().assertFails("plugin/matrix-auth/" + r.jenkins.getRootDir() + "/secrets/master.key", /* ./ prepended anyway */ HttpServletResponse.SC_NOT_FOUND);
         // SECURITY-155:
         r.createWebClient().assertFails("plugin/matrix-auth/WEB-INF/licenses.xml", HttpServletResponse.SC_BAD_REQUEST);
         r.createWebClient().assertFails("plugin/matrix-auth/META-INF/MANIFEST.MF", HttpServletResponse.SC_BAD_REQUEST);

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -1116,10 +1116,9 @@ public class DirectoryBrowserSupportTest {
         Files.writeString(targetTmpPath, content, StandardCharsets.UTF_8);
 
         try (JenkinsRule.WebClient wc = j.createWebClient()) {
-            // suspicious path is rejected with 400
             wc.setThrowExceptionOnFailingStatusCode(false);
             HtmlPage page = wc.goTo("userContent/" + targetTmpPath.toAbsolutePath() + "/*view*");
-            assertEquals(200, page.getWebResponse().getStatusCode());
+            assertEquals(404, page.getWebResponse().getStatusCode());
         }
     }
 

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -151,10 +151,6 @@ public class DirectoryBrowserSupportTest {
 
         try (JenkinsRule.WebClient wc = j.createWebClient()) {
             // normal path provided by the UI succeeds
-            wc.goTo("job/" + p.getName() + "/ws/abc/def.bin", "application/octet-stream");
-
-            // suspicious path is rejected with 400
-            wc.setThrowExceptionOnFailingStatusCode(false);
             Page page = wc.goTo("job/" + p.getName() + "/ws/abc%5Cdef.bin", "application/octet-stream");
             assertEquals(200, page.getWebResponse().getStatusCode());
         }

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -1119,8 +1119,7 @@ public class DirectoryBrowserSupportTest {
             // suspicious path is rejected with 400
             wc.setThrowExceptionOnFailingStatusCode(false);
             HtmlPage page = wc.goTo("userContent/" + targetTmpPath.toAbsolutePath() + "/*view*");
-            assertEquals(400, page.getWebResponse().getStatusCode());
-            assertEquals("Error 400 Suspicious Path Character", page.getTitleText());
+            assertEquals(200, page.getWebResponse().getStatusCode());
         }
     }
 

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -155,9 +155,8 @@ public class DirectoryBrowserSupportTest {
 
             // suspicious path is rejected with 400
             wc.setThrowExceptionOnFailingStatusCode(false);
-            HtmlPage page = wc.goTo("job/" + p.getName() + "/ws/abc%5Cdef.bin");
+            Page page = wc.goTo("job/" + p.getName() + "/ws/abc%5Cdef.bin", "application/octet-stream");
             assertEquals(400, page.getWebResponse().getStatusCode());
-            assertEquals("Error 400 Suspicious Path Character", page.getTitleText());
         }
     }
 

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -156,7 +156,7 @@ public class DirectoryBrowserSupportTest {
             // suspicious path is rejected with 400
             wc.setThrowExceptionOnFailingStatusCode(false);
             Page page = wc.goTo("job/" + p.getName() + "/ws/abc%5Cdef.bin", "application/octet-stream");
-            assertEquals(400, page.getWebResponse().getStatusCode());
+            assertEquals(200, page.getWebResponse().getStatusCode());
         }
     }
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -647,7 +647,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-maven-plugin</artifactId>
-        <version>12.0.16</version>
+        <version>12.0.17</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-75278](https://issues.jenkins.io/browse/JENKINS-75278).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Upgrade to Jetty 12.0.17 to fix User pages for users with `'\'` in the user name fail

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
