### PR TITLE
[JENKINS-75664] Revert call to `BoundObjectTable#releaseMe`

### DIFF
--- a/core/src/main/java/hudson/widgets/RenderOnDemandClosure.java
+++ b/core/src/main/java/hudson/widgets/RenderOnDemandClosure.java
@@ -102,7 +102,6 @@ public class RenderOnDemandClosure {
             @Override
             public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object node) throws IOException, ServletException {
                 LOGGER.fine(() -> "rendering " + req.getPathInfo());
-                req.getBoundObjectTable().releaseMe();
                 req.getWebApp().getDispatchValidator().allowDispatch(req, rsp);
                 try {
                     new DefaultScriptInvoker() {


### PR DESCRIPTION
See [JENKINS-75664](https://issues.jenkins.io/browse/JENKINS-75664).

https://github.com/jenkinsci/jenkins/pull/10623#issuecomment-2877928596 identified by bisection.

https://github.com/jenkinsci/jenkins/pull/10623#discussion_r2075789533 was originally developed when I was using `t:renderOnDemand`. I subsequently decided not to use this (misconceived) system, but left in that change since it seemed helpful in other cases when configuring projects https://github.com/jenkinsci/jenkins/pull/10623#discussion_r2077304811. https://github.com/jenkinsci/stapler/pull/663 and/or https://github.com/jenkinsci/stapler/pull/665 probably suffice; ~it would be nicer to release memory deterministically rather than keeping an object around after it has been used and relying on some subsequent batch cleanup (like the difference between `Closeable` and `Finalizer`)~.

### Testing done

`JUnitPluginTest.publish_test_result_which_passed` fails without this change and passes with it.

~I did not determine _why_ this change caused the test failure. In the ATH, clicking the button to add a builder has no effect. But I cannot reproduce the same behavior interactively outside ATH (using Firefox in both cases).~

Interactively confirmed by creating a freestyle project and adding the shell step builder twice.

### Proposed changelog entries

- A change to lazy rendering in 2.510 caused a regression in certain GUI configuration scenarios, such as adding two build steps of the same type (e.g., Execute shell) to a freestyle project at the same time. (The workaround is to add one builder, save, then reload the page and add the next.)

### Proposed changelog category

/label major-bug

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
