### PR TITLE
Cleanup HudsonPrivateSecurityRealmTest

### DIFF
--- a/core/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/core/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -15,25 +15,26 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import javax.crypto.SecretKeyFactory;
-import org.junit.Assert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.mockito.Mockito;
 
-public class HudsonPrivateSecurityRealmTest {
+class HudsonPrivateSecurityRealmTest {
 
     // MySecurePassword
     private static final String PBKDF2_HMAC_SHA512_ENCODED_PASSWORD =
             "$HMACSHA512:210000:30f9e0a5470a8bc67f128ca1aae25dd4$88abaca4f442caeff0096ec0f75df2d77cc31a956c564133232f4d2532a72c8d4380a718d5b2a3dccab9e752027eeadd8f9f2c0c624505531bf3a57ec7d08aad";
 
     /*
-     * This exists so that we can easily  check the complexity of how long this takes (ie is the number of iterations we
+     * This exists so that we can easily check the complexity of how long this takes (ie is the number of iterations we
      * use correct for the state of CPUs).
-     * We do not want to assert that the range < x and  > y  as that would make the test flaky on overloaded
-     * or slow hardware, so this is commented out but left for ease of running locally when desired.
+     * We do not want to assert that the range < x and > y as that would make the test flaky on overloaded
+     * or slow hardware, so this is disabled but left for ease of running locally when desired.
      */
-    //@Test
-    public void timingPBKDF2() {
+    @Test
+    @Disabled
+    void timingPBKDF2() {
         // ignore the salt generation - check just matching....
         PBKDF2PasswordEncoder encoder = new PBKDF2PasswordEncoder();
         String encoded = encoder.encode("thisIsMyPassword1");
@@ -53,13 +54,14 @@ public class HudsonPrivateSecurityRealmTest {
     }
 
     /*
-     * This exists so that we can easily  check the complexity of how long this takes (ie is the number of iterations we
+     * This exists so that we can easily check the complexity of how long this takes (ie is the number of iterations we
      * use correct for the state of CPUs).
-     * We do not want to assert that the range < x and  > y  as that would make the test flaky on overloaded
-     * or slow hardware, so this is commented out but left for ease of running locally when desired.
+     * We do not want to assert that the range < x and > y as that would make the test flaky on overloaded
+     * or slow hardware, so this is disabled but left for ease of running locally when desired.
      */
-    //@Test
-    public void timingJBCrypt() {
+    @Test
+    @Disabled
+    void timingJBCrypt() {
         // ignore the salt generation - check just matching....
         JBCryptEncoder encoder = new JBCryptEncoder();
         String encoded = encoder.encode("thisIsMyPassword1");
@@ -111,7 +113,6 @@ public class HudsonPrivateSecurityRealmTest {
         assertFalse(encoder.isHashValid(
                 "::$sfdfssdf"),
                 "wrong format");
-
     }
 
     @Test
@@ -123,7 +124,7 @@ public class HudsonPrivateSecurityRealmTest {
     }
 
     @Test
-    void passwordPBKDF2WithMissingAgorithm() throws Exception {
+    void passwordPBKDF2WithMissingAlgorithm() throws Exception {
         HudsonPrivateSecurityRealm.PBKDF2PasswordEncoder pbkdf2PasswordEncoder = new HudsonPrivateSecurityRealm.PBKDF2PasswordEncoder();
         try (var ignored = mockStatic(SecretKeyFactory.class)) {
             when(SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512")).thenThrow(NoSuchAlgorithmException.class);
@@ -157,14 +158,17 @@ public class HudsonPrivateSecurityRealmTest {
     }
 
     @Issue("JENKINS-75533")
-    public void ensureExpectedMessageAscii() {
-        final IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode("1234567890123456789012345678901234567890123456789012345678901234567890123"));
+    @Test
+    void ensureExpectedMessageAscii() {
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode(
+                "1234567890123456789012345678901234567890123456789012345678901234567890123"));
         assertThat(ex.getMessage(), is(Messages.HudsonPrivateSecurityRealm_CreateAccount_BCrypt_PasswordTooLong_ASCII()));
     }
 
     @Issue("JENKINS-75533")
-    public void ensureExpectedMessageEmoji() {
-        final IllegalArgumentException ex = Assert.assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode(
+    @Test
+    void ensureExpectedMessageEmoji() {
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode(
                 "\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20" +
                         "\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20")); // 🤠
         assertThat(ex.getMessage(), is(Messages.HudsonPrivateSecurityRealm_CreateAccount_BCrypt_PasswordTooLong()));


### PR DESCRIPTION
Follow-up for https://github.com/jenkinsci/jenkins/pull/10576#issuecomment-2955493611

Cleanup typos, use correct assertions and (re-)enable tests.

### Testing done

`mvn clean verify`

### Proposed changelog entries

- Cleanup `HudsonPrivateSecurityRealmTest`

### Proposed changelog category

/label internal,tests,skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@NotMyFault
@jenkinsci/core-pr-reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
