### PR TITLE
[Fixes JENKINS-75456] De-flake DisconnectNodeCommandTest

### DIFF
--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -85,38 +85,28 @@ public class DisconnectNodeCommandTest {
     @Test
     public void disconnectNodeShouldSucceed() throws Exception {
         DumbSlave slave = j.createSlave("aNode", "", null);
-        slave.toComputer().waitUntilOnline();
-        assertThat(slave.toComputer().isOnline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), equalTo(null));
+        assertOnline(slave);
 
         CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("aNode");
         assertThat(result, succeededSilently());
-        assertThat(slave.toComputer().isOffline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave.toComputer().getOfflineCause()).message, equalTo(null));
+        assertOffline(slave, null);
 
         slave.toComputer().connect(true);
-        slave.toComputer().waitUntilOnline();
-        assertThat(slave.toComputer().isOnline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), equalTo(null));
+        assertOnline(slave);
 
         result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("aNode");
         assertThat(result, succeededSilently());
-        assertThat(slave.toComputer().isOffline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave.toComputer().getOfflineCause()).message, equalTo(null));
+        assertOffline(slave, null);
 
         result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("aNode");
         assertThat(result, succeededSilently());
-        assertThat(slave.toComputer().isOffline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave.toComputer().getOfflineCause()).message, equalTo(null));
+        assertOffline(slave, null);
     }
 
     @Test
@@ -194,12 +184,8 @@ public class DisconnectNodeCommandTest {
     public void disconnectNodeManyShouldFailIfANodeDoesNotExist() throws Exception {
         DumbSlave slave1 = j.createSlave("aNode1", "", null);
         DumbSlave slave2 = j.createSlave("aNode2", "", null);
-        slave1.toComputer().waitUntilOnline();
-        assertThat(slave1.toComputer().isOnline(), equalTo(true));
-        assertThat(slave1.toComputer().getOfflineCause(), equalTo(null));
-        slave2.toComputer().waitUntilOnline();
-        assertThat(slave2.toComputer().isOnline(), equalTo(true));
-        assertThat(slave2.toComputer().getOfflineCause(), equalTo(null));
+        assertOnline(slave1);
+        assertOnline(slave2);
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
@@ -208,35 +194,23 @@ public class DisconnectNodeCommandTest {
         assertThat(result, hasNoStandardOutput());
         assertThat(result.stderr(), containsString("never_created: No such agent \"never_created\" exists. Did you mean \"aNode1\"?"));
         assertThat(result.stderr(), containsString("ERROR: " + CLICommand.CLI_LISTPARAM_SUMMARY_ERROR_TEXT));
-        assertThat(slave1.toComputer().isOffline(), equalTo(true));
-        assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo("aCause"));
-        assertThat(slave2.toComputer().isOffline(), equalTo(true));
-        assertThat(slave2.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave2.toComputer().getOfflineCause()).message, equalTo("aCause"));
+        assertOffline(slave1, "aCause");
+        assertOffline(slave2, "aCause");
     }
 
     @Test
     public void disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice() throws Exception {
         DumbSlave slave1 = j.createSlave("aNode1", "", null);
         DumbSlave slave2 = j.createSlave("aNode2", "", null);
-        slave1.toComputer().waitUntilOnline();
-        assertThat(slave1.toComputer().isOnline(), equalTo(true));
-        assertThat(slave1.toComputer().getOfflineCause(), equalTo(null));
-        slave2.toComputer().waitUntilOnline();
-        assertThat(slave2.toComputer().isOnline(), equalTo(true));
-        assertThat(slave2.toComputer().getOfflineCause(), equalTo(null));
+        assertOnline(slave1);
+        assertOnline(slave2);
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("aNode1", "aNode2", "aNode1", "-m", "aCause");
         assertThat(result, succeededSilently());
-        assertThat(slave1.toComputer().isOffline(), equalTo(true));
-        assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo("aCause"));
-        assertThat(slave2.toComputer().isOffline(), equalTo(true));
-        assertThat(slave2.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave2.toComputer().getOfflineCause()).message, equalTo("aCause"));
+        assertOffline(slave1, "aCause");
+        assertOffline(slave2, "aCause");
     }
 
     private static void assertOnline(DumbSlave slave) throws InterruptedException {

--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -122,38 +122,28 @@ public class DisconnectNodeCommandTest {
     @Test
     public void disconnectNodeShouldSucceedWithCause() throws Exception {
         DumbSlave slave = j.createSlave("aNode", "", null);
-        slave.toComputer().waitUntilOnline();
-        assertThat(slave.toComputer().isOnline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), equalTo(null));
+        assertOnline(slave);
 
         CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("aNode", "-m", "aCause");
         assertThat(result, succeededSilently());
-        assertThat(slave.toComputer().isOffline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave.toComputer().getOfflineCause()).message, equalTo("aCause"));
+        assertOffline(slave, "aCause");
 
         slave.toComputer().connect(true);
-        slave.toComputer().waitUntilOnline();
-        assertThat(slave.toComputer().isOnline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), equalTo(null));
+        assertOnline(slave);
 
         result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("aNode", "-m", "anotherCause");
         assertThat(result, succeededSilently());
-        assertThat(slave.toComputer().isOffline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave.toComputer().getOfflineCause()).message, equalTo("anotherCause"));
+        assertOffline(slave, "anotherCause");
 
         result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("aNode", "-m", "yetAnotherCause");
         assertThat(result, succeededSilently());
-        assertThat(slave.toComputer().isOffline(), equalTo(true));
-        assertThat(slave.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave.toComputer().getOfflineCause()).message, equalTo("yetAnotherCause"));
+        assertOffline(slave, "yetAnotherCause");
     }
 
     @Test
@@ -161,29 +151,17 @@ public class DisconnectNodeCommandTest {
         DumbSlave slave1 = j.createSlave("aNode1", "", null);
         DumbSlave slave2 = j.createSlave("aNode2", "", null);
         DumbSlave slave3 = j.createSlave("aNode3", "", null);
-        slave1.toComputer().waitUntilOnline();
-        assertThat(slave1.toComputer().isOnline(), equalTo(true));
-        assertThat(slave1.toComputer().getOfflineCause(), equalTo(null));
-        slave2.toComputer().waitUntilOnline();
-        assertThat(slave2.toComputer().isOnline(), equalTo(true));
-        assertThat(slave2.toComputer().getOfflineCause(), equalTo(null));
-        slave3.toComputer().waitUntilOnline();
-        assertThat(slave3.toComputer().isOnline(), equalTo(true));
-        assertThat(slave3.toComputer().getOfflineCause(), equalTo(null));
+        assertOnline(slave1);
+        assertOnline(slave2);
+        assertOnline(slave3);
 
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Computer.DISCONNECT, Jenkins.READ)
                 .invokeWithArgs("aNode1", "aNode2", "aNode3");
         assertThat(result, succeededSilently());
-        assertThat(slave1.toComputer().isOffline(), equalTo(true));
-        assertThat(slave1.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave1.toComputer().getOfflineCause()).message, equalTo(null));
-        assertThat(slave2.toComputer().isOffline(), equalTo(true));
-        assertThat(slave2.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave2.toComputer().getOfflineCause()).message, equalTo(null));
-        assertThat(slave3.toComputer().isOffline(), equalTo(true));
-        assertThat(slave3.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
-        assertThat(((OfflineCause.ByCLI) slave3.toComputer().getOfflineCause()).message, equalTo(null));
+        assertOffline(slave1, null);
+        assertOffline(slave2, null);
+        assertOffline(slave3, null);
     }
 
     @Test
@@ -194,10 +172,7 @@ public class DisconnectNodeCommandTest {
             agents.add(j.createSlave("aNode" + i, "", null));
         }
         for (var agent : agents) {
-            var computer = agent.toComputer();
-            computer.waitUntilOnline();
-            assertThat(computer.isOnline(), equalTo(true));
-            assertThat(computer.getOfflineCause(), equalTo(null));
+            assertOnline(agent);
         }
 
         var args = new ArrayList<String>();
@@ -211,14 +186,7 @@ public class DisconnectNodeCommandTest {
                 .invokeWithArgs(args.toArray(String[]::new));
         assertThat(result, succeededSilently());
         for (var agent : agents) {
-            var computer = agent.toComputer();
-            assertThat(computer.isOffline(), equalTo(true));
-            var cause = computer.getOfflineCause();
-            if (cause instanceof OfflineCause.ByCLI cliCause) {
-                assertThat(cliCause.message, equalTo("aCause"));
-            } else {
-                assertThat("seen occasionally in CI", cause, instanceOf(OfflineCause.ChannelTermination.class));
-            }
+            assertOffline(agent, "aCause");
         }
     }
 
@@ -269,5 +237,23 @@ public class DisconnectNodeCommandTest {
         assertThat(slave2.toComputer().isOffline(), equalTo(true));
         assertThat(slave2.toComputer().getOfflineCause(), instanceOf(OfflineCause.ByCLI.class));
         assertThat(((OfflineCause.ByCLI) slave2.toComputer().getOfflineCause()).message, equalTo("aCause"));
+    }
+
+    private static void assertOnline(DumbSlave slave) throws InterruptedException {
+        var computer = slave.toComputer();
+        computer.waitUntilOnline();
+        assertThat(computer.isOnline(), equalTo(true));
+        assertThat(computer.getOfflineCause(), equalTo(null));
+    }
+
+    private static void assertOffline(DumbSlave slave, String message) {
+        var computer = slave.toComputer();
+        assertThat(computer.isOffline(), equalTo(true));
+        var offlineCause = computer.getOfflineCause();
+        if (offlineCause instanceof OfflineCause.ByCLI cliCause) {
+            assertThat(cliCause.message, equalTo(message));
+        } else {
+            assertThat("seen occasionally in CI", offlineCause, instanceOf(OfflineCause.ChannelTermination.class));
+        }
     }
 }

--- a/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisconnectNodeCommandTest.java
@@ -227,7 +227,7 @@ public class DisconnectNodeCommandTest {
         if (offlineCause instanceof OfflineCause.ByCLI cliCause) {
             assertThat(cliCause.message, equalTo(message));
         } else {
-            assertThat("seen occasionally in CI", offlineCause, instanceOf(OfflineCause.ChannelTermination.class));
+            assertThat("sometimes overrides ByCLI", offlineCause, instanceOf(OfflineCause.ChannelTermination.class));
         }
     }
 }


### PR DESCRIPTION
See [JENKINS-75456](https://issues.jenkins.io/browse/JENKINS-75456), and taking reference from https://github.com/jenkinsci/jenkins/pull/10307

------------------------

I've recently noticed flakes in the DisconnectNodeCommandTest, which have impacted the CI execution for my other PR: https://github.com/jenkinsci/jenkins/pull/10396.

The table below contains links to the test failures. The build numbers in the table correspond to the builds of my mentioned PR.

They always fail with
```
Expected: an instance of hudson.slaves.OfflineCause$ByCLI
     but: <Connection was broken> is a hudson.slaves.OfflineCause$ChannelTermination
```

|Test name| failure occurreces|
|---|---|
|disconnectNodeManyShouldSucceed|[ref in build#11](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10396/11/testReport/hudson.cli/DisconnectNodeCommandTest/linux_jdk17___Linux___JDK_17___Build___Test___disconnectNodeManyShouldSucceed/), [ref in build#3](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10396/3/testReport/hudson.cli/DisconnectNodeCommandTest/linux_jdk17___Linux___JDK_17___Build___Test___disconnectNodeManyShouldSucceed/)|
|disconnectNodeShouldSucceedWithCause|[ref in build#9](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10396/9/testReport/hudson.cli/DisconnectNodeCommandTest/linux_jdk17___Linux___JDK_17___Build___Test___disconnectNodeShouldSucceedWithCause/), [ref in build#3](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10396/3/testReport/hudson.cli/DisconnectNodeCommandTest/linux_jdk17___Linux___JDK_17___Build___Test___disconnectNodeShouldSucceedWithCause/)|
|disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice|[ref in build#6](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10396/6/testReport/hudson.cli/DisconnectNodeCommandTest/linux_jdk17___Linux___JDK_17___Build___Test___disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice/)|

----------------------

I can reproduce the failures on my laptop about 40% of the time. The failing test is random among the ones mentioned.
I ran the tests more than 25 times using the following command:
```
mvn clean test -Dtest=DisconnectNodeCommandTest
```

**Example logs from local**

<details><summary>local failure - disconnectNodeManyShouldSucceed</summary>

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running hudson.cli.DisconnectNodeCommandTest
=== Starting disconnectNodeManyShouldSucceed(hudson.cli.DisconnectNodeCommandTest)
   0.052 [id=20]	INFO	o.jvnet.hudson.test.WarExploder#explode: Using jenkins.war resources from /Users/gbhat/CBProjects/jenkins/war/target/jenkins
   0.306 [id=20]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:49458/jenkins/
   0.366 [id=20]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.416 [id=35]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.991 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/command-launcher.jpi as a dependency of gradle
   1.002 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/apache-httpcomponents-client-4-api.jpi as a dependency of gradle
   1.023 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/jdk-tool.jpi as a dependency of gradle
   1.037 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/trilead-api.jpi as a dependency of gradle
   1.066 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/eddsa-api.jpi as a dependency of gradle
   1.071 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/gson-api.jpi as a dependency of gradle
   1.086 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/mina-sshd-api-common.jpi as a dependency of gradle
   1.097 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/mina-sshd-api-core.jpi as a dependency of gradle
   1.116 [id=53]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins2546161032237968349/sshd.jpi as a dependency of gradle
   1.345 [id=49]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   1.354 [id=42]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h8627155503259126653/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   1.912 [id=37]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   1.917 [id=34]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   1.917 [id=33]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   2.252 [id=35]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   2.252 [id=35]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   2.252 [id=55]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   2.255 [id=45]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   2.306 [id=35]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   2.921 [id=93]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode3
   3.020 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode2
   3.128 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode1
   3.263 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99845, exitValue=0] with {HUDSON_COOKIE=8ad95fb7-2798-4760-bfca-57810167d04a} for aNode3
   3.263 [id=102]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode3
   3.271 [id=101]	INFO	h.r.SynchronousCommandTransport$ReaderThread#run: I/O error in channel aNode2
java.io.EOFException
	at java.base/java.io.ObjectInputStream$PeekInputStream.readFully(ObjectInputStream.java:2915)
	at java.base/java.io.ObjectInputStream$BlockDataInputStream.readShort(ObjectInputStream.java:3410)
	at java.base/java.io.ObjectInputStream.readStreamHeader(ObjectInputStream.java:954)
	at java.base/java.io.ObjectInputStream.<init>(ObjectInputStream.java:392)
	at hudson.remoting.ObjectInputStreamEx.<init>(ObjectInputStreamEx.java:50)
	at hudson.remoting.Command.readFrom(Command.java:141)
	at hudson.remoting.Command.readFrom(Command.java:127)
	at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.read(AbstractSynchronousByteArrayCommandTransport.java:35)
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:62)
Caused: java.io.IOException: Unexpected termination of the channel
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:80)
   3.345 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99844, exitValue=143] with {HUDSON_COOKIE=3ccddc1c-f6c9-4b27-b26a-938e42f8329c} for aNode2
   3.345 [id=101]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   3.412 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99843, exitValue=143] with {HUDSON_COOKIE=b752c51e-642b-48ff-9e28-5d6e4683cee6} for aNode1
   3.412 [id=103]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
   3.435 [id=20]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   3.439 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode3
   3.440 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   3.440 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   3.463 [id=20]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   3.481 [id=20]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h8627155503259126653
=== Starting disconnectNodeShouldSucceed(hudson.cli.DisconnectNodeCommandTest)
   0.057 [id=126]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:49465/jenkins/
   0.067 [id=126]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.078 [id=139]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.079 [id=156]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.080 [id=139]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h3268783803261382938/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.143 [id=139]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.144 [id=145]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.145 [id=152]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.251 [id=159]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.251 [id=158]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.251 [id=143]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.252 [id=149]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.256 [id=161]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.721 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode
   0.784 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99857, exitValue=143] with {HUDSON_COOKIE=c697302a-4f2a-4cb9-a559-9dc531bb58e2} for aNode
   0.784 [id=183]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.232 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode
   1.317 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99864, exitValue=143] with {HUDSON_COOKIE=afba4395-6d9b-4e60-818b-2681ea9f7428} for aNode
   1.317 [id=192]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.352 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.369 [id=126]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   1.370 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   1.383 [id=126]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   1.398 [id=126]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h3268783803261382938
=== Starting disconnectNodeShouldFailIfNodeDoesNotExist(hudson.cli.DisconnectNodeCommandTest)
   0.049 [id=207]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:49468/jenkins/
   0.055 [id=207]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.065 [id=220]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.065 [id=238]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.067 [id=224]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h732118728648865708/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.128 [id=229]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.129 [id=223]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.129 [id=235]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.203 [id=235]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.203 [id=240]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.203 [id=222]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.203 [id=222]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.207 [id=233]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.303 [id=207]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   0.319 [id=207]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   0.336 [id=207]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h732118728648865708
=== Starting disconnectNodeShouldFailWithoutComputerDisconnectPermission(hudson.cli.DisconnectNodeCommandTest)
   0.050 [id=266]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:49473/jenkins/
   0.059 [id=266]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.068 [id=279]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.068 [id=296]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.070 [id=292]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h16439883957225426757/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.128 [id=281]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.129 [id=280]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.129 [id=290]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.249 [id=290]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.249 [id=292]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.250 [id=292]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.250 [id=288]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.254 [id=286]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.326 [id=266]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   0.329 [id=83]	WARNING	o.j.h.test.SimpleCommandLauncher#launch
java.io.EOFException: unexpected stream termination
	at hudson.remoting.ChannelBuilder.negotiate(ChannelBuilder.java:493)
	at hudson.remoting.ChannelBuilder.build(ChannelBuilder.java:437)
	at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:440)
	at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:407)
	at org.jvnet.hudson.test.SimpleCommandLauncher.launch(SimpleCommandLauncher.java:83)
	at hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:297)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
   0.363 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99866, exitValue=143] with {HUDSON_COOKIE=45f498d6-6d31-4892-936f-afc548ba9069} for aNode
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   0.363 [id=266]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   0.379 [id=266]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h16439883957225426757
=== Starting disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice(hudson.cli.DisconnectNodeCommandTest)
   0.060 [id=330]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:49478/jenkins/
   0.068 [id=330]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.076 [id=343]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.077 [id=360]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.078 [id=350]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h11624881250035241034/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.131 [id=355]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.132 [id=355]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.132 [id=363]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.223 [id=342]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.223 [id=364]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.223 [id=361]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.224 [id=343]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.228 [id=363]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.718 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode2
   0.821 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode1
   0.880 [id=93]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99868, exitValue=143] with {HUDSON_COOKIE=4e1c7c51-c4fb-4170-9295-d549ccdff245} for aNode2
   0.880 [id=392]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   0.955 [id=93]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99867, exitValue=143] with {HUDSON_COOKIE=4dbe43be-1f07-49d1-86db-77ffcedb33a5} for aNode1
   0.956 [id=391]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
   0.976 [id=330]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   0.977 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   0.978 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   0.988 [id=330]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   1.004 [id=330]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h11624881250035241034
=== Starting disconnectNodeManyShouldFailIfANodeDoesNotExist(hudson.cli.DisconnectNodeCommandTest)
   0.044 [id=406]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:49482/jenkins/
   0.053 [id=406]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.061 [id=419]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.061 [id=437]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.062 [id=441]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h6389703467877810732/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.116 [id=432]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.116 [id=441]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.117 [id=433]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.219 [id=418]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.220 [id=436]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.220 [id=436]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.220 [id=418]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.224 [id=427]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.714 [id=93]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode2
   0.815 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode1
   0.865 [id=109]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99878, exitValue=143] with {HUDSON_COOKIE=b99469a9-160b-4bfa-96f3-8cc4df2c1e7f} for aNode2
   0.865 [id=468]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   0.932 [id=109]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99877, exitValue=143] with {HUDSON_COOKIE=7870e7d4-8f11-4311-8eb7-2bb2651d67e8} for aNode1
   0.932 [id=467]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
   0.953 [id=406]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   0.955 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   0.955 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   0.969 [id=406]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   0.988 [id=406]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h6389703467877810732
=== Starting disconnectNodeShouldSucceedWithCause(hudson.cli.DisconnectNodeCommandTest)
   0.047 [id=482]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:49485/jenkins/
   0.056 [id=482]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.063 [id=495]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.064 [id=512]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.065 [id=517]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h12096839586984300337/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.121 [id=517]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.122 [id=499]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.122 [id=514]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.192 [id=516]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.192 [id=496]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.192 [id=497]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.192 [id=497]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.196 [id=513]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.648 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode
   0.693 [id=93]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99880, exitValue=143] with {HUDSON_COOKIE=3004e016-c9b6-47a1-964b-dbdc6b5b7f5f} for aNode
   0.693 [id=539]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.135 [id=93]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode
   1.221 [id=109]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99887, exitValue=143] with {HUDSON_COOKIE=ac6c5e97-48b2-49df-bcb7-5efe12794808} for aNode
   1.222 [id=548]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.259 [id=109]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.277 [id=482]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   1.278 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   1.295 [id=482]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   1.316 [id=482]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h12096839586984300337
=== Starting disconnectNodeManyShouldSucceedWithCause(hudson.cli.DisconnectNodeCommandTest)
   0.045 [id=563]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:49488/jenkins/
   0.054 [id=563]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.062 [id=576]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.062 [id=593]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.063 [id=596]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h15340928632870977181/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.117 [id=596]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.117 [id=583]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.117 [id=583]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.195 [id=583]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.196 [id=595]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.196 [id=595]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.196 [id=578]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.200 [id=576]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.694 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode1
   0.800 [id=109]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode2
   0.900 [id=93]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode3
   0.974 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99896, exitValue=143] with {HUDSON_COOKIE=1fa16e74-8430-466e-ad25-5726ac3a6a63} for aNode3
   0.975 [id=630]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode3
   0.991 [id=629]	INFO	h.r.SynchronousCommandTransport$ReaderThread#run: I/O error in channel aNode2
java.io.EOFException
	at java.base/java.io.ObjectInputStream$PeekInputStream.readFully(ObjectInputStream.java:2915)
	at java.base/java.io.ObjectInputStream$BlockDataInputStream.readShort(ObjectInputStream.java:3410)
	at java.base/java.io.ObjectInputStream.readStreamHeader(ObjectInputStream.java:954)
	at java.base/java.io.ObjectInputStream.<init>(ObjectInputStream.java:392)
	at hudson.remoting.ObjectInputStreamEx.<init>(ObjectInputStreamEx.java:50)
	at hudson.remoting.Command.readFrom(Command.java:141)
	at hudson.remoting.Command.readFrom(Command.java:127)
	at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.read(AbstractSynchronousByteArrayCommandTransport.java:35)
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:62)
Caused: java.io.IOException: Unexpected termination of the channel
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:80)
   1.030 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99895, exitValue=143] with {HUDSON_COOKIE=72ca7297-80d1-4838-a1a2-5e13a07998cd} for aNode2
   1.031 [id=629]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   1.046 [id=628]	INFO	h.r.SynchronousCommandTransport$ReaderThread#run: I/O error in channel aNode1
java.io.EOFException
	at java.base/java.io.ObjectInputStream$PeekInputStream.readFully(ObjectInputStream.java:2915)
	at java.base/java.io.ObjectInputStream$BlockDataInputStream.readShort(ObjectInputStream.java:3410)
	at java.base/java.io.ObjectInputStream.readStreamHeader(ObjectInputStream.java:954)
	at java.base/java.io.ObjectInputStream.<init>(ObjectInputStream.java:392)
	at hudson.remoting.ObjectInputStreamEx.<init>(ObjectInputStreamEx.java:50)
	at hudson.remoting.Command.readFrom(Command.java:141)
	at hudson.remoting.Command.readFrom(Command.java:127)
	at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.read(AbstractSynchronousByteArrayCommandTransport.java:35)
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:62)
Caused: java.io.IOException: Unexpected termination of the channel
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:80)
   1.112 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=99894, exitValue=143] with {HUDSON_COOKIE=fa0ac6c7-0635-4d6d-a285-95bf08367066} for aNode1
   1.113 [id=628]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
   1.131 [id=563]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   1.133 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode3
   1.133 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   1.133 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   1.149 [id=563]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   1.168 [id=563]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h15340928632870977181
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 10.43 s <<< FAILURE! -- in hudson.cli.DisconnectNodeCommandTest
[ERROR] hudson.cli.DisconnectNodeCommandTest.disconnectNodeManyShouldSucceed -- Time elapsed: 3.798 s <<< FAILURE!
java.lang.AssertionError:

Expected: an instance of hudson.slaves.OfflineCause$ByCLI
     but: <Connection was broken> is a hudson.slaves.OfflineCause$ChannelTermination
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at hudson.cli.DisconnectNodeCommandTest.disconnectNodeManyShouldSucceed(DisconnectNodeCommandTest.java:182)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:659)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:840)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   DisconnectNodeCommandTest.disconnectNodeManyShouldSucceed:182
Expected: an instance of hudson.slaves.OfflineCause$ByCLI
     but: <Connection was broken> is a hudson.slaves.OfflineCause$ChannelTermination
[INFO]
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22.549 s
[INFO] Finished at: 2025-03-20T12:02:01+05:30
[INFO] ------------------------------------------------------------------------
```
</details>

<details><summary>local failure - disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice</summary>

```
[INFO] Running hudson.cli.DisconnectNodeCommandTest
=== Starting disconnectNodeManyShouldSucceed(hudson.cli.DisconnectNodeCommandTest)
   0.053 [id=20]	INFO	o.jvnet.hudson.test.WarExploder#explode: Using jenkins.war resources from /Users/gbhat/CBProjects/jenkins/war/target/jenkins
   0.317 [id=20]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:50458/jenkins/
   0.386 [id=20]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.439 [id=35]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   1.029 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/command-launcher.jpi as a dependency of gradle
   1.039 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/apache-httpcomponents-client-4-api.jpi as a dependency of gradle
   1.060 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/jdk-tool.jpi as a dependency of gradle
   1.081 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/trilead-api.jpi as a dependency of gradle
   1.110 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/eddsa-api.jpi as a dependency of gradle
   1.114 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/gson-api.jpi as a dependency of gradle
   1.129 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/mina-sshd-api-common.jpi as a dependency of gradle
   1.140 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/mina-sshd-api-core.jpi as a dependency of gradle
   1.159 [id=44]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins4117894325428321725/sshd.jpi as a dependency of gradle
   1.391 [id=55]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   1.401 [id=56]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h9003882254723767457/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   1.955 [id=48]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   1.961 [id=46]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   1.961 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   2.257 [id=39]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   2.258 [id=51]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   2.258 [id=45]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   2.260 [id=44]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   2.310 [id=52]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   2.904 [id=93]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode3
   3.012 [id=83]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode1
   3.114 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode2
   3.249 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4500, exitValue=0] with {HUDSON_COOKIE=b72b40f0-df8d-4987-9c56-acd50488f4f9} for aNode3
   3.249 [id=103]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode3
   3.340 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4499, exitValue=143] with {HUDSON_COOKIE=ac01ee2d-e592-4cb8-a56e-0bf24405fe9e} for aNode2
   3.342 [id=102]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   3.425 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4498, exitValue=143] with {HUDSON_COOKIE=73f92672-7384-40b5-9f16-f91af841778c} for aNode1
   3.425 [id=101]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
   3.449 [id=20]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   3.454 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode3
   3.454 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   3.455 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   3.483 [id=20]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   3.506 [id=20]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h9003882254723767457
=== Starting disconnectNodeShouldSucceed(hudson.cli.DisconnectNodeCommandTest)
   0.058 [id=126]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:50466/jenkins/
   0.067 [id=126]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.076 [id=139]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.077 [id=156]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.078 [id=159]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h14793724899303834154/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.150 [id=153]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.151 [id=140]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.151 [id=148]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.273 [id=146]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.273 [id=155]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.273 [id=156]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.273 [id=156]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.277 [id=161]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.742 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode
   0.800 [id=108]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4517, exitValue=143] with {HUDSON_COOKIE=a361c506-e9ec-4cee-8462-b3796c5a1f08} for aNode
   0.800 [id=183]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.245 [id=108]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode
   1.324 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4520, exitValue=143] with {HUDSON_COOKIE=cc70d441-99b5-43fc-8487-4af67aaac036} for aNode
   1.324 [id=192]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.349 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.364 [id=126]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   1.365 [id=108]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   1.377 [id=126]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   1.395 [id=126]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h14793724899303834154
=== Starting disconnectNodeShouldFailIfNodeDoesNotExist(hudson.cli.DisconnectNodeCommandTest)
   0.063 [id=207]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:50473/jenkins/
   0.073 [id=207]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.083 [id=220]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.084 [id=237]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.085 [id=235]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h3136718683709537032/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.150 [id=220]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.151 [id=239]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.151 [id=221]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.362 [id=226]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.363 [id=232]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.363 [id=241]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.363 [id=241]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.367 [id=242]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.443 [id=207]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   0.460 [id=207]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   0.477 [id=207]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h3136718683709537032
=== Starting disconnectNodeShouldFailWithoutComputerDisconnectPermission(hudson.cli.DisconnectNodeCommandTest)
   0.043 [id=266]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:50476/jenkins/
   0.050 [id=266]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.059 [id=279]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.060 [id=296]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.061 [id=289]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h15345889817949594240/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.122 [id=301]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.123 [id=281]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.123 [id=288]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.237 [id=300]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.237 [id=281]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.237 [id=278]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.237 [id=282]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.241 [id=288]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.318 [id=266]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   0.320 [id=108]	WARNING	o.j.h.test.SimpleCommandLauncher#launch
java.io.EOFException: unexpected stream termination
	at hudson.remoting.ChannelBuilder.negotiate(ChannelBuilder.java:493)
	at hudson.remoting.ChannelBuilder.build(ChannelBuilder.java:437)
	at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:440)
	at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:407)
	at org.jvnet.hudson.test.SimpleCommandLauncher.launch(SimpleCommandLauncher.java:83)
	at hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:297)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
   0.356 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4531, exitValue=143] with {HUDSON_COOKIE=632f01a4-a160-4abc-b8e9-66f05db74f20} for aNode
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   0.356 [id=266]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   0.374 [id=266]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h15345889817949594240
=== Starting disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice(hudson.cli.DisconnectNodeCommandTest)
   0.051 [id=330]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:50479/jenkins/
   0.059 [id=330]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.068 [id=343]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.069 [id=360]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.070 [id=363]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h7344918633919655176/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.132 [id=365]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.133 [id=355]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.133 [id=358]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.225 [id=363]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.226 [id=352]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.226 [id=359]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.226 [id=355]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.230 [id=343]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.706 [id=87]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode1
   0.813 [id=108]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode2
   0.872 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4533, exitValue=143] with {HUDSON_COOKIE=6058d70f-9445-470b-87c9-43ad5e7cb9e1} for aNode2
   0.872 [id=392]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   0.877 [id=391]	INFO	h.r.SynchronousCommandTransport$ReaderThread#run: I/O error in channel aNode1
java.io.EOFException
	at java.base/java.io.ObjectInputStream$PeekInputStream.readFully(ObjectInputStream.java:2915)
	at java.base/java.io.ObjectInputStream$BlockDataInputStream.readShort(ObjectInputStream.java:3410)
	at java.base/java.io.ObjectInputStream.readStreamHeader(ObjectInputStream.java:954)
	at java.base/java.io.ObjectInputStream.<init>(ObjectInputStream.java:392)
	at hudson.remoting.ObjectInputStreamEx.<init>(ObjectInputStreamEx.java:50)
	at hudson.remoting.Command.readFrom(Command.java:141)
	at hudson.remoting.Command.readFrom(Command.java:127)
	at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.read(AbstractSynchronousByteArrayCommandTransport.java:35)
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:62)
Caused: java.io.IOException: Unexpected termination of the channel
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:80)
   0.937 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4532, exitValue=143] with {HUDSON_COOKIE=46596e4e-c61b-4f2d-a698-2398294ac263} for aNode1
   0.937 [id=391]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
   0.952 [id=330]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   0.953 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   0.953 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   0.967 [id=330]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   0.983 [id=330]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h7344918633919655176
=== Starting disconnectNodeManyShouldFailIfANodeDoesNotExist(hudson.cli.DisconnectNodeCommandTest)
   0.042 [id=406]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:50482/jenkins/
   0.049 [id=406]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.058 [id=419]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.058 [id=436]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.059 [id=430]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h7932132530179420085/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.113 [id=436]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.114 [id=424]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.114 [id=420]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.175 [id=438]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.175 [id=424]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.175 [id=428]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.176 [id=420]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.179 [id=431]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.640 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode1
   0.748 [id=108]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode2
   0.799 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4535, exitValue=143] with {HUDSON_COOKIE=14a224d7-7883-42d5-a272-68fadc585d25} for aNode2
   0.799 [id=468]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   0.850 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4534, exitValue=143] with {HUDSON_COOKIE=792b7e3d-bab4-40be-8124-fa0f8090befa} for aNode1
   0.850 [id=467]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
   0.868 [id=406]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   0.869 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   0.870 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   0.882 [id=406]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   0.899 [id=406]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h7932132530179420085
=== Starting disconnectNodeShouldSucceedWithCause(hudson.cli.DisconnectNodeCommandTest)
   0.042 [id=482]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:50486/jenkins/
   0.052 [id=482]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.059 [id=495]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.060 [id=513]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.060 [id=498]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h6638739865216180435/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.113 [id=512]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.113 [id=512]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.114 [id=511]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.218 [id=502]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.219 [id=495]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.219 [id=495]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.219 [id=502]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.223 [id=511]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.678 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode
   0.733 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4545, exitValue=143] with {HUDSON_COOKIE=49955e2e-3c60-40ed-a493-e63abd172184} for aNode
   0.733 [id=539]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.166 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode
   1.214 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4551, exitValue=143] with {HUDSON_COOKIE=bbe3e4c5-f869-4431-bbae-4679622da4b7} for aNode
   1.214 [id=548]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.243 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
   1.259 [id=482]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   1.261 [id=108]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   1.279 [id=482]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   1.298 [id=482]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h6638739865216180435
=== Starting disconnectNodeManyShouldSucceedWithCause(hudson.cli.DisconnectNodeCommandTest)
   0.043 [id=563]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:50490/jenkins/
   0.050 [id=563]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.503-SNAPSHOT
   0.058 [id=576]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.058 [id=594]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.059 [id=585]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/jenkins/test/target/j h16058240300886579459/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.110 [id=582]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.110 [id=589]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.110 [id=595]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.181 [id=588]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.181 [id=581]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.181 [id=581]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.181 [id=581]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.185 [id=591]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.659 [id=108]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode1
   0.763 [id=107]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode2
   0.865 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for aNode3
   0.916 [id=106]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4556, exitValue=143] with {HUDSON_COOKIE=29764774-5a5d-4b74-a267-276f0a33eb0c} for aNode3
   0.916 [id=630]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode3
   0.970 [id=106]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4555, exitValue=143] with {HUDSON_COOKIE=91a462c1-84ed-49fa-96e9-d62e62a2d117} for aNode2
   0.971 [id=629]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   1.043 [id=106]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=4554, exitValue=143] with {HUDSON_COOKIE=f653645f-59e1-458a-a429-190bc616a27d} for aNode1
   1.043 [id=628]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
   1.059 [id=563]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   1.060 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode3
   1.060 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode2
   1.061 [id=105]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for aNode1
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
   1.071 [id=563]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   1.090 [id=563]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/jenkins/test/target/j h16058240300886579459
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 10.38 s <<< FAILURE! -- in hudson.cli.DisconnectNodeCommandTest
[ERROR] hudson.cli.DisconnectNodeCommandTest.disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice -- Time elapsed: 0.990 s <<< FAILURE!
java.lang.AssertionError:

Expected: an instance of hudson.slaves.OfflineCause$ByCLI
     but: <Connection was broken> is a hudson.slaves.OfflineCause$ChannelTermination
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at hudson.cli.DisconnectNodeCommandTest.disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice(DisconnectNodeCommandTest.java:267)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:659)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:840)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   DisconnectNodeCommandTest.disconnectNodeManyShouldSucceedEvenANodeIsSpecifiedTwice:267
Expected: an instance of hudson.slaves.OfflineCause$ByCLI
     but: <Connection was broken> is a hudson.slaves.OfflineCause$ChannelTermination
[INFO]
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22.436 s
[INFO] Finished at: 2025-03-20T12:13:25+05:30
[INFO] ------------------------------------------------------------------------
```
</details>

### Testing done

Manual testing to reproduce the issue (see the details above). After the fix the tests are passing

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label skip-changelog
/label tests

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jglick, @Vlatombe

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
