### PR TITLE
`LabelComputerSource`

### DIFF
--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -235,6 +235,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     }
 
     @Restricted(DoNotUse.class) // Jelly
+    @NonNull
     public Collection<? extends IComputer> getComputers() {
         return ExtensionList.lookupFirst(LabelComputerSource.class).get(this).stream().sorted(Comparator.comparing(IComputer::getName)).toList();
     }
@@ -245,14 +246,16 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
      */
     @Restricted(Beta.class)
     public interface LabelComputerSource extends ExtensionPoint {
-        Collection<? extends IComputer> get(Label label);
+        @NonNull
+        Collection<? extends IComputer> get(@NonNull Label label);
     }
 
     @Extension(ordinal = -1)
     @Restricted(DoNotUse.class)
     public static class LabelComputerSourceImpl implements LabelComputerSource {
         @Override
-        public Collection<? extends IComputer> get(Label label) {
+        @NonNull
+        public Collection<? extends IComputer> get(@NonNull Label label) {
             return label.getNodes().stream().map(Node::toComputer).filter(Objects::nonNull).toList();
         }
     }

--- a/core/src/main/resources/hudson/model/Label/index.jelly
+++ b/core/src/main/resources/hudson/model/Label/index.jelly
@@ -43,8 +43,7 @@ THE SOFTWARE.
 
       <div>
         <h2>${%Nodes}</h2>
-        <j:forEach var="n" items="${it.sortedNodes}">
-          <j:set var="c" value="${app.getComputer(n.nodeName)}"/>
+        <j:forEach var="c" items="${it.computers}">
           <j:set var="url" value="${rootURL}/${c.url}"/>
           <nobr>
             <a href="${url}" class="jenkins-link--with-icon"><l:icon src="${c.iconClassName}" /></a>


### PR DESCRIPTION
Analogous to #9749 but for displaying the list of nodes assigned to a label, which can be used by CloudBees CI in high availability mode for the same purpose except scoped to a label rather than the full node list.

### Testing done

With `jetty:run`, able to define some (permanent) agents with labels and see them with their current online/offline status under the label link. Also assigned a label to the built-in computer. (In that case the label index page did not immediately show it but did after I made a change to an agent, which might have been #10538.)

I tested the overridden implementation in CloudBees interactively and with an automated test.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label developer

### Proposed upgrade guidelines

N/A

### Desired reviewers

@Vlatombe

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
