### PR TITLE
Reduce test flakiness

### DIFF
--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -138,7 +138,7 @@ $semantics: (
   --jenkins-border--subtle-shadow: 0 0 0 var(--jenkins-border-width)
     var(--jenkins-border-color--subtle);
 
-  @media (resolution <= 1x) {
+  @media (resolution <= 1dppx) {
     --jenkins-border-width: 2px;
   }
 

--- a/test/src/test/java/hudson/cli/ComputerStateTest.java
+++ b/test/src/test/java/hudson/cli/ComputerStateTest.java
@@ -154,6 +154,9 @@ class ComputerStateTest {
 
         slave.toComputer().disconnect(null);
 
+        // Test fails sometimes because agent is not yet disconnected
+        // Wait 1 second for disconnect to complete
+        Thread.sleep(1009);
         HtmlPage page = wc.getPage(slave);
 
         assertLinkDoesNotExist(page, "Disconnect");

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -462,6 +462,13 @@ public class QueueTest {
         p.setAssignedLabel(label);
         p.scheduleBuild2(0);
 
+        // Wait 3 seconds if job is not already in the queue, reduce test flakes
+        if (!p.isInQueue()) {
+            Thread.sleep(3000);
+        }
+
+        assertTrue(p.isInQueue(), "Build not queued");
+
         JenkinsRule.WebClient webclient = r.createWebClient();
 
         XmlPage queueItems = webclient.goToXml("queue/api/xml");

--- a/test/src/test/java/hudson/model/RunTest.java
+++ b/test/src/test/java/hudson/model/RunTest.java
@@ -196,6 +196,9 @@ class RunTest  {
 
         // keeping the minimum to validate it's working and it's not exploitable as there are some modifications
         // like adding double quotes
+        // Some test flakes due to JavaScript objects not yet available
+        // Wait 2 seconds before checking the assertion
+        Thread.sleep(2003);
         ensureXssIsPrevented(up, "Down", "<img");
     }
 


### PR DESCRIPTION
## Reduce test flakiness

[Launchable](https://app.launchableinc.com/organizations/jenkins/workspaces/jenkins/data/test-paths/class%3Dhudson.model.QueueTest%23%23%23testcase%3DinQueueTaskLookupByAPI?dateFilter=90d) reports that inQueueTaskLookupByAPI has been flaky in the past 90 days.  The flakiness seems to be specific to Windows and seems to be related to the job not being in the queue quickly enough after the call to schedule the build.

If the job is not queued, sleep for 3 seconds to allow it time to queue.

Since the first test run showed another flaky test, I added a Thread.sleep() to that flaky test, along with an explanation of the details. Refer to https://github.com/jenkinsci/jenkins/commit/d5a6e2c2b4d98482ef7421f7f057d2eed378a058 for the details.

The SCSS media query was causing HTMLUnit to report a warning that `1x` is not the right unit of measure for the media query. https://developer.mozilla.org/en-US/docs/Web/CSS/resolution says that x is an alias for dppx so I replaced 1x with 1dppx in the one place where it occurs. The HTMLUnit warning no longer appears.

Detected while processing the 2.516.1 backporting pull request:

* https://github.com/jenkinsci/jenkins/pull/10808

### Testing done

Confirmed that the job queues consistently on my Linux computer, so the sleep statement is not executed.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog
/label internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
