### PR TITLE
Attempt Deflake - Disable JS in FileParameterValueTest and DirectoryBrowserSupportTest

### DIFF
--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -107,6 +107,12 @@ public class DirectoryBrowserSupportTest {
 
     @Rule public JenkinsRule j = new JenkinsRule();
 
+    private JenkinsRule.WebClient getWebClient() {
+        var wc = j.createWebClient();
+        wc.getOptions().setJavaScriptEnabled(false);
+        return wc;
+    }
+
     /**
      * Double dots that appear in file name is OK.
      */
@@ -122,7 +128,7 @@ public class DirectoryBrowserSupportTest {
         j.buildAndAssertSuccess(p);
 
         // can we see it?
-        j.createWebClient().goTo("job/" + p.getName() + "/ws/abc..def", "application/octet-stream");
+        getWebClient().goTo("job/" + p.getName() + "/ws/abc..def", "application/octet-stream");
 
         // TODO: implement negative check to make sure we aren't serving unexpected directories.
         // the following trivial attempt failed. Someone in between is normalizing.
@@ -149,7 +155,7 @@ public class DirectoryBrowserSupportTest {
         p.getBuildersList().add(new Shell("mkdir abc; touch abc/def.bin"));
         j.buildAndAssertSuccess(p);
 
-        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+        try (JenkinsRule.WebClient wc = getWebClient()) {
             // normal path provided by the UI succeeds
             Page page = wc.goTo("job/" + p.getName() + "/ws/abc%5Cdef.bin", "application/octet-stream");
             assertEquals(200, page.getWebResponse().getStatusCode());
@@ -170,7 +176,7 @@ public class DirectoryBrowserSupportTest {
         j.buildAndAssertSuccess(p);
 
         // can we see it?
-        j.createWebClient().goTo("job/" + p.getName() + "/ws/%e6%bc%a2%e5%ad%97.bin", "application/octet-stream");
+        getWebClient().goTo("job/" + p.getName() + "/ws/%e6%bc%a2%e5%ad%97.bin", "application/octet-stream");
     }
 
     @Test
@@ -190,7 +196,7 @@ public class DirectoryBrowserSupportTest {
             }
         });
         j.buildAndAssertSuccess(p);
-        String text = j.createWebClient().goTo("job/" + p.getName() + "/ws/**/*.java").asNormalizedText();
+        String text = getWebClient().goTo("job/" + p.getName() + "/ws/**/*.java").asNormalizedText();
         assertTrue(text, text.contains("X.java"));
         assertTrue(text, text.contains("XTest.java"));
         assertFalse(text, text.contains("pom.xml"));
@@ -205,7 +211,7 @@ public class DirectoryBrowserSupportTest {
         p.getPublishersList().add(new ArtifactArchiver("*", "", true));
         j.buildAndAssertSuccess(p);
 
-        HtmlPage page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
+        HtmlPage page = getWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
         Page download = page.getAnchorByHref("./*zip*/archive.zip").click();
         File zipfile = download((UnexpectedPage) download);
 
@@ -231,7 +237,7 @@ public class DirectoryBrowserSupportTest {
         p.getPublishersList().add(new ArtifactArchiver("*", "", true));
         j.buildAndAssertSuccess(p);
 
-        HtmlPage page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
+        HtmlPage page = getWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
         Page downloadPage = page.getAnchorByHref("artifact.out").click();
         assertEquals(content, downloadPage.getWebResponse().getContentAsString());
     }
@@ -254,7 +260,7 @@ public class DirectoryBrowserSupportTest {
             p.getPublishersList().add(new ArtifactArchiver("*", "", true));
             j.buildAndAssertSuccess(p);
 
-            HtmlPage page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
+            HtmlPage page = getWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
             for (int clicks = 0; clicks < numOfClicks; clicks++) {
                 page.getAnchorByHref("artifact.out").click();
             }
@@ -308,7 +314,7 @@ public class DirectoryBrowserSupportTest {
         p.getPublishersList().add(new ArtifactArchiver("*", "", true));
         j.buildAndAssertSuccess(p);
 
-        HtmlPage page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.html");
+        HtmlPage page = getWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.html");
         for (String header : new String[]{"Content-Security-Policy", "X-WebKit-CSP", "X-Content-Security-Policy"}) {
             assertEquals("Header set: " + header, DirectoryBrowserSupport.DEFAULT_CSP_VALUE, page.getWebResponse().getResponseHeaderValue(header));
         }
@@ -317,7 +323,7 @@ public class DirectoryBrowserSupportTest {
         String initialValue = System.getProperty(propName);
         try {
             System.setProperty(propName, "");
-            page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.html");
+            page = getWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.html");
             List<String> headers = page.getWebResponse().getResponseHeaders().stream().map(NameValuePair::getName).collect(Collectors.toList());
             for (String header : new String[]{"Content-Security-Policy", "X-WebKit-CSP", "X-Content-Security-Policy"}) {
                 assertThat(headers, not(hasItem(header)));
@@ -351,7 +357,7 @@ public class DirectoryBrowserSupportTest {
         p.setScm(new SingleFileSCM("f", "Hello world!"));
         p.getPublishersList().add(new ArtifactArchiver("f"));
         j.buildAndAssertSuccess(p);
-        HtmlPage page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
+        HtmlPage page = getWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/");
         Page download = page.getAnchorByText("f").click();
         assertEquals("Hello world!", download.getWebResponse().getContentAsString());
     }
@@ -614,7 +620,7 @@ public class DirectoryBrowserSupportTest {
 
         j.buildAndAssertSuccess(p);
 
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = getWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
         { // workspace root must be reachable (regular case)
             Page page = wc.goTo(p.getUrl() + "ws/", null);
@@ -759,7 +765,7 @@ public class DirectoryBrowserSupportTest {
 
         j.buildAndAssertSuccess(p);
 
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = getWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
         // the pattern allow us to search inside the files / folders,
@@ -822,7 +828,7 @@ public class DirectoryBrowserSupportTest {
 
         j.buildAndAssertSuccess(p);
 
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = getWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
         { // workspace root must be reachable (regular case)
             Page page = wc.goTo(p.getUrl() + "ws/", null);
@@ -975,7 +981,7 @@ public class DirectoryBrowserSupportTest {
         c3.mkdirs();
         c3.child("to_secrets3").symlinkTo(secretsFolder.getAbsolutePath(), TaskListener.NULL);
 
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = getWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
         {
             Page zipPage = wc.goTo(p.getUrl() + "ws/*zip*/ws.zip", null);
@@ -1042,7 +1048,7 @@ public class DirectoryBrowserSupportTest {
 
         j.buildAndAssertSuccess(p);
 
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = getWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
         { // workspace root must be reachable (regular case)
             Page page = wc.goTo(p.getUrl() + "ws/", null);
@@ -1111,7 +1117,7 @@ public class DirectoryBrowserSupportTest {
         String content = "random data provided as fixed value";
         Files.writeString(targetTmpPath, content, StandardCharsets.UTF_8);
 
-        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+        try (JenkinsRule.WebClient wc = getWebClient()) {
             wc.setThrowExceptionOnFailingStatusCode(false);
             HtmlPage page = wc.goTo("userContent/" + targetTmpPath.toAbsolutePath() + "/*view*");
             assertEquals(404, page.getWebResponse().getStatusCode());
@@ -1133,7 +1139,7 @@ public class DirectoryBrowserSupportTest {
         });
         assertEquals(Result.SUCCESS, p.scheduleBuild2(0).get().getResult());
 
-        String text = j.createWebClient().goTo("job/" + p.getName() + "/ws/").asNormalizedText();
+        String text = getWebClient().goTo("job/" + p.getName() + "/ws/").asNormalizedText();
         assertTrue(text, text.contains("anotherDir"));
         assertFalse(text, text.contains("subdir"));
     }
@@ -1163,7 +1169,7 @@ public class DirectoryBrowserSupportTest {
 
         assertEquals(Result.SUCCESS, p.scheduleBuild2(0).get().getResult());
 
-        String text = j.createWebClient().goTo("job/" + p.getName() + "/ws/**/*.txt").asNormalizedText();
+        String text = getWebClient().goTo("job/" + p.getName() + "/ws/**/*.txt").asNormalizedText();
         assertTrue(text, text.contains("one.txt"));
         assertTrue(text, text.contains("two.txt"));
         assertFalse(text, text.contains("three.txt"));
@@ -1192,7 +1198,7 @@ public class DirectoryBrowserSupportTest {
         });
         assertEquals(Result.SUCCESS, p.scheduleBuild2(0).get().getResult());
 
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = getWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
         Page page = wc.goTo(p.getUrl() + "ws/anotherDir/", null);
@@ -1222,7 +1228,7 @@ public class DirectoryBrowserSupportTest {
         });
         assertEquals(Result.SUCCESS, p.scheduleBuild2(0).get().getResult());
 
-        String text = j.createWebClient().goTo("job/" + p.getName() + "/ws/*plain*", "text/plain").getWebResponse().getContentAsString();
+        String text = getWebClient().goTo("job/" + p.getName() + "/ws/*plain*", "text/plain").getWebResponse().getContentAsString();
         assertTrue(text, text.contains("anotherDir"));
         assertFalse(text, text.contains("subdir"));
     }
@@ -1255,7 +1261,7 @@ public class DirectoryBrowserSupportTest {
         });
         assertEquals(Result.SUCCESS, p.scheduleBuild2(0).get().getResult());
 
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = getWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
         //http://localhost:54407/jenkins/job/test0/ws/**/*.txt/*zip*/glob.zip
@@ -1308,7 +1314,7 @@ public class DirectoryBrowserSupportTest {
         });
         assertEquals(Result.SUCCESS, p.scheduleBuild2(0).get().getResult());
 
-        JenkinsRule.WebClient wc = j.createWebClient();
+        JenkinsRule.WebClient wc = getWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
         Page zipPage = wc.goTo("job/" + p.getName() + "/ws/**/*.txt/*zip*/glob.zip", null);
@@ -1329,7 +1335,7 @@ public class DirectoryBrowserSupportTest {
 
         Files.writeString(testFile.toPath(), content, StandardCharsets.UTF_8);
 
-        JenkinsRule.WebClient wc = j.createWebClient().withThrowExceptionOnFailingStatusCode(false);
+        JenkinsRule.WebClient wc = getWebClient().withThrowExceptionOnFailingStatusCode(false);
         Page page = wc.goTo("userContent/test.txt/*view*", null);
 
         MatcherAssert.assertThat(page.getWebResponse().getStatusCode(), equalTo(200));

--- a/test/src/test/java/hudson/model/FileParameterValueTest.java
+++ b/test/src/test/java/hudson/model/FileParameterValueTest.java
@@ -40,9 +40,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.htmlunit.Page;
+import org.htmlunit.WebClient;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.util.NameValuePair;
 import org.junit.Assume;
@@ -53,6 +55,7 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
 public class FileParameterValueTest {
@@ -64,6 +67,9 @@ public class FileParameterValueTest {
 
     @ClassRule
     public static BuildWatcher bw = new BuildWatcher();
+
+    @Rule
+    public LoggerRule lr = new LoggerRule().recordPackage(WebClient.class, Level.ALL);
 
     public static final Logger LOGGER = Logger.getLogger(FileParameterValueTest.class.getName());
 

--- a/test/src/test/java/hudson/model/FileParameterValueTest.java
+++ b/test/src/test/java/hudson/model/FileParameterValueTest.java
@@ -40,14 +40,17 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.htmlunit.Page;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.util.NameValuePair;
 import org.junit.Assume;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -58,6 +61,11 @@ public class FileParameterValueTest {
 
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
+
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
+    public static final Logger LOGGER = Logger.getLogger(FileParameterValueTest.class.getName());
 
     @Test
     @Issue("SECURITY-1074")
@@ -318,15 +326,23 @@ public class FileParameterValueTest {
 
         // and reachable using request
         JenkinsRule.WebClient wc = j.createWebClient();
+
+        LOGGER.info("getting ws");
         HtmlPage workspacePage = wc.goTo(p.getUrl() + "ws");
+        LOGGER.info("got htmlunit for ws");
         String workspaceContent = workspacePage.getWebResponse().getContentAsString();
+        LOGGER.info("got ws");
         assertThat(workspaceContent, allOf(
                 containsString("direct-child1.txt"),
                 containsString("parent")
         ));
+        LOGGER.info("getting ws/parent");
         HtmlPage workspaceParentPage = wc.goTo(p.getUrl() + "ws" + "/parent");
+        LOGGER.info("got htmlunit for ws/parent");
         String workspaceParentContent = workspaceParentPage.getWebResponse().getContentAsString();
+        LOGGER.info("got ws/parent");
         assertThat(workspaceParentContent, containsString("child2.txt"));
+        LOGGER.info("completed");
     }
 
     @Test

--- a/test/src/test/java/hudson/model/FileParameterValueTest.java
+++ b/test/src/test/java/hudson/model/FileParameterValueTest.java
@@ -332,6 +332,7 @@ public class FileParameterValueTest {
 
         // and reachable using request
         JenkinsRule.WebClient wc = j.createWebClient();
+        wc.getOptions().setJavaScriptEnabled(false);
 
         LOGGER.info("getting ws");
         HtmlPage workspacePage = wc.goTo(p.getUrl() + "ws");


### PR DESCRIPTION
This PR proposes to disable the javascript in `WebClient` in all places in the mentioned two test classes,
* as several of these tests can be potentially affected - the ones visiting the `ws` URL.
* and since `getWebClient()` is now called in several methods, to keep consistency with the entire class - using it all methods.

Besides possibly it fixing the flakiness, it speeds up the tests (slowness affected by https://github.com/jenkinsci/jenkins-test-harness/issues/946),

|Test Class|Execution time before|Execution time after|
|---|---|---|
|FileParameterValueTest|`01:29 min`|`23.766s`|
|DirectoryBrowserSupportTest|`02:49 min`|`37.973 s`|

------------
Noticed that two tests failed in CI with same kind of error,
* `FileParameterValueTest#fileParameter_canStillUse_internalHierarchy`
* `DirectoryBrowserSupportTest.tmpNotListed`

<details><summary>failure log</summary>

```
java.lang.NullPointerException: Cannot invoke "org.htmlunit.html.DomElement.getHtmlElementDescendants()" because "doc" is null
	at org.htmlunit.html.HtmlPage.executeDeferredScriptsIfNeeded(HtmlPage.java:1466)
	at org.htmlunit.html.HtmlPage.initialize(HtmlPage.java:265)
	at org.htmlunit.WebClient.loadWebResponseInto(WebClient.java:701)
	at org.htmlunit.WebClient.loadWebResponseInto(WebClient.java:575)
	at org.htmlunit.WebClient.getPage(WebClient.java:493)
	at org.htmlunit.WebClient.getPage(WebClient.java:402)
	at org.htmlunit.WebClient.getPage(WebClient.java:538)
	at org.htmlunit.WebClient.getPage(WebClient.java:520)
	at org.jvnet.hudson.test.JenkinsRule$WebClient.getPage(JenkinsRule.java:2740)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:519)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:677)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:840)
```
</details>

Example CI Failure reports
|Test|Failure|
|----|---|
|`FileParameterValueTest#fileParameter_canStillUse_internalHierarchy`|[PR-10456](https://github.com/jenkinsci/jenkins/pull/10456) ([ref failed test result](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10456/7/testReport/))|
|`FileParameterValueTest#fileParameter_canStillUse_internalHierarchy`|[PR-10467](https://github.com/jenkinsci/jenkins/pull/10467) ([ref failed test result](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10467/2/testReport/))|
|`DirectoryBrowserSupportTest.tmpNotListed`|[PR-10470](https://github.com/jenkinsci/jenkins/pull/10470) ([ref failed test result](https://ci.jenkins.io/job/Core/job/jenkins/job/PR-10470/4/testReport/hudson.model/DirectoryBrowserSupportTest/linux_jdk21___Linux___JDK_21___Build___Test___tmpNotListed/))|

-----------

I didn't reproduce the error, but hopefully it fixes the flakiness, possibly causes by the javascript issue.

<details><summary>example showing slowness</summary>

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running hudson.model.FileParameterValueTest
=== Starting fileParameter_canStillUse_internalHierarchy(hudson.model.FileParameterValueTest)
   0.047 [id=21]	INFO	o.jvnet.hudson.test.WarExploder#explode: Using jenkins.war resources from /.../jenkins/war/target/jenkins
   0.304 [id=21]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:64862/jenkins/
   0.367 [id=21]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.504-SNAPSHOT
   0.421 [id=36]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   1.002 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/command-launcher.jpi as a dependency of gradle
   1.012 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/apache-httpcomponents-client-4-api.jpi as a dependency of gradle
   1.034 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/jdk-tool.jpi as a dependency of gradle
   1.052 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/trilead-api.jpi as a dependency of gradle
   1.079 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/eddsa-api.jpi as a dependency of gradle
   1.084 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/gson-api.jpi as a dependency of gradle
   1.098 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/mina-sshd-api-common.jpi as a dependency of gradle
   1.109 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/mina-sshd-api-core.jpi as a dependency of gradle
   1.134 [id=46]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins1642946911825735225/sshd.jpi as a dependency of gradle
   1.353 [id=41]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   1.362 [id=37]	INFO	j.b.api.BouncyCastlePlugin#start: /.../jenkins/test/target/j h15288515834251035408/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   1.931 [id=53]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   1.937 [id=34]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   1.937 [id=47]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   2.254 [id=53]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   2.255 [id=53]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   2.255 [id=37]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   2.255 [id=37]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   2.307 [id=50]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   2.466 [test0 #1] Started by user SYSTEM
   2.466 [test0 #1] Running as SYSTEM
   2.466 [test0 #1] Building in workspace /.../jenkins/test/target/j h15288515834251035408/workspace/test0
   2.466 [test0 #1] Copying file to direct-child1.txt
   2.466 [test0 #1] Copying file to parent/child2.txt
   2.899 [test0 #1] Finished: SUCCESS
   3.046 [id=21]	INFO	h.model.FileParameterValueTest#fileParameter_canStillUse_internalHierarchy: getting ws
  14.449 [id=21]	INFO	h.model.FileParameterValueTest#fileParameter_canStillUse_internalHierarchy: got htmlunit for ws
  14.450 [id=21]	INFO	h.model.FileParameterValueTest#fileParameter_canStillUse_internalHierarchy: got ws
  14.452 [id=21]	INFO	h.model.FileParameterValueTest#fileParameter_canStillUse_internalHierarchy: getting ws/parent
  24.720 [id=21]	INFO	h.model.FileParameterValueTest#fileParameter_canStillUse_internalHierarchy: got htmlunit for ws/parent
  24.733 [id=21]	INFO	h.model.FileParameterValueTest#fileParameter_canStillUse_internalHierarchy: got ws/parent
  24.733 [id=21]	INFO	h.model.FileParameterValueTest#fileParameter_canStillUse_internalHierarchy: completed
  34.767 [id=21]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
  34.799 [id=21]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
  34.840 [id=21]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /.../jenkins/test/target/j h15288515834251035408
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.15 s -- in hudson.model.FileParameterValueTest
```
</details>

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

Tests run in local, and faster

<details><summary>Before: execution summary log</summary>

```
[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 160.0 s -- in hudson.model.DirectoryBrowserSupportTest
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 2
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:49 min
[INFO] Finished at: 2025-03-27T20:58:02+05:30
[INFO] ------------------------------------------------------------------------


[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 85.56 s -- in hudson.model.FileParameterValueTest
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:29 min
[INFO] Finished at: 2025-03-27T21:13:11+05:30
[INFO] ------------------------------------------------------------------------
```
</details>

<details><summary>After: execution summary log</summary>

```
[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 28.58 s -- in hudson.model.DirectoryBrowserSupportTest
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 22, Failures: 0, Errors: 0, Skipped: 2
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  37.973 s
[INFO] Finished at: 2025-03-27T20:43:10+05:30
[INFO] ------------------------------------------------------------------------


[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 14.90 s -- in hudson.model.FileParameterValueTest
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.766 s
[INFO] Finished at: 2025-03-27T20:49:39+05:30
[INFO] ------------------------------------------------------------------------
```
</details>


### Proposed changelog entries

### Proposed changelog category

/label skip-changelog,tests

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
