### PR TITLE
Use dropdown for the default view of a user

### DIFF
--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -33,6 +33,7 @@ import hudson.model.Descriptor.FormException;
 import hudson.model.userproperty.UserPropertyCategory;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.views.MyViewsTabBar;
 import hudson.views.ViewsTabBar;
 import jakarta.servlet.ServletException;
@@ -48,6 +49,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -272,6 +274,16 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
         @Override
         public @NonNull UserPropertyCategory getUserPropertyCategory() {
             return UserPropertyCategory.get(UserPropertyCategory.Preferences.class);
+        }
+
+        public ListBoxModel doFillPrimaryViewNameItems(@AncestorInPath User user) {
+            ListBoxModel items = new ListBoxModel();
+            if (user != null) {
+                MyViewsProperty viewsProperty = user.getProperty(MyViewsProperty.class);
+                viewsProperty.views.forEach(v -> items.add(new ListBoxModel.Option(v.getViewName(),
+                        v.getViewName(), v.getViewName().equals(viewsProperty.primaryViewName))));
+            }
+            return items;
         }
     }
 

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -276,12 +276,20 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
             return UserPropertyCategory.get(UserPropertyCategory.Preferences.class);
         }
 
-        public ListBoxModel doFillPrimaryViewNameItems(@AncestorInPath User user) {
+        @POST
+        public ListBoxModel doFillPrimaryViewNameItems(@AncestorInPath User user) throws IOException {
             ListBoxModel items = new ListBoxModel();
+            user = user == null ? User.current() : user;
             if (user != null) {
-                MyViewsProperty viewsProperty = user.getProperty(MyViewsProperty.class);
-                viewsProperty.views.forEach(v -> items.add(new ListBoxModel.Option(v.getViewName(),
-                        v.getViewName(), v.getViewName().equals(viewsProperty.primaryViewName))));
+                MyViewsProperty property = user.getProperty(MyViewsProperty.class);
+                if (property == null) {
+                    property = new MyViewsProperty();
+                    user.addProperty(property);
+                }
+                for (View view : property.views) {
+                    items.add(new ListBoxModel.Option(view.getDisplayName(), view.getViewName(),
+                            view == property.getPrimaryView()));
+                }
             }
             return items;
         }

--- a/core/src/main/resources/hudson/model/MyViewsProperty/config.jelly
+++ b/core/src/main/resources/hudson/model/MyViewsProperty/config.jelly
@@ -24,12 +24,8 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:invisibleEntry>
-    <!-- This only exists to provide the parameter of the checkUrl -->
-    <f:checkbox name="exists" checked="true"/>
-  </f:invisibleEntry>
   <f:entry title="${%Default View}"
     description="${%description}">
-    <f:textbox field="primaryViewName" checkUrl="${rootURL}/${instance.url}viewExistsCheck" checkDependsOn="exists"/>
+    <f:select field="primaryViewName"/>
   </f:entry>
 </j:jelly>


### PR DESCRIPTION
Currently one has to manually type name of the view and ony after leaving the field one knows if it was correct.
This PR changes it to a select with all known views for the user (extracted from #10379)

Before:
![image](https://github.com/user-attachments/assets/447c44ea-0ab0-4e9b-9a6f-18b7b7deec53)


After:
![image](https://github.com/user-attachments/assets/431ced46-ea84-4d41-a2b8-17ab9071cef4)


<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->



<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Use dropdown for the default view of a user

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe,web-ui

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
