### PR TITLE
[JENKINS-33704] Computer configuration not updated correctly after updating nodes

### DIFF
--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -166,11 +166,10 @@ public class Nodes implements PersistenceRoot {
                     @Override
                     public void run() {
                         nodes.compute(node.getNodeName(), (ignoredNodeName, ignoredNode) -> old);
+                        jenkins.updateComputers(node);
                         if (old != null) {
-                            jenkins.updateComputers(node, old);
                             jenkins.trimLabels(node, old);
                         } else {
-                            jenkins.updateComputers(node);
                             jenkins.trimLabels(node);
                         }
                     }
@@ -265,7 +264,7 @@ public class Nodes implements PersistenceRoot {
                 Util.deleteRecursive(new File(getRootDir(), oldOne.getNodeName()));
             }
             Queue.withLock(() -> {
-                jenkins.updateComputers(oldOne, newOne);
+                jenkins.updateComputers(newOne);
                 jenkins.trimLabels(oldOne, newOne);
             });
             NodeListener.fireOnUpdated(oldOne, newOne);

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import jenkins.model.Jenkins;
 import jenkins.security.SlaveToMasterCallable;
 import jenkins.slaves.RemotingWorkDirSettings;
 import org.htmlunit.Page;
@@ -59,6 +60,7 @@ import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.SimpleCommandLauncher;
 import org.jvnet.hudson.test.SmokeTest;
 import org.jvnet.hudson.test.recipes.LocalData;
 
@@ -234,6 +236,18 @@ public class JNLPLauncherTest {
 
         Thread.sleep(500);
         assertTrue(c.isOffline());
+    }
+
+    @Test
+    public void changeLauncher() throws Exception {
+        Computer c = addTestAgent(false);
+        var name = c.getName();
+        var node = c.getNode();
+        assertThat(c.isLaunchSupported(), is(false));
+        var nodeCopy = (Slave) Jenkins.XSTREAM2.fromXML(Jenkins.XSTREAM2.toXML(node));
+        nodeCopy.setLauncher(new SimpleCommandLauncher("true"));
+        Jenkins.get().getNodesObject().replaceNode(node, nodeCopy);
+        assertThat(Jenkins.get().getComputer(name).isLaunchSupported(), is(true));
     }
 
     /**


### PR DESCRIPTION
Amends #10494

Several ATHs are failing since #10494

https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/PR-1956/7/testReport/

This is due to the call to `Jenkins#updateComputers(Node...)` being passed both the old and new object for a node when applying an update. This resulted into the old node configuration to be applied to the computer. Changed the call to only pass the new node object.

The previous global call to `Jenkins#updateComputerList()` was looking up all nodes attached to the Jenkins node, so was not applying the logic to old node configurations.

Added a unit test catching the regression, as this was only caught in ATH.

See [JENKINS-33704](https://issues.jenkins.io/browse/JENKINS-33704).

### Testing done

Confirmed that before this fix I was able to change the launcher of an agent from the UI and save it without the save persisting completely.  The change to the launcher did not fully persist until the next time I applied or saved the agent configuration.

Confirmed that after this fix, the change of the launcher from the UI was immediately effective.

### Proposed changelog entries

- Ensure computer configuration is updated correctly after updating a node.

### Proposed changelog category

/label regression-fix

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
