### PR TITLE
Revert "[JENKINS-75834] make sure only one instance of the dropdown is visible"

### DIFF
--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -38,13 +38,13 @@ function dropdown() {
     onShow: (instance) => {
       // Make sure only one instance is visible at all times
       const dropdowns = document.querySelectorAll("[data-tippy-root]");
-      Array.from(dropdowns).forEach((element) => {
-        // Check if the Tippy.js instance exists
-        if (element && element._tippy) {
-          // To just hide the dropdown
-          element._tippy.hide();
-        }
-      });
+        Array.from(dropdowns).forEach(element=>{
+          // Check if the Tippy.js instance exists
+          if (element && element._tippy) {
+              // To just hide the dropdown
+              element._tippy.hide();
+          }
+      })
       const referenceParent = instance.reference.parentNode;
 
       if (referenceParent.classList.contains("model-link")) {

--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -36,15 +36,6 @@ function dropdown() {
     animation: "dropdown",
     duration: 250,
     onShow: (instance) => {
-      // Make sure only one instance is visible at all times
-      const dropdowns = document.querySelectorAll("[data-tippy-root]");
-        Array.from(dropdowns).forEach(element=>{
-          // Check if the Tippy.js instance exists
-          if (element && element._tippy) {
-              // To just hide the dropdown
-              element._tippy.hide();
-          }
-      })
       const referenceParent = instance.reference.parentNode;
 
       if (referenceParent.classList.contains("model-link")) {


### PR DESCRIPTION
## Revert "[JENKINS-75834] make sure only one instance of the dropdown is visible"

Revert "[JENKINS-75834] make sure only one instance of the dropdown is visible"

Change causes test failures in the acceptance test harness.  Pull request that shows the test failures is:

* https://github.com/jenkinsci/jenkins/pull/10786

Originally merged from pull request:

* https://github.com/jenkinsci/jenkins/pull/10786

### Testing done

Confirmed that quick-build passes.  Basil confirmed that the revert of the pull request fixed the acceptance test harness failure.

### Proposed changelog entries

- Revert change that limited dropdown visibility.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
