### PR TITLE
[JENKINS-75533] Remove jbcrypt mindrot, use Spring Security instead

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -207,11 +207,6 @@ THE SOFTWARE.
         <version>${groovy.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.connectbot</groupId>
-        <artifactId>jbcrypt</artifactId>
-        <version>1.0.2</version>
-      </dependency>
-      <dependency>
         <!-- Groovy shell uses this, but it doesn't declare the dependency -->
         <groupId>org.fusesource.jansi</groupId>
         <artifactId>jansi</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -247,10 +247,6 @@ THE SOFTWARE.
       <artifactId>groovy-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.connectbot</groupId>
-      <artifactId>jbcrypt</artifactId>
-    </dependency>
-    <dependency>
       <!-- Groovy shell uses this, but it doesn't declare the dependency -->
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -91,7 +91,6 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
-import org.mindrot.jbcrypt.BCrypt;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -100,6 +99,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
@@ -451,11 +451,12 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
             si.errors.put("password1", Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordRequired());
         }
 
-        if (FIPS140.useCompliantAlgorithms()) {
-            if (si.password1.length() < FIPS_PASSWORD_LENGTH) {
-                si.errors.put("password1", Messages.HudsonPrivateSecurityRealm_CreateAccount_FIPS_PasswordLengthInvalid());
-            }
+        try {
+            PASSWORD_HASH_ENCODER.encode(si.password1);
+        }  catch (RuntimeException ex) {
+            si.errors.put("password1", ex.getMessage());
         }
+
         if (si.fullname == null || si.fullname.isEmpty()) {
             si.fullname = si.username;
         }
@@ -823,10 +824,6 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
                     throw new FormException("Please confirm the password by typing it twice", "user.password2");
                 }
 
-                if (FIPS140.useCompliantAlgorithms() && pwd.length() < FIPS_PASSWORD_LENGTH) {
-                     throw new FormException(Messages.HudsonPrivateSecurityRealm_CreateAccount_FIPS_PasswordLengthInvalid(), "user.password");
-                }
-
                 // will be null if it wasn't encrypted
                 String data = Protector.unprotect(pwd);
                 String data2 = Protector.unprotect(pwd2);
@@ -849,8 +846,16 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
                 if (data != null) {
                     String prefix = Stapler.getCurrentRequest2().getSession().getId() + ':';
                     if (data.startsWith(prefix)) {
+                        // The password is not being changed
                         return Details.fromHashedPassword(data.substring(prefix.length()));
                     }
+                }
+
+                // The password is being changed
+                try {
+                    PASSWORD_HASH_ENCODER.encode(pwd);
+                } catch (RuntimeException ex) {
+                    throw new FormException(ex.getMessage(), "user.password");
                 }
 
                 User user = Util.getNearestAncestorOfTypeOrThrow(req, User.class);
@@ -917,11 +922,10 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         }
     }
 
-    // TODO can we instead use BCryptPasswordEncoder from Spring Security, which has its own copy of BCrypt so we could drop the special library?
     /**
      * {@link PasswordHashEncoder} that uses jBCrypt.
      */
-    static class JBCryptEncoder implements PasswordHashEncoder {
+    static class JBCryptEncoder extends BCryptPasswordEncoder implements PasswordHashEncoder {
         // in jBCrypt the maximum is 30, which takes ~22h with laptop late-2017
         // and for 18, it's "only" 20s
         @Restricted(NoExternalUse.class)
@@ -931,12 +935,14 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
         @Override
         public String encode(CharSequence rawPassword) {
-            return BCrypt.hashpw(rawPassword.toString(), BCrypt.gensalt());
-        }
-
-        @Override
-        public boolean matches(CharSequence rawPassword, String encodedPassword) {
-            return BCrypt.checkpw(rawPassword.toString(), encodedPassword);
+            try {
+                return super.encode(rawPassword);
+            } catch (IllegalArgumentException ex) {
+                if (ex.getMessage().equals("password cannot be more than 72 bytes")) {
+                    throw new IllegalArgumentException(Messages.HudsonPrivateSecurityRealm_CreateAccount_BCrypt_PasswordTooLong());
+                }
+                throw ex;
+            }
         }
 
         /**
@@ -978,6 +984,9 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
         @Override
         public String encode(CharSequence rawPassword) {
+            if (rawPassword.length() < FIPS_PASSWORD_LENGTH) {
+                throw new IllegalArgumentException(Messages.HudsonPrivateSecurityRealm_CreateAccount_FIPS_PasswordLengthInvalid());
+            }
             try {
                 return generatePasswordHashWithPBKDF2(rawPassword);
             } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {

--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -37,6 +37,7 @@ HudsonPrivateSecurityRealm.ManageUserLinks.Description=Create/delete/modify user
 HudsonPrivateSecurityRealm.CreateAccount.TextNotMatchWordInImage=Text didn''t match the word shown in the image
 HudsonPrivateSecurityRealm.CreateAccount.PasswordNotMatch=Password didn''t match
 HudsonPrivateSecurityRealm.CreateAccount.FIPS.PasswordLengthInvalid=Password must be at least 14 characters long
+HudsonPrivateSecurityRealm.CreateAccount.BCrypt.PasswordTooLong=Jenkins’ own user database currently only supports passwords of up to 72 bytes UTF-8 (72 basic ASCII characters, 24-36 CJK characters, or 18 emoji). Please use a shorter password.
 HudsonPrivateSecurityRealm.CreateAccount.PasswordRequired=Password is required
 HudsonPrivateSecurityRealm.CreateAccount.UserNameRequired=User name is required
 HudsonPrivateSecurityRealm.CreateAccount.UserNameInvalidCharacters=User name must only contain alphanumeric characters, underscore and dash

--- a/core/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/core/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -1,5 +1,7 @@
 package hudson.security;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,7 +15,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import javax.crypto.SecretKeyFactory;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
 import org.mockito.Mockito;
 
 public class HudsonPrivateSecurityRealmTest {
@@ -150,5 +154,11 @@ public class HudsonPrivateSecurityRealmTest {
         String encoded = encoder.encode("thisIsMyPassword");
         assertTrue(encoder.matches("thisIsMyPassword", encoded));
         assertFalse(encoder.matches("thisIsNotMyPassword", encoded));
+    }
+
+    @Issue("JENKINS-75533")
+    public void ensureExpectedMessage() {
+        final IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode("1234567890123456789012345678901234567890123456789012345678901234567890123"));
+        assertThat(ex.getMessage(), is(Messages.HudsonPrivateSecurityRealm_CreateAccount_BCrypt_PasswordTooLong()));
     }
 }

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmFIPSTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmFIPSTest.java
@@ -98,7 +98,7 @@ public class HudsonPrivateSecurityRealmFIPSTest {
         setupLogRecorder();
         HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
         j.jenkins.setSecurityRealm(securityRealm);
-        // "password" after it has gone through the KDF
+        // "passwordpassword" after it has gone through the KDF
         securityRealm.createAccountWithHashedPassword("user_hashed",
                 "$PBKDF2$HMACSHA512:210000:92857a190ac711436e8a9cb56595d642$0d66e61da0b04283148b4a574422a17762c96c46bcd3aa587b6d447a908367fe8030bd2083dc54313639561d36cc9ac707bed72fc3400465e7dc1d6805cffb66");
 

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmFIPSTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmFIPSTest.java
@@ -35,7 +35,6 @@ import hudson.logging.LogRecorder;
 import hudson.logging.LogRecorderManager;
 import hudson.model.User;
 import hudson.security.HudsonPrivateSecurityRealm.Details;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -52,13 +51,14 @@ import org.jvnet.hudson.test.For;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.RealJenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 
 @For(HudsonPrivateSecurityRealm.class)
 public class HudsonPrivateSecurityRealmFIPSTest {
 
-    // the jbcrypt encoded for of "a" without the quotes
-    private static final String JBCRYPT_ENCODED_PASSWORD = "#jbcrypt:$2a$06$m0CrhHm10qJ3lXRY.5zDGO3rS2KdeeWLuGmsfGlMfOxih58VYVfxe";
+    // the bcrypt encoded form of "passwordpassword" without the quotes
+    private static final String JBCRYPT_ENCODED_PASSWORD = "#jbcrypt:$2a$10$Nm37vwdZwJ5T2QTBwYuBYONHD3qKilgd5UO7wuDXI83z5dAdrgi4i";
 
     private static final String LOG_RECORDER_NAME = "HPSR_LOG_RECORDER";
 
@@ -75,7 +75,7 @@ public class HudsonPrivateSecurityRealmFIPSTest {
         HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
         j.jenkins.setSecurityRealm(securityRealm);
 
-        User u1 = securityRealm.createAccount("user", "password");
+        User u1 = securityRealm.createAccount("user", "passwordpassword");
         u1.setFullName("A User");
         u1.save();
 
@@ -84,8 +84,8 @@ public class HudsonPrivateSecurityRealmFIPSTest {
         assertThat(hashedPassword, startsWith("$PBKDF2$HMACSHA512:210000:"));
 
         try (WebClient wc = j.createWebClient()) {
-            wc.login("user", "password");
-            assertThrows(FailingHttpStatusCodeException.class, () -> wc.login("user", "wrongPass"));
+            wc.login("user", "passwordpassword");
+            assertThrows(FailingHttpStatusCodeException.class, () -> wc.login("user", "wrongPass123456"));
         }
     }
 
@@ -100,17 +100,18 @@ public class HudsonPrivateSecurityRealmFIPSTest {
         j.jenkins.setSecurityRealm(securityRealm);
         // "password" after it has gone through the KDF
         securityRealm.createAccountWithHashedPassword("user_hashed",
-                "$PBKDF2$HMACSHA512:210000:ffbb207b847010af98cdd2b09c79392c$f67c3b985daf60db83a9088bc2439f7b77016d26c1439a9877c4f863c377272283ce346edda4578a5607ea620a4beb662d853b800f373297e6f596af797743a6");
+                "$PBKDF2$HMACSHA512:210000:92857a190ac711436e8a9cb56595d642$0d66e61da0b04283148b4a574422a17762c96c46bcd3aa587b6d447a908367fe8030bd2083dc54313639561d36cc9ac707bed72fc3400465e7dc1d6805cffb66");
 
         try (WebClient wc = j.createWebClient()) {
             // login should succeed
-            wc.login("user_hashed", "password");
-            assertThrows(FailingHttpStatusCodeException.class, () -> wc.login("user_hashed", "password2"));
+            wc.login("user_hashed", "passwordpassword");
+            assertThrows(FailingHttpStatusCodeException.class, () -> wc.login("user_hashed", "passwordpassword2"));
         }
         assertThat(getLogRecords(), not(hasItem(incorrectHashingLogEntry())));
     }
 
     @Test
+    @LocalData
     public void userLoginAfterEnablingFIPS() throws Throwable {
         rjr.then(HudsonPrivateSecurityRealmFIPSTest::userLoginAfterEnablingFIPSStep);
     }
@@ -120,19 +121,10 @@ public class HudsonPrivateSecurityRealmFIPSTest {
         HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
         j.jenkins.setSecurityRealm(securityRealm);
 
-        User u1 = securityRealm.createAccount("user", "a");
-        u1.setFullName("A User");
-        // overwrite the password property using an password created using an incorrect algorithm
-        Method m = Details.class.getDeclaredMethod("fromHashedPassword", String.class);
-        m.setAccessible(true);
-        Details d = (Details) m.invoke(null, JBCRYPT_ENCODED_PASSWORD);
-        u1.addProperty(d);
-
-        u1.save();
-        assertThat(u1.getProperty(Details.class).getPassword(), is(JBCRYPT_ENCODED_PASSWORD));
+        assertThat(securityRealm.getUser("user").getProperty(Details.class).getPassword(), is(JBCRYPT_ENCODED_PASSWORD));
 
         try (WebClient wc = j.createWebClient()) {
-            assertThrows(FailingHttpStatusCodeException.class, () -> wc.login("user", "a"));
+            assertThrows(FailingHttpStatusCodeException.class, () -> wc.login("user", "passwordpassword"));
         }
         assertThat(getLogRecords(), hasItem(incorrectHashingLogEntry()));
     }

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -762,9 +762,20 @@ public class HudsonPrivateSecurityRealmTest {
     }
 
     @Issue("JENKINS-75533")
-    public void ensureExpectedMessage() {
-        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode("1234567890123456789012345678901234567890123456789012345678901234567890123"));
-        assertThat(ex.getMessage(), is(Messages.HudsonPrivateSecurityRealm_CreateAccount_BCrypt_PasswordTooLong()));
+    public void supportLongerPasswordToLogIn() throws Exception {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        j.jenkins.setSecurityRealm(securityRealm);
+        final String _72CharPass = "123456789012345678901234567890123456789012345678901234567890123456789012";
+        final String username = "user";
+        securityRealm.createAccount(username, _72CharPass);
+        try (WebClient wc = j.createWebClient()) {
+            // can log in with the real 72 byte password
+            wc.login(username, _72CharPass);
+        }
+        try (WebClient wc = j.createWebClient()) {
+            // can log in with even longer password for this edge case
+            wc.login(username, _72CharPass + "345");
+        }
     }
 
     private static Matcher<LoggerRule> hasIncorrectHashingLogEntry() {

--- a/test/src/test/resources/hudson/security/HudsonPrivateSecurityRealmFIPSTest/userLoginAfterEnablingFIPS/users/user_1072549610582667998/config.xml
+++ b/test/src/test/resources/hudson/security/HudsonPrivateSecurityRealmFIPSTest/userLoginAfterEnablingFIPS/users/user_1072549610582667998/config.xml
@@ -1,0 +1,41 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<user>
+  <version>10</version>
+  <id>user</id>
+  <fullName>The User</fullName>
+  <properties>
+    <jenkins.console.ConsoleUrlProviderUserProperty/>
+    <hudson.model.MyViewsProperty>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>all</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.model.PaneStatusProperties>
+      <collapsed/>
+    </hudson.model.PaneStatusProperties>
+    <hudson.search.UserSearchProperty>
+      <insensitiveSearch>true</insensitiveSearch>
+    </hudson.search.UserSearchProperty>
+    <hudson.model.TimeZoneProperty/>
+    <jenkins.model.experimentalflags.UserExperimentalFlagsProperty>
+      <flags/>
+    </jenkins.model.experimentalflags.UserExperimentalFlagsProperty>
+    <jenkins.security.ApiTokenProperty>
+      <tokenStore>
+        <tokenList/>
+      </tokenStore>
+    </jenkins.security.ApiTokenProperty>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <passwordHash>#jbcrypt:$2a$10$Nm37vwdZwJ5T2QTBwYuBYONHD3qKilgd5UO7wuDXI83z5dAdrgi4i</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+    <jenkins.security.seed.UserSeedProperty>
+      <seed>ec31fd374346de1e</seed>
+    </jenkins.security.seed.UserSeedProperty>
+  </properties>
+</user>

--- a/test/src/test/resources/hudson/security/HudsonPrivateSecurityRealmFIPSTest/userLoginAfterEnablingFIPS/users/users.xml
+++ b/test/src/test/resources/hudson/security/HudsonPrivateSecurityRealmFIPSTest/userLoginAfterEnablingFIPS/users/users.xml
@@ -1,0 +1,10 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.model.UserIdMapper>
+  <version>1</version>
+  <idToDirectoryNameMap class="concurrent-hash-map">
+    <entry>
+      <string>user</string>
+      <string>user_1072549610582667998</string>
+    </entry>
+  </idToDirectoryNameMap>
+</hudson.model.UserIdMapper>


### PR DESCRIPTION
See [JENKINS-75533](https://issues.jenkins.io/browse/JENKINS-75533).

During development of this change, Spring Security [added the backward compatibility](https://github.com/spring-projects/spring-security/commit/c1aa99fdd2113a232986e9c3a44673ae752de840) I considered here, but without exposing the potential problem to users. I considered doing that for Jenkins, but there's no great way built-in to expose that information to users and ask them to change the password. I can do that if required, basically all of the code is written but I think unnecessary.

As a side effect of moving the validation into the `PasswordHashEncoder` this would address [JENKINS-74918](https://issues.jenkins.io/browse/JENKINS-74918) as well, as demonstrated by the necessary test changes (`password` is shorter than 14 chars).

Depends on https://github.com/jenkinsci/active-directory-plugin/pull/241 which would break.

### Testing done

<details><summary>Screenshots</summary>

#### Regular

> ![Setup wizard](https://github.com/user-attachments/assets/ff419561-fa07-45f5-a4e5-090038b58145)

> ![User profile](https://github.com/user-attachments/assets/9061f7c0-d673-4802-abe8-2f7c6ef9df1e)

> ![Create user](https://github.com/user-attachments/assets/2acf62de-7bc7-4a65-ac94-48e89703ca0e)

#### FIPS-140

> ![Setup wizard](https://github.com/user-attachments/assets/bdb62502-73bc-459c-9f10-1dfbf88bf6f4)

> ![User profile](https://github.com/user-attachments/assets/d547118a-b601-469f-b4b0-5933c7efdab3)

</details>

### Proposed changelog entries

- Improvement: Jenkins' own user database no longer accepts new passwords longer than supported by bcrypt (72 bytes). Users with longer passwords are advised to change their password.
- Internal: Switch jbcrypt implementation used for Jenkins' own user database from jbcrypt to Spring Security.
- Remove jbcrypt library. If you're using Active Directory plugin, make sure to update to version 2.40 at the same time as updating Jenkins.
- Developer: Remove `org.connectbot:jbcrypt` library from core BOM.

### Proposed changelog category

/label developer,dependencies,internal,rfe,removed

### Proposed upgrade guidelines

Unless operating in [FIPS-140 mode](https://www.jenkins.io/doc/book/system-administration/FIPS-140/), Jenkins' own user database no longer supports creating passwords longer than 72 bytes (UTF-8), which is the maximum length supported by the [bcrypt password hashing function](https://en.wikipedia.org/wiki/Bcrypt) it uses. This length corresponds to 72 basic ASCII characters, 24-36 CJK characters, or 18 emoji 🤠.

Existing passwords longer than 72 bytes can still be used to log in. <!-- https://github.com/spring-projects/spring-security/commit/c1aa99fdd2113a232986e9c3a44673ae752de840 -->

Users with longer passwords are advised to change their password to be at most 72 bytes (and, e.g., choose from a larger character set to achieve the same complexity).

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
