### PR TITLE
Improve avatars in high contrast mode

### DIFF
--- a/src/main/js/components/command-palette/models.js
+++ b/src/main/js/components/command-palette/models.js
@@ -19,7 +19,7 @@ export function LinkResult(params) {
       return `<a class="jenkins-command-palette__results__item" href="${xmlEscape(
         params.url,
       )}">
-        ${params.type === "image" ? `<img alt="${xmlEscape(params.label)}" class="jenkins-command-palette__results__item__icon" src="${params.icon}" />` : ""}
+        ${params.type === "image" ? `<img alt="${xmlEscape(params.label)}" class="jenkins-command-palette__results__item__icon jenkins-avatar" src="${params.icon}" />` : ""}
         ${params.type !== "image" ? `<div class="jenkins-command-palette__results__item__icon">${params.icon}</div>` : ""}
         ${xmlEscape(params.label)}
         ${params.isExternal ? Symbols.EXTERNAL_LINK : ""}

--- a/src/main/scss/components/_avatar.scss
+++ b/src/main/scss/components/_avatar.scss
@@ -1,8 +1,14 @@
 .jenkins-avatar {
   &[src] {
     border-radius: 100px;
-    outline: 1px solid color-mix(in sRGB, var(--text-color) 10%, transparent);
-    background: color-mix(in sRGB, var(--text-color) 5%, transparent);
-    outline-offset: -1px;
+    outline: var(--jenkins-border-width) solid
+      color-mix(in sRGB, var(--text-color-secondary) 10%, transparent);
+    background: color-mix(in sRGB, var(--text-color-secondary) 5%, transparent);
+    outline-offset: calc(var(--jenkins-border-width) * -1);
+    object-fit: cover;
+
+    @media (prefers-contrast: more) {
+      outline-color: var(--text-color);
+    }
   }
 }

--- a/src/main/scss/components/_command-palette.scss
+++ b/src/main/scss/components/_command-palette.scss
@@ -186,14 +186,6 @@ $command-palette-background: color-mix(
           width: 1.25rem;
           height: 1.25rem;
         }
-
-        &[src] {
-          border-radius: 100px;
-          outline: 1px solid
-            color-mix(in sRGB, var(--text-color) 10%, transparent);
-          background: color-mix(in sRGB, var(--text-color) 5%, transparent);
-          outline-offset: -1px;
-        }
       }
 
       &__description {


### PR DESCRIPTION
Small one to improve the appearance of avatars in high contrast mode.

**What’s changed**

* A solid border now appears around avatars in high contrast mode
* Reduce code duplication by using `jenkins-avatar` class in Command Palette

_Default_

<img width="203" alt="image" src="https://github.com/user-attachments/assets/d8ade228-2b0d-4a6d-816a-a4d3e95c25b8" />

_High contrast_

<img width="197" alt="image" src="https://github.com/user-attachments/assets/59ede8bf-6cce-40a1-8503-72df584e774b" />

---

**How do I turn high contrast mode on?**

Check your system’s settings, e.g. on macOS it’s System Settings > Accessibility > Display > Increase contrast.

### Testing done

* Avatars appear as expected by default
* Avatars appear as expected in high contrast mode

### Proposed changelog entries

- N/A

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
