### PR TITLE
[JENKINS-75615] remove jenkins-avatar class from header icons other than user icon

### DIFF
--- a/core/src/main/resources/lib/layout/header/actions.jelly
+++ b/core/src/main/resources/lib/layout/header/actions.jelly
@@ -46,7 +46,7 @@
         <x:attribute name="data-type">header-action</x:attribute>
         <x:attribute name="draggable">false</x:attribute>
         <x:attribute name="class">jenkins-button ${isCurrent ? '' : 'jenkins-button--tertiary'}</x:attribute>
-        <l:icon src="${icon}" class="jenkins-avatar" />
+        <l:icon src="${icon}" class="${action.class.name == 'jenkins.model.navigation.UserAction' ? 'jenkins-avatar' : ''}"/>
         <span class="jenkins-visually-hidden" data-type="action-label">${action.displayName}</span>
         <j:if test="${badge != null}">
           <span class="jenkins-badge jenkins-!-${badge.severity}-color" />


### PR DESCRIPTION
the `jenkins-avatar` class should only be applied on the UserAction and not on every icon.

See [JENKINS-75615](https://issues.jenkins.io/browse/JENKINS-75615).

### Testing done
interactively tested that only the user icon gets the class.

### Proposed changelog entries

- Fix the display of icons in the header by only applying the `jenkins-avatar` class to user icons, not the other header icons.

### Proposed changelog category

/label bug,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
