### PR TITLE
Remove legacy compat for LogRecorder

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorder.java
+++ b/core/src/main/java/hudson/logging/LogRecorder.java
@@ -31,7 +31,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.AbstractModelObject;
@@ -43,7 +42,6 @@ import hudson.model.listeners.SaveableListener;
 import hudson.remoting.Channel;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.ComputerListener;
-import hudson.util.CopyOnWriteList;
 import hudson.util.FormApply;
 import hudson.util.FormValidation;
 import hudson.util.HttpResponses;
@@ -104,15 +102,6 @@ import org.kohsuke.stapler.verb.POST;
 public class LogRecorder extends AbstractModelObject implements Loadable, Saveable {
     private volatile String name;
 
-    /**
-     * No longer used.
-     *
-     * @deprecated use {@link #getLoggers()}
-     */
-    @Deprecated
-    @Restricted(NoExternalUse.class)
-    @RestrictedSince("2.324")
-    public final transient CopyOnWriteList<Target> targets = new CopyOnWriteList<>();
     private List<Target> loggers = new ArrayList<>();
     private static final TargetComparator TARGET_COMPARATOR = new TargetComparator();
 
@@ -122,22 +111,6 @@ public class LogRecorder extends AbstractModelObject implements Loadable, Saveab
         // register it only once when constructed, and when this object dies
         // WeakLogHandler will remove it
         new WeakLogHandler(handler, Logger.getLogger(""));
-    }
-
-    private Object readResolve() {
-        if (loggers == null) {
-            loggers = new ArrayList<>();
-        }
-
-        List<Target> tempLoggers = new ArrayList<>(loggers);
-
-        if (!targets.isEmpty()) {
-            loggers.addAll(targets.getView());
-        }
-        if (!tempLoggers.isEmpty() && !targets.getView().equals(tempLoggers)) {
-            targets.addAll(tempLoggers);
-        }
-        return this;
     }
 
     public List<Target> getLoggers() {
@@ -455,7 +428,6 @@ public class LogRecorder extends AbstractModelObject implements Loadable, Saveab
             recorders.remove(new LogRecorder(name));
             this.name = newName;
             recorders.add(this);
-            getParent().setRecorders(recorders); // ensure that legacy logRecorders field is synced on save
             redirect = "../" + Util.rawEncode(newName) + '/';
         }
 
@@ -491,29 +463,10 @@ public class LogRecorder extends AbstractModelObject implements Loadable, Saveab
     public synchronized void save() throws IOException {
         if (BulkChange.contains(this))   return;
 
-        handlePluginUpdatingLegacyLogManagerMap();
         getConfigFile().write(this);
         loggers.forEach(Target::enable);
 
         SaveableListener.fireOnChange(this, getConfigFile());
-    }
-
-    @SuppressWarnings("deprecation") // this is for compatibility
-    private void handlePluginUpdatingLegacyLogManagerMap() {
-        if (getParent().logRecorders.size() > getParent().getRecorders().size()) {
-            for (LogRecorder logRecorder : getParent().logRecorders.values()) {
-                if (!getParent().getRecorders().contains(logRecorder)) {
-                    getParent().getRecorders().add(logRecorder);
-                }
-            }
-        }
-        if (getParent().getRecorders().size() > getParent().logRecorders.size()) {
-            for (LogRecorder logRecorder : getParent().getRecorders()) {
-                if (!getParent().logRecorders.containsKey(logRecorder.getName())) {
-                    getParent().logRecorders.put(logRecorder.getName(), logRecorder);
-                }
-            }
-        }
     }
 
     @Override

--- a/core/src/main/java/hudson/logging/LogRecorderManager.java
+++ b/core/src/main/java/hudson/logging/LogRecorderManager.java
@@ -155,7 +155,6 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
             lr.load();
             recorders.add(lr);
         }
-        setRecorders(recorders); // ensure that legacy logRecorders field is synced on load
     }
 
     /**

--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -172,42 +171,6 @@ public class LogRecorderManagerTest {
         assertFalse(text, text.contains("msg #4"));
         assertTrue(text, text.contains("LambdaLog @FINE"));
         assertFalse(text, text.contains("LambdaLog @FINER"));
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    public void addingLogRecorderToLegacyMapAddsToRecordersList() throws IOException {
-        LogRecorderManager log = j.jenkins.getLog();
-
-        assertThat(log.logRecorders.size(), is(0));
-        assertThat(log.getRecorders().size(), is(0));
-
-        LogRecorder logRecorder = new LogRecorder("dummy");
-        logRecorder.getLoggers().add(new LogRecorder.Target("dummy", Level.ALL));
-
-        log.logRecorders.put("dummy", logRecorder);
-        logRecorder.save();
-
-        assertThat(log.logRecorders.size(), is(1));
-        assertThat(log.getRecorders().size(), is(1));
-    }
-
-    @Test
-    @SuppressWarnings("deprecation")
-    public void addingLogRecorderToListAddsToLegacyRecordersMap() throws IOException {
-        LogRecorderManager log = j.jenkins.getLog();
-
-        assertThat(log.logRecorders.size(), is(0));
-        assertThat(log.getRecorders().size(), is(0));
-
-        LogRecorder logRecorder = new LogRecorder("dummy");
-        logRecorder.getLoggers().add(new LogRecorder.Target("dummy", Level.ALL));
-
-        log.getRecorders().add(logRecorder);
-        logRecorder.save();
-
-        assertThat(log.logRecorders.size(), is(1));
-        assertThat(log.getRecorders().size(), is(1));
     }
 
     @Test


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See https://github.com/jenkinsci/jenkins/pull/4538#issuecomment-1089023754, better late than never...

The status quo hasn't really changed much, the 2 maintained plugins have been updated. mesos is dead ([deprecated](https://github.com/jenkins-infra/update-center2/pull/865#event-17485039907)) and the other plugin doesn't appear to be used it only has ~100 installations.

Fixes test flake noted in https://github.com/jenkinsci/bom/pull/4934#issuecomment-2842921046
Started occurring since moving to JUnit 5 recently, timing must've adjusted slightly

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

- CI build
- Sanity check, was able to create, update and configure LogRecorders and restart Jenkins seeing the log recorder still being there

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- (skip changelog)

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
