### PR TITLE
Remove `Job#getDynamic` compatibility layer

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -895,37 +895,6 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     @Override
     public Object getDynamic(String token, StaplerRequest2 req,
                              StaplerResponse2 rsp) {
-        if (Util.isOverridden(Job.class, getClass(), "getDynamic", String.class, StaplerRequest.class, StaplerResponse.class)) {
-            return getDynamic(token, StaplerRequest.fromStaplerRequest2(req), StaplerResponse.fromStaplerResponse2(rsp));
-        }
-        try {
-            // try to interpret the token as build number
-            return getBuildByNumber(Integer.parseInt(token));
-        } catch (NumberFormatException e) {
-            // try to map that to widgets
-            for (Widget w : getWidgets()) {
-                if (w.getUrlName().equals(token))
-                    return w;
-            }
-
-            // is this a permalink?
-            for (Permalink p : getPermalinks()) {
-                if (p.getId().equals(token))
-                    return p.resolve(this);
-            }
-
-            return super.getDynamic(token, req, rsp);
-        }
-    }
-
-    /**
-     * @deprecated use {@link #getDynamic(String, StaplerRequest2, StaplerResponse2)}
-     */
-    @Deprecated
-    @Override
-    public Object getDynamic(String token, StaplerRequest req,
-            StaplerResponse rsp) {
-        // Intentionally not factoring this out into a common implementation method because it contains a call to super.
         try {
             // try to interpret the token as build number
             return getBuildByNumber(Integer.parseInt(token));


### PR DESCRIPTION
While probing for unnecessary uses of the EE 9 compatibility layer, I found lots of calls to

```
org.kohsuke.stapler.StaplerResponse.fromStaplerResponse2(StaplerResponse.java:287)
	at hudson.model.Actionable.getDynamic(Actionable.java:349)
	at hudson.model.Job.getDynamic(Job.java:917)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:484)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:497)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:218)
	at org.kohsuke.stapler.MetaClass$10.dispatch(MetaClass.java:588)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:800)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:937)
	at org.kohsuke.stapler.MetaClass$5.doDispatch(MetaClass.java:369)
	at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:61)
	at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:800)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:937)
	at org.kohsuke.stapler.Stapler.invoke(Stapler.java:721)
	at org.kohsuke.stapler.Stapler.service(Stapler.java:253)
```

This logic was only needed to support EE 8 versions of Ivy, Matrix Project, and Maven jobs, all of which have now been released with EE 9 updates (I checked CloudBees CI, as well). So removing this logic should do no harm, as well as reducing usage of the compatibility layer in the common case as well.

### Testing done

Tested running Jenkins before and after this PR with tracing of the compatibility layer. Usage of the compatibility layer was almost completely gone after this PR.

### Proposed changelog entries

Reduce usage of EE 8 compatibility layer in a common case. Users of the Ivy, Matrix Project, or Maven plugins should update to the following versions along with this core upgrade:

- https://github.com/jenkinsci/ivy-plugin/releases/tag/ivy-2.9
- https://github.com/jenkinsci/matrix-project-plugin/releases/tag/840.v812f627cb_578
- https://github.com/jenkinsci/maven-plugin/releases/tag/maven-plugin-3.25

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
