### PR TITLE
Do not inspect non-`AbstractProject` for `Computer.getBuilds`

### DIFF
--- a/core/src/main/java/hudson/model/Computer.java
+++ b/core/src/main/java/hudson/model/Computer.java
@@ -782,7 +782,7 @@ public /*transient*/ abstract class Computer extends Actionable implements Acces
     }
 
     public RunList getBuilds() {
-        return RunList.fromJobs((Iterable) Jenkins.get().allItems(Job.class)).node(getNode());
+        return RunList.fromJobs((Iterable) Jenkins.get().allItems(AbstractProject.class)).node(getNode());
     }
 
     /**


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/blob/81caa4e94a8135ba01946e5c47ebaf26d8c8d648/core/src/main/java/hudson/util/RunList.java#L327-L329 is limited to `AbstractBuild`. (#4207 warns users to this effect.) Yet its caller `Computer.getBuilds` was potentially searching unbounded histories of `WorkflowJob`s loading `WorkflowRun`s which would never match the criteria. Should just check histories of the non-Pipeline projects and exit.

### Testing done

Ran some freestyle & Pipeline builds using some (mock) agents and confirmed that the **Build History** link still shows just the freestyle builds. Did not try to assert that Pipeline builds are not loaded, though this would be possible I think with `RunLoadCounter`.

### Proposed changelog entries

- N/A (optimization, should not affect visible behavior other than CPU/IO consumption on controller)

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
