### PR TITLE
Update editable-description.js

### DIFF
--- a/core/src/main/resources/lib/hudson/editable-description.js
+++ b/core/src/main/resources/lib/hudson/editable-description.js
@@ -12,6 +12,17 @@
         let description = descriptionLink.getAttribute("data-description");
         return replaceDescription(description, url);
       });
+      // Adding a  new line whenever 'enter' key is detected.
+      description.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          let cursorPos = this.selectionStart;
+          let textBefore = this.value.substring(0, cursorPos);
+          let textAfter = this.value.substring(cursorPos);
+          this.value = textBefore + "\n" + textAfter;
+          this.selectionStart = this.selectionEnd = cursorPos + 1;
+        }
+      });
     }
   });
 


### PR DESCRIPTION

<img width="677" alt="edit_description_without_br_tag" src="https://github.com/user-attachments/assets/12e4db14-401a-4ce2-be1a-8f19530ab4c6" />
<img width="678" alt="no_new_line_was_added_without_br_tag" src="https://github.com/user-attachments/assets/c55ed170-0f6e-4d1d-b2bc-a57e21759d9b" />
<img width="676" alt="edit_description_with_br_tag" src="https://github.com/user-attachments/assets/3e306a85-d462-4d21-b139-2eb341a5a176" />
<img width="681" alt="after_adding_br_tag_manually" src="https://github.com/user-attachments/assets/a64e6cc2-4b25-429c-9e60-f408fed091bb" />

Adding a new line whenever 'enter' key is pressed.

Issue: While updating the description of a build/suite/job, had to manually add a "<br" tag to insert the contents in a new line.

Fix: Added an eventListener to add a new line everytime "enter' is pressed.
