### PR TITLE
Backporting for Jenkins 2.492.3 release candidate

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -49,7 +49,10 @@ THE SOFTWARE.
                     clazz="${page.runs.isEmpty() and page.queueItems.isEmpty() ? 'jenkins-hidden' : ''}"/>
 
       <div class="app-builds-container">
-        <div id="no-builds" class="app-builds-container__placeholder">
+        <div id="loading-builds" class="app-builds-container__placeholder">
+          <l:spinner text="${%Loading builds...}"/>
+        </div>
+        <div id="no-builds" style="display:none" class="app-builds-container__placeholder">
           ${%No builds}
         </div>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.30</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.4</winstone.version>
+    <winstone.version>8.5</winstone.version>
     <node.version>20.18.1</node.version>
   </properties>
 

--- a/src/main/js/pages/project/builds-card.js
+++ b/src/main/js/pages/project/builds-card.js
@@ -9,6 +9,7 @@ const ajaxUrl = buildHistoryPage.getAttribute("page-ajax");
 const card = document.querySelector("#jenkins-builds");
 const contents = card.querySelector("#jenkins-build-history");
 const container = card.querySelector(".app-builds-container");
+const loadingBuilds = card.querySelector("#loading-builds");
 const noBuilds = card.querySelector("#no-builds");
 
 // Pagination controls
@@ -58,6 +59,7 @@ function load(options = {}) {
         if (responseText.trim() === "") {
           contents.innerHTML = "";
           noBuilds.style.display = "block";
+          loadingBuilds.style.display = "none";
           updateCardControls({
             pageHasUp: false,
             pageHasDown: false,
@@ -69,7 +71,7 @@ function load(options = {}) {
 
         // Show the refreshed builds list
         contents.innerHTML = responseText;
-        noBuilds.style.display = "none";
+        loadingBuilds.style.display = "none";
         behaviorShim.applySubtree(contents);
 
         // Show the card controls
@@ -146,6 +148,7 @@ document.addEventListener("DOMContentLoaded", function () {
     debouncedLoad();
   });
 
+  container.classList.add("app-builds-container--loading");
   load();
 
   window.addEventListener("focus", function () {

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -178,7 +178,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2370.vfb_b_0c547a_659</version>
+      <version>2414.v185474555e66</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/test/src/test/java/hudson/PluginTest.java
+++ b/test/src/test/java/hudson/PluginTest.java
@@ -54,7 +54,7 @@ public class PluginTest {
         r.createWebClient().assertFails("plugin/matrix-auth/images/%2e%2e%2fWEB-INF/licenses.xml", HttpServletResponse.SC_BAD_REQUEST);
         r.createWebClient().assertFails("plugin/matrix-auth/images/%2e.%2fWEB-INF/licenses.xml", HttpServletResponse.SC_BAD_REQUEST);
         r.createWebClient().assertFails("plugin/matrix-auth/images/..%2f..%2f..%2f" + r.jenkins.getRootDir().getName() + "%2fsecrets%2fmaster.key", HttpServletResponse.SC_BAD_REQUEST);
-        r.createWebClient().assertFails("plugin/matrix-auth/" + r.jenkins.getRootDir() + "/secrets/master.key", /* ./ prepended anyway */ Functions.isWindows() ? HttpServletResponse.SC_BAD_REQUEST : HttpServletResponse.SC_NOT_FOUND);
+        r.createWebClient().assertFails("plugin/matrix-auth/" + r.jenkins.getRootDir() + "/secrets/master.key", /* ./ prepended anyway */ HttpServletResponse.SC_NOT_FOUND);
         // SECURITY-155:
         r.createWebClient().assertFails("plugin/matrix-auth/WEB-INF/licenses.xml", HttpServletResponse.SC_BAD_REQUEST);
         r.createWebClient().assertFails("plugin/matrix-auth/META-INF/MANIFEST.MF", HttpServletResponse.SC_BAD_REQUEST);

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -151,13 +151,8 @@ public class DirectoryBrowserSupportTest {
 
         try (JenkinsRule.WebClient wc = j.createWebClient()) {
             // normal path provided by the UI succeeds
-            wc.goTo("job/" + p.getName() + "/ws/abc/def.bin", "application/octet-stream");
-
-            // suspicious path is rejected with 400
-            wc.setThrowExceptionOnFailingStatusCode(false);
-            HtmlPage page = wc.goTo("job/" + p.getName() + "/ws/abc%5Cdef.bin");
-            assertEquals(400, page.getWebResponse().getStatusCode());
-            assertEquals("Error 400 Suspicious Path Character", page.getTitleText());
+            Page page = wc.goTo("job/" + p.getName() + "/ws/abc%5Cdef.bin", "application/octet-stream");
+            assertEquals(200, page.getWebResponse().getStatusCode());
         }
     }
 
@@ -1117,11 +1112,9 @@ public class DirectoryBrowserSupportTest {
         Files.writeString(targetTmpPath, content, StandardCharsets.UTF_8);
 
         try (JenkinsRule.WebClient wc = j.createWebClient()) {
-            // suspicious path is rejected with 400
             wc.setThrowExceptionOnFailingStatusCode(false);
             HtmlPage page = wc.goTo("userContent/" + targetTmpPath.toAbsolutePath() + "/*view*");
-            assertEquals(400, page.getWebResponse().getStatusCode());
-            assertEquals("Error 400 Suspicious Path Character", page.getTitleText());
+            assertEquals(404, page.getWebResponse().getStatusCode());
         }
     }
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -645,7 +645,7 @@ THE SOFTWARE.
       <plugin>
         <groupId>org.eclipse.jetty.ee9</groupId>
         <artifactId>jetty-ee9-maven-plugin</artifactId>
-        <version>12.0.16</version>
+        <version>12.0.17</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
See:
 - [JENKINS-75278](https://issues.jenkins.io/browse/JENKINS-75278)
 - [JENKINS-75321](https://issues.jenkins.io/browse/JENKINS-75321)

```console
Fixed
-----

JENKINS-75278           Minor                   2025-02-13 11:10
        User pages for users with '\' in the user name fail after upgrading to 2.479.1
        bug
        https://issues.jenkins.io/browse/JENKINS-75278           

JENKINS-75321           Minor                   2025-02-21 13:28
        "No builds" displayed for a brief time when loading build history
        bug
        https://issues.jenkins.io/browse/JENKINS-75321
```

### Testing done

`mvn clean verify` passes with Java 21 on Linux

Interactive testing in my [home lab](https://github.com/MarkEWaite/docker-lfs/tree/lts-with-plugins) checked the following scenarios:

* Created a user "coleen-waite" and then edited the users.xml file to use `coleen\waite` as the username.  Restarted Jenkins and logged in as the user `coleen\waite`.  Launched many jobs as that user.  Viewed the user account, preferences, security, and experiments pages.  Confirmed that preferences could be changed and were honored
* Launched jobs that tested many different git providers like Assembla, Beanstalk, Bitbucket, GitHub, GitLab, and Microsoft
* Confirmed that the "No builds" was never displayed (needs a slower connection or longer response time to test it)

### Proposed changelog entries

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Proposed changelog entries

N/A

### Proposed upgrade guidelines

N/A

### Desired reviewers

* N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

