### PR TITLE
Remove unnecessary SpotBugs suppressions

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -1810,6 +1810,7 @@ public class Functions {
         return s.toString();
     }
 
+    @SuppressFBWarnings(value = "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE", justification = "Jenkins handles this issue differently or doesn't care about it")
     private static void doPrintStackTrace(@NonNull StringBuilder s, @NonNull Throwable t, @CheckForNull Throwable higher, @NonNull String prefix, @NonNull Set<Throwable> encountered) {
         if (!encountered.add(t)) {
             s.append("<cycle to ").append(t).append(">\n");
@@ -1863,6 +1864,7 @@ public class Functions {
      * @param pw the log
      * @since 2.43
      */
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "TODO needs triage")
     public static void printStackTrace(@CheckForNull Throwable t, @NonNull PrintWriter pw) {
         pw.println(printThrowable(t).trim());
     }

--- a/core/src/main/java/hudson/Launcher.java
+++ b/core/src/main/java/hudson/Launcher.java
@@ -1000,6 +1000,7 @@ public abstract class Launcher {
         }
 
         @Override
+        @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "TODO needs triage")
         public Channel launchChannel(String[] cmd, OutputStream out, FilePath workDir, Map<String, String> envVars) throws IOException {
             printCommandLine(cmd, workDir);
 
@@ -1437,11 +1438,15 @@ public abstract class Launcher {
             this.envOverrides = envOverrides;
         }
 
+        @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "TODO needs triage")
+        private Process launchProcess() throws IOException {
+            return Runtime.getRuntime()
+                    .exec(cmd, Util.mapToEnv(inherit(envOverrides)), workDir == null ? null : new File(workDir));
+        }
+
         @Override
         public OutputStream call() throws IOException {
-            Process p = Runtime.getRuntime().exec(cmd,
-                Util.mapToEnv(inherit(envOverrides)),
-                workDir == null ? null : new File(workDir));
+            Process p = launchProcess();
 
             List<String> cmdLines = Arrays.asList(cmd);
             new StreamCopyThread("stdin copier for remote agent on " + cmdLines,

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -363,6 +363,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      * This is used to report a message that Jenkins needs to be restarted
      * for new plugins to take effect.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public volatile boolean pluginUploaded = false;
 
     /**

--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -27,6 +27,7 @@ package hudson;
 import com.thoughtworks.xstream.XStream;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Saveable;
@@ -113,6 +114,7 @@ public final class ProxyConfiguration extends AbstractDescribableImpl<ProxyConfi
      * @see #getNoProxyHostPatterns()
      */
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public String noProxyHost;
 
     @Deprecated

--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -206,6 +206,7 @@ public final class TcpSlaveAgentListener extends Thread {
     /**
      * Initiates the shuts down of the listener.
      */
+    @SuppressFBWarnings(value = "UNENCRYPTED_SOCKET", justification = "TODO needs triage")
     public void shutdown() {
         shuttingDown = true;
         try {

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -124,6 +124,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
      * (In contrast, calling {@code System.out.println(...)} would print out
      * the message to the server log file, which is probably not what you want.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public transient PrintStream stdout, stderr;
 
     /**
@@ -139,6 +140,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
      * <p>
      * This input stream is buffered to hide the latency in the remoting.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public transient InputStream stdin;
 
     /**
@@ -150,6 +152,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
     /**
      * The locale of the client. Messages should be formatted with this resource.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public transient Locale locale;
 
     /**

--- a/core/src/main/java/hudson/cli/Connection.java
+++ b/core/src/main/java/hudson/cli/Connection.java
@@ -208,6 +208,7 @@ public class Connection {
         return new Connection(i, o);
     }
 
+    @SuppressFBWarnings(value = "STATIC_IV", justification = "TODO needs triage")
     private IvParameterSpec createIv(SecretKey sessionKey) {
         return new IvParameterSpec(sessionKey.getEncoded());
     }

--- a/core/src/main/java/hudson/cli/CopyJobCommand.java
+++ b/core/src/main/java/hudson/cli/CopyJobCommand.java
@@ -24,6 +24,7 @@
 
 package hudson.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.TopLevelItem;
@@ -47,6 +48,7 @@ public class CopyJobCommand extends CLICommand {
     public TopLevelItem src;
 
     @Argument(metaVar = "DST", usage = "Name of the new job to be created.", index = 1, required = true)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public String dst;
 
     @Override

--- a/core/src/main/java/hudson/cli/CreateJobCommand.java
+++ b/core/src/main/java/hudson/cli/CreateJobCommand.java
@@ -24,6 +24,7 @@
 
 package hudson.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Item;
 import jenkins.model.Jenkins;
@@ -43,6 +44,7 @@ public class CreateJobCommand extends CLICommand {
     }
 
     @Argument(metaVar = "NAME", usage = "Name of the job to create", required = true)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public String name;
 
     @Override

--- a/core/src/main/java/hudson/cli/SetBuildDescriptionCommand.java
+++ b/core/src/main/java/hudson/cli/SetBuildDescriptionCommand.java
@@ -25,6 +25,7 @@ public class SetBuildDescriptionCommand extends CLICommand implements Serializab
     public int number;
 
     @Argument(metaVar = "DESCRIPTION", required = true, usage = "Description to be set. '=' to read from stdin.", index = 2)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public String description;
 
     @Override

--- a/core/src/main/java/hudson/cli/SetBuildDisplayNameCommand.java
+++ b/core/src/main/java/hudson/cli/SetBuildDisplayNameCommand.java
@@ -1,5 +1,6 @@
 package hudson.cli;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
@@ -23,6 +24,7 @@ public class SetBuildDisplayNameCommand extends CLICommand implements Serializab
     public int number;
 
     @Argument(metaVar = "DISPLAYNAME", required = true, usage = "DisplayName to be set. '-' to read from stdin.", index = 2)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public String displayName;
 
     @Override

--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -193,6 +193,7 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
      * Technically, this method only works if the {@link Writer} to {@link OutputStream}
      * encoding is ASCII compatible.
      */
+    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "TODO needs triage")
     public void encodeTo(Writer out) throws IOException {
         out.write(encodeToBytes().toString());
     }
@@ -223,6 +224,7 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
     /**
      * Works like {@link #encodeTo(Writer)} but obtain the result as a string.
      */
+    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "TODO needs triage")
     public String encode() throws IOException {
         return encodeToBytes().toString();
     }

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -27,6 +27,7 @@ package hudson.lifecycle;
 import static hudson.util.jna.Kernel32.MOVEFILE_DELAY_UNTIL_REBOOT;
 import static hudson.util.jna.Kernel32.MOVEFILE_REPLACE_EXISTING;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import hudson.Launcher.LocalLauncher;
 import hudson.Util;
@@ -118,6 +119,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
     }
 
     @Override
+    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "TODO needs triage")
     public void restart() throws IOException, InterruptedException {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         try {

--- a/core/src/main/java/hudson/model/AutoCompletionCandidates.java
+++ b/core/src/main/java/hudson/model/AutoCompletionCandidates.java
@@ -25,6 +25,7 @@
 package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.search.Search;
 import hudson.search.UserSearchProperty;
 import jakarta.servlet.ServletException;
@@ -90,6 +91,7 @@ public class AutoCompletionCandidates implements HttpResponse {
      *      The nearby contextual {@link ItemGroup} to resolve relative job names from.
      * @since 1.489
      */
+    @SuppressFBWarnings(value = "EC_UNRELATED_TYPES_USING_POINTER_EQUALITY", justification = "TODO needs triage")
     public static <T extends Item> AutoCompletionCandidates ofJobNames(final Class<T> type, final String value, @CheckForNull Item self, ItemGroup container) {
         if (self == container)
             container = self.getParent();

--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -1682,6 +1682,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
         relocateOldLogs(Jenkins.get().getRootDir());
     }
 
+    @SuppressFBWarnings(value = "REDOS", justification = "TODO needs triage")
     /*package*/ static void relocateOldLogs(File dir) {
         final Pattern logfile = Pattern.compile("slave-(.*)\\.log(\\.[0-9]+)?");
         File[] logfiles = dir.listFiles((dir1, name) -> logfile.matcher(name).matches());

--- a/core/src/main/java/hudson/model/FileParameterValue.java
+++ b/core/src/main/java/hudson/model/FileParameterValue.java
@@ -96,6 +96,7 @@ public class FileParameterValue extends ParameterValue {
      * @deprecated use {@link #FileParameterValue(String, FileItem)}
      */
     @Deprecated
+    @SuppressFBWarnings(value = "FILE_UPLOAD_FILENAME", justification = "TODO needs triage")
     public FileParameterValue(String name, org.apache.commons.fileupload.FileItem file) {
         this(name, file.toFileUpload2FileItem(), FilenameUtils.getName(file.getName()));
     }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -193,6 +193,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     protected CopyOnWriteList<JobProperty<? super JobT>> properties = new CopyOnWriteList<>();
 
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public transient RunIdMigrator runIdMigrator;
 
     protected Job(ItemGroup parent, String name) {

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1203,12 +1203,14 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     /** {@link Run.ArtifactList} without the implicit link to {@link Run} */
+    @SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS", justification = "TODO needs triage")
     private static final class SerializableArtifactList extends ArrayList<SerializableArtifact> {
         private static final long serialVersionUID = 1L;
         private LinkedHashMap<SerializableArtifact, String> tree = new LinkedHashMap<>();
         private int idSeq = 0;
     }
 
+    @SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS", justification = "TODO needs triage")
     public final class ArtifactList extends ArrayList<Artifact> {
         private static final long serialVersionUID = 1L;
         /**

--- a/core/src/main/java/hudson/model/StringParameterValue.java
+++ b/core/src/main/java/hudson/model/StringParameterValue.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Util;
 import hudson.util.VariableResolver;
@@ -40,6 +41,7 @@ import org.kohsuke.stapler.export.Exported;
 public class StringParameterValue extends ParameterValue {
     @Exported(visibility = 4)
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public String value;
 
     @DataBoundConstructor

--- a/core/src/main/java/hudson/model/UsageStatistics.java
+++ b/core/src/main/java/hudson/model/UsageStatistics.java
@@ -233,6 +233,7 @@ public class UsageStatistics extends PageDecorator implements PersistentDescript
      * with the asymmetric cipher. The rest of the stream will be encrypted by a symmetric cipher.
      */
     public static final class CombinedCipherOutputStream extends FilterOutputStream {
+        @SuppressFBWarnings(value = "STATIC_IV", justification = "TODO needs triage")
         public CombinedCipherOutputStream(OutputStream out, Cipher asym, String algorithm) throws IOException, GeneralSecurityException {
             super(out);
 

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -172,6 +172,7 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     private static final String[] ILLEGAL_PERSISTED_USERNAMES = new String[]{ACL.ANONYMOUS_USERNAME,
             ACL.SYSTEM_USERNAME, UNKNOWN_USERNAME};
 
+    @SuppressFBWarnings(value = "SS_SHOULD_BE_STATIC", justification = "Reserved for future use")
     private final int version = 10; // Not currently used, but it may be helpful in the future to store a version.
     private String id;
     private volatile String fullName;

--- a/core/src/main/java/hudson/model/UserIdMapper.java
+++ b/core/src/main/java/hudson/model/UserIdMapper.java
@@ -25,6 +25,7 @@
 package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Util;
@@ -57,6 +58,7 @@ public class UserIdMapper {
     private static final Logger LOGGER = Logger.getLogger(UserIdMapper.class.getName());
     private static final int PREFIX_MAX = 15;
     private static final Pattern PREFIX_PATTERN = Pattern.compile("[^A-Za-z0-9]");
+    @SuppressFBWarnings(value = "SS_SHOULD_BE_STATIC", justification = "Reserved for future use")
     private final int version = 1; // Not currently used, but it may be helpful in the future to store a version.
 
     private transient File usersDirectory;

--- a/core/src/main/java/hudson/os/WindowsUtil.java
+++ b/core/src/main/java/hudson/os/WindowsUtil.java
@@ -25,6 +25,7 @@
 package hudson.os;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Functions;
 import java.io.File;
 import java.io.IOException;
@@ -95,6 +96,7 @@ public class WindowsUtil {
      * @param argv arguments to be quoted or escaped for {@code cmd.exe /C ...}.
      * @return properly quoted and escaped arguments to {@code cmd.exe /C ...}.
      */
+    @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "TODO needs triage")
     public static @NonNull Process execCmd(String... argv) throws IOException {
         String command = Arrays.stream(argv).map(WindowsUtil::quoteArgumentForCmd).collect(Collectors.joining(" "));
         return Runtime.getRuntime().exec(new String[]{"cmd.exe", "/C", command});

--- a/core/src/main/java/hudson/search/Search.java
+++ b/core/src/main/java/hudson/search/Search.java
@@ -271,6 +271,7 @@ public class Search implements StaplerProxy {
         return builder.make();
     }
 
+    @SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS", justification = "TODO needs triage")
     private static class SearchResultImpl extends ArrayList<SuggestedItem> implements SearchResult {
 
         private boolean hasMoreResults = false;

--- a/core/src/main/java/hudson/security/AccessDeniedException3.java
+++ b/core/src/main/java/hudson/security/AccessDeniedException3.java
@@ -1,5 +1,6 @@
 package hudson.security;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.servlet.http.HttpServletResponseWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
@@ -75,6 +76,7 @@ public class AccessDeniedException3 extends AccessDeniedException {
      * This method is similar to {@link #reportAsHeaders(HttpServletResponse)} for the intention
      * but instead of using HTTP headers, this version is meant to go inside the payload.
      */
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "TODO needs triage")
     public void report(PrintWriter w) {
         w.println("You are authenticated as: " + authentication.getName());
         w.println("Groups that you are in:");

--- a/core/src/main/java/hudson/security/Permission.java
+++ b/core/src/main/java/hudson/security/Permission.java
@@ -26,6 +26,7 @@ package hudson.security;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Hudson;
 import java.util.Collections;
 import java.util.Comparator;
@@ -105,6 +106,7 @@ public final class Permission {
      *
      * @since 1.325
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public boolean enabled;
 
     /**

--- a/core/src/main/java/hudson/slaves/Channels.java
+++ b/core/src/main/java/hudson/slaves/Channels.java
@@ -24,6 +24,7 @@
 
 package hudson.slaves;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import hudson.Launcher.LocalLauncher;
 import hudson.Proc;
@@ -219,6 +220,7 @@ public class Channels {
      * @deprecated removed without replacement
      */
     @Deprecated
+    @SuppressFBWarnings(value = "UNENCRYPTED_SERVER_SOCKET", justification = "TODO needs triage")
     public static Channel newJVM(String displayName, TaskListener listener, JVMBuilder vmb, FilePath workDir, ClasspathBuilder classpath) throws IOException {
         ServerSocket serverSocket = new ServerSocket();
         serverSocket.bind(new InetSocketAddress("localhost", 0));

--- a/core/src/main/java/hudson/slaves/JNLPLauncher.java
+++ b/core/src/main/java/hudson/slaves/JNLPLauncher.java
@@ -58,6 +58,7 @@ public class JNLPLauncher extends ComputerLauncher {
      * Deprecated (only used with deprecated {@code -jnlpUrl} mode), but cannot mark it as such without breaking CasC.
      */
     @CheckForNull
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public String tunnel;
 
     /**

--- a/core/src/main/java/hudson/slaves/NodeList.java
+++ b/core/src/main/java/hudson/slaves/NodeList.java
@@ -31,6 +31,7 @@ import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Node;
 import hudson.util.RobustCollectionConverter;
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "EQ_DOESNT_OVERRIDE_EQUALS", justification = "TODO needs triage")
 public final class NodeList extends ArrayList<Node> {
 
     private Map<String, Node> map = new HashMap<>();

--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -955,6 +955,7 @@ public class SlaveComputer extends Computer {
     }
 
     @Override
+    @SuppressFBWarnings(value = "UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR", justification = "TODO needs triage")
     protected void setNode(final Node node) {
         super.setNode(node);
         launcher = grabLauncher(node);

--- a/core/src/main/java/hudson/tasks/Fingerprinter.java
+++ b/core/src/main/java/hudson/tasks/Fingerprinter.java
@@ -485,6 +485,7 @@ public class Fingerprinter extends Recorder implements Serializable, DependencyD
          *  the result, even if it doesn't exist
          * @since 1.430
          */
+        @SuppressFBWarnings(value = "EC_UNRELATED_TYPES_USING_POINTER_EQUALITY", justification = "TODO needs triage")
         public Map<AbstractProject, Integer> getDependencies(boolean includeMissing) {
             Map<AbstractProject, Integer> r = new HashMap<>();
 

--- a/core/src/main/java/hudson/tasks/Maven.java
+++ b/core/src/main/java/hudson/tasks/Maven.java
@@ -127,6 +127,7 @@ public class Maven extends Builder {
      *
      * @since 1.322
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public boolean usePrivateRepository;
 
     /**

--- a/core/src/main/java/hudson/triggers/Trigger.java
+++ b/core/src/main/java/hudson/triggers/Trigger.java
@@ -252,6 +252,7 @@ public abstract class Trigger<J extends Item> implements Describable<Trigger<?>>
 
     private static Future previousSynchronousPolling;
 
+    @SuppressFBWarnings(value = "LI_LAZY_INIT_STATIC", justification = "TODO needs triage")
     public static void checkTriggers(final Calendar cal) {
         Jenkins inst = Jenkins.get();
 

--- a/core/src/main/java/hudson/util/Graph.java
+++ b/core/src/main/java/hudson/util/Graph.java
@@ -27,6 +27,7 @@ package hudson.util;
 import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
 import jakarta.servlet.ServletOutputStream;
 import java.awt.Color;
@@ -72,6 +73,7 @@ public abstract class Graph {
     private final long timestamp;
     private final int defaultWidth;
     private final int defaultHeight;
+    @SuppressFBWarnings(value = "SS_SHOULD_BE_STATIC", justification = "Reserved for future use")
     private final int defaultScale = 1;
     private volatile JFreeChart graph;
 

--- a/core/src/main/java/hudson/util/HttpResponses.java
+++ b/core/src/main/java/hudson/util/HttpResponses.java
@@ -25,6 +25,7 @@
 package hudson.util;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +45,7 @@ import org.kohsuke.stapler.StaplerResponse2;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Used for backward compatibility and extending utility classes")
 public class HttpResponses extends org.kohsuke.stapler.HttpResponses {
     public static HttpResponse staticResource(File f) throws IOException {
         return staticResource(f.toURI().toURL());

--- a/core/src/main/java/hudson/util/ReflectionUtils.java
+++ b/core/src/main/java/hudson/util/ReflectionUtils.java
@@ -25,6 +25,7 @@
 package hudson.util;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
@@ -45,6 +46,7 @@ import org.kohsuke.stapler.ClassDescriptor;
  * @author Kohsuke Kawaguchi
  * @since 1.351
  */
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Used for backward compatibility and extending utility classes")
 public class ReflectionUtils extends org.springframework.util.ReflectionUtils {
     /**
      * Finds a public method of the given name, regardless of its parameter definitions,

--- a/core/src/main/java/hudson/util/TextFile.java
+++ b/core/src/main/java/hudson/util/TextFile.java
@@ -25,6 +25,7 @@
 package hudson.util;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
 import java.io.BufferedReader;
 import java.io.File;
@@ -111,6 +112,7 @@ public class TextFile {
     /**
      * Reads the first N characters or until we hit EOF.
      */
+    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "TODO needs triage")
     public @NonNull String head(int numChars) throws IOException {
         char[] buf = new char[numChars];
         int read = 0;

--- a/core/src/main/java/hudson/widgets/HistoryWidget.java
+++ b/core/src/main/java/hudson/widgets/HistoryWidget.java
@@ -26,6 +26,7 @@ package hudson.widgets;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Functions;
 import hudson.model.Job;
@@ -71,6 +72,7 @@ public class HistoryWidget<O extends ModelObject, T> extends Widget {
     /**
      * The given data model of records. Newer ones first.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public Iterable<T> baseList;
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -633,6 +633,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     public final transient PluginManager pluginManager;
 
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public transient volatile TcpSlaveAgentListener tcpSlaveAgentListener;
 
     private final transient Object tcpSlaveAgentListenerLock = new Object();
@@ -870,6 +871,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * HTTP proxy configuration.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public transient volatile ProxyConfiguration proxy;
 
     /**
@@ -5619,10 +5621,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Version number of this Jenkins.
      */
-    @SuppressFBWarnings(value = "MS_CANNOT_BE_FINAL", justification = "cannot be made immutable without breaking compatibility")
+    @SuppressFBWarnings(value = {"MS_CANNOT_BE_FINAL", "PA_PUBLIC_PRIMITIVE_ATTRIBUTE"}, justification = "Preserve API compatibility")
     public static String VERSION = UNCOMPUTED_VERSION;
 
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public static String CHANGELOG_URL;
 
     /**
@@ -5685,6 +5688,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     /**
      * Hash of {@link #VERSION}.
      */
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public static String VERSION_HASH;
 
     /**
@@ -5694,7 +5698,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * We used to use {@link #VERSION_HASH}, but making this session local allows us to
      * reuse the same {@link #RESOURCE_PATH} for static resources in plugins.
      */
-    @SuppressFBWarnings(value = "MS_CANNOT_BE_FINAL", justification = "cannot be made immutable without breaking compatibility")
+    @SuppressFBWarnings(value = {"MS_CANNOT_BE_FINAL", "PA_PUBLIC_PRIMITIVE_ATTRIBUTE"}, justification = "Preserve API compatibility")
     public static String SESSION_HASH;
 
     /**
@@ -5704,7 +5708,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * <p>
      * Value computed in {@link WebAppMain}.
      */
-    @SuppressFBWarnings(value = "MS_CANNOT_BE_FINAL", justification = "cannot be made immutable without breaking compatibility")
+    @SuppressFBWarnings(value = {"MS_CANNOT_BE_FINAL", "PA_PUBLIC_PRIMITIVE_ATTRIBUTE"}, justification = "Preserve API compatibility")
     public static String RESOURCE_PATH = "";
 
     /**
@@ -5714,7 +5718,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * <p>
      * Value computed in {@link WebAppMain}.
      */
-    @SuppressFBWarnings(value = "MS_CANNOT_BE_FINAL", justification = "cannot be made immutable without breaking compatibility")
+    @SuppressFBWarnings(value = {"MS_CANNOT_BE_FINAL", "PA_PUBLIC_PRIMITIVE_ATTRIBUTE"}, justification = "Preserve API compatibility")
     public static String VIEW_RESOURCE_PATH = "/resources/TBD";
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")

--- a/core/src/main/java/jenkins/security/CryptoConfidentialKey.java
+++ b/core/src/main/java/jenkins/security/CryptoConfidentialKey.java
@@ -1,5 +1,6 @@
 package jenkins.security;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.Secret;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -71,6 +72,7 @@ public class CryptoConfidentialKey extends ConfidentialKey {
      * @return the cipher
      */
     @Restricted(NoExternalUse.class) // TODO pending API
+    @SuppressFBWarnings(value = "STATIC_IV", justification = "TODO needs triage")
     public Cipher encrypt(byte[] iv) {
         try {
             Cipher cipher = Secret.getCipher(ALGORITHM);

--- a/core/src/main/java/jenkins/security/stapler/StaplerDispatchValidator.java
+++ b/core/src/main/java/jenkins/security/stapler/StaplerDispatchValidator.java
@@ -311,6 +311,7 @@ public class StaplerDispatchValidator implements DispatchValidator {
             }
         }
 
+        @SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC", justification = "TODO needs triage")
         private class Validator {
             // lazy load parents to avoid trying to load potentially unavailable classes
             private final Supplier<Collection<Validator>> parentsSupplier;

--- a/core/src/main/java/jenkins/slaves/restarter/WinswSlaveRestarter.java
+++ b/core/src/main/java/jenkins/slaves/restarter/WinswSlaveRestarter.java
@@ -3,6 +3,7 @@ package jenkins.slaves.restarter;
 import static java.util.logging.Level.FINE;
 import static org.apache.commons.io.IOUtils.copy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,6 +30,7 @@ public class WinswSlaveRestarter extends SlaveRestarter {
         }
     }
 
+    @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "TODO needs triage")
     private int exec(String cmd) throws InterruptedException, IOException {
         ProcessBuilder pb = new ProcessBuilder(exe, cmd);
         pb.redirectErrorStream(true);

--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -61,15 +61,17 @@ public class HistoryPageFilter<T> {
     public final List<HistoryPageEntry<QueueItem>> queueItems = new ArrayList<>();
     public final List<HistoryPageEntry<HistoricalBuild>> runs = new ArrayList<>();
 
-    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
+    @SuppressFBWarnings(value = {"PA_PUBLIC_PRIMITIVE_ATTRIBUTE", "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"}, justification = "Preserve API compatibility; read by Stapler")
     public boolean hasUpPage = false; // there are newer builds than on this page
-    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
+    @SuppressFBWarnings(value = {"PA_PUBLIC_PRIMITIVE_ATTRIBUTE", "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"}, justification = "Preserve API compatibility; read by Stapler")
     public boolean hasDownPage = false; // there are older builds than on this page
-    @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
+    @SuppressFBWarnings(value = {"PA_PUBLIC_PRIMITIVE_ATTRIBUTE", "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"}, justification = "Preserve API compatibility; read by Stapler")
     public long nextBuildNumber;
     public HistoryWidget widget;
 
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public long newestOnPage = Long.MIN_VALUE; // see updateNewestOldest()
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility")
     public long oldestOnPage = Long.MAX_VALUE; // see updateNewestOldest()
 
     /**

--- a/core/src/spotbugs/excludesFilter.xml
+++ b/core/src/spotbugs/excludesFilter.xml
@@ -7,14 +7,8 @@
     <Or>
       <!-- We don't care about this behavior -->
       <Bug pattern="CRLF_INJECTION_LOGS"/>
-      <!-- Pending https://github.com/spotbugs/spotbugs/issues/1515 -->
-      <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
       <!-- Silly check; it is perfectly reasonable to implement Comparable by writing a compareTo without an equals. -->
       <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS"/>
-      <!-- Jenkins handles this issue differently or doesn't care about it -->
-      <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
-      <!-- Used for backward compatibility and extending utility classes -->
-      <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS"/>
     </Or>
   </Match>
   <Match>
@@ -53,125 +47,6 @@
     <Bug pattern="SF_SWITCH_NO_DEFAULT"/>
     <Class name="hudson.scheduler.CrontabParser"/>
   </Match>
-  <Match>
-    <!-- Preserve API compatibility -->
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.PluginManager"/>
-    <Field name="pluginUploaded"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.ProxyConfiguration"/>
-    <Field name="noProxyHost"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.cli.CLICommand"/>
-    <Or>
-      <Field name="locale"/>
-      <Field name="stderr"/>
-      <Field name="stdin"/>
-      <Field name="stdout"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.cli.CopyJobCommand"/>
-    <Field name="dst"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.cli.CreateJobCommand"/>
-    <Field name="name"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.cli.SetBuildDescriptionCommand"/>
-    <Field name="description"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.cli.SetBuildDisplayNameCommand"/>
-    <Field name="displayName"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.model.Job"/>
-    <Field name="runIdMigrator"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.model.StringParameterValue"/>
-    <Field name="value"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.security.Permission"/>
-    <Field name="enabled"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.tasks.Maven"/>
-    <Field name="usePrivateRepository"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.util.Graph"/>
-    <Field name="defaultScale"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.widgets.HistoryWidget"/>
-    <Field name="baseList"/>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="jenkins.model.Jenkins"/>
-    <Or>
-      <Field name="tcpSlaveAgentListener"/>
-      <Field name="proxy"/>
-      <Field name="VERSION"/>
-      <Field name="CHANGELOG_URL"/>
-      <Field name="VERSION_HASH"/>
-      <Field name="SESSION_HASH"/>
-      <Field name="RESOURCE_PATH"/>
-      <Field name="VIEW_RESOURCE_PATH"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="jenkins.widgets.HistoryPageFilter"/>
-    <Or>
-      <Field name="hasDownPage"/>
-      <Field name="hasUpPage"/>
-      <Field name="newestOnPage"/>
-      <Field name="nextBuildNumber"/>
-      <Field name="oldestOnPage"/>
-    </Or>
-  </Match>
-  <Match>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
-    <Class name="hudson.slaves.JNLPLauncher"/>
-    <Field name="tunnel"/>
-  </Match>
-  <Match>
-    <!-- Reserved for future use -->
-    <Bug pattern="SS_SHOULD_BE_STATIC"/>
-    <Class name="hudson.model.User"/>
-    <Field name="version"/>
-  </Match>
-  <Match>
-    <!-- Reserved for future use -->
-    <Bug pattern="SS_SHOULD_BE_STATIC"/>
-    <Class name="hudson.model.UserIdMapper"/>
-    <Field name="version"/>
-  </Match>
-  <Match>
-    <!-- Reserved for future use -->
-    <Bug pattern="SS_SHOULD_BE_STATIC"/>
-    <Class name="hudson.util.Graph"/>
-    <Field name="defaultScale"/>
-  </Match>
   <!--
     Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
     on this section, pick an exclusion to triage, then:
@@ -181,68 +56,8 @@
     - If it is not a false positive, fix the bug, then remove the exclusion from this section.
    -->
   <Match>
-    <And>
-      <Bug pattern="DM_DEFAULT_ENCODING"/>
-      <Or>
-        <Class name="hudson.console.ConsoleNote"/>
-        <Class name="hudson.lifecycle.WindowsServiceLifecycle"/>
-        <Class name="hudson.util.TextFile"/>
-      </Or>
-    </And>
-  </Match>
-  <Match>
     <Confidence value="2"/>
     <Or>
-      <And>
-        <Bug pattern="COMMAND_INJECTION"/>
-        <Or>
-          <Class name="hudson.Launcher$LocalLauncher"/>
-          <Class name="hudson.Launcher$RemoteChannelLaunchCallable"/>
-          <Class name="hudson.os.WindowsUtil"/>
-          <Class name="jenkins.slaves.restarter.WinswSlaveRestarter"/>
-        </Or>
-      </And>
-      <And>
-        <Bug pattern="EC_UNRELATED_TYPES_USING_POINTER_EQUALITY"/>
-        <Or>
-          <Class name="hudson.model.AutoCompletionCandidates"/>
-          <Class name="hudson.tasks.Fingerprinter$FingerprintAction"/>
-        </Or>
-      </And>
-      <And>
-        <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS"/>
-        <Or>
-          <Class name="hudson.model.Run$ArtifactList"/>
-          <Class name="hudson.model.Run$SerializableArtifactList"/>
-          <Class name="hudson.search.Search$SearchResultImpl"/>
-          <Class name="hudson.slaves.NodeList"/>
-        </Or>
-      </And>
-      <And>
-        <Bug pattern="FILE_UPLOAD_FILENAME"/>
-        <Or>
-          <Class name="hudson.model.FileParameterDefinition"/>
-          <Class name="hudson.model.FileParameterValue"/>
-          <Class name="hudson.PluginManager"/>
-        </Or>
-      </And>
-      <And>
-        <Bug pattern="HTTP_PARAMETER_POLLUTION"/>
-        <Class name="hudson.ProxyConfiguration$DescriptorImpl"/>
-      </And>
-      <And>
-        <Bug pattern="HTTP_RESPONSE_SPLITTING"/>
-        <Or>
-          <Class name="hudson.Functions"/>
-          <Class name="jenkins.install.InstallUtil"/>
-          <Class name="jenkins.model.Jenkins"/>
-          <Class name="jenkins.util.xml.XMLUtils"/>
-        </Or>
-      </And>
-      <And>
-        <Bug pattern="LI_LAZY_INIT_STATIC"/>
-        <Class name="hudson.triggers.Trigger"/>
-      </And>
       <And>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
         <Or>
@@ -273,7 +88,6 @@
           <Class name="hudson.model.Run"/>
           <Class name="hudson.model.RunParameterValue"/>
           <Class name="hudson.model.Slave"/>
-          <Class name="hudson.model.TopLevelItemDescriptor"/>
           <Class name="hudson.model.UpdateCenter$HudsonDowngradeJob"/>
           <Class name="hudson.model.UpdateCenter$HudsonUpgradeJob"/>
           <Class name="hudson.model.UpdateSite$Plugin"/>
@@ -287,7 +101,6 @@
           <Class name="hudson.tasks.BuildTrigger"/>
           <Class name="hudson.tasks.Maven"/>
           <Class name="hudson.tasks.Maven$MavenInstallation"/>
-          <Class name="hudson.TcpSlaveAgentListener$TcpSlaveAgentListenerRescheduler"/>
           <Class name="hudson.tools.DownloadFromUrlInstaller$DescriptorImpl"/>
           <Class name="hudson.tools.ToolInstallation"/>
           <Class name="hudson.triggers.SCMTrigger$DescriptorImpl"/>
@@ -299,7 +112,6 @@
           <Class name="jenkins.fingerprints.FingerprintStorage"/>
           <Class name="jenkins.install.SetupWizard"/>
           <Class name="jenkins.model.Jenkins"/>
-          <Class name="jenkins.model.Nodes"/>
           <Class name="jenkins.model.RunIdMigrator"/>
           <Class name="jenkins.mvn.SettingsPathHelper"/>
           <Class name="jenkins.security.CustomClassFilter$Contributed"/>
@@ -336,7 +148,6 @@
           <Class name="hudson.Launcher$RemoteLaunchCallable"/>
           <Class name="hudson.lifecycle.Lifecycle"/>
           <Class name="hudson.lifecycle.WindowsServiceLifecycle"/>
-          <Class name="hudson.LocalPluginManager"/>
           <Class name="hudson.logging.LogRecorder"/>
           <Class name="hudson.model.AsyncAperiodicWork"/>
           <Class name="hudson.model.AsyncPeriodicWork"/>
@@ -352,7 +163,6 @@
           <Class name="hudson.model.Run"/>
           <Class name="hudson.model.Run$Artifact"/>
           <Class name="hudson.model.UpdateCenter"/>
-          <Class name="hudson.model.UpdateCenter$DownloadJob"/>
           <Class name="hudson.model.UpdateCenter$HudsonDowngradeJob"/>
           <Class name="hudson.model.UpdateCenter$InstallationJob"/>
           <Class name="hudson.model.UpdateCenter$PluginDowngradeJob"/>
@@ -385,19 +195,15 @@
           <Class name="jenkins.model.Jenkins"/>
           <Class name="jenkins.model.Nodes"/>
           <Class name="jenkins.model.PeepholePermalink"/>
-          <Class name="jenkins.model.RunIdMigrator"/>
           <Class name="jenkins.mvn.FilePathGlobalSettingsProvider"/>
           <Class name="jenkins.mvn.FilePathSettingsProvider"/>
           <Class name="jenkins.mvn.SettingsPathHelper"/>
-          <Class name="jenkins.plugins.DetachedPluginsUtil$DetachedPlugin"/>
           <Class name="jenkins.security.ClassFilterImpl"/>
           <Class name="jenkins.security.ConfidentialKey"/>
           <Class name="jenkins.security.DefaultConfidentialStore"/>
-          <Class name="jenkins.security.s2m.ConfigDirectory"/>
           <Class name="jenkins.security.stapler.StaplerDispatchValidator$ValidatorCache"/>
           <Class name="jenkins.security.stapler.StaticRoutingDecisionProvider"/>
           <Class name="jenkins.slaves.restarter.UnixSlaveRestarter"/>
-          <Class name="jenkins.SoloFilePathFilter"/>
           <Class name="jenkins.util.groovy.GroovyHookScript"/>
           <Class name="jenkins.util.io.FileBoolean"/>
           <Class name="jenkins.util.JavaVMArguments"/>
@@ -408,58 +214,7 @@
       </And>
       <And>
         <Bug pattern="REDOS"/>
-        <Or>
-          <Class name="hudson.model.Computer"/>
-          <Class name="jenkins.org.apache.commons.validator.routines.UrlValidator"/>
-        </Or>
-      </And>
-      <And>
-        <Bug pattern="REQUESTDISPATCHER_FILE_DISCLOSURE"/>
-        <Or>
-          <Class name="hudson.cli.CLIAction"/>
-          <Class name="hudson.model.AbstractProject"/>
-          <Class name="hudson.model.Descriptor"/>
-          <Class name="hudson.model.DirectoryBrowserSupport"/>
-          <Class name="hudson.model.RSS"/>
-          <Class name="hudson.model.Run"/>
-          <Class name="hudson.scm.AbstractScmTagAction"/>
-          <Class name="hudson.search.Search"/>
-          <Class name="hudson.security.BasicAuthenticationFilter"/>
-          <Class name="hudson.security.FederatedLoginService$UnclaimedIdentityException"/>
-          <Class name="hudson.security.HudsonPrivateSecurityRealm"/>
-          <Class name="hudson.slaves.NodeDescriptor"/>
-          <Class name="hudson.slaves.SlaveComputer"/>
-          <Class name="hudson.util.DoubleLaunchChecker"/>
-          <Class name="hudson.util.ErrorObject"/>
-          <Class name="hudson.util.HudsonIsLoading"/>
-          <Class name="hudson.util.HudsonIsRestarting"/>
-          <Class name="hudson.widgets.HistoryWidget"/>
-          <Class name="jenkins.agents.CloudSet"/>
-          <Class name="jenkins.management.AdministrativeMonitorsApi"/>
-          <Class name="jenkins.model.Jenkins"/>
-          <Class name="jenkins.model.ParameterizedJobMixIn"/>
-          <Class name="jenkins.slaves.EncryptedSlaveAgentJnlpFile"/>
-        </Or>
-      </And>
-      <And>
-        <Bug pattern="SE_BAD_FIELD"/>
-        <Class name="hudson.scm.PollingResult"/>
-      </And>
-      <And>
-        <Bug pattern="STATIC_IV"/>
-        <Or>
-          <Class name="hudson.cli.Connection"/>
-          <Class name="hudson.model.UsageStatistics$CombinedCipherOutputStream"/>
-          <Class name="jenkins.security.CryptoConfidentialKey"/>
-        </Or>
-      </And>
-      <And>
-        <Bug pattern="UNENCRYPTED_SERVER_SOCKET"/>
-        <Class name="hudson.slaves.Channels"/>
-      </And>
-      <And>
-        <Bug pattern="UNENCRYPTED_SOCKET"/>
-        <Class name="hudson.TcpSlaveAgentListener"/>
+        <Class name="jenkins.org.apache.commons.validator.routines.UrlValidator"/>
       </And>
       <And>
         <Bug pattern="URLCONNECTION_SSRF_FD"/>
@@ -475,21 +230,6 @@
           <Class name="jenkins.security.ResourceDomainConfiguration"/>
         </Or>
       </And>
-      <And>
-        <Bug pattern="UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR"/>
-        <Class name="hudson.slaves.SlaveComputer"/>
-      </And>
-      <And>
-        <Bug pattern="XSS_SERVLET"/>
-        <Or>
-          <Class name="hudson.Functions"/>
-          <Class name="hudson.security.AccessDeniedException3"/>
-        </Or>
-      </And>
     </Or>
-  </Match>
-  <Match>
-    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC"/>
-    <Class name="jenkins.security.stapler.StaplerDispatchValidator$ValidatorCache$Validator"/>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Amends #10376 by removing more unnecessary SpotBugs suppressions. Where convenient, moved the existing suppressions out of XML into `@SuppressFBWarnings` annotations, where unnecessary suppressions will be enforced by SpotBugs itself. Where inconvenient to use `@SuppressFBWarnings`, kept the supressions in XML but simply removed unnecessary ones.

### Testing done

`mvn clean verify -DskipTests`

### Proposed changelog entries

- N/A

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
