### PR TITLE
[JENKINS-75849] Makes scriptConsole layout configurable

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/_script.jelly
+++ b/core/src/main/resources/hudson/model/Computer/_script.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <t:scriptConsole layout="two-column">
+  <t:scriptConsole>
     <pre>println System.getenv("PATH")</pre>
     <pre>println "uname -a".execute().text</pre>
     <p>

--- a/core/src/main/resources/hudson/model/Computer/_script.jelly
+++ b/core/src/main/resources/hudson/model/Computer/_script.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <t:scriptConsole>
+  <t:scriptConsole layout="two-column">
     <pre>println System.getenv("PATH")</pre>
     <pre>println "uname -a".execute().text</pre>
     <p>

--- a/core/src/main/resources/jenkins/model/Jenkins/_script.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_script.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <t:scriptConsole>
+  <t:scriptConsole layout="one-column">
     <pre>println(Jenkins.instance.pluginManager.plugins)</pre>
   </t:scriptConsole>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -31,12 +31,13 @@ THE SOFTWARE.
     <st:attribute name="layout" use="optional">
       Specify which layout to be use for the page.
       See the type in layout for more details.
-      By default, it is `one-column`.
+      By default, it is `two-column`.
     </st:attribute>
   </st:documentation>
 
-  <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="${attrs.layout != null ? attrs.layout : 'one-column'}">
-    <j:if test="${attrs.layout == 'two-column'}">
+  <j:set var="layout" value="${attrs.layout != null ? attrs.layout : 'two-columns'}" />
+  <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="${layout}">
+    <j:if test="${layout == 'two-column'}">
       <st:include page="sidepanel.jelly" />
     </j:if>
 

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -27,7 +27,18 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-  <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="one-column">
+  <st:documentation>
+    <st:attribute name="layout" use="optional">
+      Specify which layout to be use for the page.
+      See the type in layout for more details.
+      By default, it is `one-column`.
+    </st:attribute>
+  </st:documentation>
+
+  <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="${attrs.layout != null ? attrs.layout : 'one-column'}">
+    <j:if test="${attrs.layout == 'two-column'}">
+      <st:include page="sidepanel.jelly" />
+    </j:if>
 
     <l:breadcrumb title="${%scriptConsole}"/>
     <l:main-panel>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
-  <j:set var="layout" value="${attrs.layout != null ? attrs.layout : 'two-columns'}" />
+  <j:set var="layout" value="${attrs.layout != null ? attrs.layout : 'two-column'}" />
   <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="${layout}">
     <j:if test="${layout == 'two-column'}">
       <st:include page="sidepanel.jelly" />


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-75849](https://issues.jenkins.io/browse/JENKINS-75849).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

When we redesigned the header, we set the `scriptConsole` to always be using the `one-column` layout.
This may be fine with the script console in Jenkins Core, this can be problematic when plugins are using it.

This is trying to overcome this change by providing a way for plugins to set which layout to be used.
By default, it's reverting to two column and include the sidepanel, but the one column layout can be selected.

### Testing done

Connecting an agent to the controller, you can access its script console: it is using two column layout and includes the sidepanel.
The system script console however is using the one column layout.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Makes script console layout configurable

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @janfaracik 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
