### PR TITLE
[JENKINS-75571] Upgrade core from EE 9 to EE 10

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -32,6 +32,9 @@
     <file url="file://$PROJECT_DIR$/websocket/jetty12-ee9/src/filter/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/jetty12-ee9/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/jetty12-ee9/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/websocket/jetty12-ee10/src/filter/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/websocket/jetty12-ee10/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/websocket/jetty12-ee10/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/spi/src/filter/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/spi/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/websocket/spi/src/main/resources" charset="UTF-8" />

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,8 +40,10 @@ THE SOFTWARE.
   <properties>
     <commons-fileupload2.version>2.0.0-M2</commons-fileupload2.version>
     <groovy.version>2.4.21</groovy.version>
-    <jelly.version>1.1-jenkins-20250108</jelly.version>
-    <stapler.version>1971.vf47a_d79853d7</stapler.version>
+    <!-- TODO https://github.com/jenkinsci/jelly/pull/140 -->
+    <jelly.version>1.1-jenkins-20250109-rc236.04a_a_57a_f8d9b_</jelly.version>
+    <!-- TODO https://github.com/jenkinsci/stapler/pull/617 -->
+    <stapler.version>1972.va_2b_2b_d237eca_</stapler.version>
   </properties>
 
   <dependencyManagement>
@@ -129,12 +131,12 @@ THE SOFTWARE.
       <dependency>
         <groupId>jakarta.servlet</groupId>
         <artifactId>jakarta.servlet-api</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0</version>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet.jsp.jstl</groupId>
         <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-        <version>2.0.0</version>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>jaxen</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@ THE SOFTWARE.
     <module>bom</module>
     <module>websocket/spi</module>
     <module>websocket/jetty12-ee9</module>
+    <module>websocket/jetty12-ee10</module>
     <module>core</module>
     <module>war</module>
     <module>test</module>
@@ -96,8 +97,9 @@ THE SOFTWARE.
     <antlr.version>4.13.2</antlr.version>
     <bridge-method-injector.version>1.31</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
-    <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.7</winstone.version>
+    <!-- Make sure to keep the jetty-ee10-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
+    <!-- TODO https://github.com/jenkinsci/winstone/pull/422 -->
+    <winstone.version>8.8-rc969.23328d87ea_d1</winstone.version>
     <node.version>20.19.0</node.version>
   </properties>
 

--- a/test/src/test/java/jenkins/util/SystemPropertiesTest.java
+++ b/test/src/test/java/jenkins/util/SystemPropertiesTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 import jakarta.servlet.ServletContextEvent;
-import org.eclipse.jetty.ee9.webapp.WebAppContext;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assume;
@@ -103,7 +103,7 @@ public class SystemPropertiesTest {
      * @param value value of the property
      */
     protected void setWebAppInitParameter(String property, String value) {
-        Assume.assumeThat(j.jenkins.getServletContext(), Matchers.instanceOf(WebAppContext.Context.class));
-        ((WebAppContext.Context) j.jenkins.getServletContext()).getContextHandler().getInitParams().put(property, value);
+        Assume.assumeThat(j.jenkins.getServletContext(), Matchers.instanceOf(WebAppContext.ServletApiContext.class));
+        ((WebAppContext.ServletApiContext) j.jenkins.getServletContext()).getContext().getServletContextHandler().getInitParams().put(property, value);
     }
 }

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -82,6 +82,11 @@ THE SOFTWARE.
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>websocket-jetty12-ee10</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
       <artifactId>websocket-jetty12-ee9</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -158,6 +163,7 @@ THE SOFTWARE.
                     <exclude>org.jenkins-ci.main:jenkins-core</exclude>
                     <exclude>org.jenkins-ci.main:remoting</exclude>
                     <exclude>org.jenkins-ci.main:websocket-jetty12-ee9</exclude>
+                    <exclude>org.jenkins-ci.main:websocket-jetty12-ee10</exclude>
                     <exclude>org.jenkins-ci.main:websocket-spi</exclude>
                     <exclude>org.jenkins-ci:memory-monitor</exclude>
                     <exclude>org.jenkins-ci:symbol-annotation</exclude>
@@ -580,7 +586,7 @@ THE SOFTWARE.
             </configuration>
           </execution>
           <execution>
-            <!-- see jetty-ee9-maven-plugin config and WebAppMain -->
+            <!-- see jetty-ee10-maven-plugin config and WebAppMain -->
             <id>support-log-formatter</id>
             <goals>
               <goal>copy</goal>
@@ -646,8 +652,8 @@ THE SOFTWARE.
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.jetty.ee9</groupId>
-        <artifactId>jetty-ee9-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-maven-plugin</artifactId>
         <!--
           Make sure to keep the Winstone version in pom.xml in sync with this version. If the current Winstone release
           contains a version of Jetty that is older than this, trigger Dependabot in jenkinsci/winstone and release the

--- a/websocket/jetty12-ee10/pom.xml
+++ b/websocket/jetty12-ee10/pom.xml
@@ -32,9 +32,9 @@ THE SOFTWARE.
     <relativePath>../..</relativePath>
   </parent>
 
-  <artifactId>websocket-jetty12-ee9</artifactId>
-  <name>Jetty 12 (EE 9) implementation for WebSocket</name>
-  <description>An implementation of the WebSocket handler that works with Jetty 12 (EE 9).</description>
+  <artifactId>websocket-jetty12-ee10</artifactId>
+  <name>Jetty 12 (EE 10) implementation for WebSocket</name>
+  <description>An implementation of the WebSocket handler that works with Jetty 12 (EE 10).</description>
 
   <dependencyManagement>
     <dependencies>
@@ -52,7 +52,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>winstone</artifactId>
-      <version>8.7</version>
+      <version>${winstone.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/websocket/jetty12-ee10/src/main/java/jenkins/websocket/Jetty12EE10Provider.java
+++ b/websocket/jetty12-ee10/src/main/java/jenkins/websocket/Jetty12EE10Provider.java
@@ -1,0 +1,180 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022, 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.websocket;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.Future;
+import org.eclipse.jetty.ee10.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.ee10.websocket.server.JettyServerUpgradeResponse;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.websocket.api.Callback;
+import org.eclipse.jetty.websocket.api.Session;
+import org.kohsuke.MetaInfServices;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+@MetaInfServices(Provider.class)
+public class Jetty12EE10Provider implements Provider {
+
+    /**
+     * Number of seconds a WebsocketConnection may stay idle until it expires. Zero to disable. This
+     * value must be higher than the <code>jenkins.websocket.pingInterval</code>. Per <a
+     * href=https://eclipse.dev/jetty/documentation/jetty-12/programming-guide/index.html#pg-websocket-session-ping>Jetty
+     * 12 documentation</a> a ping mechanism should keep the websocket active. Therefore, the idle
+     * timeout must be higher than the ping interval to avoid timeout issues.
+     */
+    private static long IDLE_TIMEOUT_SECONDS = Long.getLong("jenkins.websocket.idleTimeout", 60L);
+
+    private static final String ATTR_LISTENER = Jetty12EE10Provider.class.getName() + ".listener";
+
+    private boolean initialized = false;
+
+    public Jetty12EE10Provider() {
+        JettyWebSocketServerContainer.class.hashCode();
+    }
+
+    private void init(HttpServletRequest req) {
+        if (!initialized) {
+            JettyWebSocketServerContainer.getContainer(req.getServletContext()).setIdleTimeout(Duration.ofSeconds(IDLE_TIMEOUT_SECONDS));
+            initialized = true;
+        }
+    }
+
+    @Override
+    public Handler handle(HttpServletRequest req, HttpServletResponse rsp, Listener listener) throws Exception {
+        init(req);
+        req.setAttribute(ATTR_LISTENER, listener);
+        // TODO Jetty 10+ has no obvious equivalent to WebSocketServerFactory.isUpgradeRequest; RFC6455Negotiation?
+        if (!"websocket".equalsIgnoreCase(req.getHeader("Upgrade"))) {
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, "only WS connections accepted here");
+            return null;
+        }
+        if (!JettyWebSocketServerContainer.getContainer(req.getServletContext()).upgrade(Jetty12EE10Provider::createWebSocket, req, rsp)) {
+            rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, "did not manage to upgrade");
+            return null;
+        }
+        return new Handler() {
+            @Override
+            public Future<Void> sendBinary(ByteBuffer data) {
+                Callback.Completable f = new Callback.Completable();
+                session().sendBinary(data, f);
+                return f;
+            }
+
+            @Override
+            public Future<Void> sendBinary(ByteBuffer partialByte, boolean isLast) {
+                Callback.Completable f = new Callback.Completable();
+                session().sendPartialBinary(partialByte, isLast, f);
+                return f;
+            }
+
+            @Override
+            public Future<Void> sendText(String text) {
+                Callback.Completable f = new Callback.Completable();
+                session().sendText(text, f);
+                return f;
+            }
+
+            @Override
+            public Future<Void> sendPing(ByteBuffer applicationData) {
+                Callback.Completable f = new Callback.Completable();
+                session().sendPing(applicationData, f);
+                return f;
+            }
+
+            @Override
+            public void close() {
+                session().close();
+            }
+
+            private Session session() {
+                Session session = (Session) listener.getProviderSession();
+                if (session == null) {
+                    throw new IllegalStateException("missing session");
+                }
+                return session;
+            }
+        };
+    }
+
+    private static Object createWebSocket(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp) {
+        Listener listener = (Listener) req.getHttpServletRequest().getAttribute(ATTR_LISTENER);
+        if (listener == null) {
+            throw new IllegalStateException("missing listener attribute");
+        }
+        return new SessionListener(listener);
+    }
+
+    public static class SessionListener implements Session.Listener.AutoDemanding {
+        private final Listener listener;
+
+        public SessionListener(Listener listener) {
+            this.listener = Objects.requireNonNull(listener);
+        }
+
+        @Override
+        public void onWebSocketOpen(Session session) {
+            listener.onWebSocketConnect(session);
+        }
+
+        @Override
+        public void onWebSocketBinary(ByteBuffer payload, Callback callback) {
+            try {
+                int len = payload.remaining();
+                if (payload.hasArray()) {
+                    listener.onWebSocketBinary(payload.array(), payload.arrayOffset() + payload.position(), len);
+                    payload.position(payload.position() + len);
+                } else {
+                    byte[] bytes = new byte[len];
+                    payload.get(bytes);
+                    listener.onWebSocketBinary(bytes, 0, len);
+                }
+                callback.succeed();
+            } catch (Throwable t) {
+                callback.fail(t);
+            }
+        }
+
+        @Override
+        public void onWebSocketText(String message) {
+            listener.onWebSocketText(message);
+        }
+
+        @Override
+        public void onWebSocketError(Throwable cause) {
+            listener.onWebSocketError(cause);
+        }
+
+        @Override
+        public void onWebSocketClose(int statusCode, String reason) {
+            listener.onWebSocketClose(statusCode, reason);
+        }
+    }
+}


### PR DESCRIPTION
### Context

See [JENKINS-75571](https://issues.jenkins.io/browse/JENKINS-75571). Part of the following series of PRs:

- https://github.com/jenkinsci/jelly/pull/140
- https://github.com/jenkinsci/stapler/pull/617
- https://github.com/jenkinsci/winstone/pull/422
- https://github.com/jenkinsci/jenkins-test-harness/pull/941

### Description

Upgrade Jenkins core from EE 9 to EE 10 by bumping the version numbers of the relevant libraries to match those used by Jetty 12 (EE 10).

The main change in this PR is adapting the WebSocket implementation to recent Jetty changes. See [the Jetty migration guide](https://jetty.org/docs/jetty/12/programming-guide/migration/11-to-12.html#websocket) for details. See also the [Jetty 12 Programming Guide](https://jetty.org/docs/jetty/12/programming-guide/client/websocket.html#endpoints-listener) documentation about WebSocket clients.

This PR is ready for review and ready for merge from a Jenkins perspective, but it is not yet ready for merge from a CloudBees CI perspective (hence the "on hold" label).

### Testing done

- Core test suite
- PCT: https://github.com/jenkinsci/bom/pull/4779
- ATH: https://github.com/jenkinsci/acceptance-test-harness/pull/1971

### Proposed changelog entries

- Upgrade from Jakarta Enterprise Edition (EE) 9 to 10.

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
