### PR TITLE
Move Jackson 2.19.0 exclusion into packageRule section

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -106,6 +106,16 @@
       ],
       "enabled": false,
       "description": "maven-metadata.xml is missing for this really old package which is required by renovate"
+    },
+    {
+      "description": "Jackson 2.19.0 causes issues with Kubernetes client. See https://github.com/jenkinsci/bom/pull/5114",
+      "matchManagers": [
+        "maven"
+      ],
+      "allowedVersions": "<2.19.0",
+      "matchPackageNames": [
+        "org.jenkins-ci.plugins:jackson2-api"
+      ]
     }
   ],
   "customManagers": [
@@ -175,16 +185,6 @@
       ],
       "depNameTemplate": "org.apache.maven.skins:maven-fluido-skin",
       "datasourceTemplate": "maven"
-    },
-    {
-      "description": "Jackson 2.19.0 causes issues with Kubernetes client. See https://github.com/jenkinsci/bom/pull/5114",
-      "matchManagers": [
-        "maven"
-      ],
-      "allowedVersions": "<2.19.0",
-      "matchPackageNames": [
-        "org.jenkins-ci.plugins:jackson2-api"
-      ]
     }
   ],
   "labels": [


### PR DESCRIPTION
## Move Jackson 2.19.0 exclusion into packageRule section

Correct the renovate configuration error introduced in #10699

Amends

* https://github.com/jenkinsci/jenkins/pull/10699

### Testing done

npx --package renovate -- renovate-config-validator .github/renovate.json

INFO: Config validated successfully

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog
/label internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
