### PR TITLE
Add copy-to-clipboard button to oops' stacktrace

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
@@ -40,7 +40,10 @@ THE SOFTWARE.
       </div>
       <j:if test="${app.shouldShowStackTrace()}">
         <p>${%checkJIRA} ${%vote} ${%pleaseReport} ${%stackTracePlease} ${%checkML}</p>
-        <h2>${%Stack trace}</h2>
+        <h2>
+            ${%Stack trace}
+            <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="${h.printThrowable(request2.getAttribute('jakarta.servlet.error.exception'))}"/>
+        </h2>
         <pre style="margin:2em; clear:both">${h.printThrowable(request2.getAttribute('jakarta.servlet.error.exception'))}</pre>
       </j:if>
     </l:main-panel>

--- a/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
@@ -40,11 +40,12 @@ THE SOFTWARE.
       </div>
       <j:if test="${app.shouldShowStackTrace()}">
         <p>${%checkJIRA} ${%vote} ${%pleaseReport} ${%stackTracePlease} ${%checkML}</p>
+        <j:set var="stacktrace" value="${h.printThrowable(request2.getAttribute('jakarta.servlet.error.exception'))}" />
         <h2>
             ${%Stack trace}
-            <l:copyButton text="${h.printThrowable(request2.getAttribute('jakarta.servlet.error.exception'))}"/>
+            <l:copyButton text="${stacktrace}"/>
         </h2>
-        <pre style="margin:2em; clear:both">${h.printThrowable(request2.getAttribute('jakarta.servlet.error.exception'))}</pre>
+        <pre style="margin:2em; clear:both">${stacktrace}</pre>
       </j:if>
     </l:main-panel>
   </l:layout>

--- a/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/oops.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
         <p>${%checkJIRA} ${%vote} ${%pleaseReport} ${%stackTracePlease} ${%checkML}</p>
         <h2>
             ${%Stack trace}
-            <l:copyButton message="${%successfullyCopied}" tooltip="${%clickToCopy}" text="${h.printThrowable(request2.getAttribute('jakarta.servlet.error.exception'))}"/>
+            <l:copyButton text="${h.printThrowable(request2.getAttribute('jakarta.servlet.error.exception'))}"/>
         </h2>
         <pre style="margin:2em; clear:both">${h.printThrowable(request2.getAttribute('jakarta.servlet.error.exception'))}</pre>
       </j:if>

--- a/core/src/main/resources/jenkins/model/Jenkins/oops.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/oops.properties
@@ -4,3 +4,5 @@ vote=If it is already reported, please vote and put a comment on it to let us ga
 pleaseReport=If you think this is a new issue, please file a new issue.
 stackTracePlease=When you file an issue, make sure to add the entire stack trace, along with the version of Jenkins and relevant plugins.
 checkML=<a href="https://www.jenkins.io/redirect/users-mailing-list">The users list</a> might be also useful in understanding what has happened.
+clickToCopy=Click to copy
+successfullyCopied=Copied to clipboard

--- a/core/src/main/resources/jenkins/model/Jenkins/oops.properties
+++ b/core/src/main/resources/jenkins/model/Jenkins/oops.properties
@@ -4,5 +4,3 @@ vote=If it is already reported, please vote and put a comment on it to let us ga
 pleaseReport=If you think this is a new issue, please file a new issue.
 stackTracePlease=When you file an issue, make sure to add the entire stack trace, along with the version of Jenkins and relevant plugins.
 checkML=<a href="https://www.jenkins.io/redirect/users-mailing-list">The users list</a> might be also useful in understanding what has happened.
-clickToCopy=Click to copy
-successfullyCopied=Copied to clipboard


### PR DESCRIPTION
The change proposed adds a clipboard button to easily grab the entire stacktrace, in case you ran into oops.jelly.

**Before**:
![Screenshot 2025-06-01 at 15 50 19](https://github.com/user-attachments/assets/09b6f358-3dfd-4001-89c6-e188e575e405)

**After**:
![Screenshot 2025-06-01 at 15 49 06](https://github.com/user-attachments/assets/c9287be8-98aa-4c5c-b996-3548a774701b)

### Testing done

Mangling a page to trigger oops.jelly to obtain the screenshots above.

### Proposed changelog entries

- Add copy to clipboard button to Jenkins error page

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
