### PR TITLE
Backporting for LTS 2.516.1 (part 1)

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/_script.jelly
+++ b/core/src/main/resources/hudson/model/Computer/_script.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <t:scriptConsole layout="two-column">
+  <t:scriptConsole>
     <pre>println System.getenv("PATH")</pre>
     <pre>println "uname -a".execute().text</pre>
     <p>

--- a/core/src/main/resources/hudson/model/Computer/_script.jelly
+++ b/core/src/main/resources/hudson/model/Computer/_script.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <t:scriptConsole>
+  <t:scriptConsole layout="two-column">
     <pre>println System.getenv("PATH")</pre>
     <pre>println "uname -a".execute().text</pre>
     <p>

--- a/core/src/main/resources/jenkins/model/Jenkins/_script.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_script.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <t:scriptConsole>
+  <t:scriptConsole layout="one-column">
     <pre>println(Jenkins.instance.pluginManager.plugins)</pre>
   </t:scriptConsole>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -31,12 +31,13 @@ THE SOFTWARE.
     <st:attribute name="layout" use="optional">
       Specify which layout to be use for the page.
       See the type in layout for more details.
-      By default, it is `one-column`.
+      By default, it is `two-column`.
     </st:attribute>
   </st:documentation>
 
-  <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="${attrs.layout != null ? attrs.layout : 'one-column'}">
-    <j:if test="${attrs.layout == 'two-column'}">
+  <j:set var="layout" value="${attrs.layout != null ? attrs.layout : 'two-columns'}" />
+  <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="${layout}">
+    <j:if test="${layout == 'two-column'}">
       <st:include page="sidepanel.jelly" />
     </j:if>
 

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -27,7 +27,18 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-  <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="one-column">
+  <st:documentation>
+    <st:attribute name="layout" use="optional">
+      Specify which layout to be use for the page.
+      See the type in layout for more details.
+      By default, it is `one-column`.
+    </st:attribute>
+  </st:documentation>
+
+  <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="${attrs.layout != null ? attrs.layout : 'one-column'}">
+    <j:if test="${attrs.layout == 'two-column'}">
+      <st:include page="sidepanel.jelly" />
+    </j:if>
 
     <l:breadcrumb title="${%scriptConsole}"/>
     <l:main-panel>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
-  <j:set var="layout" value="${attrs.layout != null ? attrs.layout : 'two-columns'}" />
+  <j:set var="layout" value="${attrs.layout != null ? attrs.layout : 'two-column'}" />
   <l:layout permission="${app.ADMINISTER}" title="${%scriptConsole}" type="${layout}">
     <j:if test="${layout == 'two-column'}">
       <st:include page="sidepanel.jelly" />

--- a/core/src/main/resources/lib/layout/dropdowns/item.jelly
+++ b/core/src/main/resources/lib/layout/dropdowns/item.jelly
@@ -40,17 +40,32 @@ THE SOFTWARE.
         <st:attribute name="clazz">
             Optional class for the menu item
         </st:attribute>
+        <st:attribute name="badge">
+            Optional jenkins.management.Badge to also show in the item
+        </st:attribute>
     </st:documentation>
 
     <j:set var="icon">
         <l:icon src="${attrs.icon}" />
     </j:set>
 
-    <template data-dropdown-type="ITEM"
-              data-dropdown-id="${attrs.id}"
-              data-dropdown-icon="${icon}"
-              data-dropdown-text="${attrs.text}"
-              data-dropdown-href="${attrs.href}"
-              data-dropdown-clazz="${attrs.clazz}"
-    />
+    <j:if test="${action.badge == null}">
+        <template data-dropdown-type="ITEM"
+                  data-dropdown-id="${attrs.id}"
+                  data-dropdown-icon="${icon}"
+                  data-dropdown-text="${attrs.text}"
+                  data-dropdown-href="${attrs.href}"
+                  data-dropdown-clazz="${attrs.clazz}"/>
+    </j:if>
+    <j:if test="${action.badge != null}">
+        <template data-dropdown-type="ITEM"
+                  data-dropdown-id="${attrs.id}"
+                  data-dropdown-icon="${icon}"
+                  data-dropdown-text="${attrs.text}"
+                  data-dropdown-href="${attrs.href}"
+                  data-dropdown-clazz="${attrs.clazz}"
+                  data-dropdown-badge-text="${attrs.badge.text}"
+                  data-dropdown-badge-tooltip="${attrs.badge.tooltip}"
+                  data-dropdown-badge-severity="${attrs.badge.severity}"/>
+    </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/header/actions.jelly
+++ b/core/src/main/resources/lib/layout/header/actions.jelly
@@ -20,17 +20,47 @@
 
     <!--  we only want the hamburger menu if there is something to display -->
     <!--  render all non primary non current actions -->
+    <j:set var="hamburgerHasBadgeWithSeverityError" value="false" />
+    <j:set var="hamburgerHasBadgeWithSeverityWarning" value="false" />
+    <j:set var="hamburgerHasBadgeWithSeverityInfo" value="false" />
     <j:set var="hamburgerEntries">
       <j:forEach var="action" items="${allActions}">
         <j:set var="isCurrent" value="${h.hyperlinkMatchesCurrentPage(action.urlName)}" />
         <j:set var="isPrimary" value="${h.showInPrimaryHeader(action)}"/>
         <j:if test="${!isCurrent and !isPrimary}">
           <h:secondaryAction action="${action}"/>
+          <j:set var="currentBadge" value="${action.badge}"/>
+          <j:if test="${currentBadge != null}">
+            <j:choose>
+              <j:when test="${currentBadge.severity == 'danger'}">
+                <j:set var="hamburgerHasBadgeWithSeverityError" value="true" />
+              </j:when>
+              <j:when test="${currentBadge.severity == 'warning'}">
+                <j:set var="hamburgerHasBadgeWithSeverityWarning" value="true" />
+              </j:when>
+              <j:otherwise>
+                <j:set var="hamburgerHasBadgeWithSeverityInfo" value="true" />
+              </j:otherwise>
+            </j:choose>
+          </j:if>
         </j:if>
       </j:forEach>
     </j:set>
     <j:if test="${hamburgerEntries.length() gt 0}">
-      <l:overflowButton icon="symbol-menu-hamburger" id="header-more-actions" clazz="jenkins-button--tertiary">
+      <j:set var="hamburgerBadge">
+        <j:choose>
+          <j:when test="${hamburgerHasBadgeWithSeverityError}">
+            <span class="jenkins-badge jenkins-!-danger-color" />
+          </j:when>
+          <j:when test="${hamburgerHasBadgeWithSeverityWarning}">
+            <span class="jenkins-badge jenkins-!-warning-color" />
+          </j:when>
+          <j:when test="${hamburgerHasBadgeWithSeverityInfo}">
+            <span class="jenkins-badge jenkins-!-info-color" />
+          </j:when>
+        </j:choose>
+      </j:set>
+      <l:overflowButton icon="symbol-menu-hamburger" id="header-more-actions" html="${hamburgerBadge}" clazz="jenkins-button--tertiary">
         <j:out value="${hamburgerEntries}" />
       </l:overflowButton>
     </j:if>

--- a/core/src/main/resources/lib/layout/header/actions.jelly
+++ b/core/src/main/resources/lib/layout/header/actions.jelly
@@ -30,7 +30,7 @@
       </j:forEach>
     </j:set>
     <j:if test="${hamburgerEntries.length() gt 0}">
-      <l:overflowButton icon="symbol-menu-hamburger" id="header-more-actions">
+      <l:overflowButton icon="symbol-menu-hamburger" id="header-more-actions" clazz="jenkins-button--tertiary">
         <j:out value="${hamburgerEntries}" />
       </l:overflowButton>
     </j:if>

--- a/core/src/main/resources/lib/layout/header/secondaryAction.jelly
+++ b/core/src/main/resources/lib/layout/header/secondaryAction.jelly
@@ -22,13 +22,11 @@
     <j:otherwise>
       <j:set var="icon" value="${action.iconClassName != null ? action.iconClassName : action.iconFileName}"/>
       <j:if test="${icon != null}">
-        <j:set var="badge" value="${action.badge}"/>
-        <j:set var="badgeClazz" value="${badge != null ? 'jenkins-badge jenkins-!-${badge.severity}-color' : ''}"/>      
 
         <dd:item icon="${action.iconClassName != null ? action.iconClassName : action.iconFileName}"
                  text="${action.displayName}"
                  href="${h.getActionUrl(app.url, action)}"
-                 clazz="${badgeClazz}">
+                 badge="${action.badge}">
         </dd:item>
       </j:if>
     </j:otherwise>

--- a/core/src/main/resources/lib/layout/overflowButton.jelly
+++ b/core/src/main/resources/lib/layout/overflowButton.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
       Optional text to be displayed on the button
     </st:attribute>
     <st:attribute name="html">
-      Optional html to be displayed on the button (only used it text is null)
+      Optional html to be displayed on the button (only used if 'text' is not provided)
     </st:attribute>
 
     <st:attribute name="tooltip">

--- a/core/src/main/resources/lib/layout/overflowButton.jelly
+++ b/core/src/main/resources/lib/layout/overflowButton.jelly
@@ -31,6 +31,10 @@ THE SOFTWARE.
     <st:attribute name="text">
       Optional text to be displayed on the button
     </st:attribute>
+    <st:attribute name="html">
+      Optional html to be displayed on the button (only used it text is null)
+    </st:attribute>
+
     <st:attribute name="tooltip">
       Optional tooltip of the button, defaults to 'More actions'
     </st:attribute>
@@ -62,8 +66,14 @@ THE SOFTWARE.
         </div>
       </j:otherwise>
     </j:choose>
-
-    ${attrs.text}
+    <j:choose>
+      <j:when test="${attrs.text != null}">
+        ${attrs.text}
+      </j:when>
+      <j:when test="${attrs.html != null}">
+        <j:out value="${attrs.html}" />
+      </j:when>
+    </j:choose>
   </button>
   <template>
     <div class="jenkins-dropdown">

--- a/core/src/main/resources/lib/layout/task.jelly
+++ b/core/src/main/resources/lib/layout/task.jelly
@@ -253,7 +253,7 @@ THE SOFTWARE.
             <dd:item icon="${action.iconClassName != null ? action.iconClassName : action.iconFileName}"
                      text="${action.displayName}"
                      href="${href}"
-                     clazz="${badgeClazz}">
+                     badge="${action.badge}">
             </dd:item>
           </j:otherwise>
         </j:choose>

--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -36,6 +36,15 @@ function dropdown() {
     animation: "dropdown",
     duration: 250,
     onShow: (instance) => {
+      // Make sure only one instance is visible at all times
+      const dropdowns = document.querySelectorAll("[data-tippy-root]");
+        Array.from(dropdowns).forEach(element=>{
+          // Check if the Tippy.js instance exists
+          if (element && element._tippy) {
+              // To just hide the dropdown
+              element._tippy.hide();
+          }
+      })
       const referenceParent = instance.reference.parentNode;
 
       if (referenceParent.classList.contains("model-link")) {

--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -38,13 +38,13 @@ function dropdown() {
     onShow: (instance) => {
       // Make sure only one instance is visible at all times
       const dropdowns = document.querySelectorAll("[data-tippy-root]");
-        Array.from(dropdowns).forEach(element=>{
-          // Check if the Tippy.js instance exists
-          if (element && element._tippy) {
-              // To just hide the dropdown
-              element._tippy.hide();
-          }
-      })
+      Array.from(dropdowns).forEach((element) => {
+        // Check if the Tippy.js instance exists
+        if (element && element._tippy) {
+          // To just hide the dropdown
+          element._tippy.hide();
+        }
+      });
       const referenceParent = instance.reference.parentNode;
 
       if (referenceParent.classList.contains("model-link")) {

--- a/src/main/js/components/dropdowns/utils.js
+++ b/src/main/js/components/dropdowns/utils.js
@@ -220,6 +220,13 @@ function convertHtmlToItems(children) {
         } else {
           item.type = "button";
         }
+        if (attributes.dropdownBadgeSeverity) {
+          item.badge = {
+            text: attributes.dropdownBadgeText,
+            tooltip: attributes.dropdownBadgeTooltip,
+            severity: attributes.dropdownBadgeSeverity,
+          };
+        }
 
         items.push(item);
         break;

--- a/src/main/js/components/header/index.js
+++ b/src/main/js/components/header/index.js
@@ -13,6 +13,10 @@ function init() {
     }
   });
 
+  window.addEventListener("computeOverflow", () => {
+    computeOverflow();
+  });
+
   // Fade in the page header on scroll, increasing opacity and intensity of the backdrop blur
   window.addEventListener("scroll", () => {
     const navigation = document.querySelector("#page-header");

--- a/src/main/js/components/header/index.js
+++ b/src/main/js/components/header/index.js
@@ -13,7 +13,7 @@ function init() {
     }
   });
 
-  window.addEventListener("computeOverflow", () => {
+  window.addEventListener("computeHeaderOverflow", () => {
     computeOverflow();
   });
 


### PR DESCRIPTION
## Backporting for LTS 2.516.1 (part 1)

See 

* [JENKINS-75818](https://issues.jenkins.io/browse/JENKINS-75818) - add event listener to trigger compute
  * https://github.com/jenkinsci/jenkins/pull/10772
* [JENKINS-75834](https://issues.jenkins.io/browse/JENKINS-75834) - make sure only one instance of the dropdown is visible
  * https://github.com/jenkinsci/jenkins/pull/10786
* [JENKINS-75853](https://issues.jenkins.io/browse/JENKINS-75853) - Remove active look of hamburger button
  * https://github.com/jenkinsci/jenkins/pull/10804
* [JENKINS-758532](https://issues.jenkins.io/browse/JENKINS-75832) - actions in the hamburger menu with badges do not render correctly
  * https://github.com/jenkinsci/jenkins/pull/10791
* [JENKINS-758549](https://issues.jenkins.io/browse/JENKINS-75849) - script console can be used with sidepanel
  * https://github.com/jenkinsci/jenkins/pull/10800

```
JENKINS-75818           Minor                   2.517
        In case custom plugins add items to the breadcrumb the initial rendering is not collapsing the path
        https://issues.jenkins.io/browse/JENKINS-75818

JENKINS-75834           Major                   2.518
        Dropdown can produce multiples dropdowns visible
        https://issues.jenkins.io/browse/JENKINS-75834

JENKINS-75853           Minor                   2.518
        Secondary actions in header look focused
        https://issues.jenkins.io/browse/JENKINS-75853

JENKINS-75832           Major                   2.518
        actions in the hamburger menu with badges do not render correctly
        https://issues.jenkins.io/browse/JENKINS-75832

JENKINS-75849           Major                   2.518
        script console can be used with sidepanel
        https://issues.jenkins.io/browse/JENKINS-75849
```

### Testing done

Confirmed each of the individual commits in the pull request matches the original commit on the master branch.

Ran a `quick-build` and confirmed that the active look of hamburger button was resolved.

### Proposed changelog entries

N/A

### Proposed changelog category

/label into-lts

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
