### PR TITLE
Fixed spotbugs issue and provided test for `FileBoolean`

### DIFF
--- a/core/src/main/java/jenkins/util/io/FileBoolean.java
+++ b/core/src/main/java/jenkins/util/io/FileBoolean.java
@@ -7,7 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import jenkins.model.Jenkins;
+import org.apache.commons.io.FilenameUtils;
 
 /**
  * Uses a presence/absence of a file as a persisted boolean storage.
@@ -29,7 +31,7 @@ public class FileBoolean {
     }
 
     public FileBoolean(Class owner, String name) {
-        this(new File(Jenkins.get().getRootDir(), owner.getName().replace('$', '.') + '/' + name));
+        this(new File(Jenkins.get().getRootDir(), owner.getName().replace('$', '.') + '/' + FilenameUtils.getName(name)));
     }
 
     /**
@@ -37,6 +39,14 @@ public class FileBoolean {
      */
     public boolean get() {
         return state = file.exists();
+    }
+
+    /**
+     * @return the getFilePath or empty string
+     */
+    public String getFilePath() {
+        if (file == null) return "";
+        return file.getAbsolutePath();
     }
 
     /**

--- a/core/src/main/java/jenkins/util/io/FileBoolean.java
+++ b/core/src/main/java/jenkins/util/io/FileBoolean.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FilenameUtils;
 

--- a/core/src/spotbugs/excludesFilter.xml
+++ b/core/src/spotbugs/excludesFilter.xml
@@ -399,7 +399,6 @@
           <Class name="jenkins.slaves.restarter.UnixSlaveRestarter"/>
           <Class name="jenkins.SoloFilePathFilter"/>
           <Class name="jenkins.util.groovy.GroovyHookScript"/>
-          <Class name="jenkins.util.io.FileBoolean"/>
           <Class name="jenkins.util.JavaVMArguments"/>
           <Class name="jenkins.util.SystemProperties"/>
           <Class name="jenkins.util.VirtualFile$FilePathVF"/>

--- a/test/src/test/java/jenkins/util/io/FileBooleanTest.java
+++ b/test/src/test/java/jenkins/util/io/FileBooleanTest.java
@@ -1,0 +1,20 @@
+package jenkins.util.io;
+
+import java.io.File;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FileBooleanTest {
+
+    @Test
+    void getFileName(JenkinsRule j) {
+        String path = j.jenkins.getRootDir().getAbsolutePath();
+        final String foo = new FileBoolean(Jenkins.class, "foo").getFilePath();
+        final String fooPath = String.join(File.separator, path, Jenkins.class.getName(), "foo");
+        Assertions.assertEquals(fooPath, foo);
+    }
+}


### PR DESCRIPTION
Fixed spotbugs issue and provided test for `FileBoolean`. Thanks to  @daniel-beck for his suggestion in https://github.com/jenkinsci/jenkins/pull/10022
Unfortunately, I had to provide another method to really test it. 

### Testing done

Added a Unit Test and verified that there was no change after the Spotbugs fix.
Also ran `new jenkins.util.io.FileBoolean(Jenkins.class, "foo").file` in the script console with the following result: 
`Result: C:\projekte\jenkins\jenkins\war\work\jenkins.model.Jenkins\foo`

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label internal 
/label skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
