### PR TITLE
Allow setting the target attribute for summary links

### DIFF
--- a/core/src/main/resources/lib/hudson/summary.jelly
+++ b/core/src/main/resources/lib/hudson/summary.jelly
@@ -35,6 +35,9 @@ THE SOFTWARE.
     <st:attribute name="href">
       where the summary icon links to.
     </st:attribute>
+    <st:attribute name="newWindow" type="boolean">
+      if true, hyperlink will open in a new window.
+    </st:attribute>
     <st:attribute name="iconOnly" type="boolean">
       if true, hyperlink will only cover the icon, not the body.
     </st:attribute>
@@ -51,9 +54,18 @@ THE SOFTWARE.
         <td style="vertical-align:middle">
           <j:choose>
             <j:when test="${attrs.href!=null &amp;&amp; !attrs.iconOnly}">
-              <a href="${attrs.href}">
-                <d:invokeBody />
-              </a>
+              <j:choose>
+                <j:when test="${attrs.newWindow}">
+                  <a href="${attrs.href}" target="_blank" rel="noopener noreferrer">
+                    <d:invokeBody />
+                  </a>
+                </j:when>
+                <j:otherwise>
+                  <a href="${attrs.href}">
+                    <d:invokeBody />
+                  </a>
+                </j:otherwise>
+              </j:choose>
             </j:when>
             <j:otherwise>
               <d:invokeBody />


### PR DESCRIPTION
Allow setting the `target` attribute for links in `summary.jelly`.

While validating and testing https://github.com/jenkinsci/badge-plugin/pull/244 I found that right now it is not possible to set the `target` attribute for links in `summary.jelly`. It may come handy to open links in a new window.

### Testing done

I manually verified the changes in using the `badge-plugin`. Right now I don't see a way to test the behavior otherwise.

### Proposed changelog entries

- Allow setting the target attribute for summary links

### Proposed changelog category

/label rfe,developer,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
