### PR TITLE
Return `Future` from `Provider#sendBinary(ByteBuffer, boolean)`

### DIFF
--- a/core/src/main/java/jenkins/websocket/WebSocketSession.java
+++ b/core/src/main/java/jenkins/websocket/WebSocketSession.java
@@ -108,8 +108,8 @@ public abstract class WebSocketSession {
         return handler.sendBinary(data);
     }
 
-    protected final void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
-        handler.sendBinary(partialByte, isLast);
+    protected final Future<Void> sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
+        return handler.sendBinary(partialByte, isLast);
     }
 
     protected final Future<Void> sendText(String text) throws IOException {

--- a/websocket/jetty12-ee9/src/main/java/jenkins/websocket/Jetty12EE9Provider.java
+++ b/websocket/jetty12-ee9/src/main/java/jenkins/websocket/Jetty12EE9Provider.java
@@ -92,8 +92,10 @@ public class Jetty12EE9Provider implements Provider {
             }
 
             @Override
-            public void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
-                session().getRemote().sendPartialBytes(partialByte, isLast);
+            public Future<Void> sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
+                CompletableFuture<Void> f = new CompletableFuture<>();
+                session().getRemote().sendPartialBytes(partialByte, isLast, new WriteCallbackImpl(f));
+                return f;
             }
 
             @Override

--- a/websocket/spi/src/main/java/jenkins/websocket/Provider.java
+++ b/websocket/spi/src/main/java/jenkins/websocket/Provider.java
@@ -65,7 +65,7 @@ interface Provider {
 
         Future<Void> sendBinary(ByteBuffer data) throws IOException;
 
-        void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException;
+        Future<Void> sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException;
 
         Future<Void> sendText(String text) throws IOException;
 


### PR DESCRIPTION
Extracted from #10461, as this hunk can be delivered today without breaking compatibility. Makes this method more consistent with the others in the same file, as well as preparing the way for EE 10 as in #10461.

### Testing done

CI build

### Proposed changelog entries

- N/A

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
