### PR TITLE
Clearer assertion for `QueueTest.inQueueTaskLookupByAPI`

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -444,7 +445,7 @@ public class QueueTest {
         XmlPage queueItem = webclient.goToXml("queue/item/" + queueTaskId + "/api/xml");
         assertNotNull(queueItem);
         String tagName = queueItem.getDocumentElement().getTagName();
-        assertTrue(tagName.equals("blockedItem") || tagName.equals("buildableItem"));
+        assertThat(tagName, oneOf("blockedItem", "buildableItem"));
 
         // Clear the queue
         assertTrue(r.jenkins.getQueue().cancel(p));


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/10555/checks?check_run_id=40720147353 looks like a flake unrelated to #10555 but the failure message is not helpful.

### Testing done

Passes for me locally on Linux.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
