### PR TITLE
Relax checks for flaky tests in ComputerStateTest

### DIFF
--- a/test/src/test/java/hudson/cli/ComputerStateTest.java
+++ b/test/src/test/java/hudson/cli/ComputerStateTest.java
@@ -34,8 +34,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeThat;
 
 import hudson.cli.CLICommandInvoker.Result;
 import hudson.model.Computer;
@@ -108,9 +106,7 @@ public class ComputerStateTest {
             assertThat(userCause.toString(), endsWith("Custom cause message"));
             assertThat(userCause.getUser(), equalTo(command.user()));
         } else {
-            // Compensate for test being flaky in CI
-            assumeThat(cause, not(instanceOf(OfflineCause.ChannelTermination.class)));
-            fail("OfflineCause should have been UserCause or ChannelTermination, but was " + cause.getClass().getSimpleName() + " instead");
+            assertThat("seen occasionally in CI", cause, instanceOf(OfflineCause.ChannelTermination.class));
         }
     }
 
@@ -133,9 +129,7 @@ public class ComputerStateTest {
             assertThat(userCause.toString(), endsWith("Custom cause message"));
             assertThat(userCause.getUser(), equalTo(command.user()));
         } else {
-            // Compensate for test being flaky in CI
-            assumeThat(cause, not(instanceOf(OfflineCause.ChannelTermination.class)));
-            fail("OfflineCause should have been UserCause or ChannelTermination, but was " + cause.getClass().getSimpleName() + " instead");
+            assertThat("seen occasionally in CI", cause, instanceOf(OfflineCause.ChannelTermination.class));
         }
     }
 

--- a/test/src/test/java/hudson/cli/ComputerStateTest.java
+++ b/test/src/test/java/hudson/cli/ComputerStateTest.java
@@ -30,9 +30,12 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 
 import hudson.cli.CLICommandInvoker.Result;
 import hudson.model.Computer;
@@ -94,15 +97,21 @@ public class ComputerStateTest {
         assertTrue(slave.toComputer().isOnline());
 
         Result result = command.authorizedTo(Jenkins.READ, Computer.DISCONNECT)
-                .invokeWithArgs(slave.getNodeName(), "-m", "Custom cause message")
-        ;
+                .invokeWithArgs(slave.getNodeName(), "-m", "Custom cause message");
 
         assertThat(result, succeededSilently());
         assertTrue(slave.toComputer().isOffline());
 
-        OfflineCause.UserCause cause = (OfflineCause.UserCause) slave.toComputer().getOfflineCause();
-        assertThat(cause.toString(), endsWith("Custom cause message"));
-        assertThat(cause.getUser(), equalTo(command.user()));
+        OfflineCause cause = slave.toComputer().getOfflineCause();
+
+        if (cause instanceof OfflineCause.UserCause userCause) {
+            assertThat(userCause.toString(), endsWith("Custom cause message"));
+            assertThat(userCause.getUser(), equalTo(command.user()));
+        } else {
+            // Compensate for test being flaky in CI
+            assumeThat(cause, not(instanceOf(OfflineCause.ChannelTermination.class)));
+            fail("OfflineCause should have been UserCause or ChannelTermination, but was " + cause.getClass().getSimpleName() + " instead");
+        }
     }
 
     @Test
@@ -113,15 +122,21 @@ public class ComputerStateTest {
         assertTrue(slave.toComputer().isOnline());
 
         Result result = command.authorizedTo(Jenkins.READ, Computer.DISCONNECT)
-                .invokeWithArgs(slave.getNodeName(), "-m", "Custom cause message")
-        ;
+                .invokeWithArgs(slave.getNodeName(), "-m", "Custom cause message");
 
         assertThat(result, succeededSilently());
         assertTrue(slave.toComputer().isOffline());
 
-        OfflineCause.UserCause cause = (OfflineCause.UserCause) slave.toComputer().getOfflineCause();
-        assertThat(cause.toString(), endsWith("Custom cause message"));
-        assertThat(cause.getUser(), equalTo(command.user()));
+        OfflineCause cause = slave.toComputer().getOfflineCause();
+
+        if (cause instanceof OfflineCause.UserCause userCause) {
+            assertThat(userCause.toString(), endsWith("Custom cause message"));
+            assertThat(userCause.getUser(), equalTo(command.user()));
+        } else {
+            // Compensate for test being flaky in CI
+            assumeThat(cause, not(instanceOf(OfflineCause.ChannelTermination.class)));
+            fail("OfflineCause should have been UserCause or ChannelTermination, but was " + cause.getClass().getSimpleName() + " instead");
+        }
     }
 
     @Test


### PR DESCRIPTION
It seems like `ComputerStateTest#disconnect` / `ComputerStateTest#offline` are being flaky and keep failing ever so often on `ci.jenkins.io` with

```
class hudson.slaves.OfflineCause$ChannelTermination cannot be cast to class hudson.slaves.OfflineCause$UserCause (hudson.slaves.OfflineCause$ChannelTermination and hudson.slaves.OfflineCause$UserCause are in unnamed module of loader 'app')
```

<details>
<summary>Stack trace</summary>

```
java.lang.ClassCastException: class hudson.slaves.OfflineCause$ChannelTermination cannot be cast to class hudson.slaves.OfflineCause$UserCause (hudson.slaves.OfflineCause$ChannelTermination and hudson.slaves.OfflineCause$UserCause are in unnamed module of loader 'app')
	at hudson.cli.ComputerStateTest.disconnect(ComputerStateTest.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:648)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:840)
```
</details>

<details>
<summary>Standard error</summary>

```
0.164 [id=211]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer2: Running on http://localhost:34519/jenkins/
   0.195 [id=211]	INFO	jenkins.model.Jenkins#<init>: Starting version 2.511-rc36808.b_03a_ed994795
   0.210 [id=224]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   0.254 [id=228]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   0.257 [id=228]	INFO	j.b.api.BouncyCastlePlugin#start: /home/jenkins/agent/workspace/Core_jenkins_PR-10582/test/target/j h16517884842763403567/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   0.518 [id=223]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   0.520 [id=229]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   0.521 [id=227]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   0.751 [id=228]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   0.751 [id=228]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   0.751 [id=228]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   0.752 [id=228]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   0.770 [id=224]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   0.819 [id=211]	INFO	o.jvnet.hudson.test.JenkinsRule#waitOnline: Launching slave0…
   1.616 [id=72]	INFO	o.j.h.test.SimpleCommandLauncher#launch: agent launched for slave0
   1.616 [id=211]	INFO	o.jvnet.hudson.test.JenkinsRule#waitOnline: …finished launching slave0.
   1.628 [id=79]	INFO	hudson.remoting.Request$2#run: Failed to send back a reply to the request RPCRequest:hudson.remoting.RemoteClassLoader$IClassLoader.fetch3[java.lang.String](2): hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@118ec5ac:slave0": channel is already closed
   1.645 [id=253]	INFO	h.r.SynchronousCommandTransport$ReaderThread#run: I/O error in channel slave0
java.io.EOFException
	at java.base/java.io.ObjectInputStream$PeekInputStream.readFully(ObjectInputStream.java:2915)
	at java.base/java.io.ObjectInputStream$BlockDataInputStream.readShort(ObjectInputStream.java:3410)
	at java.base/java.io.ObjectInputStream.readStreamHeader(ObjectInputStream.java:954)
	at java.base/java.io.ObjectInputStream.<init>(ObjectInputStream.java:392)
	at hudson.remoting.ObjectInputStreamEx.<init>(ObjectInputStreamEx.java:50)
	at hudson.remoting.Command.readFrom(Command.java:141)
	at hudson.remoting.Command.readFrom(Command.java:127)
	at hudson.remoting.AbstractSynchronousByteArrayCommandTransport.read(AbstractSynchronousByteArrayCommandTransport.java:35)
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:62)
Caused: java.io.IOException: Unexpected termination of the channel
	at hudson.remoting.SynchronousCommandTransport$ReaderThread.run(SynchronousCommandTransport.java:80)
   1.660 [id=72]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: killed Process[pid=21367, exitValue=143] with {HUDSON_COOKIE=85a70d7f-4b71-4b87-a831-c08fb020832f} for slave0
   1.661 [id=253]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for slave0
   1.670 [id=211]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
   1.672 [id=68]	INFO	o.j.h.test.SimpleCommandLauncher#afterDisconnect: no process for slave0
   1.675 [id=211]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
   1.750 [id=211]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /home/jenkins/agent/workspace/Core_jenkins_PR-10582/test/target/j h16517884842763403567
```
</details>

There is already plenty of _[Jenkins related threads for that error](https://www.google.com/search?&q=java.io.EOFException%3A+unexpected+stream+termination)_ yet there does not seem to be a reliable solution besides retrying.

Similar to #10654 I added some logic to relax the checks of these tests. 
My proposal is to skip / ignore the test if a channel termination is detected and fail otherwise.

### Testing done

I was unable to reproduce the error reliably on my machine however I let the tests in question run in a loop for 3 hours and found it to fail once. With my proposed changes in place I encountered it once in 6 hours (just my kind of luck...) and was able to skip it via the `assumeThat` condition.

### Proposed changelog entries

- Relax checks for flaky test in `ComputerStateTest`

### Proposed changelog category

/label internal,tests

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers 


Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
