### PR TITLE
Fix DefaultCredentialsStore javadoc

### DIFF
--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -28,7 +28,8 @@ import jenkins.util.SystemProperties;
  * <p>
  * The master key is stored by default in <code>$JENKINS_HOME/secrets/master.key</code> but another location can be provided using the system property <code>jenkins.security.DefaultConfidentialStore.file</code>.
  * <p>
- * It is also possible to prevent the generation of the master key file using the system property <code>-Djenkins.security.DefaultConfidentialStore.file.readOnly</code>. In this case, the master key file must be provided or startup will fail.
+ * It is also possible to prevent the generation of the master key file using the system property <code>-Djenkins.security.DefaultConfidentialStore.file.readOnly</code>.
+ * In this case, the master key file must be provided or startup will fail.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -28,7 +28,7 @@ import jenkins.util.SystemProperties;
  * <p>
  * The master key is stored by default in <code>$JENKINS_HOME/secrets/master.key</code> but another location can be provided using the system property <code>jenkins.security.DefaultConfidentialStore.file</code>.
  * <p>
- * It is also possible to prevent the generation of the master key file using the system property <code>-Djenkins.security.DefaultConfidentialStore.file.readOnly</code>.
+ * It is also possible to prevent the generation of the master key file using the system property <code>-Djenkins.security.DefaultConfidentialStore.readOnly</code>.
  * In this case, the master key file must be provided or startup will fail.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -28,7 +28,7 @@ import jenkins.util.SystemProperties;
  * <p>
  * The master key is stored by default in <code>$JENKINS_HOME/secrets/master.key</code> but another location can be provided using the system property <code>jenkins.security.DefaultConfidentialStore.file</code>.
  * <p>
- * It is also possible to prevent the generation of the master key file using the system property <code>-Djenkins.security.DefaultConfidentialStore.readOnly</code>.
+ * It is also possible to prevent the generation of the master key file using the system property <code>jenkins.security.DefaultConfidentialStore.readOnly</code>.
  * In this case, the master key file must be provided or startup will fail.
  *
  * @author Kohsuke Kawaguchi

--- a/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
+++ b/core/src/main/java/jenkins/security/DefaultConfidentialStore.java
@@ -26,9 +26,9 @@ import jenkins.util.SystemProperties;
  * Default portable implementation of {@link ConfidentialStore} that uses
  * a directory inside $JENKINS_HOME.
  * <p>
- * The master key is stored by default in <code>$JENKINS_HOME/secrets/master.key</code> but another location can be provided using the system property <code>jenkins.master.key.file</code>.
+ * The master key is stored by default in <code>$JENKINS_HOME/secrets/master.key</code> but another location can be provided using the system property <code>jenkins.security.DefaultConfidentialStore.file</code>.
  * <p>
- * It is also possible to prevent the generation of the master key file using the system property <code>-Djenkins.master.key.readOnly</code>. In this case, the master key file must be provided or startup will fail.
+ * It is also possible to prevent the generation of the master key file using the system property <code>-Djenkins.security.DefaultConfidentialStore.file.readOnly</code>. In this case, the master key file must be provided or startup will fail.
  *
  * @author Kohsuke Kawaguchi
  */


### PR DESCRIPTION
cf. https://github.com/jenkinsci/jenkins/pull/10235#discussion_r2013684803

Amends #10235

### Testing done

```
mvn -am -pl war,bom -Pquick-build clean install
mvn javadoc:javadoc
```

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
