### PR TITLE
Fix FileChannelWriterTest.flush on Windows by reverting "Migrate tests to JUnit5 (core / hudson / 2)"

### DIFF
--- a/core/src/test/java/hudson/BulkChangeTest.java
+++ b/core/src/test/java/hudson/BulkChangeTest.java
@@ -24,18 +24,18 @@
 
 package hudson;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import hudson.model.Saveable;
 import java.io.IOException;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests {@link BulkChange}.
  *
  * @author Kohsuke Kawaguchi
  */
-class BulkChangeTest {
+public class BulkChangeTest {
 
     private static class Point implements Saveable {
         /**
@@ -72,7 +72,7 @@ class BulkChangeTest {
      * If there is no BulkChange, we should see two saves.
      */
     @Test
-    void noBulkChange() throws Exception {
+    public void noBulkChange() throws Exception {
         Point pt = new Point();
         pt.set(0, 0);
         assertEquals(2, pt.saveCount);
@@ -82,7 +82,7 @@ class BulkChangeTest {
      * With a {@link BulkChange}, this will become just one save.
      */
     @Test
-    void bulkChange() throws Exception {
+    public void bulkChange() throws Exception {
         Point pt = new Point();
         BulkChange bc = new BulkChange(pt);
         try {
@@ -97,7 +97,7 @@ class BulkChangeTest {
      * {@link BulkChange}s can be nested.
      */
     @Test
-    void nestedBulkChange() throws Exception {
+    public void nestedBulkChange() throws Exception {
         Point pt = new Point();
         Point pt2 = new Point();
         BulkChange bc1 = new BulkChange(pt);

--- a/core/src/test/java/hudson/ChannelRule.java
+++ b/core/src/test/java/hudson/ChannelRule.java
@@ -1,0 +1,64 @@
+package hudson;
+
+
+import hudson.remoting.Channel;
+import hudson.remoting.ChannelBuilder;
+import hudson.remoting.FastPipedInputStream;
+import hudson.remoting.FastPipedOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.rules.ExternalResource;
+
+/**
+ * Test that uses a connected channel.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public final class ChannelRule extends ExternalResource {
+    /**
+     * Two channels that are connected to each other, but shares the same classloader.
+     */
+    public Channel french;
+    public Channel british;
+    private ExecutorService executors;
+
+    @Override protected void before() throws Exception {
+        executors = Executors.newCachedThreadPool();
+        final FastPipedInputStream p1i = new FastPipedInputStream();
+        final FastPipedInputStream p2i = new FastPipedInputStream();
+        final FastPipedOutputStream p1o = new FastPipedOutputStream(p1i);
+        final FastPipedOutputStream p2o = new FastPipedOutputStream(p2i);
+
+        Future<Channel> f1 = executors.submit(new Callable<>() {
+            @Override
+            public Channel call() throws Exception {
+                return new ChannelBuilder("This side of the channel", executors).withMode(Channel.Mode.BINARY).build(p1i, p2o);
+            }
+        });
+        Future<Channel> f2 = executors.submit(new Callable<>() {
+            @Override
+            public Channel call() throws Exception {
+                return new ChannelBuilder("The other side of the channel", executors).withMode(Channel.Mode.BINARY).build(p2i, p1o);
+            }
+        });
+        french = f1.get();
+        british = f2.get();
+    }
+
+    @Override protected void after() {
+        try {
+            french.close(); // this will automatically initiate the close on the other channel, too.
+            french.join();
+            british.join();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException x) {
+            throw new AssertionError(x);
+        }
+        executors.shutdownNow();
+    }
+}

--- a/core/src/test/java/hudson/ClassicPluginStrategyTest.java
+++ b/core/src/test/java/hudson/ClassicPluginStrategyTest.java
@@ -37,10 +37,10 @@ import org.junit.jupiter.api.Test;
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-class ClassicPluginStrategyTest {
+public class ClassicPluginStrategyTest {
 
     @Test
-    void test_getDetachedPlugins() {
+    public void test_getDetachedPlugins() {
         List<DetachedPlugin> list = DetachedPluginsUtil.getDetachedPlugins(new VersionNumber("1.296"));
 
         assertTrue(list.size() >= 14); // There were 14 at the time of writing this test

--- a/core/src/test/java/hudson/EnvVarsTest.java
+++ b/core/src/test/java/hudson/EnvVarsTest.java
@@ -41,17 +41,17 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Kohsuke Kawaguchi
  */
-class EnvVarsTest {
+public class EnvVarsTest {
 
     @Test
-    void caseInsensitive() {
+    public void caseInsensitive() {
         EnvVars ev = new EnvVars(Map.of("Path", "A:B:C"));
         assertTrue(ev.containsKey("PATH"));
         assertEquals("A:B:C", ev.get("PATH"));
     }
 
     @Test
-    void overrideExpandingAll() {
+    public void overrideExpandingAll() {
         EnvVars env = new EnvVars();
         env.put("PATH", "orig");
         env.put("A", "Value1");
@@ -71,7 +71,7 @@ class EnvVarsTest {
     }
 
     @Test
-    void overrideOrderCalculatorSimple() {
+    public void overrideOrderCalculatorSimple() {
         EnvVars env = new EnvVars();
         EnvVars overrides = new EnvVars();
         overrides.put("A", "NoReference");
@@ -87,7 +87,7 @@ class EnvVarsTest {
     }
 
     @Test
-    void overrideOrderCalculatorInOrder() {
+    public void overrideOrderCalculatorInOrder() {
         EnvVars env = new EnvVars();
         EnvVars overrides = new EnvVars();
         overrides.put("A", "NoReference");
@@ -102,7 +102,7 @@ class EnvVarsTest {
     }
 
     @Test
-    void overrideOrderCalculatorMultiple() {
+    public void overrideOrderCalculatorMultiple() {
         EnvVars env = new EnvVars();
         EnvVars overrides = new EnvVars();
         overrides.put("A", "Noreference");
@@ -115,7 +115,7 @@ class EnvVarsTest {
     }
 
     @Test
-    void overrideOrderCalculatorSelfReference() {
+    public void overrideOrderCalculatorSelfReference() {
         EnvVars env = new EnvVars();
         EnvVars overrides = new EnvVars();
         overrides.put("PATH", "some;${PATH}");
@@ -126,7 +126,7 @@ class EnvVarsTest {
     }
 
     @Test
-    void overrideOrderCalculatorCyclic() {
+    public void overrideOrderCalculatorCyclic() {
         EnvVars env = new EnvVars();
         env.put("C", "Existing");
         EnvVars overrides = new EnvVars();
@@ -144,7 +144,7 @@ class EnvVarsTest {
     }
 
     @Test
-    void putIfNotNull() {
+    public void putIfNotNull() {
         EnvVars env = new EnvVars();
         env.putIfNotNull("foo", null);
         assertTrue(env.isEmpty());
@@ -153,7 +153,7 @@ class EnvVarsTest {
     }
 
     @Test
-    void putAllNonNull() {
+    public void putAllNonNull() {
         EnvVars env = new EnvVars();
         TreeMap<String, String> map = new TreeMap<>();
         map.put("A", "a");

--- a/core/src/test/java/hudson/FunctionsTest.java
+++ b/core/src/test/java/hudson/FunctionsTest.java
@@ -30,9 +30,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -56,18 +56,17 @@ import java.util.logging.LogRecord;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.mockito.MockedStatic;
 
-class FunctionsTest {
-
+public class FunctionsTest {
     @Test
-    void testGetActionUrl_absoluteUriWithAuthority() {
+    public void testGetActionUrl_absoluteUriWithAuthority() {
         String[] uris = {
             "http://example.com/foo/bar",
             "https://example.com/foo/bar",
@@ -82,7 +81,7 @@ class FunctionsTest {
 
     @Test
     @Issue("JENKINS-7725")
-    void testGetActionUrl_absoluteUriWithoutAuthority() {
+    public void testGetActionUrl_absoluteUriWithoutAuthority() {
         String[] uris = {
             "mailto:nobody@example.com",
             "mailto:nobody@example.com?subject=hello",
@@ -95,7 +94,7 @@ class FunctionsTest {
     }
 
     @Test
-    void testGetActionUrl_absolutePath() {
+    public void testGetActionUrl_absolutePath() {
         String contextPath = "/jenkins";
         StaplerRequest2 req = createMockRequest(contextPath);
         String[] paths = {
@@ -113,7 +112,7 @@ class FunctionsTest {
     }
 
     @Test
-    void testGetActionUrl_relativePath() {
+    public void testGetActionUrl_relativePath() {
         String contextPath = "/jenkins";
         String itUrl = "iturl/";
         StaplerRequest2 req = createMockRequest(contextPath);
@@ -132,7 +131,7 @@ class FunctionsTest {
     }
 
     @Test
-    void testGetRelativeLinkTo_JobContainedInView() {
+    public void testGetRelativeLinkTo_JobContainedInView() {
         String contextPath = "/jenkins";
         StaplerRequest2 req = createMockRequest(contextPath);
         try (
@@ -154,7 +153,7 @@ class FunctionsTest {
     }
 
     @Test
-    void testGetRelativeLinkTo_JobFromComputer() {
+    public void testGetRelativeLinkTo_JobFromComputer() {
         String contextPath = "/jenkins";
         StaplerRequest2 req = createMockRequest(contextPath);
         try (
@@ -172,9 +171,9 @@ class FunctionsTest {
         }
     }
 
-    @Disabled("too expensive to make it correct")
+    @Ignore("too expensive to make it correct")
     @Test
-    void testGetRelativeLinkTo_JobNotContainedInView() {
+    public void testGetRelativeLinkTo_JobNotContainedInView() {
         String contextPath = "/jenkins";
         StaplerRequest2 req = createMockRequest(contextPath);
         try (
@@ -197,7 +196,7 @@ class FunctionsTest {
     private interface TopLevelItemAndItemGroup<T extends TopLevelItem> extends TopLevelItem, ItemGroup<T>, ViewGroup {}
 
     @Test
-    void testGetRelativeLinkTo_JobContainedInViewWithinItemGroup() {
+    public void testGetRelativeLinkTo_JobContainedInViewWithinItemGroup() {
         String contextPath = "/jenkins";
         StaplerRequest2 req = createMockRequest(contextPath);
         try (
@@ -220,8 +219,7 @@ class FunctionsTest {
     }
 
     @Issue("JENKINS-17713")
-    @Test
-    void getRelativeLinkTo_MavenModules() {
+    @Test public void getRelativeLinkTo_MavenModules() {
         StaplerRequest2 req = createMockRequest("/jenkins");
         try (
                 MockedStatic<Stapler> mocked = mockStatic(Stapler.class);
@@ -241,7 +239,7 @@ class FunctionsTest {
     }
 
     @Test
-    void testGetRelativeDisplayName() {
+    public void testGetRelativeDisplayName() {
         Item i = mock(Item.class);
         when(i.getName()).thenReturn("jobName");
         when(i.getFullDisplayName()).thenReturn("displayName");
@@ -249,7 +247,7 @@ class FunctionsTest {
     }
 
     @Test
-    void testGetRelativeDisplayNameInsideItemGroup() {
+    public void testGetRelativeDisplayNameInsideItemGroup() {
         Item i = mock(Item.class);
         when(i.getName()).thenReturn("jobName");
         when(i.getDisplayName()).thenReturn("displayName");
@@ -299,7 +297,7 @@ class FunctionsTest {
     }
 
     @Test
-    void testGetActionUrl_unparseable() {
+    public void testGetActionUrl_unparseable() {
         assertNull(Functions.getActionUrl(null, createMockAction("http://example.net/stuff?something=^woohoo")));
     }
 
@@ -317,7 +315,7 @@ class FunctionsTest {
 
     @Test
     @Issue("JENKINS-16630")
-    void testHumanReadableFileSize() {
+    public void testHumanReadableFileSize() {
         Locale defaultLocale = Locale.getDefault();
         try {
             Locale.setDefault(Locale.ENGLISH);
@@ -337,7 +335,7 @@ class FunctionsTest {
 
     @Issue("JENKINS-17030")
     @Test
-    void testBreakableString() {
+    public void testBreakableString() {
 
         assertBrokenAs("Hello world!", "Hello world!");
         assertBrokenAs("Hello-world!", "Hello", "-world!");
@@ -365,129 +363,110 @@ class FunctionsTest {
     }
 
     @Issue("JENKINS-20800")
-    @Test
-    void printLogRecordHtml() {
+    @Test public void printLogRecordHtml() {
         LogRecord lr = new LogRecord(Level.INFO, "Bad input <xml/>");
         lr.setLoggerName("test");
         assertEquals("Bad input &lt;xml/&gt;\n", Functions.printLogRecordHtml(lr, null)[3]);
     }
 
-    @Test
-    void printLogRecordHtmlNoLogger() {
+    @Test public void printLogRecordHtmlNoLogger() {
         LogRecord lr = new LogRecord(Level.INFO, "<discarded/>");
         assertEquals("&lt;discarded/&gt;\n", Functions.printLogRecordHtml(lr, null)[3]);
     }
 
     @Test
-    void extractPluginNameFromIconSrcHandlesNull() {
+    public void extractPluginNameFromIconSrcHandlesNull() {
         String result = Functions.extractPluginNameFromIconSrc(null);
 
         assertThat(result, is(emptyString()));
     }
 
     @Test
-    void extractPluginNameFromIconSrcHandlesEmptyString() {
+    public void extractPluginNameFromIconSrcHandlesEmptyString() {
         String result = Functions.extractPluginNameFromIconSrc("");
 
         assertThat(result, is(emptyString()));
     }
 
     @Test
-    void extractPluginNameFromIconSrcOnlyReturnsPluginFromStart() {
+    public void extractPluginNameFromIconSrcOnlyReturnsPluginFromStart() {
         String result = Functions.extractPluginNameFromIconSrc("symbol-plugin-mailer plugin-design-library");
 
         assertThat(result, is(equalTo("design-library")));
     }
 
     @Test
-    void extractPluginNameFromIconSrcExtractsPlugin() {
+    public void extractPluginNameFromIconSrcExtractsPlugin() {
         String result = Functions.extractPluginNameFromIconSrc("symbol-padlock plugin-design-library");
 
         assertThat(result, is(equalTo("design-library")));
     }
 
     @Test
-    void extractPluginNameFromIconSrcWhichContainsPluginWordInThePluginName() {
+    public void extractPluginNameFromIconSrcWhichContainsPluginWordInThePluginName() {
         String result = Functions.extractPluginNameFromIconSrc("symbol-padlock plugin-design-library-plugin");
 
         assertThat(result, is(equalTo("design-library-plugin")));
     }
 
     @Issue("JDK-6507809")
-    @Test
-    void printThrowable() {
+    @Test public void printThrowable() {
         // Basics: a single exception. No change.
         assertPrintThrowable(new Stack("java.lang.NullPointerException: oops", "p.C.method1:17", "m.Main.main:1"),
-                """
-                        java.lang.NullPointerException: oops
-                        \tat p.C.method1(C.java:17)
-                        \tat m.Main.main(Main.java:1)
-                        """,
-                """
-                        java.lang.NullPointerException: oops
-                        \tat p.C.method1(C.java:17)
-                        \tat m.Main.main(Main.java:1)
-                        """);
+            "java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "\tat m.Main.main(Main.java:1)\n",
+            "java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "\tat m.Main.main(Main.java:1)\n");
         // try {…} catch (Exception x) {throw new IllegalStateException(x);}
         assertPrintThrowable(new Stack("java.lang.IllegalStateException: java.lang.NullPointerException: oops", "p.C.method1:19", "m.Main.main:1").
                        cause(new Stack("java.lang.NullPointerException: oops", "p.C.method2:23", "p.C.method1:17", "m.Main.main:1")),
-                """
-                        java.lang.IllegalStateException: java.lang.NullPointerException: oops
-                        \tat p.C.method1(C.java:19)
-                        \tat m.Main.main(Main.java:1)
-                        Caused by: java.lang.NullPointerException: oops
-                        \tat p.C.method2(C.java:23)
-                        \tat p.C.method1(C.java:17)
-                        \t... 1 more
-                        """,
-                """
-                        java.lang.NullPointerException: oops
-                        \tat p.C.method2(C.java:23)
-                        \tat p.C.method1(C.java:17)
-                        Caused: java.lang.IllegalStateException
-                        \tat p.C.method1(C.java:19)
-                        \tat m.Main.main(Main.java:1)
-                        """);
+            "java.lang.IllegalStateException: java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method1(C.java:19)\n" +
+            "\tat m.Main.main(Main.java:1)\n" +
+            "Caused by: java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method2(C.java:23)\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "\t... 1 more\n",
+            "java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method2(C.java:23)\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "Caused: java.lang.IllegalStateException\n" +
+            "\tat p.C.method1(C.java:19)\n" +
+            "\tat m.Main.main(Main.java:1)\n");
         // try {…} catch (Exception x) {throw new IllegalStateException("more info");}
         assertPrintThrowable(new Stack("java.lang.IllegalStateException: more info", "p.C.method1:19", "m.Main.main:1").
                        cause(new Stack("java.lang.NullPointerException: oops", "p.C.method2:23", "p.C.method1:17", "m.Main.main:1")),
-                """
-                        java.lang.IllegalStateException: more info
-                        \tat p.C.method1(C.java:19)
-                        \tat m.Main.main(Main.java:1)
-                        Caused by: java.lang.NullPointerException: oops
-                        \tat p.C.method2(C.java:23)
-                        \tat p.C.method1(C.java:17)
-                        \t... 1 more
-                        """,
-                """
-                        java.lang.NullPointerException: oops
-                        \tat p.C.method2(C.java:23)
-                        \tat p.C.method1(C.java:17)
-                        Caused: java.lang.IllegalStateException: more info
-                        \tat p.C.method1(C.java:19)
-                        \tat m.Main.main(Main.java:1)
-                        """);
+            "java.lang.IllegalStateException: more info\n" +
+            "\tat p.C.method1(C.java:19)\n" +
+            "\tat m.Main.main(Main.java:1)\n" +
+            "Caused by: java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method2(C.java:23)\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "\t... 1 more\n",
+            "java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method2(C.java:23)\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "Caused: java.lang.IllegalStateException: more info\n" +
+            "\tat p.C.method1(C.java:19)\n" +
+            "\tat m.Main.main(Main.java:1)\n");
         // try {…} catch (Exception x) {throw new IllegalStateException("more info: " + x);}
         assertPrintThrowable(new Stack("java.lang.IllegalStateException: more info: java.lang.NullPointerException: oops", "p.C.method1:19", "m.Main.main:1").
                        cause(new Stack("java.lang.NullPointerException: oops", "p.C.method2:23", "p.C.method1:17", "m.Main.main:1")),
-                """
-                        java.lang.IllegalStateException: more info: java.lang.NullPointerException: oops
-                        \tat p.C.method1(C.java:19)
-                        \tat m.Main.main(Main.java:1)
-                        Caused by: java.lang.NullPointerException: oops
-                        \tat p.C.method2(C.java:23)
-                        \tat p.C.method1(C.java:17)
-                        \t... 1 more
-                        """,
-                """
-                        java.lang.NullPointerException: oops
-                        \tat p.C.method2(C.java:23)
-                        \tat p.C.method1(C.java:17)
-                        Caused: java.lang.IllegalStateException: more info
-                        \tat p.C.method1(C.java:19)
-                        \tat m.Main.main(Main.java:1)
-                        """);
+            "java.lang.IllegalStateException: more info: java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method1(C.java:19)\n" +
+            "\tat m.Main.main(Main.java:1)\n" +
+            "Caused by: java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method2(C.java:23)\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "\t... 1 more\n",
+            "java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method2(C.java:23)\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "Caused: java.lang.IllegalStateException: more info\n" +
+            "\tat p.C.method1(C.java:19)\n" +
+            "\tat m.Main.main(Main.java:1)\n");
         // Synthetic stack showing an exception made elsewhere, such as happens with hudson.remoting.Channel.attachCallSiteStackTrace.
         Throwable t = new Stack("remote.Exception: oops", "remote.Place.method:17", "remote.Service.run:9");
         StackTraceElement[] callSite = new Stack("wrapped.Exception", "local.Side.call:11", "local.Main.main:1").getStackTrace();
@@ -498,22 +477,18 @@ class FunctionsTest {
         System.arraycopy(callSite, 0, combined, original.length + 1, callSite.length);
         t.setStackTrace(combined);
         assertPrintThrowable(t,
-                """
-                        remote.Exception: oops
-                        \tat remote.Place.method(Place.java:17)
-                        \tat remote.Service.run(Service.java:9)
-                        \tat ......remote call(Native Method)
-                        \tat local.Side.call(Side.java:11)
-                        \tat local.Main.main(Main.java:1)
-                        """,
-                """
-                        remote.Exception: oops
-                        \tat remote.Place.method(Place.java:17)
-                        \tat remote.Service.run(Service.java:9)
-                        \tat ......remote call(Native Method)
-                        \tat local.Side.call(Side.java:11)
-                        \tat local.Main.main(Main.java:1)
-                        """);
+            "remote.Exception: oops\n" +
+            "\tat remote.Place.method(Place.java:17)\n" +
+            "\tat remote.Service.run(Service.java:9)\n" +
+            "\tat ......remote call(Native Method)\n" +
+            "\tat local.Side.call(Side.java:11)\n" +
+            "\tat local.Main.main(Main.java:1)\n",
+            "remote.Exception: oops\n" +
+            "\tat remote.Place.method(Place.java:17)\n" +
+            "\tat remote.Service.run(Service.java:9)\n" +
+            "\tat ......remote call(Native Method)\n" +
+            "\tat local.Side.call(Side.java:11)\n" +
+            "\tat local.Main.main(Main.java:1)\n");
         // Same but now using a cause on the remote side.
         t = new Stack("remote.Wrapper: remote.Exception: oops", "remote.Place.method2:19", "remote.Service.run:9").cause(new Stack("remote.Exception: oops", "remote.Place.method1:11", "remote.Place.method2:17", "remote.Service.run:9"));
         callSite = new Stack("wrapped.Exception", "local.Side.call:11", "local.Main.main:1").getStackTrace();
@@ -524,18 +499,16 @@ class FunctionsTest {
         System.arraycopy(callSite, 0, combined, original.length + 1, callSite.length);
         t.setStackTrace(combined);
         assertPrintThrowable(t,
-                """
-                        remote.Wrapper: remote.Exception: oops
-                        \tat remote.Place.method2(Place.java:19)
-                        \tat remote.Service.run(Service.java:9)
-                        \tat ......remote call(Native Method)
-                        \tat local.Side.call(Side.java:11)
-                        \tat local.Main.main(Main.java:1)
-                        Caused by: remote.Exception: oops
-                        \tat remote.Place.method1(Place.java:11)
-                        \tat remote.Place.method2(Place.java:17)
-                        \tat remote.Service.run(Service.java:9)
-                        """,
+            "remote.Wrapper: remote.Exception: oops\n" +
+            "\tat remote.Place.method2(Place.java:19)\n" +
+            "\tat remote.Service.run(Service.java:9)\n" +
+            "\tat ......remote call(Native Method)\n" +
+            "\tat local.Side.call(Side.java:11)\n" +
+            "\tat local.Main.main(Main.java:1)\n" +
+            "Caused by: remote.Exception: oops\n" +
+            "\tat remote.Place.method1(Place.java:11)\n" +
+            "\tat remote.Place.method2(Place.java:17)\n" +
+            "\tat remote.Service.run(Service.java:9)\n",
             "remote.Exception: oops\n" +
             "\tat remote.Place.method1(Place.java:11)\n" +
             "\tat remote.Place.method2(Place.java:17)\n" +
@@ -552,44 +525,40 @@ class FunctionsTest {
                   suppressed(new Stack("java.io.IOException: could not close", "p.C.close:99", "p.C.method1:18", "m.Main.main:1"),
                              new Stack("java.io.IOException: java.lang.NullPointerException", "p.C.flush:77", "p.C.method1:18", "m.Main.main:1").
                        cause(new Stack("java.lang.NullPointerException", "p.C.findFlushee:70", "p.C.flush:75", "p.C.method1:18", "m.Main.main:1"))),
-                """
-                        java.lang.IllegalStateException: java.lang.NullPointerException: oops
-                        \tat p.C.method1(C.java:19)
-                        \tat m.Main.main(Main.java:1)
-                        \tSuppressed: java.io.IOException: could not close
-                        \t\tat p.C.close(C.java:99)
-                        \t\tat p.C.method1(C.java:18)
-                        \t\t... 1 more
-                        \tSuppressed: java.io.IOException: java.lang.NullPointerException
-                        \t\tat p.C.flush(C.java:77)
-                        \t\tat p.C.method1(C.java:18)
-                        \t\t... 1 more
-                        \tCaused by: java.lang.NullPointerException
-                        \t\tat p.C.findFlushee(C.java:70)
-                        \t\tat p.C.flush(C.java:75)
-                        \t\t... 2 more
-                        Caused by: java.lang.NullPointerException: oops
-                        \tat p.C.method2(C.java:23)
-                        \tat p.C.method1(C.java:17)
-                        \t... 1 more
-                        """,
-                """
-                        java.lang.NullPointerException: oops
-                        \tat p.C.method2(C.java:23)
-                        \tat p.C.method1(C.java:17)
-                        Also:   java.io.IOException: could not close
-                        \t\tat p.C.close(C.java:99)
-                        \t\tat p.C.method1(C.java:18)
-                        Also:   java.lang.NullPointerException
-                        \t\tat p.C.findFlushee(C.java:70)
-                        \t\tat p.C.flush(C.java:75)
-                        \tCaused: java.io.IOException
-                        \t\tat p.C.flush(C.java:77)
-                        \t\tat p.C.method1(C.java:18)
-                        Caused: java.lang.IllegalStateException
-                        \tat p.C.method1(C.java:19)
-                        \tat m.Main.main(Main.java:1)
-                        """);
+            "java.lang.IllegalStateException: java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method1(C.java:19)\n" +
+            "\tat m.Main.main(Main.java:1)\n" +
+            "\tSuppressed: java.io.IOException: could not close\n" +
+            "\t\tat p.C.close(C.java:99)\n" +
+            "\t\tat p.C.method1(C.java:18)\n" +
+            "\t\t... 1 more\n" +
+            "\tSuppressed: java.io.IOException: java.lang.NullPointerException\n" +
+            "\t\tat p.C.flush(C.java:77)\n" +
+            "\t\tat p.C.method1(C.java:18)\n" +
+            "\t\t... 1 more\n" +
+            "\tCaused by: java.lang.NullPointerException\n" +
+            "\t\tat p.C.findFlushee(C.java:70)\n" +
+            "\t\tat p.C.flush(C.java:75)\n" +
+            "\t\t... 2 more\n" +
+            "Caused by: java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method2(C.java:23)\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "\t... 1 more\n",
+            "java.lang.NullPointerException: oops\n" +
+            "\tat p.C.method2(C.java:23)\n" +
+            "\tat p.C.method1(C.java:17)\n" +
+            "Also:   java.io.IOException: could not close\n" +
+            "\t\tat p.C.close(C.java:99)\n" +
+            "\t\tat p.C.method1(C.java:18)\n" +
+            "Also:   java.lang.NullPointerException\n" +
+            "\t\tat p.C.findFlushee(C.java:70)\n" +
+            "\t\tat p.C.flush(C.java:75)\n" +
+            "\tCaused: java.io.IOException\n" +
+            "\t\tat p.C.flush(C.java:77)\n" +
+            "\t\tat p.C.method1(C.java:18)\n" +
+            "Caused: java.lang.IllegalStateException\n" +
+            "\tat p.C.method1(C.java:19)\n" +
+            "\tat m.Main.main(Main.java:1)\n");
         // Custom printStackTrace implementations:
         assertPrintThrowable(new Throwable() {
             @Override
@@ -607,36 +576,28 @@ class FunctionsTest {
         if (getVersion().isNewerThanOrEqualTo(new VersionNumber("11.0.9")) ||
                 (getVersion().getDigitAt(0) == 8 && getVersion().isNewerThanOrEqualTo(new VersionNumber("8.0.272")))) {
             assertPrintThrowable(stack1,
-                    """
-                            p.Exc1
-                            \tat p.C.method1(C.java:17)
-                            Caused by: p.Exc2
-                            \tat p.C.method2(C.java:27)
-                            Caused by: [CIRCULAR REFERENCE: p.Exc1]
-                            """,
-                    """
-                            <cycle to p.Exc1>
-                            Caused: p.Exc2
-                            \tat p.C.method2(C.java:27)
-                            Caused: p.Exc1
-                            \tat p.C.method1(C.java:17)
-                            """);
+                    "p.Exc1\n" +
+                            "\tat p.C.method1(C.java:17)\n" +
+                            "Caused by: p.Exc2\n" +
+                            "\tat p.C.method2(C.java:27)\n" +
+                            "Caused by: [CIRCULAR REFERENCE: p.Exc1]\n",
+                    "<cycle to p.Exc1>\n" +
+                            "Caused: p.Exc2\n" +
+                            "\tat p.C.method2(C.java:27)\n" +
+                            "Caused: p.Exc1\n" +
+                            "\tat p.C.method1(C.java:17)\n");
         } else {
             assertPrintThrowable(stack1,
-                    """
-                            p.Exc1
-                            \tat p.C.method1(C.java:17)
-                            Caused by: p.Exc2
-                            \tat p.C.method2(C.java:27)
-                            \t[CIRCULAR REFERENCE:p.Exc1]
-                            """,
-                    """
-                            <cycle to p.Exc1>
-                            Caused: p.Exc2
-                            \tat p.C.method2(C.java:27)
-                            Caused: p.Exc1
-                            \tat p.C.method1(C.java:17)
-                            """);
+                    "p.Exc1\n" +
+                            "\tat p.C.method1(C.java:17)\n" +
+                            "Caused by: p.Exc2\n" +
+                            "\tat p.C.method2(C.java:27)\n" +
+                            "\t[CIRCULAR REFERENCE:p.Exc1]\n",
+                    "<cycle to p.Exc1>\n" +
+                            "Caused: p.Exc2\n" +
+                            "\tat p.C.method2(C.java:27)\n" +
+                            "Caused: p.Exc1\n" +
+                            "\tat p.C.method1(C.java:17)\n");
         }
     }
 
@@ -690,42 +651,42 @@ class FunctionsTest {
     }
 
     @Test
-    void tryGetIcon_shouldReturnNullForNull() {
+    public void tryGetIcon_shouldReturnNullForNull() throws Exception {
         assertThat(Functions.tryGetIcon(null), is(nullValue()));
     }
 
     @Test
-    void tryGetIcon_shouldReturnNullForSymbol() {
+    public void tryGetIcon_shouldReturnNullForSymbol() throws Exception {
         assertThat(Functions.tryGetIcon("symbol-search"), is(nullValue()));
     }
 
     @Test
-    void tryGetIcon_shouldReturnMetadataForExactSpec() {
+    public void tryGetIcon_shouldReturnMetadataForExactSpec() throws Exception {
         assertThat(Functions.tryGetIcon("icon-help icon-sm"), is(not(nullValue())));
     }
 
     @Test
-    void tryGetIcon_shouldReturnMetadataForExtraSpec() {
+    public void tryGetIcon_shouldReturnMetadataForExtraSpec() throws Exception {
         assertThat(Functions.tryGetIcon("icon-help icon-sm extra-class"), is(not(nullValue())));
     }
 
     @Test
-    void tryGetIcon_shouldReturnMetadataForFilename() {
+    public void tryGetIcon_shouldReturnMetadataForFilename() throws Exception {
         assertThat(Functions.tryGetIcon("help.svg"), is(not(nullValue())));
     }
 
     @Test
-    void tryGetIcon_shouldReturnMetadataForUrl() {
+    public void tryGetIcon_shouldReturnMetadataForUrl() throws Exception {
         assertThat(Functions.tryGetIcon("48x48/green.gif"), is(not(nullValue())));
     }
 
     @Test
-    void tryGetIcon_shouldReturnNullForUnknown() {
+    public void tryGetIcon_shouldReturnNullForUnknown() throws Exception {
         assertThat(Functions.tryGetIcon("icon-nosuchicon"), is(nullValue()));
     }
 
     @Test
-    void guessIcon() {
+    public void guessIcon() throws Exception {
         Jenkins.RESOURCE_PATH = "/static/12345678";
         assertEquals("/jenkins/static/12345678/images/48x48/green.gif", Functions.guessIcon("jenkins/images/48x48/green.gif", "/jenkins"));
         assertEquals("/jenkins/static/12345678/images/48x48/green.gif", Functions.guessIcon("/jenkins/images/48x48/green.gif", "/jenkins"));

--- a/core/src/test/java/hudson/GetLocaleStaticHelpUrlTest.java
+++ b/core/src/test/java/hudson/GetLocaleStaticHelpUrlTest.java
@@ -40,10 +40,10 @@ import org.jvnet.hudson.test.Issue;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.lang.Klass;
 
-class GetLocaleStaticHelpUrlTest {
+public class GetLocaleStaticHelpUrlTest {
 
     @Test
-    void getStaticHelpUrlAcceptEnResDefault() {
+    public void getStaticHelpUrlAcceptEnResDefault() {
         // Accept-Language: en
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.ENGLISH
@@ -58,7 +58,7 @@ class GetLocaleStaticHelpUrlTest {
     }
 
     @Test
-    void getStaticHelpUrlAcceptDeResDeNoCountry() {
+    public void getStaticHelpUrlAcceptDeResDeNoCountry() {
         // Accept-Language: de-DE,de;q=0.9,en;q=0.8
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.GERMANY,
@@ -76,7 +76,7 @@ class GetLocaleStaticHelpUrlTest {
     }
 
     @Test
-    void getStaticHelpUrlAcceptDeResDeCountry() {
+    public void getStaticHelpUrlAcceptDeResDeCountry() {
         // Accept-Language: de-DE,de;q=0.9,en;q=0.8
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.GERMANY,
@@ -94,7 +94,7 @@ class GetLocaleStaticHelpUrlTest {
     }
 
     @Test
-    void getStaticHelpUrlAcceptDeResBoth() {
+    public void getStaticHelpUrlAcceptDeResBoth() {
         // Accept-Language: de-DE,de;q=0.9,en;q=0.8
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.GERMANY,
@@ -113,7 +113,7 @@ class GetLocaleStaticHelpUrlTest {
     }
 
     @Test
-    void getStaticHelpUrlAcceptZhResDefault() {
+    public void getStaticHelpUrlAcceptZhResDefault() {
         // Accept-Language: zh,zh-CN;q=0.9,en-US;q=0.8,en;q=0.7,zh-TW;q=0.6
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.CHINESE,
@@ -132,7 +132,7 @@ class GetLocaleStaticHelpUrlTest {
     }
 
     @Test
-    void getStaticHelpUrlAcceptZhResZhCountry() {
+    public void getStaticHelpUrlAcceptZhResZhCountry() {
         // Accept-Language: zh,zh-CN;q=0.9,en-US;q=0.8,en;q=0.7,zh-TW;q=0.6
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.CHINESE,
@@ -152,7 +152,7 @@ class GetLocaleStaticHelpUrlTest {
     }
 
     @Test
-    void getStaticHelpUrlAcceptZhResBoth() {
+    public void getStaticHelpUrlAcceptZhResBoth() {
         // Accept-Language: zh,zh-CN;q=0.9,en-US;q=0.8,en;q=0.7,zh-TW;q=0.6
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.CHINESE,
@@ -172,7 +172,7 @@ class GetLocaleStaticHelpUrlTest {
     }
 
     @Test
-    void getStaticHelpUrlAcceptZhResMore() {
+    public void getStaticHelpUrlAcceptZhResMore() {
         // Accept-Language: zh,zh-CN;q=0.9,en-US;q=0.8,en;q=0.7,zh-TW;q=0.6
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.CHINESE,
@@ -194,7 +194,7 @@ class GetLocaleStaticHelpUrlTest {
 
     @Issue("JENKINS-73246")
     @Test
-    void getStaticHelpUrlAcceptEnFirst() {
+    public void getStaticHelpUrlAcceptEnFirst() {
         // Accept-Language: en-US,en;q=0.9,de;q=0.8
         StaplerRequest2 req = mockStaplerRequest2(
                 Locale.US,

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -24,85 +24,39 @@
 
 package hudson;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
-import hudson.remoting.Channel;
-import hudson.remoting.ChannelBuilder;
-import hudson.remoting.FastPipedInputStream;
-import hudson.remoting.FastPipedOutputStream;
 import hudson.util.ProcessTree;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import jenkins.security.MasterToSlaveCallable;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
-class LauncherTest {
+public class LauncherTest {
 
-    @TempDir
-    private File temp;
-
-    /**
-     * Two channels that are connected to each other, but shares the same classloader.
-     */
-    private Channel french;
-    private Channel british;
-    private ExecutorService executors;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        executors = Executors.newCachedThreadPool();
-        final FastPipedInputStream p1i = new FastPipedInputStream();
-        final FastPipedInputStream p2i = new FastPipedInputStream();
-        final FastPipedOutputStream p1o = new FastPipedOutputStream(p1i);
-        final FastPipedOutputStream p2o = new FastPipedOutputStream(p2i);
-
-        Future<Channel> f1 = executors.submit(() -> new ChannelBuilder("This side of the channel", executors).withMode(Channel.Mode.BINARY).build(p1i, p2o));
-        Future<Channel> f2 = executors.submit(() -> new ChannelBuilder("The other side of the channel", executors).withMode(Channel.Mode.BINARY).build(p2i, p1o));
-        french = f1.get();
-        british = f2.get();
-    }
-
-    @AfterEach
-    void tearDown() {
-        try {
-            french.close(); // this will automatically initiate the close on the other channel, too.
-            french.join();
-            british.join();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        } catch (InterruptedException x) {
-            throw new AssertionError(x);
-        }
-        executors.shutdownNow();
-    }
+    @Rule public ChannelRule channels = new ChannelRule();
+    @Rule public TemporaryFolder temp = new TemporaryFolder();
 
     @Issue("JENKINS-4611")
-    @Test
-    void remoteKill() throws Exception {
+    @Test public void remoteKill() throws Exception {
         assumeFalse(Functions.isWindows());
 
-        File tmp = File.createTempFile("junit", null, temp);
+        File tmp = temp.newFile();
 
-            FilePath f = new FilePath(french, tmp.getPath());
+            FilePath f = new FilePath(channels.french, tmp.getPath());
             Launcher l = f.createLauncher(StreamTaskListener.fromStderr());
             Proc p = l.launch().cmds("sh", "-c", "echo $$$$ > " + tmp + "; sleep 30").stdout(System.out).stderr(System.err).start();
             while (!tmp.exists())
@@ -112,10 +66,10 @@ class LauncherTest {
             assertNotEquals(0, p.join());
             long end = System.currentTimeMillis();
             long terminationTime = end - start;
-            assertTrue(terminationTime < 15000, "Join did not finish promptly. The completion time (" + terminationTime + "ms) is longer than expected 15s");
-            french.call(new NoopCallable()); // this only returns after the other side of the channel has finished executing cancellation
+            assertTrue("Join did not finish promptly. The completion time (" + terminationTime + "ms) is longer than expected 15s", terminationTime < 15000);
+            channels.french.call(new NoopCallable()); // this only returns after the other side of the channel has finished executing cancellation
             Thread.sleep(2000); // more delay to make sure it's gone
-            assertNull(ProcessTree.get().get(Integer.parseInt(Files.readString(tmp.toPath(), Charset.defaultCharset()).trim())), "process should be gone");
+            assertNull("process should be gone", ProcessTree.get().get(Integer.parseInt(Files.readString(tmp.toPath(), Charset.defaultCharset()).trim())));
 
             // Manual version of test: set up instance w/ one agent. Now in script console
             // new hudson.FilePath(new java.io.File("/tmp")).createLauncher(new hudson.util.StreamTaskListener(System.err)).
@@ -134,8 +88,7 @@ class LauncherTest {
     }
 
     @Issue("JENKINS-15733")
-    @Test
-    void decorateByEnv() throws Exception {
+    @Test public void decorateByEnv() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TaskListener l = new StreamBuildListener(baos, Charset.defaultCharset());
         Launcher base = new Launcher.LocalLauncher(l);
@@ -143,13 +96,12 @@ class LauncherTest {
         Launcher decorated = base.decorateByEnv(env);
         int res = decorated.launch().envs("key2=val2").cmds(Functions.isWindows() ? new String[] {"cmd", "/q", "/c", "echo %key1% %key2%"} : new String[] {"sh", "-c", "echo $key1 $key2"}).stdout(l).join();
         String log = baos.toString(Charset.defaultCharset());
-        assertEquals(0, res, log);
-        assertTrue(log.contains("val1 val2"), log);
+        assertEquals(log, 0, res);
+        assertTrue(log, log.contains("val1 val2"));
     }
 
     @Issue("JENKINS-18368")
-    @Test
-    void decoratedByEnvMaintainsIsUnix() {
+    @Test public void decoratedByEnvMaintainsIsUnix() {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         TaskListener listener = new StreamBuildListener(output, Charset.defaultCharset());
         Launcher remoteLauncher = new Launcher.RemoteLauncher(listener, FilePath.localChannel, false);
@@ -161,8 +113,7 @@ class LauncherTest {
     }
 
     @Issue("JENKINS-18368")
-    @Test
-    void decoratedByPrefixMaintainsIsUnix() {
+    @Test public void decoratedByPrefixMaintainsIsUnix() {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         TaskListener listener = new StreamBuildListener(output, Charset.defaultCharset());
         Launcher remoteLauncher = new Launcher.RemoteLauncher(listener, FilePath.localChannel, false);

--- a/core/src/test/java/hudson/MarkupTextTest.java
+++ b/core/src/test/java/hudson/MarkupTextTest.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Kohsuke Kawaguchi
  */
-class MarkupTextTest {
+public class MarkupTextTest {
 
     @Test
-    void test1() {
+    public void test1() {
         MarkupText t = new MarkupText("I fixed issue #155. The rest is trick text: xissue #155 issue #123x");
         for (SubText st : t.findTokens(pattern)) {
             assertEquals(1, st.groupCount());
@@ -48,7 +48,7 @@ class MarkupTextTest {
     }
 
     @Test
-    void boundary() {
+    public void boundary() {
         MarkupText t = new MarkupText("issue #155---issue #123");
         for (SubText st : t.findTokens(pattern))
             st.surroundWith("<$1>", "<$1>");
@@ -57,7 +57,7 @@ class MarkupTextTest {
     }
 
     @Test
-    void findTokensOnSubText() {
+    public void findTokensOnSubText() {
         MarkupText t = new MarkupText("Fixed 2 issues in this commit, fixing issue 155, 145");
         List<SubText> tokens = t.findTokens(Pattern.compile("issue .*"));
         assertEquals(1, tokens.size(), "Expected one token");
@@ -69,7 +69,7 @@ class MarkupTextTest {
     }
 
     @Test
-    void literalTextSurround() {
+    public void literalTextSurround() {
         MarkupText text = new MarkupText("AAA test AAA");
         for (SubText token : text.findTokens(Pattern.compile("AAA"))) {
             token.surroundWithLiteral("$9", "$9");
@@ -81,7 +81,7 @@ class MarkupTextTest {
      * Start/end tag nesting should be correct regardless of the order tags are added.
      */
     @Test
-    void addMarkupInOrder() {
+    public void addMarkupInOrder() {
         MarkupText text = new MarkupText("abcdef");
         text.addMarkup(0, 3, "$", "$");
         text.addMarkup(3, 6, "#", "#");
@@ -89,7 +89,7 @@ class MarkupTextTest {
     }
 
     @Test
-    void addMarkupInReversedOrder() {
+    public void addMarkupInReversedOrder() {
         MarkupText text = new MarkupText("abcdef");
         text.addMarkup(3, 6, "#", "#");
         text.addMarkup(0, 3, "$", "$");
@@ -97,7 +97,7 @@ class MarkupTextTest {
     }
 
     @Test
-    void escape() {
+    public void escape() {
         MarkupText text = new MarkupText("&&&");
         assertEquals("&amp;&amp;&amp;", text.toString(false));
 
@@ -107,7 +107,7 @@ class MarkupTextTest {
     }
 
     @Test
-    void preEscape() {
+    public void preEscape() {
         MarkupText text = new MarkupText("Line\n2   & 3\n<End>\n");
         assertEquals("Line\n2   &amp; 3\n&lt;End&gt;\n", text.toString(true));
         text.addMarkup(4, "<hr/>");
@@ -116,7 +116,7 @@ class MarkupTextTest {
 
     /* @Issue("JENKINS-6252") */
     @Test
-    void subTextSubText() {
+    public void subTextSubText() {
         MarkupText text = new MarkupText("abcdefgh");
         SubText sub = text.subText(2, 7);
         assertEquals("cdefg", sub.getText());

--- a/core/src/test/java/hudson/PluginManagerTest.java
+++ b/core/src/test/java/hudson/PluginManagerTest.java
@@ -58,13 +58,12 @@ import org.xml.sax.SAXException;
 /**
  * Tests of {@link PluginManager}.
  */
-class PluginManagerTest {
+public class PluginManagerTest {
 
-    @TempDir
-    private Path tmp;
+    @TempDir Path tmp;
 
     @Test
-    void parseRequestedPlugins() throws Exception {
+    public void parseRequestedPlugins() throws Exception {
         Path output = Files.createFile(
                 tmp.resolve("output.txt")
         );
@@ -74,19 +73,17 @@ class PluginManagerTest {
 
     @Issue("SECURITY-167")
     @Test
-    void parseInvalidRequestedPlugins() throws Exception {
-        String evilXML = """
-                <?xml version='1.0' encoding='UTF-8'?>
-                <!DOCTYPE project[<!ENTITY foo SYSTEM "file:///">]>
-                <root>
-                  <stuff plugin='stuff@1.0'>
-                &foo;\
-                    <more plugin='other@2.0'>
-                      <things plugin='stuff@1.2'/>
-                    </more>
-                  </stuff>
-                </root>
-                """;
+    public void parseInvalidRequestedPlugins() throws Exception {
+        String evilXML = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                "<!DOCTYPE project[<!ENTITY foo SYSTEM \"file:///\">]>\n" +
+                "<root>\n" +
+                "  <stuff plugin='stuff@1.0'>\n" +
+                "&foo;" +
+                "    <more plugin='other@2.0'>\n" +
+                "      <things plugin='stuff@1.2'/>\n" +
+                "    </more>\n" +
+                "  </stuff>\n" +
+                "</root>\n";
 
         PluginManager pluginManager = new LocalPluginManager(Util.createTempDir());
         final IOException ex = assertThrows(IOException.class,
@@ -98,7 +95,7 @@ class PluginManagerTest {
     }
 
     @Test
-    void shouldProperlyParseManifestFromJar() throws IOException {
+    public void shouldProperlyParseManifestFromJar() throws IOException {
         File jar = createHpiWithManifest();
         final Manifest manifest = PluginManager.parsePluginManifest(jar.toURI().toURL());
 
@@ -115,7 +112,7 @@ class PluginManagerTest {
     }
 
     @Test
-    void shouldProperlyRetrieveModificationDate() throws IOException {
+    public void shouldProperlyRetrieveModificationDate() throws IOException {
         File jar = createHpiWithManifest();
         URL url = toManifestUrl(jar);
         assertThat("Manifest last modified date should be equal to the file date",
@@ -126,7 +123,7 @@ class PluginManagerTest {
 
     @Test
     @Issue("JENKINS-70420")
-    void updateSiteURLCheckValidation() throws Exception {
+    public void updateSiteURLCheckValidation() throws Exception {
         LocalPluginManager pm = new LocalPluginManager(tmp.toFile());
 
         assertThat("ftp urls are not acceptable", pm.checkUpdateSiteURL("ftp://foo/bar"),
@@ -166,30 +163,29 @@ class PluginManagerTest {
 
     }
 
-    private static final String SAMPLE_MANIFEST_FILE = """
-            Manifest-Version: 1.0
-            Archiver-Version: Plexus Archiver
-            Created-By: Apache Maven
-            Built-By: jglick
-            Build-Jdk: 1.8.0_92
-            Extension-Name: matrix-auth
-            Specification-Title:\s
-             Offers matrix-based security\s
-             authorization strate
-             gies (global and per-project).
-            Implementation-Title: matrix-auth
-            Implementation-Version: 1.4
-            Group-Id: org.jenkins-ci.plugins
-            Short-Name: matrix-auth
-            Long-Name: Matrix Authorization Strategy Plugin
-            Url: http://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+S
-             trategy+Plugin
-            Plugin-Version: 1.4
-            Hudson-Version: 1.609.1
-            Jenkins-Version: 1.609.1
-            Plugin-Dependencies: icon-shim:2.0.3,cloudbees-folder:5.2.2;resolution
-             :=optional
-            Plugin-Developers:\s""";
+    private static final String SAMPLE_MANIFEST_FILE = "Manifest-Version: 1.0\n" +
+                "Archiver-Version: Plexus Archiver\n" +
+                "Created-By: Apache Maven\n" +
+                "Built-By: jglick\n" +
+                "Build-Jdk: 1.8.0_92\n" +
+                "Extension-Name: matrix-auth\n" +
+                "Specification-Title: \n" +
+                " Offers matrix-based security \n" +
+                " authorization strate\n" +
+                " gies (global and per-project).\n" +
+                "Implementation-Title: matrix-auth\n" +
+                "Implementation-Version: 1.4\n" +
+                "Group-Id: org.jenkins-ci.plugins\n" +
+                "Short-Name: matrix-auth\n" +
+                "Long-Name: Matrix Authorization Strategy Plugin\n" +
+                "Url: http://wiki.jenkins-ci.org/display/JENKINS/Matrix+Authorization+S\n" +
+                " trategy+Plugin\n" +
+                "Plugin-Version: 1.4\n" +
+                "Hudson-Version: 1.609.1\n" +
+                "Jenkins-Version: 1.609.1\n" +
+                "Plugin-Dependencies: icon-shim:2.0.3,cloudbees-folder:5.2.2;resolution\n" +
+                " :=optional\n" +
+                "Plugin-Developers: ";
 
     private File createHpiWithManifest() throws IOException {
         Path metaInf = tmp.resolve("META-INF");

--- a/core/src/test/java/hudson/PluginWrapperTest.java
+++ b/core/src/test/java/hudson/PluginWrapperTest.java
@@ -32,26 +32,26 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.mockito.stubbing.Answer;
 
-class PluginWrapperTest {
+public class PluginWrapperTest {
 
     private static Locale loc;
 
     @BeforeAll
-    static void before() {
+    public static void before() {
         Jenkins.VERSION = "2.0"; // Some value needed - tests will overwrite if necessary
         loc = Locale.getDefault();
         Locale.setDefault(new Locale("en", "GB"));
     }
 
     @AfterAll
-    static void after() {
+    public static void after() {
         if (loc != null) {
             Locale.setDefault(loc);
         }
     }
 
     @Test
-    void dependencyTest() {
+    public void dependencyTest() {
         String version = "plugin:0.0.2";
         PluginWrapper.Dependency dependency = new PluginWrapper.Dependency(version);
         assertEquals("plugin", dependency.shortName);
@@ -60,7 +60,7 @@ class PluginWrapperTest {
     }
 
     @Test
-    void optionalDependencyTest() {
+    public void optionalDependencyTest() {
         String version = "plugin:0.0.2;resolution:=optional";
         PluginWrapper.Dependency dependency = new PluginWrapper.Dependency(version);
         assertEquals("plugin", dependency.shortName);
@@ -69,7 +69,7 @@ class PluginWrapperTest {
     }
 
     @Test
-    void jenkinsCoreTooOld() {
+    public void jenkinsCoreTooOld() {
         PluginWrapper pw = pluginWrapper("fake").requiredCoreVersion("3.0").buildLoaded();
 
         final IOException ex = assertThrows(IOException.class, pw::resolvePluginDependencies);
@@ -77,7 +77,7 @@ class PluginWrapperTest {
     }
 
     @Test
-    void dependencyNotInstalled() {
+    public void dependencyNotInstalled() {
         PluginWrapper pw = pluginWrapper("dependee").deps("dependency:42").buildLoaded();
 
         final IOException ex = assertThrows(IOException.class, pw::resolvePluginDependencies);
@@ -85,7 +85,7 @@ class PluginWrapperTest {
     }
 
     @Test
-    void dependencyOutdated() {
+    public void dependencyOutdated() {
         pluginWrapper("dependency").version("3").buildLoaded();
         PluginWrapper pw = pluginWrapper("dependee").deps("dependency:5").buildLoaded();
 
@@ -94,7 +94,7 @@ class PluginWrapperTest {
     }
 
     @Test
-    void dependencyFailedToLoad() {
+    public void dependencyFailedToLoad() {
         pluginWrapper("dependency").version("5").buildFailed();
         PluginWrapper pw = pluginWrapper("dependee").deps("dependency:3").buildLoaded();
 
@@ -104,7 +104,7 @@ class PluginWrapperTest {
 
     @Issue("JENKINS-66563")
     @Test
-    void insertJarsIntoClassPath() throws Exception {
+    public void insertJarsIntoClassPath() throws Exception {
         try (URLClassLoader2 cl = new URLClassLoader2("Test", new URL[0])) {
             assertInjectingJarsWorks(cl);
         }
@@ -210,7 +210,7 @@ class PluginWrapperTest {
 
     @Issue("JENKINS-52665")
     @Test
-    void isSnapshot() {
+    public void isSnapshot() {
         assertFalse(PluginWrapper.isSnapshot("1.0"));
         assertFalse(PluginWrapper.isSnapshot("1.0-alpha-1"));
         assertFalse(PluginWrapper.isSnapshot("1.0-rc9999.abc123def456"));

--- a/core/src/test/java/hudson/ProxyConfigurationTest.java
+++ b/core/src/test/java/hudson/ProxyConfigurationTest.java
@@ -29,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.net.Proxy;
 import org.junit.jupiter.api.Test;
 
-class ProxyConfigurationTest {
+public class ProxyConfigurationTest {
 
     @Test
-    void noProxyHost() {
+    public void noProxyHost() {
         String noProxyHost = "*.example.com|192.168.*";
         assertEquals(Proxy.Type.HTTP, ProxyConfiguration.createProxy("test.example.co.jp", "proxy.example.com", 8080, noProxyHost).type());
         assertEquals(Proxy.Type.DIRECT, ProxyConfiguration.createProxy("test.example.com", "proxy.example.com", 8080, noProxyHost).type());

--- a/core/src/test/java/hudson/RemoveWindowsDirectoryJunctionTest.java
+++ b/core/src/test/java/hudson/RemoveWindowsDirectoryJunctionTest.java
@@ -4,50 +4,40 @@
 
 package hudson;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.os.WindowsUtil;
 import java.io.File;
-import java.io.IOException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.For;
 import org.jvnet.hudson.test.Issue;
 
 @For(Util.class)
 // https://superuser.com/q/343074
-class RemoveWindowsDirectoryJunctionTest {
+public class RemoveWindowsDirectoryJunctionTest {
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
-    @TempDir
-    private File tmp;
-
-    @BeforeEach
-    void windowsOnly() {
+    @Before
+    public void windowsOnly() {
        assumeTrue(Functions.isWindows());
     }
 
     @Test
     @Issue("JENKINS-2995")
-    void testJunctionIsRemovedButNotContents() throws Exception {
-        File subdir1 = newFolder(tmp, "notJunction");
+    public void testJunctionIsRemovedButNotContents() throws Exception {
+        File subdir1 = tmp.newFolder("notJunction");
         File f1 = new File(subdir1, "testfile1.txt");
-        assertTrue(f1.createNewFile(), "Unable to create temporary file in notJunction directory");
-        File j1 = WindowsUtil.createJunction(new File(tmp, "test junction"), subdir1);
+        assertTrue("Unable to create temporary file in notJunction directory", f1.createNewFile());
+        File j1 = WindowsUtil.createJunction(new File(tmp.getRoot(), "test junction"), subdir1);
         Util.deleteRecursive(j1);
-        assertFalse(j1.exists(), "Windows Junction should have been removed");
-        assertTrue(f1.exists(), "Contents of Windows Junction should not be removed");
-    }
-
-    private static File newFolder(File root, String... subDirs) throws IOException {
-        String subFolder = String.join("/", subDirs);
-        File result = new File(root, subFolder);
-        if (!result.mkdirs()) {
-            throw new IOException("Couldn't create folders " + root);
-        }
-        return result;
+        assertFalse("Windows Junction should have been removed", j1.exists());
+        assertTrue("Contents of Windows Junction should not be removed", f1.exists());
     }
 
 }

--- a/core/src/test/java/hudson/XmlFileTest.java
+++ b/core/src/test/java/hudson/XmlFileTest.java
@@ -3,7 +3,7 @@ package hudson;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertThrows;
 
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.io.StreamException;
@@ -14,12 +14,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import jenkins.model.Jenkins;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
-class XmlFileTest {
+public class XmlFileTest {
 
     @Test
-    void canReadXml1_0Test() throws IOException {
+    public void canReadXml1_0Test() throws IOException {
         URL configUrl = getClass().getResource("/hudson/config_1_0.xml");
         XStream2  xs = new XStream2();
         xs.alias("hudson", Jenkins.class);
@@ -33,7 +33,7 @@ class XmlFileTest {
     }
 
     @Test
-    void xml1_0_withSpecialCharsShouldFail() {
+    public void xml1_0_withSpecialCharsShouldFail() {
         URL configUrl = getClass().getResource("/hudson/config_1_0_with_special_chars.xml");
         XStream2  xs = new XStream2();
         xs.alias("hudson", Jenkins.class);
@@ -53,7 +53,7 @@ class XmlFileTest {
     }
 
     @Test
-    void canReadXml1_1Test() throws IOException {
+    public void canReadXml1_1Test() throws IOException {
         URL configUrl = getClass().getResource("/hudson/config_1_1.xml");
         XStream2  xs = new XStream2();
         xs.alias("hudson", Jenkins.class);
@@ -67,7 +67,7 @@ class XmlFileTest {
     }
 
     @Test
-    void canReadXmlWithControlCharsTest() throws IOException {
+    public void canReadXmlWithControlCharsTest() throws IOException {
         URL configUrl = getClass().getResource("/hudson/config_1_1_with_special_chars.xml");
         XStream2  xs = new XStream2();
         xs.alias("hudson", Jenkins.class);

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -27,88 +27,88 @@ package hudson.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-class ArgumentListBuilderTest {
+public class ArgumentListBuilderTest {
 
     @Test
-    void assertEmptyMask() {
+    public void assertEmptyMask() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.add("arg");
         builder.add("other", "arguments");
 
-        assertFalse(builder.hasMaskedArguments(), "There should not be any masked arguments");
+        assertFalse("There should not be any masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
-        assertNotNull(array, "The mask array should not be null");
+        assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, false, false }));
     }
 
     @Test
-    void assertLastArgumentIsMasked() {
+    public void assertLastArgumentIsMasked() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.add("arg");
         builder.addMasked("ismasked");
 
-        assertTrue(builder.hasMaskedArguments(), "There should be masked arguments");
+        assertTrue("There should be masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
-        assertNotNull(array, "The mask array should not be null");
+        assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, true }));
     }
 
     @Test
-    void assertSeveralMaskedArguments() {
+    public void assertSeveralMaskedArguments() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.add("arg");
         builder.addMasked("ismasked");
         builder.add("non masked arg");
         builder.addMasked("ismasked2");
 
-        assertTrue(builder.hasMaskedArguments(), "There should be masked arguments");
+        assertTrue("There should be masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
-        assertNotNull(array, "The mask array should not be null");
+        assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, true, false, true }));
     }
 
     @Test
-    void assertPrependAfterAddingMasked() {
+    public void assertPrependAfterAddingMasked() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.addMasked("ismasked");
         builder.add("arg");
         builder.prepend("first", "second");
 
-        assertTrue(builder.hasMaskedArguments(), "There should be masked arguments");
+        assertTrue("There should be masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
-        assertNotNull(array, "The mask array should not be null");
+        assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, false, true, false }));
     }
 
     @Test
-    void assertPrependBeforeAddingMasked() {
+    public void assertPrependBeforeAddingMasked() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.prepend("first", "second");
         builder.addMasked("ismasked");
         builder.add("arg");
 
-        assertTrue(builder.hasMaskedArguments(), "There should be masked arguments");
+        assertTrue("There should be masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
-        assertNotNull(array, "The mask array should not be null");
+        assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, false, true, false }));
     }
 
     @Test
-    void testToWindowsCommand() {
+    public void testToWindowsCommand() {
         ArgumentListBuilder builder = new ArgumentListBuilder().
                 add("ant.bat").add("-Dfoo1=abc").  // nothing special, no quotes
                 add("-Dfoo2=foo bar").add("-Dfoo3=/u*r").add("-Dfoo4=/us?").  // add quotes
@@ -148,9 +148,9 @@ class ArgumentListBuilderTest {
     }
 
     @Test
-    @Disabled("It's only for reproduce JENKINS-28790 issue. It's added to testToWindowsCommand")
+    @Ignore("It's only for reproduce JENKINS-28790 issue. It's added to testToWindowsCommand")
     @Issue("JENKINS-28790")
-    void testToWindowsCommandMasked() {
+    public void testToWindowsCommandMasked() {
         ArgumentListBuilder builder = new ArgumentListBuilder().
                 add("ant.bat").add("-Dfoo1=abc").  // nothing special, no quotes
                 add("-Dfoo2=foo bar").add("-Dfoo3=/u*r").add("-Dfoo4=/us?").  // add quotes
@@ -177,16 +177,16 @@ class ArgumentListBuilderTest {
     }
 
     @Test
-    void assertMaskOnClone() {
+    public void assertMaskOnClone() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.add("arg1");
         builder.addMasked("masked1");
         builder.add("arg2");
 
         ArgumentListBuilder clone = builder.clone();
-        assertTrue(clone.hasMaskedArguments(), "There should be masked arguments");
+        assertTrue("There should be masked arguments", clone.hasMaskedArguments());
         boolean[] array = clone.toMaskArray();
-        assertNotNull(array, "The mask array should not be null");
+        assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(builder.toMaskArray()));
     }
 
@@ -201,30 +201,30 @@ class ArgumentListBuilderTest {
     private static final Set<String> MASKS = Set.of("key2");
 
     @Test
-    void assertKeyValuePairsWithMask() {
+    public void assertKeyValuePairsWithMask() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.addKeyValuePairs(null, KEY_VALUES, MASKS);
 
-        assertTrue(builder.hasMaskedArguments(), "There should be masked arguments");
+        assertTrue("There should be masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
-        assertNotNull(array, "The mask array should not be null");
+        assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, true, false }));
 
     }
 
     @Test
-    void assertKeyValuePairs() {
+    public void assertKeyValuePairs() {
         ArgumentListBuilder builder = new ArgumentListBuilder();
         builder.addKeyValuePairs(null, KEY_VALUES);
 
-        assertFalse(builder.hasMaskedArguments(), "There should not be any masked arguments");
+        assertFalse("There should not be any masked arguments", builder.hasMaskedArguments());
         boolean[] array = builder.toMaskArray();
-        assertNotNull(array, "The mask array should not be null");
+        assertNotNull("The mask array should not be null", array);
         assertThat("The mask array was incorrect", array, is(new boolean[] { false, false, false }));
     }
 
     @Test
-    void addKeyValuePairsFromPropertyString() throws IOException {
+    public void addKeyValuePairsFromPropertyString() throws IOException {
         final Map<String, String> map = new HashMap<>();
         map.put("PATH", "C:\\Windows");
         final VariableResolver<String> resolver = new VariableResolver.ByMap<>(map);
@@ -241,17 +241,15 @@ class ArgumentListBuilderTest {
     }
 
     @Test
-    void numberOfBackslashesInPropertiesShouldBePreservedAfterMacroExpansion() throws IOException {
+    public void numberOfBackslashesInPropertiesShouldBePreservedAfterMacroExpansion() throws IOException {
         final Map<String, String> map = new HashMap<>();
         map.put("ONE", "one\\backslash");
         map.put("TWO", "two\\\\backslashes");
         map.put("FOUR", "four\\\\\\\\backslashes");
 
-        final String properties = """
-                one=$ONE
-                two=$TWO
-                four=$FOUR
-                """
+        final String properties = "one=$ONE\n" +
+                "two=$TWO\n" +
+                "four=$FOUR\n"
         ;
 
         final String args = new ArgumentListBuilder()

--- a/core/src/test/java/hudson/util/CompoundEnumerationTest.java
+++ b/core/src/test/java/hudson/util/CompoundEnumerationTest.java
@@ -1,17 +1,17 @@
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
-class CompoundEnumerationTest {
+public class CompoundEnumerationTest {
 
     @Test
-    void smokes() {
+    public void smokes() {
         assertEquals(
                 rangeClosed(1, 12),
                 Collections.list(
@@ -22,7 +22,7 @@ class CompoundEnumerationTest {
     }
 
     @Test
-    void empty() {
+    public void empty() {
         assertEquals(Collections.emptyList(), Collections.list(new CompoundEnumeration<>()));
         assertEquals(
                 Collections.emptyList(),
@@ -42,7 +42,7 @@ class CompoundEnumerationTest {
     }
 
     @Test
-    void gaps() {
+    public void gaps() {
         assertEquals(
                 rangeClosed(1, 8),
                 Collections.list(

--- a/core/src/test/java/hudson/util/ConsistentHashTest.java
+++ b/core/src/test/java/hudson/util/ConsistentHashTest.java
@@ -24,12 +24,12 @@
 
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,18 +37,18 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-class ConsistentHashTest {
+public class ConsistentHashTest {
     /**
      * Just some random tests to ensure that we have no silly NPE or that kind of error.
      */
     @Test
-    void basic() {
+    public void basic() {
         ConsistentHash<String> hash = new ConsistentHash<>();
         hash.add("data1");
         hash.add("data2");
@@ -77,7 +77,7 @@ class ConsistentHashTest {
      * Uneven distribution should result in uneven mapping.
      */
     @Test
-    void unevenDistribution() {
+    public void unevenDistribution() {
         ConsistentHash<String> hash = new ConsistentHash<>();
         hash.add("Even", 10);
         hash.add("Odd", 100);
@@ -102,7 +102,7 @@ class ConsistentHashTest {
      * Removal shouldn't affect existing nodes
      */
     @Test
-    void removal() {
+    public void removal() {
         ConsistentHash<Integer> hash = new ConsistentHash<>();
         for (int i = 0; i < 10; i++) {
             hash.add(i);
@@ -127,7 +127,7 @@ class ConsistentHashTest {
     }
 
     @Test
-    void emptyBehavior() {
+    public void emptyBehavior() {
         ConsistentHash<String> hash = new ConsistentHash<>();
         assertEquals(0, hash.countAllPoints());
         assertFalse(hash.list(0).iterator().hasNext());
@@ -136,7 +136,7 @@ class ConsistentHashTest {
     }
 
     @Test
-    void countAllPoints() {
+    public void countAllPoints() {
         ConsistentHash<String> hash = new ConsistentHash<>();
         assertEquals(0, hash.countAllPoints());
         hash.add("foo", 10);
@@ -148,7 +148,7 @@ class ConsistentHashTest {
     }
 
     @Test
-    void defaultReplicationIsOneHundred() {
+    public void defaultReplicationIsOneHundred() {
         ConsistentHash<String> hash = new ConsistentHash<>();
         assertEquals(0, hash.countAllPoints());
         hash.add("foo");
@@ -156,7 +156,7 @@ class ConsistentHashTest {
     }
 
     @Test
-    void setCustomDefaultReplication() {
+    public void setCustomDefaultReplication() {
         ConsistentHash<String> hash = new ConsistentHash<>((ConsistentHash.Hash<String>) ConsistentHash.DEFAULT_HASH, 7);
         assertEquals(0, hash.countAllPoints());
         hash.add("foo");
@@ -164,7 +164,7 @@ class ConsistentHashTest {
     }
 
     @Test
-    void usesCustomHash() {
+    public void usesCustomHash() {
         final RuntimeException exception = new RuntimeException();
         ConsistentHash.Hash<String> hashFunction = str -> {
             throw exception;
@@ -179,8 +179,8 @@ class ConsistentHashTest {
      * This test doesn't fail but it's written to measure the performance of the consistent hash function with large data set.
      */
     @Test
-    @Disabled("Helper test for performance, no assertion")
-    void speed() {
+    @Ignore("Helper test for performance, no assertion")
+    public void speed() {
         Map<String, Integer> data = new CopyOnWriteMap.Hash<>();
         for (int i = 0; i < 1000; i++) {
             data.put("node" + i, 100);

--- a/core/src/test/java/hudson/util/CopyOnWriteListTest.java
+++ b/core/src/test/java/hudson/util/CopyOnWriteListTest.java
@@ -25,20 +25,20 @@
 package hudson.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.ElementSelectors;
 
 /**
  * @author Kohsuke Kawaguchi, Alan Harder
  */
-class CopyOnWriteListTest {
+public class CopyOnWriteListTest {
 
     public static final class TestData {
         CopyOnWriteList list1 = new CopyOnWriteList();
@@ -49,7 +49,7 @@ class CopyOnWriteListTest {
      * Verify that the serialization form of List and CopyOnWriteList are the same.
      */
     @Test
-    void serialization() {
+    public void serialization() {
         XStream2 xs = new XStream2();
         TestData td = new TestData();
 

--- a/core/src/test/java/hudson/util/CopyOnWriteMapTest.java
+++ b/core/src/test/java/hudson/util/CopyOnWriteMapTest.java
@@ -24,19 +24,19 @@
 
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * @author Mike Dillon, Alan Harder
  */
-class CopyOnWriteMapTest {
+public class CopyOnWriteMapTest {
     public static final class HashData {
         CopyOnWriteMap.Hash<String, String> map1 = new CopyOnWriteMap.Hash<>();
         HashMap<String, String> map2 = new HashMap<>();
@@ -45,16 +45,14 @@ class CopyOnWriteMapTest {
     /**
      * Verify that serialization form of CopyOnWriteMap.Hash and HashMap are the same.
      */
-    @Test
-    void hashSerialization() {
+    @Test public void hashSerialization() {
         HashData td = new HashData();
         XStream2 xs = new XStream2();
 
         String out = xs.toXML(td);
-        assertEquals("<hudson.util.CopyOnWriteMapTest_-HashData>"
+        assertEquals("empty maps", "<hudson.util.CopyOnWriteMapTest_-HashData>"
                 + "<map1/><map2/></hudson.util.CopyOnWriteMapTest_-HashData>",
-                out.replaceAll("\\s+", ""),
-                "empty maps");
+                out.replaceAll("\\s+", ""));
         HashData td2 = (HashData) xs.fromXML(out);
         assertTrue(td2.map1.isEmpty());
         assertTrue(td2.map2.isEmpty());
@@ -62,12 +60,11 @@ class CopyOnWriteMapTest {
         td.map1.put("foo1", "bar1");
         td.map2.put("foo2", "bar2");
         out = xs.toXML(td);
-        assertEquals("<hudson.util.CopyOnWriteMapTest_-HashData><map1>"
+        assertEquals("maps", "<hudson.util.CopyOnWriteMapTest_-HashData><map1>"
                 + "<entry><string>foo1</string><string>bar1</string></entry></map1>"
                 + "<map2><entry><string>foo2</string><string>bar2</string></entry>"
                 + "</map2></hudson.util.CopyOnWriteMapTest_-HashData>",
-                out.replaceAll("\\s+", ""),
-                "maps");
+                out.replaceAll("\\s+", ""));
         td2 = (HashData) xs.fromXML(out);
         assertEquals("bar1", td2.map1.get("foo1"));
         assertEquals("bar2", td2.map2.get("foo2"));
@@ -92,17 +89,15 @@ class CopyOnWriteMapTest {
      * Verify that an empty CopyOnWriteMap.Tree can be serialized,
      * and that serialization form is the same as a standard TreeMap.
      */
-    @Test
-    void treeSerialization() {
+    @Test public void treeSerialization() {
         TreeData td = new TreeData();
         XStream2 xs = new XStream2();
 
         String out = xs.toXML(td);
-        assertEquals("<hudson.util.CopyOnWriteMapTest_-TreeData>"
+        assertEquals("empty maps", "<hudson.util.CopyOnWriteMapTest_-TreeData>"
                 + "<map1/><map2/>"
                 + "</hudson.util.CopyOnWriteMapTest_-TreeData>",
-                out.replaceAll("\\s+", ""),
-                "empty maps");
+                out.replaceAll("\\s+", ""));
         TreeData td2 = (TreeData) xs.fromXML(out);
         assertTrue(td2.map1.isEmpty());
         assertTrue(td2.map2.isEmpty());
@@ -111,22 +106,20 @@ class CopyOnWriteMapTest {
         td.map1.put("foo1", "bar1");
         td.map2.put("foo2", "bar2");
         out = xs.toXML(td);
-        assertEquals("<hudson.util.CopyOnWriteMapTest_-TreeData><map1>"
+        assertEquals("maps", "<hudson.util.CopyOnWriteMapTest_-TreeData><map1>"
                 + "<comparator class=\"java.lang.String$CaseInsensitiveComparator\"/>"
                 + "<entry><string>foo1</string><string>bar1</string></entry></map1>"
                 + "<map2><comparator class=\"java.lang.String$CaseInsensitiveComparator\""
                 + " reference=\"../../map1/comparator\"/>"
                 + "<entry><string>foo2</string><string>bar2</string></entry></map2>"
                 + "</hudson.util.CopyOnWriteMapTest_-TreeData>",
-                out.replaceAll(">\\s+<", "><"),
-                "maps");
+                out.replaceAll(">\\s+<", "><"));
         td2 = (TreeData) xs.fromXML(out);
         assertEquals("bar1", td2.map1.get("foo1"));
         assertEquals("bar2", td2.map2.get("foo2"));
     }
 
-    @Test
-    void equalsHashCodeToString() {
+    @Test public void equalsHashCodeToString() {
         Map<String, Integer> m1 = new TreeMap<>();
         Map<String, Integer> m2 = new CopyOnWriteMap.Tree<>();
         m1.put("foo", 5);

--- a/core/src/test/java/hudson/util/CyclicGraphDetectorTest.java
+++ b/core/src/test/java/hudson/util/CyclicGraphDetectorTest.java
@@ -1,19 +1,19 @@
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import hudson.util.CyclicGraphDetector.CycleDetectedException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-class CyclicGraphDetectorTest {
+public class CyclicGraphDetectorTest {
 
     private static class Edge {
         String src, dst;
@@ -61,27 +61,28 @@ class CyclicGraphDetectorTest {
         }
 
         void mustContainCycle(String... members) {
-            final CycleDetectedException e = assertThrows(CycleDetectedException.class, this::check, "Cycle expected");
+            final CycleDetectedException e = assertThrows("Cycle expected",
+                    CycleDetectedException.class, this::check);
 
             final String msg = "Expected cycle of " + Arrays.asList(members) + " but found " + e.cycle;
             for (String s : members) {
-                assertTrue(e.cycle.contains(s), msg);
+                assertTrue(msg, e.cycle.contains(s));
             }
         }
     }
 
     @Test
-    void cycle1() {
+    public void cycle1() {
         new Graph().e("A", "B").e("B", "C").e("C", "A").mustContainCycle("A", "B", "C");
     }
 
     @Test
-    void cycle2() {
+    public void cycle2() {
         new Graph().e("A", "B").e("B", "C").e("C", "C").mustContainCycle("C");
     }
 
     @Test
-    void cycle3() {
+    public void cycle3() {
         new Graph().e("A", "B").e("B", "C").e("C", "D").e("B", "E").e("E", "D").e("E", "A").mustContainCycle("A", "B", "E");
     }
 }

--- a/core/src/test/java/hudson/util/DescribableListTest.java
+++ b/core/src/test/java/hudson/util/DescribableListTest.java
@@ -27,21 +27,21 @@ package hudson.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Saveable;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-class DescribableListTest {
+public class DescribableListTest {
 
     @Issue("JENKINS-49054")
     @Test
-    void exceptionDuringUnmarshalling() {
+    public void exceptionDuringUnmarshalling() {
         Data data = new Data();
         data.list.add(new Datum(1));
         data.list.add(new Datum(2));
@@ -54,7 +54,7 @@ class DescribableListTest {
     }
 
     @Test
-    void replace() throws Exception {
+    public void replace() throws Exception {
         AtomicInteger count = new AtomicInteger();
         DescribableList<Datum, Descriptor<Datum>> list = new DescribableList<>((Saveable) count::incrementAndGet);
         list.add(new Datum(1));

--- a/core/src/test/java/hudson/util/DirScannerTest.java
+++ b/core/src/test/java/hudson/util/DirScannerTest.java
@@ -24,25 +24,24 @@
 
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import hudson.FilePath;
 import java.io.File;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Christoph Thelen
  */
-class DirScannerTest {
+public class DirScannerTest {
 
-    @TempDir
-    private File tmpRule;
+    @Rule public TemporaryFolder tmpRule = new TemporaryFolder();
 
-    @Test
-    void globShouldUseDefaultExcludes() throws Exception {
-        FilePath tmp = new FilePath(tmpRule);
+    @Test public void globShouldUseDefaultExcludes() throws Exception {
+        FilePath tmp = new FilePath(tmpRule.getRoot());
         try {
             tmp.child(".gitignore").touch(0);
             FilePath git = tmp.child(".git");
@@ -64,9 +63,8 @@ class DirScannerTest {
         }
     }
 
-    @Test
-    void globShouldIgnoreDefaultExcludesByRequest() throws Exception {
-        FilePath tmp = new FilePath(tmpRule);
+    @Test public void globShouldIgnoreDefaultExcludesByRequest() throws Exception {
+        FilePath tmp = new FilePath(tmpRule.getRoot());
         try {
             tmp.child(".gitignore").touch(0);
             FilePath git = tmp.child(".git");

--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -2,7 +2,7 @@ package hudson.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,26 +10,26 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-class FileChannelWriterTest {
+public class FileChannelWriterTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    @TempDir
-    private File temporaryFolder;
+    File file;
+    FileChannelWriter writer;
 
-    private File file;
-    private FileChannelWriter writer;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        file = File.createTempFile("junit", null, temporaryFolder);
+    @Before
+    public void setUp() throws Exception {
+        file = temporaryFolder.newFile();
         writer = new FileChannelWriter(file.toPath(), StandardCharsets.UTF_8, true, true,  StandardOpenOption.WRITE);
     }
 
     @Test
-    void write() throws Exception {
+    public void write() throws Exception {
         writer.write("helloooo");
         writer.close();
 
@@ -38,7 +38,7 @@ class FileChannelWriterTest {
 
 
     @Test
-    void flush() throws Exception {
+    public void flush() throws Exception {
         writer.write("hello é è à".toCharArray());
 
         writer.flush();
@@ -46,7 +46,7 @@ class FileChannelWriterTest {
     }
 
     @Test
-    void close() throws Exception {
+    public void close() throws Exception {
         writer.write("helloooo");
         writer.close();
 

--- a/core/src/test/java/hudson/util/FormValidationTest.java
+++ b/core/src/test/java/hudson/util/FormValidationTest.java
@@ -28,35 +28,35 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * @author sogabe
  */
-class FormValidationTest {
+public class FormValidationTest {
 
     @Test
-    void testValidateRequired_OK() {
+    public void testValidateRequired_OK() {
         FormValidation actual = FormValidation.validateRequired("Name");
         assertEquals(FormValidation.ok(), actual);
     }
 
     @Test
-    void testValidateRequired_Null() {
+    public void testValidateRequired_Null() {
         FormValidation actual = FormValidation.validateRequired(null);
         assertNotNull(actual);
         assertEquals(FormValidation.Kind.ERROR, actual.kind);
     }
 
     @Test
-    void testValidateRequired_Empty() {
+    public void testValidateRequired_Empty() {
         FormValidation actual = FormValidation.validateRequired("  ");
         assertNotNull(actual);
         assertEquals(FormValidation.Kind.ERROR, actual.kind);
@@ -64,17 +64,17 @@ class FormValidationTest {
 
     // @Issue("JENKINS-7438")
     @Test
-    void testMessage() {
+    public void testMessage() {
         assertEquals("test msg", FormValidation.errorWithMarkup("test msg").getMessage());
     }
 
     @Test
-    void aggregateZeroValidations() {
+    public void aggregateZeroValidations() {
         assertEquals(FormValidation.ok(), aggregate());
     }
 
     @Test
-    void aggregateSingleValidations() {
+    public void aggregateSingleValidations() {
         FormValidation ok = FormValidation.ok();
         FormValidation warning = FormValidation.warning("");
         FormValidation error = FormValidation.error("");
@@ -85,7 +85,7 @@ class FormValidationTest {
     }
 
     @Test
-    void aggregateSeveralValidations() {
+    public void aggregateSeveralValidations() {
         FormValidation ok = FormValidation.ok("ok_message");
         FormValidation warning = FormValidation.warning("warning_message");
         FormValidation error = FormValidation.error("error_message");
@@ -115,13 +115,13 @@ class FormValidationTest {
     }
 
     @Test
-    void formValidationException() {
+    public void formValidationException() {
         FormValidation fv = FormValidation.error(new Exception("<html"), "Message<html");
         assertThat(fv.renderHtml(), not(containsString("<html")));
     }
 
     @Test
-    void testUrlCheck() throws IOException {
+    public void testUrlCheck() throws IOException {
         FormValidation.URLCheck urlCheck = new FormValidation.URLCheck() {
             @Override
             protected FormValidation check() throws IOException {

--- a/core/src/test/java/hudson/util/GraphTest.java
+++ b/core/src/test/java/hudson/util/GraphTest.java
@@ -24,10 +24,9 @@
 
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.awt.Dimension;
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class GraphTest {
 
@@ -35,25 +34,25 @@ public class GraphTest {
     public static final int DEFAULT_H = 300;
 
     @Test
-    void testDimensions() {
+    public void testDimensions() {
         final Dimension keep = Graph.safeDimension(Graph.MAX_AREA / 1_000, 1000, DEFAULT_W, DEFAULT_H);
-        assertEquals(Graph.MAX_AREA / 1_000, keep.width);
-        assertEquals(1_000, keep.height);
+        Assert.assertEquals(Graph.MAX_AREA / 1_000, keep.width);
+        Assert.assertEquals(1_000, keep.height);
 
         final Dimension keep2 = Graph.safeDimension(Graph.MAX_AREA / 2, 2, DEFAULT_W, DEFAULT_H);
-        assertEquals(Graph.MAX_AREA / 2, keep2.width);
-        assertEquals(2, keep2.height);
+        Assert.assertEquals(Graph.MAX_AREA / 2, keep2.width);
+        Assert.assertEquals(2, keep2.height);
 
         final Dimension resetArea = Graph.safeDimension(Graph.MAX_AREA, Graph.MAX_AREA, DEFAULT_W, DEFAULT_H);
-        assertEquals(DEFAULT_W, resetArea.width);
-        assertEquals(DEFAULT_H, resetArea.height);
+        Assert.assertEquals(DEFAULT_W, resetArea.width);
+        Assert.assertEquals(DEFAULT_H, resetArea.height);
 
         final Dimension resetNegativeWidth = Graph.safeDimension(-50, 1000, DEFAULT_W, DEFAULT_H);
-        assertEquals(DEFAULT_W, resetNegativeWidth.width);
-        assertEquals(DEFAULT_H, resetNegativeWidth.height);
+        Assert.assertEquals(DEFAULT_W, resetNegativeWidth.width);
+        Assert.assertEquals(DEFAULT_H, resetNegativeWidth.height);
 
         final Dimension resetNegativeHeight = Graph.safeDimension(1000, -50, DEFAULT_W, DEFAULT_H);
-        assertEquals(DEFAULT_W, resetNegativeHeight.width);
-        assertEquals(DEFAULT_H, resetNegativeHeight.height);
+        Assert.assertEquals(DEFAULT_W, resetNegativeHeight.width);
+        Assert.assertEquals(DEFAULT_H, resetNegativeHeight.height);
     }
 }

--- a/core/src/test/java/hudson/util/IteratorsTest.java
+++ b/core/src/test/java/hudson/util/IteratorsTest.java
@@ -28,23 +28,23 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import hudson.util.Iterators.CountingPredicate;
 import java.util.Iterator;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-class IteratorsTest {
+public class IteratorsTest {
 
     @Test
-    void reverseSequence() {
+    public void reverseSequence() {
         List<Integer> lst = Iterators.reverseSequence(1, 4);
         assertEquals(3, (int) lst.get(0));
         assertEquals(2, (int) lst.get(1));
@@ -53,7 +53,7 @@ class IteratorsTest {
     }
 
     @Test
-    void sequence() {
+    public void sequence() {
         List<Integer> lst = Iterators.sequence(1, 4);
         assertEquals(1, (int) lst.get(0));
         assertEquals(2, (int) lst.get(1));
@@ -62,7 +62,7 @@ class IteratorsTest {
     }
 
     @Test
-    void wrap() {
+    public void wrap() {
         List<Integer> lst = Iterators.sequence(1, 4);
         Iterable<Integer> wrapped = Iterators.wrap(lst);
         assertThat(wrapped, not(instanceOf(List.class)));
@@ -77,7 +77,7 @@ class IteratorsTest {
     }
 
     @Test
-    void limit() {
+    public void limit() {
         assertEquals("[0]", com.google.common.collect.Iterators.toString(Iterators.limit(asList(0, 1, 2, 3, 4).iterator(), EVEN)));
         assertEquals("[]", com.google.common.collect.Iterators.toString(Iterators.limit(asList(1, 2, 4, 6).iterator(), EVEN)));
     }
@@ -86,7 +86,7 @@ class IteratorsTest {
 
     @Issue("JENKINS-51779")
     @Test
-    void skip() {
+    public void skip() {
         List<Integer> lst = Iterators.sequence(1, 4);
         Iterator<Integer> it = lst.iterator();
         Iterators.skip(it, 0);

--- a/core/src/test/java/hudson/util/JSONObjectResponseTest.java
+++ b/core/src/test/java/hudson/util/JSONObjectResponseTest.java
@@ -24,20 +24,19 @@
 
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.util.HashMap;
 import java.util.Map;
 import net.sf.json.JSONObject;
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-class JSONObjectResponseTest {
+public class JSONObjectResponseTest {
 
     @Test
-    void test() {
+    public void test() {
         Map<String, String> data = new HashMap<>();
 
         data.put("val_1", "1");
@@ -45,13 +44,13 @@ class JSONObjectResponseTest {
         HttpResponses.JSONObjectResponse response = new HttpResponses.JSONObjectResponse(data);
         JSONObject payload = response.getJsonObject();
 
-        assertEquals("ok", payload.getString("status"));
+        Assert.assertEquals("ok", payload.getString("status"));
         JSONObject payloadData = payload.getJSONObject("data");
-        assertEquals("1", payloadData.getString("val_1"));
+        Assert.assertEquals("1", payloadData.getString("val_1"));
 
         // change it to an error
         response.error("a message");
-        assertEquals("error", payload.getString("status"));
-        assertEquals("a message", payload.getString("message"));
+        Assert.assertEquals("error", payload.getString("status"));
+        Assert.assertEquals("a message", payload.getString("message"));
     }
 }

--- a/core/src/test/java/hudson/util/MultipartFormDataParserTest.java
+++ b/core/src/test/java/hudson/util/MultipartFormDataParserTest.java
@@ -24,23 +24,21 @@
 
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-class MultipartFormDataParserTest {
+public class MultipartFormDataParserTest {
 
     @Test
-    void testIsMultipart() {
-        assertFalse(MultipartFormDataParser.isMultiPartForm(null), "Wrongly identified \"multipart/form-data\"");
-        assertFalse(MultipartFormDataParser.isMultiPartForm("blah"), "Wrongly identified \"multipart/form-data\"");
+    public void testIsMultipart() {
+        Assert.assertFalse("Wrongly identified \"multipart/form-data\"", MultipartFormDataParser.isMultiPartForm(null));
+        Assert.assertFalse("Wrongly identified \"multipart/form-data\"", MultipartFormDataParser.isMultiPartForm("blah"));
 
-        assertTrue(MultipartFormDataParser.isMultiPartForm("multipart/form-data"), "Failed to identify \"multipart/form-data\"");
-        assertTrue(MultipartFormDataParser.isMultiPartForm("multipart/form-data;"), "Failed to identify \"multipart/form-data\"");
-        assertTrue(MultipartFormDataParser.isMultiPartForm("multipart/form-data; boundary=----WebKitFormBoundary8OOwv1Xp4c5XkBmD"), "Failed to identify \"multipart/form-data\"");
+        Assert.assertTrue("Failed to identify \"multipart/form-data\"", MultipartFormDataParser.isMultiPartForm("multipart/form-data"));
+        Assert.assertTrue("Failed to identify \"multipart/form-data\"", MultipartFormDataParser.isMultiPartForm("multipart/form-data;"));
+        Assert.assertTrue("Failed to identify \"multipart/form-data\"", MultipartFormDataParser.isMultiPartForm("multipart/form-data; boundary=----WebKitFormBoundary8OOwv1Xp4c5XkBmD"));
     }
 }

--- a/core/src/test/java/hudson/util/PackedMapTest.java
+++ b/core/src/test/java/hudson/util/PackedMapTest.java
@@ -1,15 +1,15 @@
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 import java.util.TreeMap;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-class PackedMapTest {
+public class PackedMapTest {
 
     static class Holder {
         PackedMap pm;
@@ -18,7 +18,7 @@ class PackedMapTest {
     private XStream2 xs = new XStream2();
 
     @Test
-    void basic() {
+    public void basic() {
         Map<String, String> o = new TreeMap<>();
         o.put("a", "b");
         o.put("c", "d");
@@ -35,19 +35,18 @@ class PackedMapTest {
         h.pm = p;
         String xml = xs.toXML(h);
         assertEquals(
-                """
-                        <hudson.util.PackedMapTest_-Holder>
-                          <pm>
-                            <entry>
-                              <string>a</string>
-                              <string>b</string>
-                            </entry>
-                            <entry>
-                              <string>c</string>
-                              <string>d</string>
-                            </entry>
-                          </pm>
-                        </hudson.util.PackedMapTest_-Holder>""",
+                "<hudson.util.PackedMapTest_-Holder>\n" +
+                "  <pm>\n" +
+                "    <entry>\n" +
+                "      <string>a</string>\n" +
+                "      <string>b</string>\n" +
+                "    </entry>\n" +
+                "    <entry>\n" +
+                "      <string>c</string>\n" +
+                "      <string>d</string>\n" +
+                "    </entry>\n" +
+                "  </pm>\n" +
+                "</hudson.util.PackedMapTest_-Holder>",
                 xml);
 
         xs.fromXML(xml);

--- a/core/src/test/java/hudson/util/ProcessTreeTest.java
+++ b/core/src/test/java/hudson/util/ProcessTreeTest.java
@@ -1,82 +1,38 @@
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 
-import hudson.remoting.Channel;
-import hudson.remoting.ChannelBuilder;
-import hudson.remoting.FastPipedInputStream;
-import hudson.remoting.FastPipedOutputStream;
+import hudson.ChannelRule;
 import hudson.remoting.VirtualChannel;
 import hudson.util.ProcessTree.OSProcess;
 import hudson.util.ProcessTree.ProcessCallable;
 import java.io.IOException;
-import java.io.Serial;
 import java.io.Serializable;
-import java.io.UncheckedIOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import jenkins.security.MasterToSlaveCallable;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-class ProcessTreeTest {
+public class ProcessTreeTest {
 
-    /**
-     * Two channels that are connected to each other, but shares the same classloader.
-     */
-    private Channel french;
-    private Channel british;
-    private ExecutorService executors;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        executors = Executors.newCachedThreadPool();
-        final FastPipedInputStream p1i = new FastPipedInputStream();
-        final FastPipedInputStream p2i = new FastPipedInputStream();
-        final FastPipedOutputStream p1o = new FastPipedOutputStream(p1i);
-        final FastPipedOutputStream p2o = new FastPipedOutputStream(p2i);
-
-        Future<Channel> f1 = executors.submit(() -> new ChannelBuilder("This side of the channel", executors).withMode(Channel.Mode.BINARY).build(p1i, p2o));
-        Future<Channel> f2 = executors.submit(() -> new ChannelBuilder("The other side of the channel", executors).withMode(Channel.Mode.BINARY).build(p2i, p1o));
-        french = f1.get();
-        british = f2.get();
-    }
-
-    @AfterEach
-    void tearDown() {
-        try {
-            french.close(); // this will automatically initiate the close on the other channel, too.
-            french.join();
-            british.join();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        } catch (InterruptedException x) {
-            throw new AssertionError(x);
-        }
-        executors.shutdownNow();
-    }
+    @Rule public ChannelRule channels = new ChannelRule();
 
     static class  Tag implements Serializable {
         ProcessTree tree;
         OSProcess p;
         int id;
-        @Serial
         private static final long serialVersionUID = 1L;
     }
 
-    @Test
-    void remoting() throws Exception {
-        Assumptions.assumeFalse(ProcessTree.get() == ProcessTree.DEFAULT, "on some platforms where we fail to list any processes");
+    @Test public void remoting() throws Exception {
+        Assume.assumeFalse("on some platforms where we fail to list any processes", ProcessTree.get() == ProcessTree.DEFAULT);
 
-        Tag t = french.call(new MyCallable());
+        Tag t = channels.french.call(new MyCallable());
 
         // make sure the serialization preserved the reference graph
         assertSame(t.p.getTree(), t.tree);
@@ -100,7 +56,6 @@ class ProcessTreeTest {
             return t;
         }
 
-        @Serial
         private static final long serialVersionUID = 1L;
     }
 

--- a/core/src/test/java/hudson/util/RetrierTest.java
+++ b/core/src/test/java/hudson/util/RetrierTest.java
@@ -1,9 +1,7 @@
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -11,13 +9,14 @@ import java.time.Instant;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
-class RetrierTest {
+public class RetrierTest {
     private static final Logger LOG = Logger.getLogger(RetrierTest.class.getName());
 
     @Test
-    void performedAtThirdAttemptTest() throws Exception {
+    public void performedAtThirdAttemptTest() throws Exception {
         final int SUCCESSFUL_ATTEMPT = 3;
         final String ACTION = "print";
 
@@ -46,14 +45,14 @@ class RetrierTest {
 
         // Begin the process
         Boolean finalResult = r.start();
-        assertTrue(finalResult != null && finalResult);
+        Assert.assertTrue(finalResult != null && finalResult);
 
         String text = Messages.Retrier_Success(ACTION, SUCCESSFUL_ATTEMPT);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().contains(text)), String.format("The log should contain '%s'", text));
+        assertTrue(String.format("The log should contain '%s'", text), handler.getView().stream().anyMatch(m -> m.getMessage().contains(text)));
     }
 
     @Test
-    void sleepWorksTest() throws Exception {
+    public void sleepWorksTest() throws Exception {
         final int SUCCESSFUL_ATTEMPT = 2;
         final String ACTION = "print";
         final int SLEEP = 500;
@@ -95,21 +94,21 @@ class RetrierTest {
         long timeElapsed = Duration.between(start, finish).toMillis();
 
         // Check delay works
-        assertTrue(timeElapsed >= SLEEP);
+        Assert.assertTrue(timeElapsed >= SLEEP);
 
         // Check result is true
-        assertTrue(finalResult != null && finalResult);
+        Assert.assertTrue(finalResult != null && finalResult);
 
         // Check the log tell us the sleep time
         String text = Messages.Retrier_Sleeping(SLEEP, ACTION);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().contains(text)), String.format("The log should contain '%s'", text));
+        assertTrue(String.format("The log should contain '%s'", text), handler.getView().stream().anyMatch(m -> m.getMessage().contains(text)));
 
         // recover log level
         retrierLogger.setLevel(currentLogLevel);
     }
 
     @Test
-    void failedActionAfterThreeAttemptsTest() throws Exception {
+    public void failedActionAfterThreeAttemptsTest() throws Exception {
         final int ATTEMPTS = 3;
         final String ACTION = "print";
 
@@ -139,15 +138,15 @@ class RetrierTest {
         // Begin the process
         Boolean finalResult = r.start();
 
-        assertFalse(finalResult != null && finalResult);
+        Assert.assertFalse(finalResult != null && finalResult);
 
         String text = Messages.Retrier_NoSuccess(ACTION, ATTEMPTS);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().contains(text)), String.format("The log should contain '%s'", text));
+        assertTrue(String.format("The log should contain '%s'", text), handler.getView().stream().anyMatch(m -> m.getMessage().contains(text)));
 
     }
 
     @Test
-    void failedActionWithExceptionAfterThreeAttemptsWithoutListenerTest() throws Exception {
+    public void failedActionWithExceptionAfterThreeAttemptsWithoutListenerTest() throws Exception {
         final int ATTEMPTS = 3;
         final String ACTION = "print";
 
@@ -175,18 +174,18 @@ class RetrierTest {
 
         // Begin the process without catching the allowed exceptions
         Boolean finalResult = r.start();
-        assertNull(finalResult);
+        Assert.assertNull(finalResult);
 
         String textNoSuccess = Messages.Retrier_NoSuccess(ACTION, ATTEMPTS);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().contains(textNoSuccess)), String.format("The log should contain '%s'", textNoSuccess));
+        assertTrue(String.format("The log should contain '%s'", textNoSuccess), handler.getView().stream().anyMatch(m -> m.getMessage().contains(textNoSuccess)));
 
         String testException = Messages.Retrier_ExceptionFailed(ATTEMPTS, ACTION);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().startsWith(testException)), String.format("The log should contain '%s'", testException));
+        assertTrue(String.format("The log should contain '%s'", testException), handler.getView().stream().anyMatch(m -> m.getMessage().startsWith(testException)));
 
     }
 
     @Test
-    void failedActionWithAllowedExceptionWithListenerChangingResultTest() throws Exception {
+    public void failedActionWithAllowedExceptionWithListenerChangingResultTest() throws Exception {
         final int ATTEMPTS = 1;
         final String ACTION = "print";
 
@@ -216,19 +215,19 @@ class RetrierTest {
 
         // Begin the process catching the allowed exception
         Boolean finalResult = r.start();
-        assertTrue(finalResult != null && finalResult);
+        Assert.assertTrue(finalResult != null && finalResult);
 
         // The action was a success
         String textSuccess = Messages.Retrier_Success(ACTION, ATTEMPTS);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().contains(textSuccess)), String.format("The log should contain '%s'", textSuccess));
+        assertTrue(String.format("The log should contain '%s'", textSuccess), handler.getView().stream().anyMatch(m -> m.getMessage().contains(textSuccess)));
 
         // And the message talking about the allowed raised is also there
         String testException = Messages.Retrier_ExceptionFailed(ATTEMPTS, ACTION);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().startsWith(testException)), String.format("The log should contain '%s'", testException));
+        assertTrue(String.format("The log should contain '%s'", testException), handler.getView().stream().anyMatch(m -> m.getMessage().startsWith(testException)));
     }
 
     @Test
-    void failedActionWithAllowedExceptionByInheritanceTest() throws Exception {
+    public void failedActionWithAllowedExceptionByInheritanceTest() throws Exception {
         final int ATTEMPTS = 1;
         final String ACTION = "print";
 
@@ -259,19 +258,19 @@ class RetrierTest {
 
         // Begin the process catching the allowed exception
         Boolean finalResult = r.start();
-        assertTrue(finalResult != null && finalResult);
+        Assert.assertTrue(finalResult != null && finalResult);
 
         // The action was a success
         String textSuccess = Messages.Retrier_Success(ACTION, ATTEMPTS);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().contains(textSuccess)), String.format("The log should contain '%s'", textSuccess));
+        assertTrue(String.format("The log should contain '%s'", textSuccess), handler.getView().stream().anyMatch(m -> m.getMessage().contains(textSuccess)));
 
         // And the message talking about the allowed raised is also there
         String testException = Messages.Retrier_ExceptionFailed(ATTEMPTS, ACTION);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().startsWith(testException)), String.format("The log should contain '%s'", testException));
+        assertTrue(String.format("The log should contain '%s'", testException), handler.getView().stream().anyMatch(m -> m.getMessage().startsWith(testException)));
     }
 
     @Test
-    void failedActionWithUnAllowedExceptionTest() {
+    public void failedActionWithUnAllowedExceptionTest() {
         final int ATTEMPTS = 1;
         final String ACTION = "print";
 
@@ -299,8 +298,8 @@ class RetrierTest {
                 .build();
 
         // Begin the process that raises an unexpected exception
-        assertThrows(IOException.class, r::start, "The process should be exited with an unexpected exception");
+        assertThrows("The process should be exited with an unexpected exception", IOException.class, r::start);
         String testFailure = Messages.Retrier_ExceptionThrown(ATTEMPTS, ACTION);
-        assertTrue(handler.getView().stream().anyMatch(m -> m.getMessage().contains(testFailure)), String.format("The log should contain '%s'", testFailure));
+        assertTrue(String.format("The log should contain '%s'", testFailure), handler.getView().stream().anyMatch(m -> m.getMessage().contains(testFailure)));
     }
 }

--- a/core/src/test/java/hudson/util/RobustCollectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustCollectionConverterTest.java
@@ -26,10 +26,10 @@ package hudson.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.thoughtworks.xstream.security.InputManipulationException;
 import hudson.model.Saveable;
@@ -43,29 +43,27 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import jenkins.util.xstream.CriticalXStreamException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-class RobustCollectionConverterTest {
+public class RobustCollectionConverterTest {
     private final boolean originalRecordFailures = RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS;
 
-    @BeforeEach
-    void before() {
+    @Before
+    public void before() {
         RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = true;
     }
 
-    @AfterEach
-    void after() {
+    @After
+    public void after() {
         RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = originalRecordFailures;
     }
 
     @Test
-    void workingByDefaultWithSimplePayload() {
+    public void workingByDefaultWithSimplePayload() {
         XStream2 xstream2 = new XStream2();
 
         Map<String, String> map = new HashMap<>();
@@ -93,10 +91,9 @@ class RobustCollectionConverterTest {
      * We had to patch it in order to not be impacted by CVE-2021-43859
      */
     // force timeout to prevent DoS due to test in the case the DoS prevention is broken
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
+    @Test(timeout = 30 * 1000)
     @Issue("SECURITY-2602")
-    void dosIsPrevented_customProgrammaticallyTimeout() {
+    public void dosIsPrevented_customProgrammaticallyTimeout() {
         XStream2 xstream2 = new XStream2();
 
         Set<Object> set = preparePayload();
@@ -108,13 +105,12 @@ class RobustCollectionConverterTest {
         assertNotNull(cause);
         assertThat(cause, instanceOf(InputManipulationException.class));
         InputManipulationException ime = (InputManipulationException) cause;
-        assertTrue(ime.getMessage().contains("exceeds 3 seconds"), "Limit expected in message");
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 3 seconds"));
     }
 
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
+    @Test(timeout = 30 * 1000)
     @Issue("SECURITY-2602")
-    void dosIsPrevented_customPropertyTimeout() {
+    public void dosIsPrevented_customPropertyTimeout() {
         String currentValue = System.getProperty(XStream2.COLLECTION_UPDATE_LIMIT_PROPERTY_NAME);
         try {
             System.setProperty(XStream2.COLLECTION_UPDATE_LIMIT_PROPERTY_NAME, "4");
@@ -129,7 +125,7 @@ class RobustCollectionConverterTest {
             assertNotNull(cause);
             assertThat(cause, instanceOf(InputManipulationException.class));
             InputManipulationException ime = (InputManipulationException) cause;
-            assertTrue(ime.getMessage().contains("exceeds 4 seconds"), "Limit expected in message");
+            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 4 seconds"));
         } finally {
             if (currentValue == null) {
                 System.clearProperty(XStream2.COLLECTION_UPDATE_LIMIT_PROPERTY_NAME);
@@ -140,10 +136,9 @@ class RobustCollectionConverterTest {
     }
 
     // force timeout to prevent DoS due to test in the case the DoS prevention is broken
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
+    @Test(timeout = 30 * 1000)
     @Issue("SECURITY-2602")
-    void dosIsPrevented_defaultTimeout() {
+    public void dosIsPrevented_defaultTimeout() {
         XStream2 xstream2 = new XStream2();
 
         Set<Object> set = preparePayload();
@@ -154,7 +149,7 @@ class RobustCollectionConverterTest {
         assertNotNull(cause);
         assertThat(cause, instanceOf(InputManipulationException.class));
         InputManipulationException ime = (InputManipulationException) cause;
-        assertTrue(ime.getMessage().contains("exceeds 5 seconds"), "Limit expected in message");
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
     }
 
     // Inspired by https://github.com/x-stream/xstream/commit/e8e88621ba1c85ac3b8620337dd672e0c0c3a846#diff-9fde4ecf1bb4dc9850c031cb161960d2e61e069b386fa0b3db0d57e0e9f5baa
@@ -197,7 +192,7 @@ class RobustCollectionConverterTest {
 
     @Issue("JENKINS-63343")
     @Test
-    void checkElementTypes() {
+    public void checkElementTypes() {
         var xmlContent =
                 """
                 <hudson.util.RobustCollectionConverterTest_-Data>
@@ -215,7 +210,7 @@ class RobustCollectionConverterTest {
     }
 
     @Test
-    void rawtypes() {
+    public void rawtypes() {
         var xmlContent =
                 """
                 <hudson.util.RobustCollectionConverterTest_-DataRaw>

--- a/core/src/test/java/hudson/util/RobustMapConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustMapConverterTest.java
@@ -27,33 +27,31 @@ package hudson.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.thoughtworks.xstream.security.InputManipulationException;
 import hudson.model.Saveable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import jenkins.util.xstream.CriticalXStreamException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-class RobustMapConverterTest {
+public class RobustMapConverterTest {
     private final boolean originalRecordFailures = RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS;
 
-    @BeforeEach
-    void before() {
+    @Before
+    public void before() {
         RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = true;
     }
 
-    @AfterEach
-    void after() {
+    @After
+    public void after() {
         RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = originalRecordFailures;
     }
 
@@ -62,10 +60,9 @@ class RobustMapConverterTest {
      * We had to patch it in order to not be impacted by CVE-2021-43859
      */
     // force timeout to prevent DoS due to test in the case the DoS prevention is broken
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
+    @Test(timeout = 30 * 1000)
     @Issue("SECURITY-2602")
-    void dosIsPrevented_customProgrammaticallyTimeout() {
+    public void dosIsPrevented_customProgrammaticallyTimeout() {
         XStream2 xstream2 = new XStream2();
 
         Map<Object, Object> map = preparePayload();
@@ -78,13 +75,12 @@ class RobustMapConverterTest {
         assertNotNull(cause);
         assertThat(cause, instanceOf(InputManipulationException.class));
         InputManipulationException ime = (InputManipulationException) cause;
-        assertTrue(ime.getMessage().contains("exceeds 3 seconds"), "Limit expected in message");
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 3 seconds"));
     }
 
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
+    @Test(timeout = 30 * 1000)
     @Issue("SECURITY-2602")
-    void dosIsPrevented_customPropertyTimeout() {
+    public void dosIsPrevented_customPropertyTimeout() {
         String currentValue = System.getProperty(XStream2.COLLECTION_UPDATE_LIMIT_PROPERTY_NAME);
         try {
             System.setProperty(XStream2.COLLECTION_UPDATE_LIMIT_PROPERTY_NAME, "4");
@@ -99,7 +95,7 @@ class RobustMapConverterTest {
             assertNotNull(cause);
             assertThat(cause, instanceOf(InputManipulationException.class));
             InputManipulationException ime = (InputManipulationException) cause;
-            assertTrue(ime.getMessage().contains("exceeds 4 seconds"), "Limit expected in message");
+            assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 4 seconds"));
         } finally {
             if (currentValue == null) {
                 System.clearProperty(XStream2.COLLECTION_UPDATE_LIMIT_PROPERTY_NAME);
@@ -110,10 +106,9 @@ class RobustMapConverterTest {
     }
 
     // force timeout to prevent DoS due to test in the case the DoS prevention is broken
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
+    @Test(timeout = 30 * 1000)
     @Issue("SECURITY-2602")
-    void dosIsPrevented_defaultTimeout() {
+    public void dosIsPrevented_defaultTimeout() {
         XStream2 xstream2 = new XStream2();
 
         Map<Object, Object> map = preparePayload();
@@ -124,7 +119,7 @@ class RobustMapConverterTest {
         assertNotNull(cause);
         assertThat(cause, instanceOf(InputManipulationException.class));
         InputManipulationException ime = (InputManipulationException) cause;
-        assertTrue(ime.getMessage().contains("exceeds 5 seconds"), "Limit expected in message");
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
     }
 
     // Inspired by https://github.com/x-stream/xstream/commit/e8e88621ba1c85ac3b8620337dd672e0c0c3a846#diff-9fde4ecf1bb4dc9850c031cb161960d2e61e069b386fa0b3db0d57e0e9f5baa
@@ -166,7 +161,7 @@ class RobustMapConverterTest {
     }
 
     @Test
-    void robustAgainstInvalidEntry() {
+    public void robustAgainstInvalidEntry() {
         RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = true;
         XStream2 xstream2 = new XStream2();
         String xml =
@@ -186,7 +181,7 @@ class RobustMapConverterTest {
     }
 
     @Test
-    void robustAgainstInvalidEntryWithNoValue() {
+    public void robustAgainstInvalidEntryWithNoValue() {
         XStream2 xstream2 = new XStream2();
         String xml =
             """
@@ -208,7 +203,7 @@ class RobustMapConverterTest {
 
     @Issue("JENKINS-63343")
     @Test
-    void robustAgainstInvalidKeyType() {
+    public void robustAgainstInvalidKeyType() {
         XStream2 xstream2 = new XStream2();
         String xml =
             """
@@ -238,7 +233,7 @@ class RobustMapConverterTest {
 
     @Issue("JENKINS-63343")
     @Test
-    void robustAgainstInvalidValueType() {
+    public void robustAgainstInvalidValueType() {
         XStream2 xstream2 = new XStream2();
         String xml =
             """
@@ -267,7 +262,7 @@ class RobustMapConverterTest {
     }
 
     @Test
-    void rawtypes() {
+    public void rawtypes() {
         XStream2 xstream2 = new XStream2();
         String xml =
             """

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -28,10 +28,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
@@ -51,40 +51,38 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.xstream.CriticalXStreamException;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-class RobustReflectionConverterTest {
+public class RobustReflectionConverterTest {
     private final boolean originalRecordFailures = RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS;
 
     static {
         Logger.getLogger(RobustReflectionConverter.class.getName()).setLevel(Level.OFF);
     }
 
-    @BeforeEach
-    void before() {
+    @Before
+    public void before() {
         RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = true;
     }
 
-    @AfterEach
-    void after() {
+    @After
+    public void after() {
         RobustReflectionConverter.RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = originalRecordFailures;
     }
 
     @Test
-    void robustUnmarshalling() {
+    public void robustUnmarshalling() {
         Point p = read(new XStream2());
         assertEquals(1, p.x);
         assertEquals(2, p.y);
@@ -96,7 +94,7 @@ class RobustReflectionConverterTest {
     }
 
     @Test
-    void ifWorkaroundNeeded() {
+    public void ifWorkaroundNeeded() {
         XStream xs = new XStream(XStream2.getDefaultDriver());
         xs.allowTypes(new Class[] {Point.class});
         final ConversionException e = assertThrows(ConversionException.class, () -> read(xs));
@@ -104,7 +102,7 @@ class RobustReflectionConverterTest {
     }
 
     @Test
-    void classOwnership() {
+    public void classOwnership() {
         Enchufla s1 = new Enchufla();
         s1.number = 1;
         s1.direction = "North";
@@ -139,37 +137,35 @@ class RobustReflectionConverterTest {
     }
 
     @Test
-    void implicitCollection() {
+    public void implicitCollection() {
         XStream2 xs = new XStream2();
         xs.alias("hold", Hold.class);
         xs.addImplicitCollection(Hold.class, "items", "item", String.class);
         Hold h = (Hold) xs.fromXML("<hold><item>a</item><item>b</item></hold>");
         assertThat(h.items, Matchers.containsInAnyOrder("a", "b"));
-        assertEquals("""
-                <hold>
-                  <item>a</item>
-                  <item>b</item>
-                </hold>""", xs.toXML(h));
+        assertEquals("<hold>\n" +
+                "  <item>a</item>\n" +
+                "  <item>b</item>\n" +
+                "</hold>", xs.toXML(h));
     }
 
-    @Disabled("Throws an NPE in writeValueToImplicitCollection. Issue has existed since RobustReflectionConverter was created.")
+    @Ignore("Throws an NPE in writeValueToImplicitCollection. Issue has existed since RobustReflectionConverter was created.")
     @Test
-    void implicitCollectionsAllowNullElements() {
+    public void implicitCollectionsAllowNullElements() {
         XStream2 xs = new XStream2();
         xs.alias("hold", Hold.class);
         xs.addImplicitCollection(Hold.class, "items", "item", String.class);
         Hold h = (Hold) xs.fromXML("<hold><null/><item>b</item></hold>");
         assertThat(h.items, Matchers.containsInAnyOrder(null, "b"));
-        assertEquals("""
-                <hold>
-                  <null/>
-                  <item>b</item>
-                </hold>""", xs.toXML(h));
+        assertEquals("<hold>\n" +
+                "  <null/>\n" +
+                "  <item>b</item>\n" +
+                "</hold>", xs.toXML(h));
     }
 
     @Issue("JENKINS-63343")
     @Test
-    void robustAgainstImplicitCollectionElementsWithBadTypes() {
+    public void robustAgainstImplicitCollectionElementsWithBadTypes() {
         XStream2 xs = new XStream2();
         xs.alias("hold", Hold.class);
         // Note that the fix only matters for `addImplicitCollection` overloads like the following where the element type is not provided.
@@ -190,13 +186,13 @@ class RobustReflectionConverterTest {
         List<String> items;
 
         @Override
-        public void save() {
+        public void save() throws IOException {
             // We only implement Saveable so that RobustReflectionConverter logs deserialization problems.
         }
     }
 
     @Test
-    void implicitCollectionRawtypes() {
+    public void implicitCollectionRawtypes() {
         XStream2 xs = new XStream2();
         xs.alias("hold", HoldRaw.class);
         xs.addImplicitCollection(HoldRaw.class, "items");
@@ -263,10 +259,9 @@ class RobustReflectionConverterTest {
     @Owner("p4")
     public static class Jean extends Lover {}
 
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
+    @Test(timeout = 30 * 1000)
     @Issue("SECURITY-2602")
-    void robustDoesNotSwallowDosException() {
+    public void robustDoesNotSwallowDosException() {
         XStream2 xstream2 = new XStream2();
 
         Set<Object> set = preparePayload();
@@ -285,12 +280,11 @@ class RobustReflectionConverterTest {
         assertNotNull(cause);
         assertThat(cause, instanceOf(InputManipulationException.class));
         InputManipulationException ime = (InputManipulationException) cause;
-        assertTrue(ime.getMessage().contains("exceeds 5 seconds"), "Limit expected in message");
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
     }
 
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
-    void customConverter_useDefaultXStreamException() {
+    @Test(timeout = 30 * 1000)
+    public void customConverter_useDefaultXStreamException() {
         XStream2 xstream2 = new XStream2();
         xstream2.registerConverter(new CustomSet.ConverterImpl(xstream2.getMapper()));
 
@@ -300,13 +294,12 @@ class RobustReflectionConverterTest {
         final String xml = xstream2.toXML(customSet);
 
         InputManipulationException e = assertThrows(InputManipulationException.class, () -> xstream2.fromXML(xml));
-        assertTrue(e.getMessage().contains("exceeds 5 seconds"), "Limit expected in message");
+        assertTrue("Limit expected in message", e.getMessage().contains("exceeds 5 seconds"));
     }
 
-    @Test
-    @Timeout(value = 30 * 1000, unit = TimeUnit.MILLISECONDS)
+    @Test(timeout = 30 * 1000)
     @Issue("SECURITY-2602")
-    void customConverter_wrapped_useCriticalXStreamException() {
+    public void customConverter_wrapped_useCriticalXStreamException() {
         XStream2 xstream2 = new XStream2();
         xstream2.registerConverter(new CustomSet.ConverterImpl(xstream2.getMapper())); // TODO Fix test so it does not pass without this
 
@@ -326,7 +319,7 @@ class RobustReflectionConverterTest {
         assertNotNull(cause);
         assertThat(cause, instanceOf(InputManipulationException.class));
         InputManipulationException ime = (InputManipulationException) cause;
-        assertTrue(ime.getMessage().contains("exceeds 5 seconds"), "Limit expected in message");
+        assertTrue("Limit expected in message", ime.getMessage().contains("exceeds 5 seconds"));
     }
 
     private Set<Object> preparePayload() {

--- a/core/src/test/java/hudson/util/RunListTest.java
+++ b/core/src/test/java/hudson/util/RunListTest.java
@@ -24,19 +24,19 @@
 
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import hudson.model.Run;
 import java.util.ArrayList;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Ignacio Albors
  */
-class RunListTest {
+public class RunListTest {
 
     // RunList for byTimestamp tests
     private RunList rlist;
@@ -60,7 +60,7 @@ class RunListTest {
     }
 
     @Test
-    void byTimestampAllRuns() {
+    public void byTimestampAllRuns() {
         setUpByTimestampRuns();
 
         RunList<Run> tested = rlist.byTimestamp(0, 400);
@@ -70,7 +70,7 @@ class RunListTest {
     @Issue("JENKINS-21159")
     @Test
     @SuppressWarnings("deprecation")
-    void byTimestampFirstRun() {
+    public void byTimestampFirstRun() {
         setUpByTimestampRuns();
         // Only r1
         RunList<Run> tested = rlist.byTimestamp(150, 250);
@@ -80,7 +80,7 @@ class RunListTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void byTimestampLastRun() {
+    public void byTimestampLastRun() {
         setUpByTimestampRuns();
         // Only r2
         RunList<Run> tested = rlist.byTimestamp(250, 350);

--- a/core/src/test/java/hudson/util/SecretUtilTest.java
+++ b/core/src/test/java/hudson/util/SecretUtilTest.java
@@ -1,42 +1,41 @@
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-class SecretUtilTest {
+public class SecretUtilTest {
 
     @Issue("JENKINS-47500")
     @Test
-    void decrypt() {
+    public void decrypt() {
         String data = "{}";
         Secret secret = Secret.decrypt(data);
-        assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
+        Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
     }
 
 
     @Issue("JENKINS-47500")
     @Test
-    void decryptJustSpace() {
+    public void decryptJustSpace() {
         String data = " ";
         Secret secret = Secret.decrypt(data);
-        assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
+        Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
     }
 
     @Issue("JENKINS-47500")
     @Test
-    void decryptWithSpace() {
+    public void decryptWithSpace() {
         String data = "{ }";
         Secret secret = Secret.decrypt(data);
-        assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
+        Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
     }
 
     @Issue("JENKINS-47500")
     @Test
-    void decryptWithSpaces() {
+    public void decryptWithSpaces() {
         String data = "{     }";
         Secret secret = Secret.decrypt(data);
-        assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
+        Assert.assertNull(secret); // expected to not throw ArrayIndexOutOfBoundsException
     }
 }

--- a/core/src/test/java/hudson/util/TextFileTest.java
+++ b/core/src/test/java/hudson/util/TextFileTest.java
@@ -1,6 +1,6 @@
 package hudson.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -8,17 +8,18 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-class TextFileTest {
+public class TextFileTest {
 
-    @TempDir
-    private File tmp;
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
     @Test
-    void head() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+    public void head() throws Exception {
+        File f = tmp.newFile();
         FileUtils.copyURLToFile(getClass().getResource("ascii.txt"), f);
 
         TextFile t = new TextFile(f);
@@ -28,8 +29,8 @@ class TextFileTest {
     }
 
     @Test
-    void shortHead() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+    public void shortHead() throws Exception {
+        File f = tmp.newFile();
         Files.writeString(f.toPath(), "hello", Charset.defaultCharset());
 
         TextFile t = new TextFile(f);
@@ -37,8 +38,8 @@ class TextFileTest {
     }
 
     @Test
-    void tail() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+    public void tail() throws Exception {
+        File f = tmp.newFile();
         FileUtils.copyURLToFile(getClass().getResource("ascii.txt"), f);
         String whole = Files.readString(f.toPath(), Charset.defaultCharset());
         TextFile t = new TextFile(f);
@@ -47,8 +48,8 @@ class TextFileTest {
     }
 
     @Test
-    void shortTail() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+    public void shortTail() throws Exception {
+        File f = tmp.newFile();
         Files.writeString(f.toPath(), "hello", Charset.defaultCharset());
 
         TextFile t = new TextFile(f);
@@ -62,8 +63,8 @@ class TextFileTest {
      * careful, we'll parse the text incorrectly.
      */
     @Test
-    void tailShiftJIS() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+    public void tailShiftJIS() throws Exception {
+        File f = tmp.newFile();
 
         TextFile t = new TextFile(f);
 

--- a/core/src/test/java/hudson/util/XStream2EncodingTest.java
+++ b/core/src/test/java/hudson/util/XStream2EncodingTest.java
@@ -27,24 +27,25 @@ package hudson.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.Assume.assumeNoException;
+import static org.junit.Assume.assumeThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * In its own suite to minimize the chance of mucking about with other tests.
  */
-class XStream2EncodingTest {
+public class XStream2EncodingTest {
 
     private static void useNonUTF8() {
         clearDefaultEncoding();
         System.setProperty("file.encoding", "ISO-8859-1");
-        assumeTrue(Charset.defaultCharset().name().equals("ISO-8859-1"));
+        assumeThat(Charset.defaultCharset().name(), is("ISO-8859-1"));
     }
 
     private static void clearDefaultEncodingAfter() {
@@ -58,13 +59,12 @@ class XStream2EncodingTest {
             defaultCharset.set(null, null);
         } catch (Exception x) {
             // Per JDK-4163515, this is not supported. It happened to work prior to Java 17, though.
-            assumeTrue(false, x.toString());
+            assumeNoException(x);
         }
     }
 
     @SuppressWarnings("deprecation")
-    @Test
-    void toXMLUnspecifiedEncoding() throws Exception {
+    @Test public void toXMLUnspecifiedEncoding() throws Exception {
       useNonUTF8();
       try {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -84,8 +84,7 @@ class XStream2EncodingTest {
       }
     }
 
-    @Test
-    void toXMLUTF8() throws Exception {
+    @Test public void toXMLUTF8() throws Exception {
       useNonUTF8();
       try {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/core/src/test/java/hudson/util/XStream2Test.java
+++ b/core/src/test/java/hudson/util/XStream2Test.java
@@ -28,12 +28,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -55,26 +55,26 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
  * Tests for XML serialization of java objects.
  * @author Kohsuke Kawaguchi, Mike Dillon, Alan Harder, Richard Mortimer
  */
-class XStream2Test {
+public class XStream2Test {
 
     public static final class Foo {
         Result r1, r2;
     }
 
     @Test
-    void marshalValue() {
+    public void marshalValue() {
         Foo f = new Foo();
         f.r1 = f.r2 = Result.FAILURE;
         String xml = Run.XSTREAM.toXML(f);
         // we should find two "FAILURE"s as they should be written out twice
-        assertEquals(3, xml.split("FAILURE").length, xml);
+        assertEquals(xml, 3, xml.split("FAILURE").length);
     }
 
     private static class Bar {
@@ -85,7 +85,7 @@ class XStream2Test {
      * Test ability to read old XML from Hudson 1.105 or older.
      */
     @Test
-    void xStream11Compatibility() {
+    public void xStream11Compatibility() {
         Bar b = (Bar) new XStream2().fromXML(
                 "<hudson.util.XStream2Test-Bar><s>foo</s></hudson.util.XStream2Test-Bar>");
         assertEquals("foo", b.s);
@@ -102,19 +102,19 @@ class XStream2Test {
      */
     @Issue("JENKINS-5768")
     @Test
-    void xmlRoundTrip() {
+    public void xmlRoundTrip() {
         XStream2 xs = new XStream2();
         __Foo_Bar$Class b = new __Foo_Bar$Class();
 
         String xml = xs.toXML(b);
         __Foo_Bar$Class b2 = (__Foo_Bar$Class) xs.fromXML(xml);
 
-        assertEquals(b.under_1, b2.under_1, xml);
-        assertEquals(b.under__2, b2.under__2, xml);
-        assertEquals(b._leadUnder1, b2._leadUnder1, xml);
-        assertEquals(b.__leadUnder2, b2.__leadUnder2, xml);
-        assertEquals(b.$dollar, b2.$dollar, xml);
-        assertEquals(b.dollar$2, b2.dollar$2, xml);
+        assertEquals(xml, b.under_1, b2.under_1);
+        assertEquals(xml, b.under__2, b2.under__2);
+        assertEquals(xml, b._leadUnder1, b2._leadUnder1);
+        assertEquals(xml, b.__leadUnder2, b2.__leadUnder2);
+        assertEquals(xml, b.$dollar, b2.$dollar);
+        assertEquals(xml, b.dollar$2, b2.dollar$2);
     }
 
     private static class Baz {
@@ -128,7 +128,7 @@ class XStream2Test {
      */
     @Issue("JENKINS-5769")
     @Test
-    void unmarshalThrowableMissingField() {
+    public void unmarshalThrowableMissingField() {
         Level oldLevel = disableLogging();
 
         Baz baz = new Baz();
@@ -171,7 +171,7 @@ class XStream2Test {
     }
 
     @Test
-    void immutableMap() {
+    public void immutableMap() {
         XStream2 xs = new XStream2();
 
         roundtripImmutableMap(xs, ImmutableMap.of());
@@ -191,8 +191,8 @@ class XStream2Test {
         a.m = m;
         String xml = xs.toXML(a);
         //System.out.println(xml);
-        assertFalse(xml.contains("google"), "shouldn't contain the class name");
-        assertFalse(xml.contains("class"), "shouldn't contain the class name");
+        assertFalse("shouldn't contain the class name", xml.contains("google"));
+        assertFalse("shouldn't contain the class name", xml.contains("class"));
         a = (ImmutableMapHolder) xs.fromXML(xml);
 
         assertSame(m.getClass(), a.m.getClass());    // should get back the exact same type, not just a random map
@@ -204,7 +204,7 @@ class XStream2Test {
         a.m = m;
         String xml = xs.toXML(a);
         //System.out.println(xml);
-        assertTrue(xml.contains('\"' + ImmutableMap.class.getName() + '\"'), "XML should mention the class name");
+        assertTrue("XML should mention the class name", xml.contains('\"' + ImmutableMap.class.getName() + '\"'));
         a = (MapHolder) xs.fromXML(xml);
 
         assertSame(m.getClass(), a.m.getClass());    // should get back the exact same type, not just a random map
@@ -220,7 +220,7 @@ class XStream2Test {
     }
 
     @Test
-    void immutableList() {
+    public void immutableList() {
         XStream2 xs = new XStream2();
 
         roundtripImmutableList(xs, ImmutableList.of());
@@ -240,8 +240,8 @@ class XStream2Test {
         a.l = l;
         String xml = xs.toXML(a);
         //System.out.println(xml);
-        assertFalse(xml.contains("google"), "shouldn't contain the class name");
-        assertFalse(xml.contains("class"), "shouldn't contain the class name");
+        assertFalse("shouldn't contain the class name", xml.contains("google"));
+        assertFalse("shouldn't contain the class name", xml.contains("class"));
         a = (ImmutableListHolder) xs.fromXML(xml);
 
         assertSame(l.getClass(), a.l.getClass());    // should get back the exact same type, not just a random list
@@ -253,7 +253,7 @@ class XStream2Test {
         a.l = l;
         String xml = xs.toXML(a);
         //System.out.println(xml);
-        assertTrue(xml.contains('\"' + ImmutableList.class.getName() + '\"'), "XML should mention the class name");
+        assertTrue("XML should mention the class name", xml.contains('\"' + ImmutableList.class.getName() + '\"'));
         a = (ListHolder) xs.fromXML(xml);
 
         assertSame(l.getClass(), a.l.getClass());    // should get back the exact same type, not just a random list
@@ -262,14 +262,14 @@ class XStream2Test {
 
     @Issue("JENKINS-8006") // Previously a null entry in an array caused NPE
     @Test
-    void emptyStack() {
+    public void emptyStack() {
         assertEquals("<object-array><null/><null/></object-array>",
                      Run.XSTREAM.toXML(new Object[2]).replaceAll("[ \n\r\t]+", ""));
     }
 
     @Issue("JENKINS-9843")
     @Test
-    void compatibilityAlias() {
+    public void compatibilityAlias() {
         XStream2 xs = new XStream2();
         xs.addCompatibilityAlias("legacy.Point", Point.class);
         Point pt = (Point) xs.fromXML("<legacy.Point><x>1</x><y>2</y></legacy.Point>");
@@ -277,7 +277,7 @@ class XStream2Test {
         assertEquals(2, pt.y);
         String xml = xs.toXML(pt);
         //System.out.println(xml);
-        assertFalse(xml.contains("legacy"), "Shouldn't use the alias when writing back");
+        assertFalse("Shouldn't use the alias when writing back", xml.contains("legacy"));
     }
 
     public static class Point {
@@ -290,7 +290,7 @@ class XStream2Test {
 
     @Issue("SECURITY-105")
     @Test
-    void dynamicProxyBlocked() {
+    public void dynamicProxyBlocked() {
         assertThrows(
                 XStreamException.class,
                 () -> ((Runnable) new XStream2().fromXML(
@@ -298,7 +298,7 @@ class XStream2Test {
                                         + Hacked.class.getName()
                                         + "'/><action>oops</action></handler></dynamic-proxy>"))
                         .run());
-        assertFalse(Hacked.tripped, "should never have run that");
+        assertFalse("should never have run that", Hacked.tripped);
     }
 
     public static final class Hacked {
@@ -310,7 +310,7 @@ class XStream2Test {
     }
 
     @Test
-    void trimVersion() {
+    public void trimVersion() {
         assertEquals("3.2", XStream2.trimVersion("3.2"));
         assertEquals("3.2.1", XStream2.trimVersion("3.2.1"));
         assertEquals("3.2-SNAPSHOT", XStream2.trimVersion("3.2-SNAPSHOT (private-09/23/2012 12:26-jhacker)"));
@@ -318,42 +318,41 @@ class XStream2Test {
 
     @Issue("JENKINS-21017")
     @Test
-    void unmarshalToDefault_populated() {
-        String populatedXml = """
-                <hudson.util.XStream2Test_-WithDefaults>
-                  <stringDefaultValue>my string</stringDefaultValue>
-                  <stringDefaultNull>not null</stringDefaultNull>
-                  <arrayDefaultValue>
-                    <string>1</string>
-                    <string>2</string>
-                    <string>3</string>
-                  </arrayDefaultValue>
-                  <arrayDefaultEmpty>
-                    <string>1</string>
-                    <string>2</string>
-                    <string>3</string>
-                  </arrayDefaultEmpty>
-                  <arrayDefaultNull>
-                    <string>1</string>
-                    <string>2</string>
-                    <string>3</string>
-                  </arrayDefaultNull>
-                  <listDefaultValue>
-                    <string>1</string>
-                    <string>2</string>
-                    <string>3</string>
-                  </listDefaultValue>
-                  <listDefaultEmpty>
-                    <string>1</string>
-                    <string>2</string>
-                    <string>3</string>
-                  </listDefaultEmpty>
-                  <listDefaultNull>
-                    <string>1</string>
-                    <string>2</string>
-                    <string>3</string>
-                  </listDefaultNull>
-                </hudson.util.XStream2Test_-WithDefaults>""";
+    public void unmarshalToDefault_populated() {
+        String populatedXml = "<hudson.util.XStream2Test_-WithDefaults>\n"
+                + "  <stringDefaultValue>my string</stringDefaultValue>\n"
+                + "  <stringDefaultNull>not null</stringDefaultNull>\n"
+                + "  <arrayDefaultValue>\n"
+                + "    <string>1</string>\n"
+                + "    <string>2</string>\n"
+                + "    <string>3</string>\n"
+                + "  </arrayDefaultValue>\n"
+                + "  <arrayDefaultEmpty>\n"
+                + "    <string>1</string>\n"
+                + "    <string>2</string>\n"
+                + "    <string>3</string>\n"
+                + "  </arrayDefaultEmpty>\n"
+                + "  <arrayDefaultNull>\n"
+                + "    <string>1</string>\n"
+                + "    <string>2</string>\n"
+                + "    <string>3</string>\n"
+                + "  </arrayDefaultNull>\n"
+                + "  <listDefaultValue>\n"
+                + "    <string>1</string>\n"
+                + "    <string>2</string>\n"
+                + "    <string>3</string>\n"
+                + "  </listDefaultValue>\n"
+                + "  <listDefaultEmpty>\n"
+                + "    <string>1</string>\n"
+                + "    <string>2</string>\n"
+                + "    <string>3</string>\n"
+                + "  </listDefaultEmpty>\n"
+                + "  <listDefaultNull>\n"
+                + "    <string>1</string>\n"
+                + "    <string>2</string>\n"
+                + "    <string>3</string>\n"
+                + "  </listDefaultNull>\n"
+                + "</hudson.util.XStream2Test_-WithDefaults>";
 
         WithDefaults existingInstance = new WithDefaults("foobar",
                 "foobar",
@@ -378,21 +377,20 @@ class XStream2Test {
 
     @Issue("JENKINS-21017")
     @Test
-    void unmarshalToDefault_default() {
-        String defaultXml = """
-                <hudson.util.XStream2Test_-WithDefaults>
-                  <stringDefaultValue>defaultValue</stringDefaultValue>
-                  <arrayDefaultValue>
-                    <string>first</string>
-                    <string>second</string>
-                  </arrayDefaultValue>
-                  <arrayDefaultEmpty/>
-                  <listDefaultValue>
-                    <string>first</string>
-                    <string>second</string>
-                  </listDefaultValue>
-                  <listDefaultEmpty/>
-                </hudson.util.XStream2Test_-WithDefaults>""";
+    public void unmarshalToDefault_default() {
+        String defaultXml = "<hudson.util.XStream2Test_-WithDefaults>\n"
+                + "  <stringDefaultValue>defaultValue</stringDefaultValue>\n"
+                + "  <arrayDefaultValue>\n"
+                + "    <string>first</string>\n"
+                + "    <string>second</string>\n"
+                + "  </arrayDefaultValue>\n"
+                + "  <arrayDefaultEmpty/>\n"
+                + "  <listDefaultValue>\n"
+                + "    <string>first</string>\n"
+                + "    <string>second</string>\n"
+                + "  </listDefaultValue>\n"
+                + "  <listDefaultEmpty/>\n"
+                + "</hudson.util.XStream2Test_-WithDefaults>";
 
         WithDefaults existingInstance = new WithDefaults("foobar",
                 "foobar",
@@ -417,7 +415,7 @@ class XStream2Test {
 
     @Issue("JENKINS-21017")
     @Test
-    void unmarshalToDefault_empty() {
+    public void unmarshalToDefault_empty() {
         String emptyXml = "<hudson.util.XStream2Test_-WithDefaults/>";
 
         WithDefaults existingInstance = new WithDefaults("foobar",
@@ -457,11 +455,9 @@ class XStream2Test {
         private List<String> listDefaultEmpty = new ArrayList<>();
         private List<String> listDefaultNull;
 
-        @SuppressWarnings("checkstyle:redundantmodifier")
         public WithDefaults() {
         }
 
-        @SuppressWarnings("checkstyle:redundantmodifier")
         public WithDefaults(String stringDefaultValue, String stringDefaultNull, String[] arrayDefaultValue,
                             String[] arrayDefaultEmpty, String[] arrayDefaultNull,
                             List<String> listDefaultValue, List<String> listDefaultEmpty,
@@ -543,15 +539,15 @@ class XStream2Test {
 
     @Issue("SECURITY-503")
     @Test
-    void crashXstream() {
+    public void crashXstream() {
         assertThrows(XStreamException.class, () -> new XStream2().fromXML("<void/>"));
     }
 
     @Test
-    void annotations() {
-        assertEquals("<hudson.util.XStream2Test_-C1/>", Jenkins.XSTREAM2.toXML(new C1()), "not registered, so sorry");
-        assertEquals("<C-2/>", Jenkins.XSTREAM2.toXML(new C2()), "manually registered");
-        assertEquals("<C-3/>", Jenkins.XSTREAM2.toXML(new C3()), "manually processed");
+    public void annotations() {
+        assertEquals("not registered, so sorry", "<hudson.util.XStream2Test_-C1/>", Jenkins.XSTREAM2.toXML(new C1()));
+        assertEquals("manually registered", "<C-2/>", Jenkins.XSTREAM2.toXML(new C2()));
+        assertEquals("manually processed", "<C-3/>", Jenkins.XSTREAM2.toXML(new C3()));
         assertThrows(CannotResolveClassException.class, () -> Jenkins.XSTREAM2.fromXML("<C-4/>"));
 
         Jenkins.XSTREAM2.processAnnotations(C5.class);
@@ -582,7 +578,7 @@ class XStream2Test {
 
     @Issue("JENKINS-69129")
     @Test
-    void testEmoji() throws Exception {
+    public void testEmoji() throws Exception {
         Bar bar;
         try (InputStream is = getClass().getResource("XStream2Emoji.xml").openStream()) {
             bar = (Bar) new XStream2().fromXML(is);
@@ -592,7 +588,7 @@ class XStream2Test {
 
     @Issue("JENKINS-69129")
     @Test
-    void testEmojiEscaped() throws Exception {
+    public void testEmojiEscaped() throws Exception {
         Bar bar;
         try (InputStream is = getClass().getResource("XStream2EmojiEscaped.xml").openStream()) {
             bar = (Bar) new XStream2().fromXML(is);
@@ -602,7 +598,7 @@ class XStream2Test {
 
     @Issue("JENKINS-71182")
     @Test
-    void writeEmoji() {
+    public void writeEmoji() throws Exception {
         Bar b = new Bar();
         String text = "Fox 🦊";
         b.s = text;
@@ -617,7 +613,7 @@ class XStream2Test {
 
     @Issue("JENKINS-71139")
     @Test
-    void nullsWithoutEncodingDeclaration() {
+    public void nullsWithoutEncodingDeclaration() throws Exception {
         Bar b = new Bar();
         b.s = "x\u0000y";
         try {
@@ -630,7 +626,7 @@ class XStream2Test {
 
     @Issue("JENKINS-71139")
     @Test
-    void nullsWithEncodingDeclaration() throws Exception {
+    public void nullsWithEncodingDeclaration() throws Exception {
         Bar b = new Bar();
         b.s = "x\u0000y";
         try {

--- a/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
+++ b/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
@@ -1,8 +1,8 @@
 package hudson.util.io;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeFalse;
 
 import hudson.FilePath;
 import hudson.Functions;
@@ -12,18 +12,19 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
-class RewindableRotatingFileOutputStreamTest {
+public class RewindableRotatingFileOutputStreamTest {
 
-    @TempDir
-    private File tmp;
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
     @Test
-    void rotation() throws IOException, InterruptedException {
-        File base = File.createTempFile("test.log", null, tmp);
+    public void rotation() throws IOException, InterruptedException {
+        File base = tmp.newFile("test.log");
         RewindableRotatingFileOutputStream os = new RewindableRotatingFileOutputStream(base, 3);
         PrintWriter w = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8), true);
         for (int i = 0; i <= 4; i++) {
@@ -44,10 +45,10 @@ class RewindableRotatingFileOutputStreamTest {
 
     @Issue("JENKINS-16634")
     @Test
-    void deletedFolder() throws Exception {
-        assumeFalse(Functions.isWindows(), "Windows does not allow deleting a directory with a "
-            + "file open, so this case should never occur");
-        File dir = newFolder(tmp, "dir");
+    public void deletedFolder() throws Exception {
+        assumeFalse("Windows does not allow deleting a directory with a "
+            + "file open, so this case should never occur", Functions.isWindows());
+        File dir = tmp.newFolder("dir");
         File base = new File(dir, "x.log");
         RewindableRotatingFileOutputStream os = new RewindableRotatingFileOutputStream(base, 3);
         for (int i = 0; i < 2; i++) {
@@ -58,15 +59,6 @@ class RewindableRotatingFileOutputStreamTest {
             FileUtils.deleteDirectory(dir);
             os.rewind();
         }
-    }
-
-    private static File newFolder(File root, String... subDirs) throws IOException {
-        String subFolder = String.join("/", subDirs);
-        File result = new File(root, subFolder);
-        if (!result.mkdirs()) {
-            throw new IOException("Couldn't create folders " + root);
-        }
-        return result;
     }
 
 }

--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -24,9 +24,9 @@
 
 package hudson.util.io;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNoException;
 
 import hudson.FilePath;
 import hudson.Functions;
@@ -46,22 +46,21 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.tools.tar.TarEntry;
 import org.apache.tools.tar.TarInputStream;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
-class TarArchiverTest {
+public class TarArchiverTest {
 
-    @TempDir
-    private File tmp;
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
     /**
      * Makes sure that permissions are properly stored in the tar file.
      */
     @Issue("JENKINS-9397")
-    @Test
-    void permission() throws Exception {
+    @Test public void permission() throws Exception {
         assumeFalse(Functions.isWindows());
 
         File tar = File.createTempFile("test", "tar");
@@ -116,27 +115,26 @@ class TarArchiverTest {
         try {
             assertEquals(0, new LocalLauncher(StreamTaskListener.fromStdout()).launch().cmds(cmds).pwd(dir).join());
         } catch (IOException x) { // perhaps restrict to x.message.contains("Cannot run program")? or "error=2, No such file or directory"?
-            assumeTrue(false, "failed to run " + Arrays.toString(cmds) + ": " + x);
+            assumeNoException("failed to run " + Arrays.toString(cmds), x);
         }
     }
 
     @Issue("JENKINS-14922")
-    @Test
-    void brokenSymlinks() throws Exception {
+    @Test public void brokenSymlinks() throws Exception {
         assumeFalse(Functions.isWindows());
-        File dir = tmp;
+        File dir = tmp.getRoot();
         Util.createSymlink(dir, "nonexistent", "link", TaskListener.NULL);
         try (OutputStream out = OutputStream.nullOutputStream()) {
             new FilePath(dir).tar(out, "**");
         }
     }
 
-    @Disabled("TODO fails to add empty directories to archive")
+    @Ignore("TODO fails to add empty directories to archive")
     @Issue("JENKINS-73837")
     @Test
-    void emptyDirectory() throws Exception {
-        Path tar = File.createTempFile("test.tar", null, tmp).toPath();
-        Path root = newFolder(tmp, "junit").toPath();
+    public void emptyDirectory() throws Exception {
+        Path tar = tmp.newFile("test.tar").toPath();
+        Path root = tmp.newFolder().toPath();
         Files.createDirectory(root.resolve("foo"));
         Files.createDirectory(root.resolve("bar"));
         Files.writeString(root.resolve("bar/file.txt"), "foobar", StandardCharsets.UTF_8);
@@ -159,15 +157,14 @@ class TarArchiverTest {
      */
 
     @Issue("JENKINS-20187")
-    @Test
-    void growingFileTar() throws Exception {
-        File file = new File(tmp, "growing.file");
+    @Test public void growingFileTar() throws Exception {
+        File file = new File(tmp.getRoot(), "growing.file");
         GrowingFileRunnable runnable1 = new GrowingFileRunnable(file);
         Thread t1 = new Thread(runnable1);
         t1.start();
 
         try (OutputStream out = OutputStream.nullOutputStream()) {
-            new FilePath(tmp).tar(out, "**");
+            new FilePath(tmp.getRoot()).tar(out, "**");
         }
 
         runnable1.doFinish();
@@ -205,15 +202,6 @@ class TarArchiverTest {
                 throw ex;
             }
         }
-    }
-
-    private static File newFolder(File root, String... subDirs) throws IOException {
-        String subFolder = String.join("/", subDirs);
-        File result = new File(root, subFolder);
-        if (!result.mkdirs()) {
-            throw new IOException("Couldn't create folders " + root);
-        }
-        return result;
     }
 
 }

--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -1,10 +1,8 @@
 package hudson.util.io;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.Assert.assertEquals;
 
 import hudson.FilePath;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -17,27 +15,28 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.Issue;
 
-class ZipArchiverTest {
+public class ZipArchiverTest {
 
-    @TempDir
-    private File tmp;
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
     @Issue("JENKINS-9942")
     @Test
-    void backwardsSlashesOnWindows() throws IOException {
+    public void backwardsSlashesOnWindows() throws IOException {
         // create foo/bar/baz/Test.txt
-        Path baz = newFolder(tmp, "junit").toPath().resolve("foo").resolve("bar").resolve("baz");
+        Path baz = tmp.newFolder().toPath().resolve("foo").resolve("bar").resolve("baz");
         Files.createDirectories(baz);
         Path tmpFile = baz.resolve("Test.txt");
         Files.createFile(tmpFile);
 
         // a file to store the zip archive in
-        Path zipFile = Files.createTempFile(tmp.toPath(), "test", ".zip");
+        Path zipFile = Files.createTempFile(tmp.getRoot().toPath(), "test", ".zip");
 
         // create zip from tmpDir
         try (ZipArchiver archiver = new ZipArchiver(Files.newOutputStream(zipFile))) {
@@ -54,19 +53,19 @@ class ZipArchiverTest {
     }
 
     @Test
-    void huge64bitFile() throws IOException {
+    public void huge64bitFile() throws IOException {
         // create huge64bitFileTest.txt
-        Path hugeFile = newFolder(tmp, "junit").toPath().resolve("huge64bitFileTest.txt");
+        Path hugeFile = tmp.newFolder().toPath().resolve("huge64bitFileTest.txt");
         long length = 4L * 1024 * 1024 * 1024 + 2;
         try (RandomAccessFile largeFile = new RandomAccessFile(hugeFile.toFile(), "rw")) {
             largeFile.setLength(length);
         } catch (IOException e) {
             // We probably don't have enough free disk space. That's ok, we'll skip this test...
-            assumeTrue(false, e.toString());
+            Assume.assumeNoException(e);
         }
 
         // a file to store the zip archive in
-        Path zipFile = Files.createTempFile(tmp.toPath(), "test", ".zip");
+        Path zipFile = Files.createTempFile(tmp.getRoot().toPath(), "test", ".zip");
 
         // create zip from tmpDir
         try (ZipArchiver archiver = new ZipArchiver(Files.newOutputStream(zipFile))) {
@@ -82,12 +81,12 @@ class ZipArchiverTest {
         }
     }
 
-    @Disabled("TODO fails to add empty directories to archive")
+    @Ignore("TODO fails to add empty directories to archive")
     @Issue("JENKINS-49296")
     @Test
-    void emptyDirectory() throws Exception {
-        Path zip = File.createTempFile("test.zip", null, tmp).toPath();
-        Path root = newFolder(tmp, "junit").toPath();
+    public void emptyDirectory() throws Exception {
+        Path zip = tmp.newFile("test.zip").toPath();
+        Path root = tmp.newFolder().toPath();
         Files.createDirectory(root.resolve("foo"));
         Files.createDirectory(root.resolve("bar"));
         Files.writeString(root.resolve("bar/file.txt"), "foobar", StandardCharsets.UTF_8);
@@ -103,14 +102,5 @@ class ZipArchiverTest {
             }
         }
         assertEquals(Set.of("foo/", "bar/", "bar/file.txt"), names);
-    }
-
-    private static File newFolder(File root, String... subDirs) throws IOException {
-        String subFolder = String.join("/", subDirs);
-        File result = new File(root, subFolder);
-        if (!result.mkdirs()) {
-            throw new IOException("Couldn't create folders " + root);
-        }
-        return result;
     }
 }

--- a/core/src/test/java/hudson/util/jna/GNUCLibraryTest.java
+++ b/core/src/test/java/hudson/util/jna/GNUCLibraryTest.java
@@ -1,24 +1,24 @@
 package hudson.util.jna;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.Functions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
-class GNUCLibraryTest {
+public class GNUCLibraryTest {
 
     private static final int O_CREAT = "Linux".equals(System.getProperty("os.name")) ? 64 : 512;
     private static final int O_RDWR = 2;
 
     @Test
-    void openTest() throws IOException {
+    public void openTest() throws IOException {
         assumeTrue(Functions.isGlibcSupported());
 
         int fd = GNUCLibrary.LIBC.open("/dev/null", 0);
@@ -42,7 +42,7 @@ class GNUCLibraryTest {
     }
 
     @Test
-    void closeTest() {
+    public void closeTest() {
         assumeTrue(Functions.isGlibcSupported());
 
         int fd = GNUCLibrary.LIBC.open("/dev/null", 0);
@@ -53,7 +53,7 @@ class GNUCLibraryTest {
     }
 
     @Test
-    void fcntlTest() {
+    public void fcntlTest() {
         assumeTrue(Functions.isGlibcSupported());
 
         int fd = GNUCLibrary.LIBC.open("/dev/null", 0);
@@ -72,7 +72,7 @@ class GNUCLibraryTest {
     }
 
     @Test
-    void renameTest() throws IOException {
+    public void renameTest() throws IOException {
         assumeTrue(Functions.isGlibcSupported());
 
         Path oldFile = Files.createTempFile("renameTest", null);


### PR DESCRIPTION
Reverts jenkinsci/jenkins#10577 because it consistently fails hudson.util.FileChannelWriterTest.flush on Windows.

Creating as a draft pull request to see if this is the change that causes the test to fail on Windows.

@strangelookingnerd my initial theory is that this is was not detected in the pull request build because the pull request build uses Launchable to select a 60 minute subset of tests on Windows and that test was not in the selected subset.

/label skip-changelog