### PR TITLE
Allow up to 15 seconds for agent reconnect

### DIFF
--- a/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
+++ b/test/src/test/java/hudson/node_monitors/ResponseTimeMonitorTest.java
@@ -51,7 +51,7 @@ public class ResponseTimeMonitorTest {
         assertNull(ResponseTimeMonitor.DESCRIPTOR.monitor(c));
 
         // Retry to compensate for test being flaky in CI
-        await().atMost(5, TimeUnit.SECONDS)
+        await().atMost(15, TimeUnit.SECONDS)
             .ignoreException(ExecutionException.class)
             .until(() -> {
                 // Now reconnect and make sure we get a non-null response.


### PR DESCRIPTION
## Allow up to 15 seconds for agent reconnect

Increase duration of retries from 5 seconds to 15 seconds for the skipOfflineAgent test.  Windows systems on AWS ci.jenkins.io seem to run this test more slowly than the Windows systems on Azure ci.jenkins.io.

The test has shown intermittent failures since Monday, including failures on the master branch and on at least one pull request branch.

### Testing done

Confirmed the test passes locally after the changes.  Rely on ci.jenkins.io to confirm it passes reliably on Windows.

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog
/label internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
