### PR TITLE
Add an indication of the language of the page in the footer. This enhancement improves accessibility and user experience by explicitly showing the language of the displayed content

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -218,17 +218,15 @@ THE SOFTWARE.
 
             <j:if test="${!empty(localeText)}">
               <div class="jenkins-page-generation-time">
-                  ${localeText == 'en' ? 'English' : 
-                  localeText == 'zh_TW' ? '中文 (繁體)' : 
+                  ${localeText == 'zh_TW' ? '中文 (繁體)' : 
                   localeText == 'tr' ? 'Türkçe' : 
                   localeText == 'ru' ? 'русский' : 
-                  'Unknown Language'}
+                  'English'}
                    &#160;&#160;&#160;&#160;
-                  ${localeText == 'en' ? 'Page generated' : 
-                    localeText == 'zh_TW' ? '畫面生成' : 
+                  ${localeText == 'zh_TW' ? '畫面生成' : 
                     localeText == 'tr' ? 'Sayfa oluşturuldu' : 
                     localeText == 'ru' ? 'Страница сгенерирована' : 
-                  'Unknown Language'}
+                  'Page generated'}
                   : <span id="page-gen-time"></span>
               </div>
             </j:if>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -213,8 +213,44 @@ THE SOFTWARE.
                        text="${%Website}"
                        href="${h.getFooterURL()}" />
             </l:overflowButton>
+
+            <j:set var="localeText" value="${request.getLocale()}"/>
+
+            <j:if test="${!empty(localeText)}">
+              <div class="jenkins-page-generation-time">
+                  ${localeText == 'en' ? 'English' : 
+                  localeText == 'zh_TW' ? '中文 (繁體)' : 
+                  localeText == 'tr' ? 'Türkçe' : 
+                  localeText == 'ru' ? 'русский' : 
+                  'Unknown Language'}
+                   &#160;&#160;&#160;&#160;
+                  ${localeText == 'en' ? 'Page generated' : 
+                    localeText == 'zh_TW' ? '畫面生成' : 
+                    localeText == 'tr' ? 'Sayfa oluşturuldu' : 
+                    localeText == 'ru' ? 'Страница сгенерирована' : 
+                  'Unknown Language'}
+                  : <span id="page-gen-time"></span>
+              </div>
+            </j:if>
           </div>
         </div>
+        <script type="text/javascript">
+            const options = { 
+                year: 'numeric', 
+                month: 'long', 
+                day: 'numeric', 
+                hour: '2-digit', 
+                minute: '2-digit', 
+                second: '2-digit', 
+                hour12: true, 
+                timeZoneName: 'short'
+            };
+            
+            const date = new Date();
+            const formattedDate = date.toLocaleString('en-GB', options).replace('at', '');;
+            
+            document.getElementById('page-gen-time').textContent = formattedDate;
+        </script>
       </footer>
     </j:if>
   </body>

--- a/src/main/scss/components/_page-footer.scss
+++ b/src/main/scss/components/_page-footer.scss
@@ -45,3 +45,17 @@
     display: none;
   }
 }
+
+.jenkins-page-generation-time {
+  pointer-events: none;
+  text-decoration: none;
+  background-color: transparent;
+  color: black;
+
+  &:hover,
+  &:focus {
+    color: black !important;
+    background-color: transparent !important;
+    text-decoration: none !important;
+  }
+}


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-62419](https://issues.jenkins.io/browse/JENKINS-62419).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Summary
This PR adds an indication of the language of the page in the footer. This enhancement improves accessibility and user experience by explicitly showing the language of the displayed content.

### Justification
Even if some localizations are missing, showing a baseline language is useful for users. The locale field should be determined from the response page so that plugins like Locale Plugin are handled correctly. Reference to the Locale Plugin filter:  
[LocaleFilter.java](https://github.com/jenkinsci/locale-plugin/blob/master/src/main/java/hudson/plugins/locale/LocaleFilter.java)

### Testing done
- Implemented changes in Jenkins Core.
- Verified that the Request object returns the correct Locale information when using the Locale Plugin.
- Screenshots attached:

	#### before：
	![screenshot-before](https://github.com/user-attachments/assets/5a314e00-3211-4931-a394-f18a7710d7a0)
	#### after：
	![screenshot-en](https://github.com/user-attachments/assets/fbfbbb8f-7780-40da-ae6c-9f5d002cf78c)
	![screenshot-ru](https://github.com/user-attachments/assets/068029e1-6cc1-4ae8-97a9-5ed9c505b541)
	![screenshot-tr](https://github.com/user-attachments/assets/a80d268c-1190-400b-933c-53d960e50c0b)

### Proposed changelog entries
- Indicate the language of the page in the footer to improve accessibility and user experience.

### Proposed changelog category
/label localization

### Proposed upgrade guidelines
N/A

### Submitter checklist
- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate.
- [X] There is automated testing or an explanation for the lack of tests.
- [X] New public classes, fields, and methods are annotated appropriately.
- [X] For dependency updates, external changelogs and full differentials are linked.
- [X] For new APIs, there is a link to at least one consumer.

### Desired reviewers
@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
