### PR TITLE
Fix FileChannelWriterTest and VirtualFileTest by reverting to JUnit 4

### DIFF
--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -2,7 +2,7 @@ package hudson.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,26 +10,26 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-class FileChannelWriterTest {
+public class FileChannelWriterTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    @TempDir
-    private File temporaryFolder;
+    File file;
+    FileChannelWriter writer;
 
-    private File file;
-    private FileChannelWriter writer;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        file = File.createTempFile("junit", null, temporaryFolder);
+    @Before
+    public void setUp() throws Exception {
+        file = temporaryFolder.newFile();
         writer = new FileChannelWriter(file.toPath(), StandardCharsets.UTF_8, true, true,  StandardOpenOption.WRITE);
     }
 
     @Test
-    void write() throws Exception {
+    public void write() throws Exception {
         writer.write("helloooo");
         writer.close();
 
@@ -38,7 +38,7 @@ class FileChannelWriterTest {
 
 
     @Test
-    void flush() throws Exception {
+    public void flush() throws Exception {
         writer.write("hello é è à".toCharArray());
 
         writer.flush();
@@ -46,7 +46,7 @@ class FileChannelWriterTest {
     }
 
     @Test
-    void close() throws Exception {
+    public void close() throws Exception {
         writer.write("helloooo");
         writer.close();
 


### PR DESCRIPTION
## Fix FileChannelWriterTest and VirtualFileTest by reverting to JUnit 4

Tests do not fail on my local Windows computer with JUnit 5 or with JUnit 4.  Reverting to JUnit 4 to see if it resolves the issue so that other pull requests will not be blocked by the failing test.

### Testing done

Confirmed that tests pass on my Windows computer before and after this change.  Rely on ci.jenkins.io to test its configurations of Windows.

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@strangelookingnerd

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
