### PR TITLE
Bump ATH from 6180.v889d0fe56785 to 6180.v889d0fe56785

### DIFF
--- a/ath.sh
+++ b/ath.sh
@@ -26,20 +26,35 @@ fi
 mkdir -p target/ath-reports
 chmod a+rwx target/ath-reports
 
-# obtain the groupId to grant to access the docker socket to run tests needing docker
-dockergid=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ubuntu:noble stat -c %g /var/run/docker.sock)
+curl \
+	--fail \
+	--silent \
+	--show-error \
+	--output /tmp/ath.yml \
+	--location "https://raw.githubusercontent.com/jenkinsci/acceptance-test-harness/refs/tags/${ATH_VERSION}/docker-compose.yml"
 
-exec docker run --rm \
+sed -i -e "s/jenkins\/ath:latest/jenkins\/ath:${ATH_VERSION}/g" /tmp/ath.yml
+
+# obtain the groupId to grant to access the docker socket to run tests needing docker
+if [[ -z ${DOCKER_GID:-} ]]; then
+	DOCKER_GID=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ubuntu:noble stat -c %g /var/run/docker.sock) || exit 1
+	export DOCKER_GID
+fi
+
+trap 'docker-compose --file /tmp/ath.yml kill && docker-compose --file /tmp/ath.yml down' EXIT
+
+exec docker-compose \
+	--file /tmp/ath.yml \
+	run \
 	--env JDK \
 	--env ATH_VERSION \
 	--env BROWSER \
-	--shm-size 2g `# avoid selenium.WebDriverException exceptions like 'Failed to decode response from marionette' and webdriver closed` \
-	--group-add ${dockergid} \
+	--name mvn \
+	--no-TTY \
+	--rm \
 	--volume "$(pwd)"/war/target/jenkins.war:/jenkins.war:ro \
-	--volume /var/run/docker.sock:/var/run/docker.sock:rw \
 	--volume "$(pwd)"/target/ath-reports:/reports:rw \
-	--interactive \
-	jenkins/ath:"$ATH_VERSION" \
+	mvn \
 	bash <<-'INSIDE'
 		set -o errexit
 		set -o nounset
@@ -47,12 +62,10 @@ exec docker run --rm \
 		set -o xtrace
 		cd
 		set-java.sh "${JDK}"
-		# Start the VNC system provided by the image from the default user home directory
-		eval "$(vnc.sh)"
 		env | sort
-		git clone --branch "$ATH_VERSION" --depth 1 https://github.com/jenkinsci/acceptance-test-harness
+		git clone --branch "${ATH_VERSION}" --depth 1 https://github.com/jenkinsci/acceptance-test-harness
 		cd acceptance-test-harness
-		run.sh "$BROWSER" /jenkins.war \
+		run.sh "remote-webdriver-${BROWSER}" /jenkins.war \
 			-Dmaven.test.failure.ignore \
 			-DforkCount=1 \
 			-Dgroups=org.jenkinsci.test.acceptance.junit.SmokeTest


### PR DESCRIPTION
Adapting to recent upstream changes to use `docker-compose`.

### Testing done

CI build

### Proposed changelog entries

- N/A

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
