### PR TITLE
More helpful `SlaveComputer.toString`

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -977,6 +977,11 @@ public class SlaveComputer extends Computer {
         }
     }
 
+    @Override
+    public String toString() {
+        return nodeName != null ? super.toString() + "[" + nodeName + "]" : super.toString();
+    }
+
     /**
      * Grabs a {@link ComputerLauncher} out of {@link Node} to keep it in this {@link Computer}.
      * The returned launcher will be set to {@link #launcher} and used to carry out the actual launch operation.


### PR DESCRIPTION
Looking at some log messages which printed `[Slave]Computer` objects, I noticed that `DumbSlave`s made `SlaveComputer`s which were identified only by hash code, so I could not tell what they were. `KubernetesComputer`s by contrast included the node name (like the `Pod`). Since https://github.com/jenkinsci/jenkins/blob/b62d8dc1d5e6225ab2a33fec13d8f2b33ac78fda/core/src/main/java/hudson/model/Slave.java#L276-L278 already includes the agent name it seemed appropriate to include it here as well.

For the built-in executor there is no need to differentiate by name.

### Testing done

None, just by code inspection.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
