### PR TITLE
start introducing data-testids for test usage

### DIFF
--- a/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
+++ b/core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core">
   <a class="jenkins-button"
      data-type="header-action"
+     data-testid="login"
      href="${rootURL}/${app.securityRealm.loginUrl}?from=${app.securityRealm.from}"
      style="aspect-ratio: unset; padding: 0.5rem 1rem"
      tooltip="${%signInTooltip}">


### PR DESCRIPTION
The Header rework exposed numerous test failures due to changes in structure.   This could have been avoided if we had already been using data-testid attributes for the various things.

This starts small with the signin button.

Using "login" as the testid as this is what cloudbees had already been using in our custom header and the jelly is still loginLink

### Testing done



### Proposed changelog entries

- Add data-test-id for the login page.

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A


### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A


Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
