### PR TITLE
Improve UI of secret and password entry

### DIFF
--- a/core/src/main/resources/lib/form/password/password.css
+++ b/core/src/main/resources/lib/form/password/password.css
@@ -27,21 +27,19 @@
 }
 
 .hidden-password-legend {
-  border: 1px solid #ccc;
-  border: 1px solid var(--input-border);
-  border-radius: 3px;
-  background: #f9f9f9;
-  background: var(--input-hidden-password-bg-color);
+  border: var(--jenkins-border-width) solid var(--input-border);
+  border-radius: var(--form-input-border-radius);
+  background: var(--input-color);
   flex-grow: 1;
   align-items: center;
   display: inline-flex;
 }
 
 .hidden-password-legend > svg {
-  margin-right: 1em;
-  margin-left: 0.5em;
+  margin-right: 0.75em;
+  margin-left: 0.75em;
 }
 
 .hidden-password-update-btn {
-  margin-left: 5px;
+  margin-left: calc(var(--section-padding) / 2);
 }

--- a/core/src/main/resources/lib/form/secretTextarea.jelly
+++ b/core/src/main/resources/lib/form/secretTextarea.jelly
@@ -100,8 +100,8 @@ Example usage:
             </div>
         </div>
         <div class="secret-input">
-            <textarea id="${id}" hidden="hidden" name="${name}" placeholder="${placeholder}"
-                      class="secretTextarea-redact ${attrs.checkUrl!=null?' jenkins-input validated':''}"
+            <textarea id="${id}" hidden="hidden" name="${name}" placeholder="${placeholder}" rows="10"
+                      class="secretTextarea-redact jenkins-input ${attrs.checkUrl!=null?'  validated':''}"
                       checkUrl="${attrs.checkUrl}" checkDependsOn="${attrs.checkDependsOn}" checkMethod="${attrs.checkMethod}">
                 <st:out value="${value}" />
             </textarea>

--- a/core/src/main/resources/lib/form/secretTextarea/secret.css
+++ b/core/src/main/resources/lib/form/secretTextarea/secret.css
@@ -58,7 +58,8 @@
 
 .secret-input textarea {
   font-family: var(--font-family-mono);
-  border-radius: 0 0 var(--form-input-border-radius) var(--form-input-border-radius);
+  border-radius: 0 0 var(--form-input-border-radius)
+    var(--form-input-border-radius);
 }
 
 .secret * [hidden] {

--- a/core/src/main/resources/lib/form/secretTextarea/secret.css
+++ b/core/src/main/resources/lib/form/secretTextarea/secret.css
@@ -23,16 +23,15 @@
  */
 
 .secret-header {
-  border: 1px solid #ccc;
-  border: 1px solid var(--input-border);
-  border-radius: 3px;
-  background: #f9f9f9;
-  background: var(--input-hidden-password-bg-color);
   display: flex;
   justify-content: space-around;
+  border: var(--jenkins-border-width) solid var(--input-border);
+  border-radius: var(--form-input-border-radius);
+  background: var(--input-color);
 }
 
-.secret-header:not(:only-child) {
+.secret-header--expanded {
+  border-bottom: none;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
@@ -41,11 +40,12 @@
   flex-grow: 1;
   display: inline-flex;
   align-items: center;
-  padding: 1.5em 1.75em;
+  padding: 0 calc(var(--section-padding) / 2);
+  min-height: 4rem;
 }
 
 .secret-legend > svg {
-  margin-right: 1em;
+  margin-right: calc(var(--section-padding) / 2);
 }
 
 .secret-update {
@@ -53,17 +53,12 @@
 }
 
 .secret-input {
-  border: solid 1px #ccc;
-  border: solid 1px var(--input-border);
-  border-top: none;
-  border-radius: 0 0 3px 3px;
+  display: flex;
 }
 
 .secret-input textarea {
-  width: 100%;
-  font-family: monospace;
-  border: none;
-  padding: 1em;
+  font-family: var(--font-family-mono);
+  border-radius: 0 0 var(--form-input-border-radius) var(--form-input-border-radius);
 }
 
 .secret * [hidden] {

--- a/core/src/main/resources/lib/form/secretTextarea/secret.js
+++ b/core/src/main/resources/lib/form/secretTextarea/secret.js
@@ -29,8 +29,11 @@ Behaviour.specify(".secret", "secret-button", 0, function (e) {
   }
 
   var unhideSecretInput = function () {
-    var textArea = e.querySelector('textarea[hidden="hidden"]');
+    const header = e.querySelector(".secret-header");
+    header.classList.add("secret-header--expanded");
+    const textArea = e.querySelector('textarea[hidden="hidden"]');
     textArea.removeAttribute("hidden");
+    textArea.focus();
   };
 
   var clearSecretValue = function () {

--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -309,7 +309,6 @@ $semantics: (
     var(--text-color-secondary) 50%,
     transparent
   );
-  --input-hidden-password-bg-color: #f9f9f9;
   --form-item-max-width: min(65vw, 1600px);
   --form-item-max-width--medium: min(50vw, 1400px);
   --form-item-max-width--small: min(35vw, 1200px);


### PR DESCRIPTION
This PR updates the appearance of the secret and password entry components, bringing it inline with other inputs but also fixing its appearance in dark mode - where it's impossible to actually read. I've also increased the minimum height on the `textarea` input to 10 rows - let me know if that's too high.

**Before**

<img width="1141" alt="image" src="https://github.com/user-attachments/assets/e94975e0-3c81-4fdc-8757-ff47da41b334" />

<img width="1146" alt="image" src="https://github.com/user-attachments/assets/dd766580-66ce-4ae0-aef7-599660ee26c8" />

**After**

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/4eae3e34-d86e-4f3b-9032-16dcb76b2d51" />

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/cfec3456-65f0-4eae-b54d-3d763e552cda" />

**The previous UI also didn't work very well in non-light contexts, e.g:**

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/f920c2fc-7773-4282-859f-0578c016d8c5" />

**Now it does:**

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/37453048-0723-4060-bdf7-2939da2bdf68" />

**Before**

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/d574a1fa-ebb6-4f00-8471-6fc5f8b0af9b" />

**After**

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/713624c6-2b36-4b2a-bcb9-2cce27e75c77" />

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Improve UI of secret and password entry

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui,rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
