### PR TITLE
Render `t:artifactList` lazily

### DIFF
--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -135,6 +135,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.jelly.XMLOutput;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
@@ -1071,6 +1072,11 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             }
             return new StandardArtifactManager(this);
         }
+    }
+
+    @Restricted(DoNotUse.class) // Jelly
+    public final boolean hasCustomArtifactManager() {
+        return artifactManager != null;
     }
 
     /**

--- a/core/src/main/java/hudson/widgets/RenderOnDemandClosure.java
+++ b/core/src/main/java/hudson/widgets/RenderOnDemandClosure.java
@@ -72,8 +72,12 @@ public class RenderOnDemandClosure {
         assert !bodyStack.isEmpty();    // there must be at least one, which is the direct child of <l:renderOnDemand>
 
         Map<String, Object> variables = new HashMap<>();
-        for (String v : Util.fixNull(attributesToCapture).split(","))
-            variables.put(v.intern(), context.getVariable(v));
+        String _attributesToCapture = Util.fixEmpty(attributesToCapture);
+        if (_attributesToCapture != null) {
+            for (String v : _attributesToCapture.split(",")) {
+                variables.put(v.intern(), context.getVariable(v));
+            }
+        }
 
         // capture the current base of context for descriptors
         currentDescriptorByNameUrl = Descriptor.getCurrentDescriptorByNameUrl();
@@ -86,6 +90,7 @@ public class RenderOnDemandClosure {
         for (String adjunct : _adjuncts) {
             this.adjuncts[i++] = adjunct.intern();
         }
+        LOGGER.fine(() -> "captured " + variables);
     }
 
     /**
@@ -96,6 +101,7 @@ public class RenderOnDemandClosure {
         return new HttpResponse() {
             @Override
             public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object node) throws IOException, ServletException {
+                LOGGER.fine(() -> "rendering " + req.getPathInfo());
                 req.getBoundObjectTable().releaseMe();
                 req.getWebApp().getDispatchValidator().allowDispatch(req, rsp);
                 try {

--- a/core/src/main/java/hudson/widgets/RenderOnDemandClosure.java
+++ b/core/src/main/java/hudson/widgets/RenderOnDemandClosure.java
@@ -96,6 +96,7 @@ public class RenderOnDemandClosure {
         return new HttpResponse() {
             @Override
             public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object node) throws IOException, ServletException {
+                req.getBoundObjectTable().releaseMe();
                 req.getWebApp().getDispatchValidator().allowDispatch(req, rsp);
                 try {
                     new DefaultScriptInvoker() {

--- a/core/src/main/resources/hudson/model/AbstractProject/main.jelly
+++ b/core/src/main/resources/hudson/model/AbstractProject/main.jelly
@@ -38,9 +38,7 @@ THE SOFTWARE.
       </t:summary>
     </j:forEach>
 
-    <t:artifactList caption="${%Last Successful Artifacts}"
-        build="${it.lastSuccessfulBuild}" baseURL="lastSuccessfulBuild/"
-        permission="${it.lastSuccessfulBuild.ARTIFACTS}"/>
+    <t:artifactList build="${it.lastSuccessfulBuild}" caption="${%Last Successful Artifacts}"/>
   </table>
 
   <!-- merge fragments from the actions -->

--- a/core/src/main/resources/hudson/model/Run/artifactList.jelly
+++ b/core/src/main/resources/hudson/model/Run/artifactList.jelly
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2025 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
+    <l:ajax>
+        <j:if test="${!h.artifactsPermissionEnabled or h.artifactsPermissionEnabled and it.hasPermission(it.ARTIFACTS)}">
+            <j:set var="artifacts" value="${it.getArtifactsUpTo(it.LIST_CUTOFF+1)}" />
+            <j:if test="${!empty(artifacts)}">
+                <t:summary icon="symbol-cube" href="${rootURL}/${it.url}artifact/">
+                    <a href="${rootURL}/${it.url}artifact/">${caption != null ? caption : request2.getParameter('caption')}</a>
+                    <j:if test="${it.building}">
+                        <p>
+                            ${%building}
+                        </p>
+                    </j:if>
+                    <j:if test="${size(artifacts) le it.LIST_CUTOFF}">
+                        <!-- if not too many, just list them -->
+                        <table class="fileList">
+                            <j:forEach var="f" items="${artifacts}">
+                                <tr>
+                                    <td>
+                                        <l:icon class="icon-document icon-sm"/>
+                                    </td>
+                                    <td>
+                                        <a href="${rootURL}/${it.url}artifact/${f.href}">${f.displayPath}</a>
+                                    </td>
+                                    <td class="fileSize">
+                                        ${h.humanReadableByteSize(f.getFileSize())}
+                                    </td>
+                                    <td>
+                                        <j:if test="${app.fingerprintMap.ready}">
+                                            <a href="${rootURL}/${it.url}artifact/${f.href}/*fingerprint*/">
+                                                <l:icon class="icon-fingerprint icon-sm"/>
+                                            </a>
+                                            <st:nbsp/>
+                                        </j:if>
+                                        <a href="${rootURL}/${it.url}artifact/${f.href}/*view*/">${%view}</a>
+                                    </td>
+                                </tr>
+                            </j:forEach>
+                        </table>
+                    </j:if>
+                    <!-- otherwise just show link to directory browser -->
+                </t:summary>
+            </j:if>
+        </j:if>
+    </l:ajax>
+</j:jelly>

--- a/core/src/main/resources/hudson/model/Run/index.jelly
+++ b/core/src/main/resources/hudson/model/Run/index.jelly
@@ -67,8 +67,7 @@ THE SOFTWARE.
 
 
           <table>
-            <t:artifactList build="${it}" caption="${%Build Artifacts}"
-                            permission="${it.ARTIFACTS}" />
+            <t:artifactList build="${it}" caption="${%Build Artifacts}"/>
 
             <!-- give actions a chance to contribute summary item -->
             <j:forEach var="a" items="${it.allActions}">

--- a/core/src/main/resources/hudson/model/Run/new-build-page.jelly
+++ b/core/src/main/resources/hudson/model/Run/new-build-page.jelly
@@ -72,7 +72,7 @@ THE SOFTWARE.
         <l:card title="Summary">
           <div>
             <table>
-              <t:artifactList build="${it}" caption="${%Build Artifacts}" permission="${it.ARTIFACTS}" />
+              <t:artifactList build="${it}" caption="${%Build Artifacts}"/>
 
               <!-- give actions a chance to contribute summary item -->
               <j:forEach var="a" items="${it.allActions}">

--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:documentation>
     Generates a listing of the build artifacts.
     Depending on the size of the artifact, this will either produce a list or a link to the directory view.
@@ -34,54 +34,17 @@ THE SOFTWARE.
     <st:attribute name="caption" use="required">
       Human readable title text
     </st:attribute>
-    <st:attribute name="baseURL">
-      If the hyperlink to artifacts are at another URL, specify the prefix.
-    </st:attribute>
   </st:documentation>
-  <j:if test="${build != null and (!h.artifactsPermissionEnabled or h.artifactsPermissionEnabled and h.hasPermission(build, attrs.permission))}">
-    <l:renderOnDemand tag="tbody" clazz="artifact-list" capture="build,caption,baseURL">
-        <l:ajax>
-            <j:set var="artifacts" value="${build.getArtifactsUpTo(build.LIST_CUTOFF+1)}" />
-            <j:if test="${!empty(artifacts)}">
-                <t:summary icon="symbol-cube" href="${baseURL}artifact/">
-                    <a href="${baseURL}artifact/">${caption}</a>
-                    <j:if test="${build.building}">
-                        <p>
-                            ${%building}
-                        </p>
-                    </j:if>
-                    <j:if test="${size(artifacts) le build.LIST_CUTOFF}">
-                         <!-- if not too many, just list them -->
-                        <table class="fileList">
-                            <j:forEach var="f" items="${artifacts}">
-                                <tr>
-                                    <td>
-                                        <l:icon class="icon-document icon-sm"/>
-                                    </td>
-                                    <td>
-                                        <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
-                                    </td>
-                                    <td class="fileSize">
-                                        ${h.humanReadableByteSize(f.getFileSize())}
-                                    </td>
-                                    <td>
-                                        <j:if test="${app.fingerprintMap.ready}">
-                                            <a href="${baseURL}artifact/${f.href}/*fingerprint*/">
-                                                <l:icon class="icon-fingerprint icon-sm"/>
-                                            </a>
-                                            <st:nbsp/>
-                                        </j:if>
-                                        <a href="${baseURL}artifact/${f.href}/*view*/">${%view}</a>
-                                    </td>
-                                </tr>
-                            </j:forEach>
-                        </table>
-                    </j:if>
-                    <!-- otherwise just show link to directory browser -->
-                </t:summary>
-            </j:if>
-        </l:ajax>
-    </l:renderOnDemand>
-    <st:adjunct includes="lib.hudson.artifactList"/>
-  </j:if>
+  <j:choose>
+    <j:when test="${build == null}">
+      <!-- nothing to render -->
+    </j:when>
+    <j:when test="${build.hasCustomArtifactManager()}">
+      <tbody class="artifact-list" data-url="${rootURL}/${build.url}artifactList" data-caption="${caption}"/>
+      <st:adjunct includes="lib.hudson.artifactList"/>
+    </j:when>
+    <j:otherwise>
+      <st:include it="${build}" page="artifactList"/>
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -39,11 +39,11 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
   <j:if test="${build != null and (!h.artifactsPermissionEnabled or h.artifactsPermissionEnabled and h.hasPermission(build, attrs.permission))}">
-    <l:renderOnDemand div="tag" clazz="artifact-list" capture="build,caption,baseURL">
+    <l:renderOnDemand tag="tbody" clazz="artifact-list" capture="build,caption,baseURL">
         <l:ajax>
             <j:set var="artifacts" value="${build.getArtifactsUpTo(build.LIST_CUTOFF+1)}" />
             <j:if test="${!empty(artifacts)}">
-                <!-- TODO does not scale correctly <t:summary icon="symbol-cube" href="${baseURL}artifact/"> -->
+                <t:summary icon="symbol-cube" href="${baseURL}artifact/">
                     <a href="${baseURL}artifact/">${caption}</a>
                     <j:if test="${build.building}">
                         <p>
@@ -78,7 +78,7 @@ THE SOFTWARE.
                         </table>
                     </j:if>
                     <!-- otherwise just show link to directory browser -->
-                    <!-- </t:summary> -->
+                </t:summary>
             </j:if>
         </l:ajax>
     </l:renderOnDemand>

--- a/core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/core/src/main/resources/lib/hudson/artifactList.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     Generates a listing of the build artifacts.
     Depending on the size of the artifact, this will either produce a list or a link to the directory view.
 
-    <st:attribute name="build" type="hudson.model.Build" use="required">
+    <st:attribute name="build" type="hudson.model.Run" use="required">
       Build object for which the artifacts are displayed
     </st:attribute>
     <st:attribute name="caption" use="required">
@@ -38,45 +38,50 @@ THE SOFTWARE.
       If the hyperlink to artifacts are at another URL, specify the prefix.
     </st:attribute>
   </st:documentation>
-  <j:if test="${!h.isArtifactsPermissionEnabled() or h.isArtifactsPermissionEnabled() and h.hasPermission(it,attrs.permission)}">
-    <j:set var="artifacts" value="${build.getArtifactsUpTo(build.LIST_CUTOFF+1)}" />
-    <j:if test="${!empty(artifacts)}">
-      <t:summary icon="symbol-cube" href="${baseURL}artifact/">
-        <a href="${baseURL}artifact/">${caption}</a>
-        <j:if test="${build.building}">
-          <p>
-            ${%building}
-          </p>
-        </j:if>
-        <j:if test="${size(artifacts) le build.LIST_CUTOFF}">
-          <!-- if not too many, just list them -->
-          <table class="fileList">
-            <j:forEach var="f" items="${artifacts}">
-              <tr>
-                <td>
-                  <l:icon class="icon-document icon-sm"/>
-                </td>
-                <td>
-                  <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
-                </td>
-                <td class="fileSize">
-                  ${h.humanReadableByteSize(f.getFileSize())}
-                </td>
-                <td>
-                  <j:if test="${app.fingerprintMap.ready}">
-                    <a href="${baseURL}artifact/${f.href}/*fingerprint*/">
-                      <l:icon class="icon-fingerprint icon-sm"/>
-                    </a>
-                    <st:nbsp/>
-                  </j:if>
-                  <a href="${baseURL}artifact/${f.href}/*view*/">${%view}</a>
-                </td>
-              </tr>
-            </j:forEach>
-          </table>
-        </j:if>
-          <!-- otherwise just show link to directory browser -->
-      </t:summary>
-    </j:if>
+  <j:if test="${build != null and (!h.artifactsPermissionEnabled or h.artifactsPermissionEnabled and h.hasPermission(build, attrs.permission))}">
+    <l:renderOnDemand div="tag" clazz="artifact-list" capture="build,caption,baseURL">
+        <l:ajax>
+            <j:set var="artifacts" value="${build.getArtifactsUpTo(build.LIST_CUTOFF+1)}" />
+            <j:if test="${!empty(artifacts)}">
+                <!-- TODO does not scale correctly <t:summary icon="symbol-cube" href="${baseURL}artifact/"> -->
+                    <a href="${baseURL}artifact/">${caption}</a>
+                    <j:if test="${build.building}">
+                        <p>
+                            ${%building}
+                        </p>
+                    </j:if>
+                    <j:if test="${size(artifacts) le build.LIST_CUTOFF}">
+                         <!-- if not too many, just list them -->
+                        <table class="fileList">
+                            <j:forEach var="f" items="${artifacts}">
+                                <tr>
+                                    <td>
+                                        <l:icon class="icon-document icon-sm"/>
+                                    </td>
+                                    <td>
+                                        <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
+                                    </td>
+                                    <td class="fileSize">
+                                        ${h.humanReadableByteSize(f.getFileSize())}
+                                    </td>
+                                    <td>
+                                        <j:if test="${app.fingerprintMap.ready}">
+                                            <a href="${baseURL}artifact/${f.href}/*fingerprint*/">
+                                                <l:icon class="icon-fingerprint icon-sm"/>
+                                            </a>
+                                            <st:nbsp/>
+                                        </j:if>
+                                        <a href="${baseURL}artifact/${f.href}/*view*/">${%view}</a>
+                                    </td>
+                                </tr>
+                            </j:forEach>
+                        </table>
+                    </j:if>
+                    <!-- otherwise just show link to directory browser -->
+                    <!-- </t:summary> -->
+            </j:if>
+        </l:ajax>
+    </l:renderOnDemand>
+    <st:adjunct includes="lib.hudson.artifactList"/>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/artifactList.js
+++ b/core/src/main/resources/lib/hudson/artifactList.js
@@ -26,4 +26,4 @@
 // TODO why is render-on-demand not specified to run this already?
 // hudson-behavior.js hard-codes this for .dropdownList,
 // and RenderOnDemandTest calls it manually which seems like cheating.
-renderOnDemand(document.getElementsBySelector('.artifact-list')[0]);
+renderOnDemand(document.getElementsBySelector(".artifact-list")[0]);

--- a/core/src/main/resources/lib/hudson/artifactList.js
+++ b/core/src/main/resources/lib/hudson/artifactList.js
@@ -26,4 +26,4 @@
 // TODO why is render-on-demand not specified to run this already?
 // hudson-behavior.js hard-codes this for .dropdownList,
 // and RenderOnDemandTest calls it manually which seems like cheating.
-renderOnDemand(document.getElementsBySelector(".artifact-list")[0]);
+renderOnDemand(document.querySelector(".artifact-list"));

--- a/core/src/main/resources/lib/hudson/artifactList.js
+++ b/core/src/main/resources/lib/hudson/artifactList.js
@@ -1,0 +1,29 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Or could use Behaviour.specify.
+// TODO why is render-on-demand not specified to run this already?
+// hudson-behavior.js hard-codes this for .dropdownList,
+// and RenderOnDemandTest calls it manually which seems like cheating.
+renderOnDemand(document.getElementsBySelector('.artifact-list')[0]);

--- a/core/src/main/resources/lib/hudson/artifactList.js
+++ b/core/src/main/resources/lib/hudson/artifactList.js
@@ -22,8 +22,18 @@
  * THE SOFTWARE.
  */
 
-// Or could use Behaviour.specify.
-// TODO why is render-on-demand not specified to run this already?
-// hudson-behavior.js hard-codes this for .dropdownList,
-// and RenderOnDemandTest calls it manually which seems like cheating.
-renderOnDemand(document.querySelector(".artifact-list"));
+// TODO package this logic into a generic utility like renderOnDemand/refreshPart with Behaviour.specify
+var e = document.querySelector(".artifact-list");
+fetch(
+  e.getAttribute("data-url") +
+    "?" +
+    new URLSearchParams({ caption: e.getAttribute("data-caption") }),
+).then((rsp) => {
+  if (rsp.ok) {
+    rsp.text().then((responseText) => {
+      e.innerHTML = responseText;
+      Behaviour.applySubtree(e);
+      layoutUpdateCallback.call();
+    });
+  }
+});

--- a/test/src/test/java/hudson/model/RunTest.java
+++ b/test/src/test/java/hudson/model/RunTest.java
@@ -27,6 +27,7 @@ package hudson.model;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -38,18 +39,23 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.XmlFile;
 import hudson.model.listeners.SaveableListener;
+import hudson.remoting.Callable;
 import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.BuildTrigger;
 import hudson.tasks.Builder;
 import hudson.tasks.Fingerprinter;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
 import jenkins.model.ArtifactManager;
 import jenkins.model.ArtifactManagerConfiguration;
 import jenkins.model.ArtifactManagerFactory;
@@ -70,6 +76,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 @Category(SmokeTest.class)
 public class RunTest  {
+
+    private static final Logger LOGGER = Logger.getLogger(RunTest.class.getName());
 
     @Rule public JenkinsRule j = new JenkinsRule();
 
@@ -273,6 +281,106 @@ public class RunTest  {
             }
 
             @TestExtension("deleteArtifactsCustom") public static final class DescriptorImpl extends ArtifactManagerFactoryDescriptor {}
+        }
+    }
+
+    @Test public void slowArtifactManager() throws Exception {
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(new SlowMgr.Factory());
+        var p = j.createFreeStyleProject();
+        j.jenkins.getWorkspaceFor(p).child("f").write("", null);
+        p.getPublishersList().add(new ArtifactArchiver("f"));
+        var b = j.buildAndAssertSuccess(p);
+        assertThat(b.getArtifactManager(), isA(SlowMgr.class));
+        var wc = j.createWebClient();
+        wc.getOptions().setJavaScriptEnabled(false);
+        wc.getPage(b);
+        wc.getPage(p);
+    }
+
+    public static final class SlowMgr extends ArtifactManager {
+        static final AtomicBoolean deleted = new AtomicBoolean();
+
+        @Override public boolean delete() {
+            return !deleted.getAndSet(true);
+        }
+
+        @Override public void onLoad(Run<?, ?> build) {}
+
+        @Override public void archive(FilePath workspace, Launcher launcher, BuildListener listener, Map<String, String> artifacts) {
+            LOGGER.info(() -> "Pretending to archive " + artifacts);
+        }
+
+        @Override public VirtualFile root() {
+            return new VirtualFile() {
+                @Override public <V> V run(Callable<V, IOException> callable) throws IOException {
+                    LOGGER.info("Sleeping");
+                    try {
+                        Thread.sleep(Long.MAX_VALUE);
+                    } catch (InterruptedException x) {
+                        throw new IOException(x);
+                    }
+                    throw new IllegalStateException();
+                }
+
+                @Override public String getName() {
+                    return "";
+                }
+
+                @Override public URI toURI() {
+                    return URI.create("no://where");
+                }
+
+                @Override public VirtualFile getParent() {
+                    return null;
+                }
+
+                @Override public boolean isDirectory() throws IOException {
+                    return true;
+                }
+
+                @Override public boolean isFile() throws IOException {
+                    return false;
+                }
+
+                @Override public boolean exists() throws IOException {
+                    return true;
+                }
+
+                @Override public VirtualFile[] list() throws IOException {
+                    return new VirtualFile[0];
+                }
+
+                @Override public VirtualFile child(String name) {
+                    return null;
+                }
+
+                @Override public long length() throws IOException {
+                    return 0;
+                }
+
+                @Override public long lastModified() throws IOException {
+                    return 0;
+                }
+
+                @Override public boolean canRead() throws IOException {
+                    return true;
+                }
+
+                @Override public InputStream open() throws IOException {
+                    throw new FileNotFoundException();
+                }
+            };
+        }
+
+        public static final class Factory extends ArtifactManagerFactory {
+            @DataBoundConstructor public Factory() {}
+
+            @Override public ArtifactManager managerFor(Run<?, ?> build) {
+                LOGGER.info(() -> "Picking manager for " + build);
+                return new SlowMgr();
+            }
+
+            @TestExtension("slowArtifactManager") public static final class DescriptorImpl extends ArtifactManagerFactoryDescriptor {}
         }
     }
 

--- a/test/src/test/java/lib/layout/RenderOnDemandTest.java
+++ b/test/src/test/java/lib/layout/RenderOnDemandTest.java
@@ -74,7 +74,9 @@ public class RenderOnDemandTest {
         j.createWebClient().goTo("self/testBehaviour"); // prime caches
         int total = 0;
         for (var element : MemoryAssert.increasedMemory(() -> {
-            j.createWebClient().goTo("self/testBehaviour");
+            for (int i = 0; i < 10; i++) {
+                j.createWebClient().goTo("self/testBehaviour");
+            }
             return null;
         }, (obj, referredFrom, reference) -> !obj.getClass().getName().contains("htmlunit"))) {
             total += element.byteSize;

--- a/test/src/test/java/lib/layout/RenderOnDemandTest.java
+++ b/test/src/test/java/lib/layout/RenderOnDemandTest.java
@@ -33,9 +33,12 @@ import hudson.model.RootAction;
 import org.htmlunit.ScriptResult;
 import org.htmlunit.WebClientUtil;
 import org.htmlunit.html.HtmlPage;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MemoryAssert;
 import org.jvnet.hudson.test.TestExtension;
 
 /**
@@ -64,27 +67,21 @@ public class RenderOnDemandTest {
         assertEquals("AlphaBravoCharlie", r.getJavaScriptResult().toString());
     }
 
-    /*
+    @Ignore("just informational")
+    @Issue("JENKINS-16341")
     @Test
     public void testMemoryConsumption() throws Exception {
         j.createWebClient().goTo("self/testBehaviour"); // prime caches
         int total = 0;
-        for (MemoryAssert.HistogramElement element : MemoryAssert.increasedMemory(new Callable<Void>() {
-            @Override public Void call() throws Exception {
-                j.createWebClient().goTo("self/testBehaviour");
-                return null;
-            }
-        }, new Filter() {
-            @Override public boolean accept(Object obj, Object referredFrom, Field reference) {
-                return !obj.getClass().getName().contains("htmlunit");
-            }
-        })) {
+        for (var element : MemoryAssert.increasedMemory(() -> {
+            j.createWebClient().goTo("self/testBehaviour");
+            return null;
+        }, (obj, referredFrom, reference) -> !obj.getClass().getName().contains("htmlunit"))) {
             total += element.byteSize;
             System.out.println(element.className + " ×" + element.instanceCount + ": " + element.byteSize);
         }
         System.out.println("total: " + total);
     }
-    */
 
     /**
      * Makes sure that scripts get evaluated.

--- a/test/src/test/java/lib/layout/RenderOnDemandTest.java
+++ b/test/src/test/java/lib/layout/RenderOnDemandTest.java
@@ -73,13 +73,18 @@ public class RenderOnDemandTest {
     public void testMemoryConsumption() throws Exception {
         j.createWebClient().goTo("self/testBehaviour"); // prime caches
         int total = 0;
+        int count = 80;
         for (var element : MemoryAssert.increasedMemory(() -> {
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < count; i++) {
+                System.err.println("#" + i);
                 j.createWebClient().goTo("self/testBehaviour");
             }
             return null;
         }, (obj, referredFrom, reference) -> !obj.getClass().getName().contains("htmlunit"))) {
             total += element.byteSize;
+            if (element.instanceCount == count) {
+                System.out.print("⚠ ️");
+            }
             System.out.println(element.className + " ×" + element.instanceCount + ": " + element.byteSize);
         }
         System.out.println("total: " + total);


### PR DESCRIPTION
A controller using `artifact-manager-s3` was slow to render build index pages ([CloudBees-internal issue](https://cloudbees.atlassian.net/browse/SECO-4538)) because the HTTP rendering thread was contacting S3. This artifact list is nice to see but not critical and could be rendered lazily.

### Testing done

Automated test that the main pages do not block. Without fix, test times out.

Set up `artifact-manager-s3`.

```bash
eval `aws configure export-credentials --format env`
mvn -pl war jetty:run
```

Ran a (Pipeline) build using S3 artifacts. Displayed correctly on build and project pages. Turned off my network, visited those pages again. Other content renders fine; the `$stapler` request hangs for a few seconds before timing out and giving a 200 and no artifacts are displayed. Without fix, main page rendering hangs for a few seconds.

### Proposed changelog entries

- Defer rendering a build’s artifact list to a background request, in case this computation is expensive.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
