### PR TITLE
Add new CLI command 'list-nodes' to list and filter Jenkins nodes

### DIFF
--- a/core/src/main/java/jenkins/cli/ListNodesCommand.java
+++ b/core/src/main/java/jenkins/cli/ListNodesCommand.java
@@ -451,7 +451,7 @@ public class ListNodesCommand extends CLICommand {
         }
 
         Instant instant = Instant.ofEpochMilli(millis);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z")
             .withZone(ZoneId.of("UTC"));
 
         return formatter.format(instant);

--- a/core/src/main/java/jenkins/cli/ListNodesCommand.java
+++ b/core/src/main/java/jenkins/cli/ListNodesCommand.java
@@ -1,0 +1,570 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Ahmed Anwar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.cli;
+
+import hudson.Extension;
+import hudson.cli.CLICommand;
+import hudson.model.Computer;
+import hudson.model.Node;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.args4j.Option;
+
+/**
+ * CLI command to list Jenkins nodes with various filtering options such as status, labels, and executors.
+ * Supports output in plain text or JSON format, with an optional verbose mode for detailed information.
+ */
+@Restricted(NoExternalUse.class)
+@Extension
+public class ListNodesCommand extends CLICommand {
+    private static final Logger LOGGER = Logger.getLogger(ListNodesCommand.class.getName());
+
+    private static final String NL = System.lineSeparator(); // Newline character for consistent output formatting
+
+    /** Maximum length for labels input to prevent excessive input size. */
+    private static final int MAX_LABELS_LENGTH = 1000;
+
+    private record NodeInfo(
+        String displayName,
+        boolean isOnline,
+        Set<String> labels,
+        int numExecutors,
+        String osDescription,
+        String architecture,
+        String javaVersion,
+        String offlineCauseReason,
+        String connectedSince,
+        String clockDifference
+    ) {}
+
+    /**
+     * Node status filter options.
+     */
+    enum Status {
+        ONLINE, OFFLINE, ALL
+    }
+
+    /**
+     * Output format options for node listing.
+     */
+    enum OutputFormat {
+        JSON, PLAIN
+    }
+
+    /**
+     * Label match mode: ANY label must match, or ALL labels must match.
+     */
+    enum LabelMatchMode {
+        ANY, ALL
+    }
+
+    // Command-line options
+
+    /**
+     * Filter nodes by status: ONLINE, OFFLINE, or ALL (default).
+     */
+    @Option(name = "-status", usage = "Filter nodes by status: ONLINE, OFFLINE, or ALL")
+    private Status status = Status.ALL;
+
+    /**
+     * Filter nodes by labels, using a comma-separated list (no spaces) (e.g., label1,label2,label3).
+     */
+    @Option(name = "-labels", usage = "Filter nodes by labels (comma-separated, no spaces) (e.g., label1,label2,label3)", metaVar = "label1,label2,...")
+    private String labels = null;
+
+    /**
+     * Label matching mode: ANY (at least one label matches) or ALL (all labels must match).
+     */
+    @Option(name = "-labels-mode", usage = "Label matching mode: ANY (at least one label matches) (Default) or ALL (all labels must match)")
+    private LabelMatchMode labelMode = LabelMatchMode.ANY;
+
+    /**
+     * Limit the number of nodes returned (positive integer, default: no limit).
+     */
+    @Option(name = "-limit", usage = "Limit the number of nodes returned (positive integer, default: no limit)", metaVar = "N")
+    private int limit = Integer.MAX_VALUE; // Default to no limit
+
+    /**
+     * Minimum number of executors for nodes to be included in the results.
+     */
+    @Option(name = "-min-executors", usage = "Filter nodes by minimum number of executors", metaVar = "N")
+    private int minExecutors = 0;
+
+    /**
+     * Exclude the built-in master node (i.e., Jenkins controller) from the results.
+     */
+    @Option(name = "-exclude-controller", usage = "Exclude the built-in master node (i.e., Jenkins controller) from the results")
+    private boolean excludeController = false;
+
+    /**
+     * Output format for the node list: JSON or PLAIN text.
+     */
+    @Option(name = "-format", usage = "Output format: JSON, PLAIN")
+    private OutputFormat format = OutputFormat.PLAIN;
+
+    /**
+     * Include detailed information for each node, such as OS, architecture, Java version, offline cause, clock difference, and connected since timestamp.
+     * Requires {@link Computer#EXTENDED_READ} permission.
+     */
+    @Option(name = "-verbose", usage = "Include detailed information for each node (e.g., OS, architecture, Java version, offline cause, clock difference, connected since timestamp). Requires 'Extended Read' permission on the node(s).")
+    private boolean verbose = false;
+
+    /**
+     * Only display node names, overriding other output formats and the verbose option.
+     * If this is set, no other information will be displayed.
+     */
+    @Option(name = "-name-only", usage = "Only display node names (overrides other output formats and verbose option)")
+    private boolean nameOnly = false;
+
+    /**
+     * Count only the number of matching nodes, overriding other output formats including name-only option.
+     * If this is set, no node details will be displayed, only the count.
+     */
+    @Option(name = "-count-only", usage = "Only print the number of matching nodes (overrides other output formats and name-only option)")
+    private boolean countOnly = false;
+
+    /**
+     * Set of labels to filter nodes by, initialized based on the provided labels input.
+     * This is used to efficiently check if a node matches the specified label criteria.
+     */
+    private Set<String> labelFilterSet = null;
+
+    @Override
+    public String getShortDescription() {
+        return Messages.ListNodesCommand_ShortDescription();
+    }
+
+    /**
+     * Executes the list-nodes command, filtering and formatting node information.
+     *
+     * @return 0 on success, 1 on invalid input or other errors.
+     * @throws Exception If an unexpected error occurs during execution.
+     */
+    @Override
+    protected int run() throws Exception {
+        Jenkins jenkins = Jenkins.get();
+
+        jenkins.checkPermission(Jenkins.READ);
+
+        // Validate inputs before processing
+        if (!validateInputs()) {
+            return 1;
+        }
+
+        initializeLabelFilter();
+
+        Computer[] computers = jenkins.getComputers();
+        if (computers == null) {
+            LOGGER.severe("Failed to retrieve nodes: Jenkins.getComputers() returned null, possible initialization failure");
+            stderr.println("Error: No nodes found. Please check if Jenkins is properly initialized.");
+
+            return 1;
+        }
+
+        List<NodeInfo> nodesList = Arrays.stream(computers)
+        .filter(this::excludeControllerIfNeeded) // Exclude controller if needed
+        .filter(this::matchesStatus)
+        .filter(this::matchesLabels)
+        .filter(this::matchesExecutorCount)
+        .limit(Math.max(0, limit)) // Apply limit, ensuring non-negative
+        .map(this::mapComputerToNodeInfo)
+        .toList();
+
+        if (countOnly) {
+            stdout.println(nodesList.size());
+            return 0;
+        }
+
+        if (nodesList.isEmpty()) {
+            stdout.println("No nodes found matching the specified criteria.");
+            return 0;
+        }
+
+        if (nameOnly) {
+            printNodeNamesOnly(nodesList);
+            return 0;
+        }
+
+        switch (format) {
+            case JSON:
+                printNodesAsJson(nodesList);
+                break;
+            case PLAIN:
+            default:
+                printNodesAsPlainText(nodesList);
+                break;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Validates command-line input options to ensure correctness before execution.
+     * @return true if all inputs are valid; false otherwise.
+     */
+    private boolean validateInputs() {
+        // Validate minExecutors
+        if (minExecutors < 0) {
+            stderr.println("Invalid input: The minimum number of executors (-min-executors) must be a non-negative value.");
+
+            return false;
+        }
+
+        // Validate limit
+        if (limit <= 0) {
+            stderr.println("Invalid input: -limit must be a positive integer.");
+
+            return false;
+        }
+
+        // Validate labels
+        if (labels != null && !labels.trim().isEmpty()) {
+            // Check length to prevent excessive input
+            if (labels.length() > MAX_LABELS_LENGTH) {
+                stderr.println("Invalid input: -labels input exceeds maximum length of " + MAX_LABELS_LENGTH + " characters.");
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Initializes the label filter set based on the provided labels input.
+     * Splits the labels by comma, trims whitespace, and converts to lowercase.
+     */
+    private void initializeLabelFilter() {
+        if (labels != null && !labels.trim().isEmpty()) {
+            labelFilterSet = Arrays.stream(labels.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(String::toLowerCase)
+                .collect(Collectors.toUnmodifiableSet());
+        }
+    }
+
+    /**
+     * Excludes the Jenkins controller node if the excludeController option is set.
+     * The controller is excluded only if it is not null and is an instance of Jenkins.
+     *
+     * @param computer The computer to check.
+     * @return true if the computer should be included, false if it should be excluded.
+     */
+    private boolean excludeControllerIfNeeded(Computer computer) {
+        if (!excludeController) {
+            return true;
+        }
+
+        Node node = computer.getNode();
+        if (node == null) {
+            return true;
+        }
+
+        return !(node instanceof Jenkins);
+    }
+
+    /**
+     * Checks if the computer matches the specified status filter.
+     * If the status is ALL, it returns true for all computers.
+     *
+     * @param computer The computer to check.
+     * @return true if the computer matches the status filter, false otherwise.
+     */
+    private boolean matchesStatus(Computer computer) {
+        switch (status) {
+            case ONLINE:
+                return computer.isOnline();
+            case OFFLINE:
+                return !computer.isOnline();
+            case ALL:
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * Checks if the computer matches the specified label filter based on the selected label mode.
+     * If no labels are specified, it returns true (no label filter applied).
+     *
+     * @param computer The computer to check.
+     * @return true if the computer matches the label filter, false otherwise.
+     */
+    private boolean matchesLabels(Computer computer) {
+        if (labels == null || labels.trim().isEmpty()) {
+            return true;
+        }
+
+        Set<String> assignedLabels = computer.getAssignedLabels().stream()
+            .map(label -> label.getName().toLowerCase())
+            .collect(Collectors.toSet());
+
+        if (labelMode == LabelMatchMode.ALL) {
+            return labelFilterSet.stream().allMatch(assignedLabels::contains);
+        } else {
+            return labelFilterSet.stream().anyMatch(assignedLabels::contains);
+        }
+    }
+
+    /**
+     * Checks if the computer has at least the specified minimum number of executors.
+     *
+     * @param computer The computer to check.
+     * @return true if the computer meets the minimum executor count, false otherwise.
+     */
+    private boolean matchesExecutorCount(Computer computer) {
+        return computer.getNumExecutors() >= minExecutors;
+    }
+
+    /**
+     * Maps a {@link Computer} object to a {@code NodeInfo} object, extracting relevant information.
+     * Handles exceptions and provides default values for missing data or insufficient permissions.
+     *
+     * @param computer The Computer object to map.
+     * @return A {@code NodeInfo} object containing the mapped information.
+     */
+    private NodeInfo mapComputerToNodeInfo(Computer computer) {
+            String displayName = "";
+            boolean isOnline = false;
+            int numExecutors = 0;
+            Set<String> labels = Set.of();
+
+            String offlineCauseReason = "N/A";
+
+            String osDescription = "N/A";
+            String architecture = "N/A";
+            String javaVersion = "N/A";
+            String connectedSince = "N/A";
+            String clockDifferenceStr = "N/A";
+
+        try {
+            displayName = computer.getDisplayName();
+            isOnline = computer.isOnline();
+            numExecutors = computer.getNumExecutors();
+
+            labels = computer.getAssignedLabels().stream()
+            .map(label -> label.getName())
+            .collect(Collectors.toUnmodifiableSet());
+
+            if (computer.hasPermission(Computer.EXTENDED_READ)) {
+                if (!isOnline) {
+                    offlineCauseReason = computer.getOfflineCauseReason();
+                }
+
+                if (verbose && isOnline) {
+                    connectedSince = formatTimestamp(computer.getConnectTime());
+                    clockDifferenceStr = getClockDifference(computer);
+
+                    // Fetch system properties
+                    try {
+                        Map<Object, Object> sysProps = computer.getSystemProperties();
+
+                        osDescription = getSystemProp(sysProps, "os.name");
+                        architecture = getSystemProp(sysProps, "os.arch");
+                        javaVersion = getSystemProp(sysProps, "java.version");
+
+                    } catch (IOException | InterruptedException e) {
+                        LOGGER.warning("Failed to fetch system properties for node '" + displayName + "': " + e.getMessage());
+                        stderr.println("Failed to fetch system properties for node '" + displayName + "'.");
+                    }
+                }
+            } else {
+                LOGGER.info("Verbose details for node '" + displayName + "' skipped due to insufficient permissions.");
+
+                osDescription = "Permission Denied";
+                architecture = "Permission Denied";
+                javaVersion = "Permission Denied";
+                connectedSince = "Permission Denied";
+                clockDifferenceStr = "Permission Denied";
+            }
+        } catch (Exception e) {
+            LOGGER.warning("Error mapping computer '" + displayName + "': " + e.getMessage());
+            stderr.println("Error: Failed to fetch node '" + displayName + "'.");
+        }
+
+        return new NodeInfo(displayName, isOnline, labels, numExecutors, osDescription, architecture, javaVersion, offlineCauseReason, connectedSince, clockDifferenceStr);
+    }
+
+    /**
+     * Retrieves a system property value from the provided map.
+     * If the property is not found or verbose mode is disabled, returns "N/A".
+     *
+     * @param sysProps The map containing system properties.
+     * @param key The key of the system property to retrieve.
+     * @return The value of the system property or "N/A" if not found or verbose mode is off.
+     */
+    private String getSystemProp(Map<Object, Object> sysProps, String key) {
+        if (!verbose || sysProps == null || sysProps.isEmpty()) {
+            return "N/A";
+        }
+
+        Object value = sysProps.get(key);
+
+        return value != null ? value.toString() : "N/A";
+    }
+
+    /**
+     * Formats a timestamp in milliseconds to a human-readable UTC date-time string.
+     * If the timestamp is less than or equal to zero, returns "N/A".
+     *
+     * @param millis The timestamp in milliseconds.
+     * @return A formatted date-time string or "N/A" if the timestamp is invalid.
+     */
+    private String formatTimestamp(long millis) {
+        if (millis <= 0) {
+            return "N/A";
+        }
+
+        Instant instant = Instant.ofEpochMilli(millis);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneId.of("UTC"));
+
+        return formatter.format(instant);
+    }
+
+    /**
+     * Retrieves the clock difference for a given computer node.
+     * If the node is offline or verbose mode is not enabled, returns "N/A".
+     *
+     * @param computer The computer to check.
+     * @return The clock difference as a string, or "N/A" if not applicable.
+     */
+    private String getClockDifference(Computer computer) {
+        if (!verbose || !computer.isOnline()) {
+            return "N/A";
+        }
+
+        try {
+            Node node = computer.getNode();
+
+            if (node == null) {
+                return "N/A";
+            }
+
+            return node.getClockDifference().toString();
+        } catch (Exception e) {
+            return "N/A";
+        }
+    }
+
+    /**
+     * Prints only the names of the nodes, one per line.
+     * This method is used when the -name-only option is specified.
+     *
+     * @param nodes The list of {@code NodeInfo} objects to print.
+     */
+    private void printNodeNamesOnly(List<NodeInfo> nodes) {
+        for (NodeInfo node : nodes) {
+            stdout.println(node.displayName());
+        }
+    }
+
+    /**
+     * Prints the list of nodes in JSON format.
+     *
+     * @param nodes The list of {@code NodeInfo} objects to print.
+     */
+    private void printNodesAsJson(List<NodeInfo> nodes) {
+        // Convert nodes to JSON format and print
+        JSONArray array = new JSONArray();
+
+        for (NodeInfo node : nodes) {
+            JSONObject json = new JSONObject();
+
+            json.put("displayName", node.displayName());
+            json.put("isOnline", node.isOnline());
+            json.put("numExecutors", node.numExecutors());
+            json.put("labels", node.labels());
+
+            if (verbose) {
+                json.put("osDescription", node.osDescription());
+                json.put("architecture", node.architecture());
+                json.put("javaVersion", node.javaVersion());
+                json.put("offlineCauseReason", node.offlineCauseReason());
+                json.put("connectedSince", node.connectedSince());
+                json.put("clockDifference", node.clockDifference());
+            }
+            array.add(json);
+        }
+
+        String output = array.toString(2); // Pretty-print JSON with indent
+
+        stdout.println(output);
+    }
+
+    /**
+     * Prints the list of nodes in plain text format.
+     * Each node's details are printed with appropriate formatting.
+     *
+     * @param nodes The list of {@code NodeInfo} objects to print.
+     */
+    private void printNodesAsPlainText(List<NodeInfo> nodes) {
+        for (int i = 0; i < nodes.size(); i++) {
+            NodeInfo node = nodes.get(i);
+            StringBuilder sb = new StringBuilder();
+
+            sb.append("Node: ").append(node.displayName()).append(NL);
+            sb.append("  Online: ").append(node.isOnline() ? "Yes" : "No").append(NL);
+            sb.append("  Executors: ").append(node.numExecutors()).append(NL);
+            sb.append("  Labels:").append(NL);
+
+            for (String label : node.labels()) {
+                sb.append("    - ").append(label).append(NL);
+            }
+
+            if (verbose) {
+                sb.append("  OS: ").append(node.osDescription()).append(NL);
+                sb.append("  Architecture: ").append(node.architecture()).append(NL);
+                sb.append("  Java Version: ").append(node.javaVersion()).append(NL);
+                sb.append("  Offline Reason: ").append(node.offlineCauseReason()).append(NL);
+                sb.append("  Connected Since: ").append(node.connectedSince()).append(NL);
+                sb.append("  Clock Difference: ").append(node.clockDifference()).append(NL);
+
+                if (node.osDescription().equals("Permission Denied")) {
+                    sb.append(" Note: Verbose details unavailable due to insufficient permissions.").append(NL);
+                }
+            }
+
+            if (i < nodes.size() - 1) {
+                sb.append("---").append(NL);
+            }
+
+            stdout.print(sb); // single print per node
+        }
+    }
+}

--- a/core/src/main/java/jenkins/cli/ListNodesCommand.java
+++ b/core/src/main/java/jenkins/cli/ListNodesCommand.java
@@ -314,7 +314,7 @@ public class ListNodesCommand extends CLICommand {
             case ONLINE:
                 return computer.isOnline();
             case OFFLINE:
-                return !computer.isOnline();
+                return computer.isOffline();
             case ALL:
             default:
                 return true;

--- a/core/src/main/resources/jenkins/cli/Messages.properties
+++ b/core/src/main/resources/jenkins/cli/Messages.properties
@@ -1,0 +1,1 @@
+ListNodesCommand.ShortDescription=Lists all nodes with options to filter by status, labels, minimum executor count, limit the number of results, display only names or count, or exclude the controller node.

--- a/test/src/test/java/jenkins/cli/ListNodesCommandTest.java
+++ b/test/src/test/java/jenkins/cli/ListNodesCommandTest.java
@@ -89,25 +89,36 @@ public class ListNodesCommandTest {
         void shouldListOnlineNodeWhenStatusIsOnline() throws Exception {
             DumbSlave onlineNode = j.createOnlineSlave();
 
+            DumbSlave tempOfflineNode = j.createOnlineSlave();
+            tempOfflineNode.toComputer().setTemporaryOfflineCause(new OfflineCause.ByCLI("Testing temporarily offline node"));
+
+            DumbSlave offlineNode = j.createOnlineSlave();
+            offlineNode.toComputer().disconnect(null).get();
+
             CLICommandInvoker.Result result = command.invokeWithArgs("-status", "ONLINE");
 
             assertThat(result.stdout(), containsString(onlineNode.getNodeName()));
+            assertThat(result.stdout(), not(containsString(offlineNode.getNodeName())));
+            assertThat(result.stdout(), not(containsString(tempOfflineNode.getNodeName())));
             assertThat(result.stderr(), is(emptyString()));
             assertThat(result.returnCode(), is(0));
         }
 
         @Test
-        void shouldListOfflineNodeWhenStatusIsOffline() throws Exception {
+        void shouldListOfflineNodesWhenStatusIsOffline() throws Exception {
             DumbSlave tempOfflineNode = j.createOnlineSlave();
             tempOfflineNode.toComputer().setTemporaryOfflineCause(new OfflineCause.ByCLI("Testing temporarily offline node"));
 
             DumbSlave offlineNode = j.createOnlineSlave();
-            offlineNode.toComputer().disconnect(null);
+            offlineNode.toComputer().disconnect(null).get();
+
+            DumbSlave onlineNode = j.createOnlineSlave();
 
             CLICommandInvoker.Result result = command.invokeWithArgs("-status", "OFFLINE");
 
             assertThat(result.stdout(), containsString(tempOfflineNode.getNodeName()));
             assertThat(result.stdout(), containsString(offlineNode.getNodeName()));
+            assertThat(result.stdout(), not(containsString(onlineNode.getNodeName())));
             assertThat(result.stderr(), is(emptyString()));
             assertThat(result.returnCode(), is(0));
         }
@@ -117,9 +128,16 @@ public class ListNodesCommandTest {
             DumbSlave tempOfflineNode = j.createOnlineSlave();
             tempOfflineNode.toComputer().setTemporaryOfflineCause(new OfflineCause.ByCLI("Testing temporarily offline node"));
 
+            DumbSlave offlineNode = j.createOnlineSlave();
+            offlineNode.toComputer().disconnect(null).get();
+
+            DumbSlave onlineNode = j.createOnlineSlave();
+
             CLICommandInvoker.Result result = command.invokeWithArgs("-status", "TEMP_OFFLINE");
 
             assertThat(result.stdout(), containsString(tempOfflineNode.getNodeName()));
+            assertThat(result.stdout(), not(containsString(offlineNode.getNodeName())));
+            assertThat(result.stdout(), not(containsString(onlineNode.getNodeName())));
             assertThat(result.stdout(), containsString("Testing temporarily offline node"));
             assertThat(result.stderr(), is(emptyString()));
             assertThat(result.returnCode(), is(0));
@@ -133,7 +151,7 @@ public class ListNodesCommandTest {
 
             // Create offline node
             DumbSlave offlineNode = j.createOnlineSlave();
-            offlineNode.toComputer().disconnect(null);
+            offlineNode.toComputer().disconnect(null).get();
             String offlineNodeName = offlineNode.getNodeName();
 
             // Create temporarily offline node
@@ -439,7 +457,7 @@ public class ListNodesCommandTest {
             node.setLabelString("test-node");
 
             // Make node offline
-            node.toComputer().disconnect(null);
+            node.toComputer().disconnect(null).get();
 
             CLICommandInvoker.Result result = command.invokeWithArgs("-verbose", "-labels", "test-node");
 

--- a/test/src/test/java/jenkins/cli/ListNodesCommandTest.java
+++ b/test/src/test/java/jenkins/cli/ListNodesCommandTest.java
@@ -1,0 +1,709 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Ahmed Anwar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import hudson.cli.CLICommand;
+import hudson.cli.CLICommandInvoker;
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.security.ACL;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.Permission;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.OfflineCause;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Tests for {@link ListNodesCommand}.
+ */
+@WithJenkins
+public class ListNodesCommandTest {
+
+    private CLICommand listNodesCommand;
+    private CLICommandInvoker command;
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+        listNodesCommand = new ListNodesCommand();
+        command = new CLICommandInvoker(j, listNodesCommand);
+    }
+
+    @Nested
+    class BasicTests {
+        @Test
+        void shouldListSingleNode() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+
+            CLICommandInvoker.Result result = command.invoke();
+
+            assertThat(result.stdout(), containsString("Node: " + node.getDisplayName()));
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class StatusTests {
+        @Test
+        void shouldListOnlineNodeWhenStatusIsOnline() throws Exception {
+            DumbSlave onlineNode = j.createOnlineSlave();
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-status", "ONLINE");
+
+            assertThat(result.stdout(), containsString(onlineNode.getNodeName()));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldListOfflineNodeWhenStatusIsOffline() throws Exception {
+            DumbSlave offlineNode = j.createOnlineSlave();
+            offlineNode.toComputer().setTemporaryOfflineCause(new OfflineCause.ByCLI("Testing offline node"));
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-status", "OFFLINE");
+
+            assertThat(result.stdout(), containsString(offlineNode.getNodeName()));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldListBothOnlineAndOfflineNodesWhenStatusIsAll() throws Exception {
+            // Create online node
+            DumbSlave onlineNode = j.createOnlineSlave();
+            String onlineNodeName = onlineNode.getNodeName();
+
+            // Create offline node
+            DumbSlave offlineNode = j.createOnlineSlave();
+            offlineNode.toComputer().setTemporaryOfflineCause(new OfflineCause.ByCLI("Testing offline node"));
+            String offlineNodeName = offlineNode.getNodeName();
+
+            // Invoke command with -status ALL
+            CLICommandInvoker.Result result = command.invokeWithArgs("-status", "ALL");
+
+            // Verify both nodes are listed
+            assertThat(result.stdout(), containsString(onlineNodeName));
+            assertThat(result.stdout(), containsString(offlineNodeName));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class ControllerTests {
+        @Test
+        void shouldExcludeControllerNodeWhenSpecified() throws Exception {
+            Jenkins controller = j.jenkins;
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-exclude-controller");
+
+            // Controller node should not be listed
+            assertThat(result.stdout(), not(containsString(controller.getDisplayName())));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class LabelTests {
+        @Test
+        void shouldFilterNodesBySingleLabel() throws Exception {
+            DumbSlave labeledNode = j.createOnlineSlave();
+            labeledNode.setLabelString("my-label");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", "my-label");
+
+            assertThat(result.stdout(), containsString(labeledNode.getNodeName()));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldFilterNodesByMultipleLabels() throws Exception {
+            DumbSlave labeledNode = j.createOnlineSlave();
+            labeledNode.setLabelString("my-label another-label");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", "my-label,another-label");
+
+            assertThat(result.stdout(), containsString(labeledNode.getNodeName()));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        public void shouldShowNoNodesWhenLabelFilterDoesNotMatch() throws Exception {
+            // Create an online node with label "existing-label"
+            DumbSlave onlineNode = j.createOnlineSlave();
+            onlineNode.setLabelString("existing-label");
+
+            // Invoke command with a label that doesn't exist
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", "nonexistent-label");
+
+            assertThat(result.stdout(), containsString("No nodes found"));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldHandleEmptyLabels() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("test-label");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", "");
+
+            assertThat(result.stdout(), containsString(node.getNodeName())); // Empty labels should match all nodes
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldRejectLabelInputThatIsTooLong() {
+            String longLabel = "a".repeat(1001); // exceeds MAX_LABELS_LENGTH
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", longLabel);
+
+            assertThat(result.stderr(), containsString("exceeds maximum length"));
+            assertThat(result.returnCode(), is(1));
+        }
+
+        // label mode tests
+
+        @Test
+        void shouldMatchNodeWhenAnyLabelMatches() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("linux docker");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", "docker,gpu", "-labels-mode", "ANY");
+
+            assertThat(result.stdout(), containsString(node.getNodeName()));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldNotMatchNodeWhenAnyLabelDoesNotMatch() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("windows");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", "gpu,mac", "-labels-mode", "ANY");
+
+            assertThat(result.stdout(), not(containsString(node.getNodeName())));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldMatchNodeWhenAllLabelsMatch() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("linux docker");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", "linux,docker", "-labels-mode", "ALL");
+
+            assertThat(result.stdout(), containsString(node.getNodeName()));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldNotMatchNodeWhenAllLabelsDoNotMatch() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("linux docker");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-labels", "linux,gpu", "-labels-mode", "ALL");
+
+            assertThat(result.stdout(), not(containsString(node.getNodeName())));
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class ExecutorTests {
+        @Test
+        void shouldFilterByMinExecutors() throws Exception {
+            // Node that matches min-executors filter
+            DumbSlave matchingNode = j.createOnlineSlave();
+            matchingNode.setNumExecutors(5);
+            j.jenkins.addNode(matchingNode); // Re-add to apply changes
+            j.configRoundtrip(matchingNode);
+            j.waitOnline(matchingNode);
+
+            // Node that does NOT match min-executors filter
+            DumbSlave nonMatchingNode = j.createOnlineSlave();
+            nonMatchingNode.setNumExecutors(2);
+            j.jenkins.addNode(nonMatchingNode); // Re-add to apply changes
+            j.configRoundtrip(nonMatchingNode);
+            j.waitOnline(nonMatchingNode);
+
+            j.jenkins.save(); // Save Jenkins configuration
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-min-executors", "4");
+
+            // Should contain matching node
+            assertThat(result.stdout(), containsString(matchingNode.getNodeName()));
+
+            // Should NOT contain non-matching node
+            assertThat(result.stdout(), not(containsString(nonMatchingNode.getNodeName())));
+
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldRejectNegativeMinExecutors() {
+            CLICommandInvoker.Result result = command.invokeWithArgs("-min-executors", "-1");
+
+            assertThat(result.stderr(), containsString("Invalid input"));
+            assertThat(result.returnCode(), is(1));
+        }
+    }
+
+    @Nested
+    class LimitTests {
+        @Test
+        void shouldLimitNumberOfResults() throws Exception {
+            j.createOnlineSlave();
+            j.createOnlineSlave();
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-limit", "1");
+
+            // Only one node should appear in the output
+            long count = result.stdout().lines().filter(line -> line.contains("Node:")).count();
+            assertThat(count, is(1L));
+        }
+
+        @Test
+        void shouldRejectNonPositiveLimit() {
+            CLICommandInvoker.Result result = command.invokeWithArgs("-limit", "0");
+
+            assertThat(result.stderr(), containsString("Invalid input"));
+            assertThat(result.returnCode(), is(1));
+        }
+    }
+
+    @Nested
+    class CountOnlyTests {
+        @Test
+        void shouldOutputCountOnly() throws Exception {
+            j.createOnlineSlave();
+            j.createOnlineSlave();
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-count-only");
+
+            assertThat(result.stdout().trim(), is("3")); // 1 master (controller) + 2 agents
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldOutputCountOnlyWithoutController() throws Exception {
+            j.createOnlineSlave();
+            j.createOnlineSlave();
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-exclude-controller", "-count-only"); // Exclude the controller (master)
+
+            assertThat(result.stdout().trim(), is("2"));
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class NameOnlyTests {
+        @Test
+        void shouldOutputNameOnly() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-exclude-controller", "-name-only"); // Exclude the controller (master)
+
+            assertThat(result.stdout().trim(), is(node.getNodeName()));
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class VerboseTests {
+        @Test
+        void shouldShowVerboseDetailsForOnlineNode() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("test-node");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-verbose", "-labels", "test-node");
+
+            String output = result.stdout();
+
+            // Basic checks
+            assertThat(output, containsString(node.getNodeName()));
+            assertThat(output, containsString("OS:"));
+            assertThat(output, containsString("Architecture:"));
+            assertThat(output, containsString("Java Version:"));
+            assertThat(output, containsString("Connected Since:"));
+            assertThat(output, containsString("Clock Difference:"));
+
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldShowVerboseDetailsForOfflineNode() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("test-node");
+
+            // Make node offline
+            node.toComputer().setTemporaryOfflineCause(new OfflineCause.ByCLI("Testing offline node"));
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-verbose", "-labels", "test-node");
+
+            String output = result.stdout();
+
+            // Basic checks
+            assertThat(output, containsString(node.getNodeName()));
+            assertThat(output, containsString("Offline Reason:")); // offlineCauseReason shown
+            assertThat(output, containsString("Connected Since: N/A")); // should say N/A
+            assertThat(output, containsString("Clock Difference: N/A")); // should say N/A
+
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class CombinationTests {
+        @Test
+        void shouldCombineFiltersCorrectly() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("combo-label");
+            node.setNumExecutors(3);
+
+            j.jenkins.addNode(node); // Re-add to apply changes
+            j.configRoundtrip(node);
+            j.waitOnline(node);
+
+            j.jenkins.save(); // Save Jenkins configuration
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-status", "ONLINE", "-labels", "combo-label", "-min-executors", "2");
+
+            assertThat(result.stdout(), containsString(node.getNodeName()));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldRespectMinExecutorsAndLimitTogether() throws Exception {
+            // Create 3 nodes with different executors
+            DumbSlave node1 = j.createOnlineSlave();
+            node1.setNumExecutors(5);
+            j.jenkins.addNode(node1);
+            j.configRoundtrip(node1);
+            j.waitOnline(node1);
+
+            DumbSlave node2 = j.createOnlineSlave();
+            node2.setNumExecutors(4);
+            j.jenkins.addNode(node2);
+            j.configRoundtrip(node2);
+            j.waitOnline(node2);
+
+            DumbSlave node3 = j.createOnlineSlave();
+            node3.setNumExecutors(2);
+            j.jenkins.addNode(node3);
+            j.configRoundtrip(node3);
+            j.waitOnline(node3);
+
+            j.jenkins.save();
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-min-executors", "3", "-limit", "1");
+
+            String output = result.stdout();
+
+            boolean containsNode1 = output.contains(node1.getNodeName());
+            boolean containsNode2 = output.contains(node2.getNodeName());
+            boolean containsNode3 = output.contains(node3.getNodeName()); // should not appear
+
+            int countMatchingNodes = 0;
+            if (containsNode1) countMatchingNodes++;
+            if (containsNode2) countMatchingNodes++;
+            if (containsNode3) countMatchingNodes++; // this must stay zero!
+
+            assertThat("Only one matching node should appear", countMatchingNodes, is(1));
+            assertThat("Node with 2 executors must NOT appear", containsNode3, is(false));
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class PermissionTests {
+        // Custom AuthorizationStrategy to grant Computer.EXTENDED_READ only for nodeWithPermission
+        private AuthorizationStrategy authorizationWithExtendedReadForNode(String nodeWithPermissionName) {
+            return new AuthorizationStrategy() {
+                private final Set<String> permittedComputers = new HashSet<>(Collections.singletonList(nodeWithPermissionName));
+
+                @Override
+                public ACL getRootACL() {
+                    return new ACL() {
+                        @Override
+                        public boolean hasPermission2(Authentication a, Permission permission) {
+                            if (a.getName().equals("user") && permission == Jenkins.READ) {
+                                return true;
+                            }
+                            return false;
+                        }
+                    };
+                }
+
+                @Override
+                public ACL getACL(Computer c) {
+                    return new ACL() {
+                        @Override
+                        public boolean hasPermission2(Authentication a, Permission permission) {
+                            if (a.getName().equals("user")) {
+                                if (permission == Jenkins.READ) {
+                                    return true;
+                                }
+                                if (permission == Computer.EXTENDED_READ && permittedComputers.contains(c.getName())) {
+                                    return true;
+                                }
+                            }
+                            return false;
+                        }
+                    };
+                }
+
+                @Override
+                public ACL getACL(Node node) {
+                    return getACL(node.toComputer());
+                }
+
+                @Override
+                public Set<String> getGroups() {
+                    return Collections.emptySet();
+                }
+            };
+        }
+
+        @Test
+        void shouldRunCommandWhenUserHasJenkinsReadPermission() throws Exception {
+            // Set up a security realm with a user "user"
+            j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+            j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to("user"));
+
+            CLICommandInvoker.Result result = command.asUser("user").invoke();
+
+            // Expect normal behavior (not a permission error)
+            assertThat(result.stderr(), not(containsString("permission")));
+            assertThat(result.returnCode(), is(0));
+        }
+
+        @Test
+        void shouldFailWhenUserLacksJenkinsReadPermission() throws Exception {
+            // Set up a security realm with a user "user"
+            j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+            j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant().everywhere().to("user")); // No permissions granted to "user"
+
+            CLICommandInvoker.Result result = command.asUser("user").invoke();
+
+            // Expect permission error
+            assertThat(result.stderr(), containsString("user is missing the Overall/Read permission"));
+            assertThat(result.returnCode(), is(6));
+        }
+
+        @Test
+        void shouldShowVerboseDetailsWhenUserHasExtendedReadPermission() throws Exception {
+            // Set up a security realm with a user "user"
+            j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+            j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ).everywhere().to("user")
+                .grant(Computer.EXTENDED_READ).everywhere().to("user")); // Grant both Jenkins.READ and Computer.EXTENDED_READ
+
+            // Create an online node
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("test-node");
+            String nodeName = node.getNodeName();
+
+            CLICommandInvoker.Result result = command.asUser("user").invokeWithArgs("-verbose", "-labels", "test-node");
+
+            // Verify the command runs successfully
+            assertThat(result.returnCode(), is(0));
+            assertThat(result.stderr(), is(emptyString())); // No errors in stderr
+            assertThat(result.stdout(), containsString(nodeName)); // Node should be listed
+            assertThat(result.stdout(), containsString("OS:"));
+            assertThat(result.stdout(), containsString("Architecture:"));
+            assertThat(result.stdout(), containsString("Java Version:"));
+            assertThat(result.stdout(), containsString("Connected Since:"));
+            assertThat(result.stdout(), containsString("Clock Difference:"));
+            assertThat(result.stdout(), not(containsString("Permission Denied"))); // No permission denied messages
+        }
+
+        @Test
+        void shouldShowVerboseDetailsForPermittedNodeAndPermissionDeniedForNonPermittedNode() throws Exception {
+            // Set up a security realm with a user "user"
+            j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+
+            // Create two online nodes
+            DumbSlave nodeWithPermission = j.createOnlineSlave();
+            nodeWithPermission.setLabelString("node-with-permission");
+            String nodeWithPermissionName = nodeWithPermission.getNodeName();
+
+            DumbSlave nodeWithoutPermission = j.createOnlineSlave();
+            nodeWithoutPermission.setLabelString("node-without-permission");
+            String nodeWithoutPermissionName = nodeWithoutPermission.getNodeName();
+
+            AuthorizationStrategy auth = authorizationWithExtendedReadForNode(nodeWithPermissionName);
+            j.jenkins.setAuthorizationStrategy(auth);
+
+            // Run command with verbose and labels to include both nodes
+            CLICommandInvoker.Result result = command.asUser("user").invokeWithArgs("-verbose", "-labels", "node-with-permission,node-without-permission", "-labels-mode", "ANY");
+
+            // Verify the command runs successfully
+            assertThat(result.returnCode(), is(0));
+            assertThat(result.stderr(), is(emptyString())); // No errors in stderr
+
+            // Verify both nodes are listed
+            assertThat(result.stdout(), containsString(nodeWithPermissionName));
+            assertThat(result.stdout(), containsString(nodeWithoutPermissionName));
+
+            // Verify verbose details for node with permission
+            assertThat(result.stdout(), containsString(nodeWithPermissionName));
+            assertThat(result.stdout(), containsString("OS:"));
+            assertThat(result.stdout(), containsString("Architecture:"));
+            assertThat(result.stdout(), containsString("Java Version:"));
+            assertThat(result.stdout(), containsString("Connected Since:"));
+            assertThat(result.stdout(), containsString("Clock Difference:"));
+            assertThat(result.stdout(), not(containsString(nodeWithPermissionName + "\nOS: Permission Denied")));
+
+            // Verify "Permission Denied" for node without permission
+            assertThat(result.stdout(), containsString(nodeWithoutPermissionName));
+            assertThat(result.stdout(), containsString("OS: Permission Denied"));
+            assertThat(result.stdout(), containsString("Architecture: Permission Denied"));
+            assertThat(result.stdout(), containsString("Java Version: Permission Denied"));
+            assertThat(result.stdout(), containsString("Connected Since: Permission Denied"));
+            assertThat(result.stdout(), containsString("Clock Difference: Permission Denied"));
+        }
+
+        @Test
+        void shouldOutputJsonWithVerboseDetailsForPermittedNodeAndPermissionDeniedForNonPermittedNode() throws Exception {
+            // Set up a security realm with a user "user"
+            j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+
+            // Create two online nodes
+            DumbSlave nodeWithPermission = j.createOnlineSlave();
+            nodeWithPermission.setLabelString("node-with-permission");
+            String nodeWithPermissionName = nodeWithPermission.getNodeName();
+
+            DumbSlave nodeWithoutPermission = j.createOnlineSlave();
+            nodeWithoutPermission.setLabelString("node-without-permission");
+            String nodeWithoutPermissionName = nodeWithoutPermission.getNodeName();
+
+            AuthorizationStrategy auth = authorizationWithExtendedReadForNode(nodeWithPermissionName);
+            j.jenkins.setAuthorizationStrategy(auth);
+
+            // Run command with JSON format, verbose, and labels to include both nodes
+            CLICommandInvoker.Result result = command.asUser("user").invokeWithArgs("-format", "JSON", "-verbose", "-labels", "node-with-permission,node-without-permission", "-labels-mode", "ANY");
+
+            // Verify the command runs successfully
+            assertThat(result.returnCode(), is(0));
+            assertThat(result.stderr(), is(emptyString()));
+
+            // Parse JSON output
+            JSONArray jsonArray = JSONArray.fromObject(result.stdout());
+            assertThat(jsonArray.size(), is(2)); // Both nodes should be listed
+
+            // Find and verify each node
+            boolean foundWithPermission = false;
+            boolean foundWithoutPermission = false;
+
+            for (int i = 0; i < jsonArray.size(); i++) {
+                JSONObject jsonNode = jsonArray.getJSONObject(i);
+                String displayName = jsonNode.getString("displayName");
+
+                if (displayName.equals(nodeWithPermissionName)) {
+                    foundWithPermission = true;
+                    assertThat(jsonNode.getString("osDescription"), not(is("Permission Denied")));
+                    assertThat(jsonNode.getString("architecture"), not(is("Permission Denied")));
+                    assertThat(jsonNode.getString("javaVersion"), not(is("Permission Denied")));
+                    assertThat(jsonNode.getString("connectedSince"), not(is("Permission Denied")));
+                    assertThat(jsonNode.getString("clockDifference"), not(is("Permission Denied")));
+                } else if (displayName.equals(nodeWithoutPermissionName)) {
+                    foundWithoutPermission = true;
+                    assertThat(jsonNode.getString("osDescription"), is("Permission Denied"));
+                    assertThat(jsonNode.getString("architecture"), is("Permission Denied"));
+                    assertThat(jsonNode.getString("javaVersion"), is("Permission Denied"));
+                    assertThat(jsonNode.getString("connectedSince"), is("Permission Denied"));
+                    assertThat(jsonNode.getString("clockDifference"), is("Permission Denied"));
+                }
+            }
+
+            assertThat("Node with permission not found", foundWithPermission, is(true));
+            assertThat("Node without permission not found", foundWithoutPermission, is(true));
+        }
+    }
+
+    @Nested
+    class NoNodesMatchingTests {
+        @Test
+        void shouldShowNoNodesMessageWhenNoNodesMatch() {
+            CLICommandInvoker.Result result = command.invokeWithArgs("-exclude-controller");
+
+            assertThat(result.stdout(), containsString("No nodes found matching the specified criteria"));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+        }
+    }
+
+    @Nested
+    class JsonOutputTests {
+        @Test
+        void shouldOutputValidJsonFormat() throws Exception {
+            DumbSlave node = j.createOnlineSlave();
+            node.setLabelString("json-test");
+
+            CLICommandInvoker.Result result = command.invokeWithArgs("-format", "JSON", "-labels", "json-test");
+
+            String output = result.stdout();
+            assertThat(output, containsString("\"displayName\": \"" + node.getNodeName() + "\""));
+            assertThat(output, containsString("\"isOnline\": true"));
+            assertThat(output, containsString("\"labels\":"));
+            assertThat(result.stderr(), is(emptyString()));
+            assertThat(result.returnCode(), is(0));
+
+            // Verify JSON is parseable
+            JSONArray jsonArray = JSONArray.fromObject(output);
+            assertThat(jsonArray.size(), is(1));
+            JSONObject jsonNode = jsonArray.getJSONObject(0);
+            assertThat(jsonNode.getString("displayName"), is(node.getNodeName()));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-75770](https://issues.jenkins.io/browse/JENKINS-75770).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

This pull request introduces a new CLI command called list-nodes into the Jenkins core.

The goal is to provide a more powerful and script-friendly way to retrieve Jenkins node information from the command line, supporting use cases like infrastructure monitoring, automation, and troubleshooting. The command works with both the controller and agent nodes and includes fine-grained filtering options and permission-sensitive output formats.

The CLI command supports the following options:

Filtering options:
- `-status <ONLINE|OFFLINE|ALL>`: Filter nodes by their online/offline status.

- `-labels <label1,label2,...>`: Filter by comma-separated labels (case-insensitive).

- `-labels-mode <ANY|ALL>`: Choose whether any or all specified labels must match.

- `-min-executors <N>`: Only include nodes with at least N executors.

- `-exclude-controller`: Exclude the built-in controller (master) node.

- `-limit <N>`: Return only up to N nodes.

Output options:
- `-format <PLAIN|JSON>`: Choose between human-readable (default) and JSON output.

- `-name-only`: Show only node names (one per line).

- `-count-only`: Show only the number of matching nodes.

- `-verbose`: Display additional system and runtime details per node, such as: OS, architecture, Java version, Offline cause, Clock difference, Connection timestamp. (Requires `Computer.EXTENDED_READ` permission per node).

The output adapts based on user permissions. If `EXTENDED_READ` is missing for a node, verbose fields are replaced with "Permission Denied" for that node.

This contribution uses the existing Jenkins CLI infrastructure and follows security and formatting guidelines.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
A dedicated test class `ListNodesCommandTest` has been implemented. It provides comprehensive automated test coverage using `JenkinsRule` and `CLICommandInvoker`.

The tests include:
-   ✅ Basic listing functionality
-   ✅ Filtering by:
    -   Status (online/offline/all)
    -   Labels and label modes (ANY/ALL)
    -   Minimum executors
    -   Excluding the controller
    -   Result limits
-   ✅ Output mode tests:
    -   JSON and plain text
    -   Name-only
    -   Count-only   
-   ✅ Verbose output for both online and offline nodes
-   ✅ Permission-sensitive tests:
    -   Behavior with/without `Jenkins.READ`
    -   Behavior with/without `Computer.EXTENDED_READ` on different nodes
-   ✅ JSON structure validation and edge case handling (e.g. no matches)
-   ✅ Combination tests using multiple filters together
 
All key features and edge cases are covered and validated under automated tests.

### Proposed changelog entries

-   Add new `list-nodes` CLI command to list and filter Jenkins nodes
-   Support output customization (plain, JSON, name-only, count-only)
-   Add filtering options for node status, labels, executors, and more
-   Introduce verbose mode to display system and runtime details for each node (permission-aware)

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label developer

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [X] The Jira issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [X] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).