### PR TITLE
Increase contrast of colorful buttons

### DIFF
--- a/src/main/scss/abstracts/_mixins.scss
+++ b/src/main/scss/abstracts/_mixins.scss
@@ -124,7 +124,7 @@
   }
 
   @if $border == false {
-    &:not(:hover, &:active, &:focus) {
+    &:not(:hover, &:active, &:focus, &[aria-expanded="true"]) {
       &::before {
         border-color: transparent;
       }

--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -90,14 +90,8 @@ $semantics: (
     var(--success-color) 10%,
     transparent
   );
-  --alert-success-border-color: color-mix(
-    in sRGB,
-    var(--success-color) 5%,
-    transparent
-  );
   --alert-info-text-color: var(--blue);
   --alert-info-bg-color: color-mix(in sRGB, var(--blue) 10%, transparent);
-  --alert-info-border-color: color-mix(in sRGB, var(--blue) 5%, transparent);
   --alert-warning-text-color: color-mix(
     in sRGB,
     var(--warning-color) 80%,
@@ -108,20 +102,10 @@ $semantics: (
     var(--warning-color) 10%,
     transparent
   );
-  --alert-warning-border-color: color-mix(
-    in sRGB,
-    var(--warning-color) 5%,
-    transparent
-  );
   --alert-danger-text-color: var(--error-color);
   --alert-danger-bg-color: color-mix(
     in sRGB,
     var(--error-color) 10%,
-    transparent
-  );
-  --alert-danger-border-color: color-mix(
-    in sRGB,
-    var(--error-color) 5%,
     transparent
   );
 
@@ -140,6 +124,7 @@ $semantics: (
     var(--text-color) 2%,
     transparent
   );
+  --jenkins-border-color--inherit-subtle: oklch(from currentColor l c h / 0.05);
 
   /* This is a harsher border - for dividers, content blocks and more */
   --jenkins-border: var(--jenkins-border-width) solid
@@ -148,6 +133,8 @@ $semantics: (
   /* This is a subtle border - for increasing contrast on elements, such as buttons, menu and more */
   --jenkins-border--subtle: var(--jenkins-border-width) solid
     var(--jenkins-border-color--subtle);
+  --jenkins-border--inherit-subtle: var(--jenkins-border-width) solid
+    var(--jenkins-border-color--inherit-subtle);
   --jenkins-border--subtle-shadow: 0 0 0 var(--jenkins-border-width)
     var(--jenkins-border-color--subtle);
 
@@ -160,6 +147,7 @@ $semantics: (
     --focus-input-border: var(--text-color);
     --jenkins-border-color: var(--text-color);
     --jenkins-border-color--subtle: var(--text-color);
+    --jenkins-border-color--inherit-subtle: var(--text-color);
   }
 
   // Table

--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -124,7 +124,7 @@ $semantics: (
     var(--text-color) 2%,
     transparent
   );
-  --jenkins-border-color--inherit-subtle: oklch(from currentColor l c h / 0.05);
+  --jenkins-border-color--inherit-subtle: oklch(from currentColor l c h / 0.06);
 
   /* This is a harsher border - for dividers, content blocks and more */
   --jenkins-border: var(--jenkins-border-width) solid

--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -137,7 +137,7 @@ $semantics: (
   );
   --jenkins-border-color--subtle: color-mix(
     in sRGB,
-    currentColor 1.5%,
+    var(--text-color) 2%,
     transparent
   );
 
@@ -148,7 +148,7 @@ $semantics: (
   /* This is a subtle border - for increasing contrast on elements, such as buttons, menu and more */
   --jenkins-border--subtle: var(--jenkins-border-width) solid
     var(--jenkins-border-color--subtle);
-  --jenkins-border--subtle-shadow: 0 0 0 1.5px
+  --jenkins-border--subtle-shadow: 0 0 0 var(--jenkins-border-width)
     var(--jenkins-border-color--subtle);
 
   @media (resolution <= 1x) {

--- a/src/main/scss/components/_alert.scss
+++ b/src/main/scss/components/_alert.scss
@@ -3,7 +3,7 @@
   font-size: var(--font-size-sm);
   padding: 15px;
   margin-bottom: var(--section-padding);
-  border: var(--jenkins-border-width) solid transparent;
+  border: var(--jenkins-border--inherit-subtle);
   border-radius: var(--form-input-border-radius);
 
   strong {
@@ -24,19 +24,16 @@
   &-success {
     color: var(--alert-success-text-color);
     background-color: var(--alert-success-bg-color);
-    border-color: var(--alert-success-border-color);
   }
 
   &-info {
     color: var(--alert-info-text-color);
     background-color: var(--alert-info-bg-color);
-    border-color: var(--alert-info-border-color);
   }
 
   &-warning {
     color: var(--alert-warning-text-color);
     background-color: var(--alert-warning-bg-color);
-    border-color: var(--alert-warning-border-color);
 
     p {
       color: var(--alert-warning-text-color);
@@ -46,7 +43,6 @@
   &-danger {
     color: var(--alert-danger-text-color);
     background-color: var(--alert-danger-bg-color);
-    border-color: var(--alert-danger-border-color);
 
     p {
       color: var(--alert-danger-text-color);

--- a/src/main/scss/components/_buttons.scss
+++ b/src/main/scss/components/_buttons.scss
@@ -48,6 +48,12 @@
   --button-background--active: oklch(from currentColor l c h / 0.25);
   --button-box-shadow--focus: oklch(from currentColor l c h / 0.125);
 
+  &:not(.jenkins-button--primary) {
+    &::before {
+      border: var(--jenkins-border--inherit-subtle);
+    }
+  }
+
   color: var(--color) !important;
 }
 

--- a/src/main/scss/components/_dropdowns.scss
+++ b/src/main/scss/components/_dropdowns.scss
@@ -126,10 +126,6 @@ $dropdown-padding: 0.375rem;
   }
 
   &__item {
-    --item-background--hover: var(--button-background--hover);
-    --item-background--active: var(--button-background--active);
-    --item-box-shadow--focus: var(--button-box-shadow--focus);
-
     @include mixins.item($border: false);
 
     appearance: none;
@@ -176,36 +172,15 @@ $dropdown-padding: 0.375rem;
     }
 
     &[class*="color"] {
-      background: transparent;
-      color: var(--color) !important;
+      --item-background--hover: oklch(from currentColor l c h / 0.15);
+      --item-background--active: oklch(from currentColor l c h / 0.25);
+      --item-box-shadow--focus: oklch(from currentColor l c h / 0.125);
 
       &::before {
-        background: currentColor !important;
-        opacity: 0;
+        border: var(--jenkins-border--inherit-subtle);
       }
 
-      &::after {
-        box-shadow: 0 0 0 0.66rem currentColor;
-        opacity: 0;
-      }
-
-      &:hover {
-        &::before {
-          opacity: 0.15;
-        }
-      }
-
-      &:active,
-      &:focus {
-        &::before {
-          opacity: 0.2;
-        }
-
-        &::after {
-          box-shadow: 0 0 0 0.33rem currentColor;
-          opacity: 0.1;
-        }
-      }
+      color: var(--color) !important;
     }
 
     &__badge {


### PR DESCRIPTION
Colorful buttons (see https://weekly.ci.jenkins.io/design-library/buttons/) have a _very_ subtle border on them at the moment in comparison to normal buttons. This is due to the border using 'currentColor' rather than the text color of the page to generate the border, resulting in mismatching borders.

I've refined this as part of this PR so that colorful buttons have their own custom border, which has higher contrast against the page and makes them pop more. With this new variable I've also extended it to alerts, so we can remove some unneeded code now.

**Before**
<img width="632" alt="image" src="https://github.com/user-attachments/assets/b3c46038-7019-4e71-85bf-68ee78480961" />

**After**
<img width="632" alt="image" src="https://github.com/user-attachments/assets/477e2e51-43db-49a3-ab71-f76c55e4991d" />

**Before (with Dark theme)**
<img width="608" alt="image" src="https://github.com/user-attachments/assets/155e6efb-3124-4ce6-8cca-b64c53273c3d" />

**After (with Dark theme)**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/35fbf05c-93f6-4d4c-9a1e-1e53c5bc9326" />

**Before (with Chocolate theme)**
<img width="739" alt="image" src="https://github.com/user-attachments/assets/cb836524-a535-4b1f-9d31-cb735fb9ea18" />

**After (with Chocolate theme)**
<img width="728" alt="image" src="https://github.com/user-attachments/assets/8b579f00-354d-414f-8dc4-770211488b62" />


### Testing done

* Checked Design Library for regressions, none found in various themes.

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui,skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
