### PR TITLE
[JENKINS-75388] Remove `?path` and `?pattern` support from DBS

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -203,15 +203,6 @@ public final class DirectoryBrowserSupport implements HttpResponse {
     }
 
     private void serveFile(StaplerRequest2 req, StaplerResponse2 rsp, VirtualFile root, String icon, boolean serveDirIndex) throws IOException, ServletException, InterruptedException {
-        // handle form submission
-        String pattern = req.getParameter("pattern");
-        if (pattern == null)
-            pattern = req.getParameter("path"); // compatibility with Hudson<1.129
-        if (pattern != null && Util.isSafeToRedirectTo(pattern)) { // avoid open redirect
-            rsp.sendRedirect2(pattern);
-            return;
-        }
-
         String path = getPath(req);
         if (path.replace('\\', '/').contains("/../")) {
             // don't serve anything other than files in the artifacts dir

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -33,17 +33,18 @@ THE SOFTWARE.
       <div class="dirTree">
       <!-- parent path -->
         <div class="parentPath">
-          <form action="${backPath}" method="get">
+          <form>
             <a href="${topPath}">${it.owner.name}</a> /
             <j:forEach var="p" items="${parentPath}">
               <a href="${p.href}">${p.title}</a>
               /
             </j:forEach>
-            <input type="text" name="pattern" value="${pattern}" class="jenkins-input" />
-            <button class="jenkins-button">
+            <input type="text" name="pattern" value="${pattern}" class="jenkins-input" id="pattern" data-restofpath="${request2.restOfPath}" data-backpath="${backPath}" />
+            <button class="jenkins-button" id="pattern-submit">
               <l:icon src="symbol-arrow-right" />
             </button>
           </form>
+          <st:adjunct includes="hudson.model.DirectoryBrowserSupport.pattern" />
         </div>
         <j:choose>
           <j:when test="${empty(files)}">

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/pattern.js
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/pattern.js
@@ -1,0 +1,18 @@
+document.addEventListener("DOMContentLoaded", function () {
+  document
+    .getElementById("pattern-submit")
+    .addEventListener("click", function (ev) {
+      ev.preventDefault();
+
+      let input = document.getElementById("pattern");
+      let pattern = input.value;
+      let back = input.dataset.backpath;
+
+      let baseurl = back;
+      if (!baseurl.endsWith("/")) {
+        baseurl = baseurl + "/";
+      }
+      baseurl = baseurl + pattern;
+      document.location.href = baseurl;
+    });
+});

--- a/test/src/test/java/jenkins/security/Security3501Test.java
+++ b/test/src/test/java/jenkins/security/Security3501Test.java
@@ -4,29 +4,56 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.util.List;
+import jenkins.security.security3501Test.Security3501RootAction;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RealJenkinsRule;
 
+@RunWith(Parameterized.class)
 public class Security3501Test {
+    // Workaround for https://github.com/jenkinsci/jenkins-test-harness/issues/933
+    private final String contextPath;
+
     @Rule
-    public RealJenkinsRule jj = new RealJenkinsRule();
+    public RealJenkinsRule jj = new RealJenkinsRule().addSyntheticPlugin(new RealJenkinsRule.SyntheticPlugin(Security3501RootAction.class.getPackage()).shortName("Security3501RootAction"));
+
+    @Parameterized.Parameters
+    public static List<String> contexts() {
+        return List.of("/jenkins", "");
+    }
+
+    public Security3501Test(String contextPath) {
+        jj.withPrefix(contextPath);
+        this.contextPath = contextPath;
+    }
 
     @Test
     public void testRedirects() throws Throwable {
-        jj.then(Security3501Test::_testRedirects);
+        jj.then(new TestRedirectsStep(contextPath));
     }
 
-    public static void _testRedirects(JenkinsRule j) throws Exception {
-        List<String> prohibitedPaths = List.of("%5C%5Cexample.org", "%5C/example.org", "/%5Cexample.org", "//example.org", "https://example.org", "\\example.org");
-        for (String path : prohibitedPaths) {
-            try (JenkinsRule.WebClient wc = j.createWebClient().withRedirectEnabled(false)) {
-                final FailingHttpStatusCodeException fhsce = Assert.assertThrows(FailingHttpStatusCodeException.class, () -> wc.goTo("userContent?path=" + path));
-                assertThat(fhsce.getStatusCode(), is(302));
-                assertThat(fhsce.getResponse().getResponseHeaderValue("Location"), is(j.getURL().toExternalForm() + "userContent/"));
+    private record TestRedirectsStep(String context) implements RealJenkinsRule.Step {
+        public void run(JenkinsRule j) throws Exception {
+            List<String> prohibitedPaths = List.of("%5C%5Cexample.org", "%5C/example.org", "/%5Cexample.org", "//example.org", "https://example.org", "\\example.org");
+            for (String path : prohibitedPaths) {
+                try (JenkinsRule.WebClient wc = j.createWebClient().withRedirectEnabled(false)) {
+                    final FailingHttpStatusCodeException fhsce = Assert.assertThrows(FailingHttpStatusCodeException.class, () -> wc.goTo("redirects/content?path=" + path));
+                    assertThat(fhsce.getStatusCode(), is(404));
+                }
+            }
+
+            List<String> allowedPaths = List.of("foo", "foo/bar");
+            for (String path : allowedPaths) {
+                try (JenkinsRule.WebClient wc = j.createWebClient().withRedirectEnabled(false)) {
+                    final FailingHttpStatusCodeException fhsce = Assert.assertThrows(FailingHttpStatusCodeException.class, () -> wc.goTo("redirects/content?path=" + path));
+                    assertThat(fhsce.getStatusCode(), is(302));
+                    assertThat(fhsce.getResponse().getResponseHeaderValue("Location"), is(context + "/redirects/" + path));
+                }
             }
         }
     }

--- a/test/src/test/java/jenkins/security/security3501Test/Security3501RootAction.java
+++ b/test/src/test/java/jenkins/security/security3501Test/Security3501RootAction.java
@@ -1,0 +1,26 @@
+package jenkins.security.security3501Test;
+
+import hudson.Util;
+import hudson.model.InvisibleAction;
+import hudson.model.RootAction;
+import java.io.IOException;
+import org.jenkinsci.plugins.variant.OptionalExtension;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
+
+@OptionalExtension
+public class Security3501RootAction extends InvisibleAction implements RootAction {
+    @Override
+    public String getUrlName() {
+        return "redirects";
+    }
+
+    public void doContent(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        final String path = req.getParameter("path");
+        if (path != null && Util.isSafeToRedirectTo(path)) {
+            rsp.sendRedirect2(path);
+            return;
+        }
+        rsp.setStatus(404);
+    }
+}

--- a/test/src/test/java/jenkins/security/security3501Test/package-info.java
+++ b/test/src/test/java/jenkins/security/security3501Test/package-info.java
@@ -1,0 +1,4 @@
+@OptionalPackage(requirePlugins = "Security3501RootAction")
+package jenkins.security.security3501Test;
+
+import org.jenkinsci.plugins.variant.OptionalPackage;


### PR DESCRIPTION
See [JENKINS-75388](https://issues.jenkins.io/browse/JENKINS-75388).

### Testing done

Some interactive testing. The filter field seems to behave basically as before. `..` is still the same (weird) redirect to the parent page. `/` (and everything starting with it) is now ambiguous path (containing `//`) when formerly it redirected to the root path. This doesn't seem like valid input anyway, so doesn't matter.

### Proposed changelog entries

- Remove support for `?path` and `?pattern` query parameters for directory listings of user content (workspaces, archived artifacts, etc.). The filter text box now uses JavaScript instead of a form submission to navigate to the expected URL. Programmatic users are advised to replace `?path` or `?pattern` in their requests with the resulting redirect URL, whose behavior did not change from before.

### Proposed changelog category

/label rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
