### PR TITLE
Add 'jenkins-!-text-color-secondary' class

### DIFF
--- a/src/main/scss/abstracts/_colors.scss
+++ b/src/main/scss/abstracts/_colors.scss
@@ -28,9 +28,17 @@
   }
 }
 
+// Custom class for secondary text colors as the
+// generator above doesn't support it
+.jenkins-\!-text-color-secondary {
+  --color: var(--text-color-secondary);
+
+  color: var(--text-color-secondary) !important;
+}
+
 // Deprecated - don't use the below classes
 .greyed {
-  color: #999;
+  color: var(--text-color-secondary);
 }
 
 .redbold {


### PR DESCRIPTION
Small fix for the CSS class `.jenkins-!-text-color-secondary` not actually existing - despite the Design Library reporting that it does (https://weekly.ci.jenkins.io/design-library/colors/).

This won't have any functional changes but will make it easier for core/plugin developers to use this color in their views. I've also updated the deprecated `.greyed` to follow this color.

Similar to https://github.com/jenkinsci/jenkins/pull/10695.

### Testing done

* Changing `.greyed` fixes the appearance of elements that use that class in other themes:

**Before**
<img width="598" alt="image" src="https://github.com/user-attachments/assets/a85d2fa0-6591-4bf6-8f77-e5acaa1f3157" />

**After**
<img width="599" alt="image" src="https://github.com/user-attachments/assets/85004421-edde-4565-8851-c2a2f545ad87" />

### Proposed changelog entries

- N/A

### Developer changelog

- Add 'jenkins-!-text-color-secondary' class

### Proposed changelog category

/label web-ui,rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
