### PR TITLE
Fix missing accessible names for UI buttons

### DIFF
--- a/core/src/main/resources/lib/layout/header/searchbox.jelly
+++ b/core/src/main/resources/lib/layout/header/searchbox.jelly
@@ -14,7 +14,7 @@
       </div>
     </j:set>
 
-    <button id="button-open-command-palette"
+    <button id="button-open-command-palette" aria-label="Open Search"
             data-html-tooltip="${commandPaletteTooltip}"
             data-keyboard-shortcut="CMD+K"
             data-search-url="${rootURL + '/search/suggest'}"


### PR DESCRIPTION
Title: Fix missing accessible name for command palette button identified by Lighthouse

Description: This PR addresses an accessibility issue identified by a Lighthouse audit, where the `button#button-open-command-palette` lacked an accessible name, making it unusable for screen reader users. The fix adds an `aria-label="Open Search"` to the button to ensure proper accessibility.

**CI Status**: Currently, there are 4 in-progress checks (Jenkins, Linux JDK 17, Linux JDK 21, Windows JDK 17) running for 27–34 minutes, 1 pending check (continuous-integration/jenkins/pr-head), and 3 successful checks. Additional time (estimated 30–90 minutes) may be required for all checks to complete.

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

### Testing done
- Verified that the `button#button-open-command-palette` now has an accessible name (`aria-label="Open Search"`).
- Used Lighthouse accessibility audit to confirm the fix for the button.
- Manually tested using screen reader tools to check proper label recognition for the button.

### Proposed changelog entries
- Improved accessibility: Added an accessible name to the `button#button-open-command-palette` button.

### Proposed changelog category
/label accessibility, bug

### Proposed upgrade guidelines
N/A

### Submitter checklist
- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
@jenkinsci/core-pr-reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).