### PR TITLE
Add retry to flaky test in ResponseTimeMonitorTest

### DIFF
--- a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
@@ -51,7 +51,7 @@ public class ResponseTimeMonitorTest {
         assertNull(ResponseTimeMonitor.DESCRIPTOR.monitor(c));
 
         // Retry to compensate for test being flaky in CI
-        await().atMost(10 * 500, TimeUnit.MILLISECONDS)
+        await().atMost(5, TimeUnit.SECONDS)
             .ignoreException(ExecutionException.class)
             .until(() -> {
                 // Now reconnect and make sure we get a non-null response.


### PR DESCRIPTION
It seems like `ResponseTimeMonitorTest#skipOfflineAgent` is being flaky and keeps failing ever so often on `ci.jenkins.io` with

```
java.io.IOException: Agent failed to connect, even though the launcher didn't report it. See the log output for details.
```

<details>
<summary>Stack trace</summary>

```
java.util.concurrent.ExecutionException: java.io.IOException: Agent failed to connect, even though the launcher didn't report it. See the log output for details.
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at hudson.node_monitors.ResponseTimeMonitorTest.skipOfflineAgent(ResponseTimeMonitorTest.java:51)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:648)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.io.IOException: Agent failed to connect, even though the launcher didn't report it. See the log output for details.
	at hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:325)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	... 1 more
```
</details>

<details>
<summary>Standard error</summary>

```
0.168 [id=98]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:33029/jenkins/
   0.176 [id=98]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.511-rc36801.ed4e4d95c47b_
   0.187 [id=111]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.189 [id=116]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.194 [id=115]	INFO	j.b.api.BouncyCastlePlugin#start: /home/jenkins/agent/workspace/Core_jenkins_master/test/target/j h12533567182710431013/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.504 [id=111]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.507 [id=113]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.507 [id=115]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.882 [id=114]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.882 [id=116]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.882 [id=112]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.884 [id=113]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.897 [id=115]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   2.403 [id=91]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for slave0
   2.668 [id=95]	WARNING	o.j.h.test.SimpleCommandLauncher#launch
java.io.EOFException: unexpected stream termination
	at hudson.remoting.ChannelBuilder.negotiate(ChannelBuilder.java:493)
	at hudson.remoting.ChannelBuilder.build(ChannelBuilder.java:437)
	at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:440)
	at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:407)
	at org.jvnet.hudson.test.SimpleCommandLauncher.launch(SimpleCommandLauncher.java:83)
	at hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:297)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
   2.673 [id=98]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   2.675 [id=77]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=77312, exitValue=143] with {HUDSON_COOKIE=9ae34207-067e-4968-80ab-ccb6b8d19cfb} for slave0
   2.675 [id=140]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for slave0
   2.678 [id=91]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for slave0
   2.683 [id=98]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   2.767 [id=98]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /home/jenkins/agent/workspace/Core_jenkins_master/test/target/j h12533567182710431013
```
</details>

There is already plenty of _[Jenkins related threads for that error](https://www.google.com/search?&q=java.io.EOFException%3A+unexpected+stream+termination)_ yet there does not seem to be a reliable solution besides retrying.

### Testing done

I was unable to reproduce the error reliably on my machine however I let the test in question run in a loop for 2 hours and found it to fail twice. With my proposed changes in place I encountered it once in 2 hours and was able to recover from it.

That being said, only time (and `ci.jenkins.io`) will tell if this fix is actually helping or not.

### Proposed changelog entries

- Add retry to flaky test in `ResponseTimeMonitorTest`

### Proposed changelog category

/label internal,tests

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers 


Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
