### PR TITLE
[JENKINS-26091] `Addressable` and `AddressableModelObject` interfaces

### DIFF
--- a/core/src/main/java/hudson/model/AbstractCIBase.java
+++ b/core/src/main/java/hudson/model/AbstractCIBase.java
@@ -73,6 +73,7 @@ public abstract class AbstractCIBase extends Node implements ItemGroup<TopLevelI
      *      Why are you calling a method that always returns ""?
     *       You probably want to call {@link Jenkins#getRootUrl()}
      */
+    @NonNull
     @Override
     @Deprecated
     public String getUrl() {

--- a/core/src/main/java/hudson/model/AbstractItem.java
+++ b/core/src/main/java/hudson/model/AbstractItem.java
@@ -530,6 +530,7 @@ public abstract class AbstractItem extends Actionable implements Loadable, Item,
     public void onCopiedFrom(Item src) {
     }
 
+    @NonNull
     @Override
     public final String getUrl() {
         // try to stick to the current view if possible

--- a/core/src/main/java/hudson/model/Actionable.java
+++ b/core/src/main/java/hudson/model/Actionable.java
@@ -51,7 +51,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * @author Kohsuke Kawaguchi
  */
 @ExportedBean
-public abstract class Actionable extends AbstractModelObject implements ModelObjectWithContextMenu {
+public abstract class Actionable extends AbstractModelObject implements ModelObject, ModelObjectWithContextMenu {
     /**
      * Actions contributed to this model object.
      *

--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
@@ -33,6 +34,7 @@ import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
 import java.io.IOException;
 import java.util.Set;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -89,7 +91,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  * @see Jenkins#administrativeMonitors
  */
 @LegacyInstancesAreScopedToHudson
-public abstract class AdministrativeMonitor extends AbstractModelObject implements ExtensionPoint, StaplerProxy {
+public abstract class AdministrativeMonitor extends AbstractModelObject implements AddressableModelObject, ExtensionPoint, StaplerProxy {
     /**
      * Human-readable ID of this monitor, which needs to be unique within the system.
      *
@@ -110,6 +112,7 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
     /**
      * Returns the URL of this monitor, relative to the context path, like "administrativeMonitor/foobar".
      */
+    @NonNull
     public String getUrl() {
         return "administrativeMonitor/" + id;
     }

--- a/core/src/main/java/hudson/model/Item.java
+++ b/core/src/main/java/hudson/model/Item.java
@@ -38,6 +38,7 @@ import hudson.security.PermissionScope;
 import hudson.util.Secret;
 import java.io.IOException;
 import java.util.Collection;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.Jenkins;
 import jenkins.search.SearchGroup;
 import jenkins.util.SystemProperties;
@@ -73,7 +74,7 @@ import org.kohsuke.stapler.StaplerRequest2;
  * @see Items
  * @see ItemVisitor
  */
-public interface Item extends PersistenceRoot, SearchableModelObject, AccessControlled, OnMaster {
+public interface Item extends AddressableModelObject, PersistenceRoot, SearchableModelObject, AccessControlled, OnMaster {
     /**
      * Gets the parent that contains this item.
      */
@@ -171,6 +172,7 @@ public interface Item extends PersistenceRoot, SearchableModelObject, AccessCont
      * @return
      *      URL that ends with '/'.
      */
+    @NonNull
     String getUrl();
 
     /**

--- a/core/src/main/java/hudson/model/ItemGroup.java
+++ b/core/src/main/java/hudson/model/ItemGroup.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import jenkins.model.AddressableModelObject;
 import org.springframework.security.access.AccessDeniedException;
 
 /**
@@ -41,7 +42,7 @@ import org.springframework.security.access.AccessDeniedException;
  * @author Kohsuke Kawaguchi
  * @see ItemGroupMixIn
  */
-public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject {
+public interface ItemGroup<T extends Item> extends PersistenceRoot, AddressableModelObject {
     /**
      * Gets the full name of this {@link ItemGroup}.
      *
@@ -85,12 +86,6 @@ public interface ItemGroup<T extends Item> extends PersistenceRoot, ModelObject 
     default Stream<T> getItemsStream(Predicate<T> pred) {
         return getItemsStream().filter(pred);
     }
-
-    /**
-     * Returns the path relative to the context root,
-     * like "foo/bar/zot/". Note no leading slash but trailing slash.
-     */
-    String getUrl();
 
     /**
      * Gets the URL token that prefixes the URLs for child {@link Item}s.

--- a/core/src/main/java/hudson/model/Label.java
+++ b/core/src/main/java/hudson/model/Label.java
@@ -67,6 +67,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.IComputer;
 import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
@@ -89,7 +90,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * @see Jenkins#getLabel(String)
  */
 @ExportedBean
-public abstract class Label extends Actionable implements Comparable<Label>, ModelObjectWithChildren {
+public abstract class Label extends Actionable implements AddressableModelObject, Comparable<Label>, ModelObjectWithChildren {
     /**
      * Display name of this label.
      */
@@ -149,6 +150,7 @@ public abstract class Label extends Actionable implements Comparable<Label>, Mod
     /**
      * Relative URL from the context path, that ends with '/'.
      */
+    @NonNull
     public String getUrl() {
         return "label/" + Util.rawEncode(name) + '/';
     }

--- a/core/src/main/java/hudson/model/ModelObject.java
+++ b/core/src/main/java/hudson/model/ModelObject.java
@@ -27,11 +27,9 @@ package hudson.model;
 import jenkins.security.stapler.StaplerAccessibleType;
 
 /**
- * A model object has a human readable name.
+ * A model object has a human-readable name.
  *
- * And it normally has URL, but this interface doesn't define one.
- * (Since there're so many classes that define the {@code getUrl} method
- * we should have such one.)
+ * If it has a URL, it should implement directly {@link jenkins.model.AddressableModelObject} instead.
  *
  * @author Kohsuke Kawaguchi
  */

--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -152,6 +152,7 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
     }
 
     ///// ViewGroup methods /////
+    @NonNull
     @Override
     public String getUrl() {
         return user.getUrl() + "/my-views/";

--- a/core/src/main/java/hudson/model/PageDecorator.java
+++ b/core/src/main/java/hudson/model/PageDecorator.java
@@ -24,11 +24,13 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.util.DescriptorList;
 import java.util.List;
+import jenkins.model.Addressable;
 import jenkins.model.Jenkins;
 
 /**
@@ -66,7 +68,7 @@ import jenkins.model.Jenkins;
  * @author Kohsuke Kawaguchi
  * @since 1.235
  */
-public abstract class PageDecorator extends Descriptor<PageDecorator> implements ExtensionPoint, Describable<PageDecorator> {
+public abstract class PageDecorator extends Descriptor<PageDecorator> implements Addressable, ExtensionPoint, Describable<PageDecorator> {
     /**
      * @param yourClass
      *      pass-in "this.getClass()" (except that the constructor parameters cannot use 'this',
@@ -96,6 +98,7 @@ public abstract class PageDecorator extends Descriptor<PageDecorator> implements
      * Every {@link PageDecorator} is bound to URL via {@link Jenkins#getDescriptor()}.
      * This method returns such an URL.
      */
+    @NonNull
     public final String getUrl() {
         return "descriptor/" + clazz.getName();
     }

--- a/core/src/main/java/hudson/model/Queue.java
+++ b/core/src/main/java/hudson/model/Queue.java
@@ -109,6 +109,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import jenkins.console.WithConsoleUrl;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.Jenkins;
 import jenkins.model.queue.AsynchronousExecution;
 import jenkins.model.queue.CompositeCauseOfBlockage;
@@ -1882,7 +1883,7 @@ public class Queue extends ResourceController implements Saveable {
      * design, a {@link Task} must have at least one sub-task.)
      * Most of the time, the primary subtask is the only sub task.
      */
-    public interface Task extends ModelObject, SubTask {
+    public interface Task extends AddressableModelObject, SubTask {
         /**
          * Returns true if the execution should be blocked
          * for temporary reasons.
@@ -1969,6 +1970,7 @@ public class Queue extends ResourceController implements Saveable {
          * @return
          *      URL that ends with '/'.
          */
+        @NonNull
         @Override
         String getUrl();
 
@@ -2316,6 +2318,7 @@ public class Queue extends ResourceController implements Saveable {
          *      URL that ends with '/'.
          * @since 1.519
          */
+        @NonNull
         @Exported
         public String getUrl() {
             return "queue/item/" + id + '/';

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -111,6 +111,7 @@ import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 import jenkins.console.ConsoleUrlProvider;
 import jenkins.console.WithConsoleUrl;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.ArtifactManager;
 import jenkins.model.ArtifactManagerConfiguration;
 import jenkins.model.ArtifactManagerFactory;
@@ -165,7 +166,7 @@ import org.springframework.security.core.Authentication;
  */
 @ExportedBean
 public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, RunT>>
-        extends Actionable implements ExtensionPoint, Comparable<RunT>, AccessControlled, PersistenceRoot, DescriptorByNameOwner, OnMaster, StaplerProxy, HistoricalBuild, WithConsoleUrl {
+        extends Actionable implements ExtensionPoint, Comparable<RunT>, AddressableModelObject, AccessControlled, PersistenceRoot, DescriptorByNameOwner, OnMaster, StaplerProxy, HistoricalBuild, WithConsoleUrl {
 
     /**
      * The original {@link Queue.Item#getId()} has not yet been mapped onto the {@link Run} instance.

--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -67,6 +67,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
 import jenkins.model.Loadable;
@@ -119,7 +120,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
  * @author Kohsuke Kawaguchi
  */
 @ExportedBean
-public class User extends AbstractModelObject implements AccessControlled, DescriptorByNameOwner, Loadable, Saveable, Comparable<User>, ModelObjectWithContextMenu, StaplerProxy {
+public class User extends AbstractModelObject implements AddressableModelObject, AccessControlled, DescriptorByNameOwner, Loadable, Saveable, Comparable<User>, ModelObjectWithContextMenu, StaplerProxy {
 
     public static final XStream2 XSTREAM = new XStream2();
     private static final Logger LOGGER = Logger.getLogger(User.class.getName());

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -89,6 +89,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ModelObjectWithContextMenu;
@@ -144,7 +145,7 @@ import org.xml.sax.SAXException;
  * @see ViewGroup
  */
 @ExportedBean
-public abstract class View extends AbstractModelObject implements AccessControlled, Describable<View>, ExtensionPoint, Saveable, ModelObjectWithChildren, DescriptorByNameOwner, HasWidgets {
+public abstract class View extends AbstractModelObject implements AccessControlled, AddressableModelObject, Describable<View>, ExtensionPoint, Saveable, ModelObjectWithChildren, DescriptorByNameOwner, HasWidgets {
 
     /**
      * Container of this view. Set right after the construction
@@ -542,6 +543,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      * Doesn't start with '/' but ends with '/' (except returns
      * empty string when this is the default view).
      */
+    @NonNull
     public String getUrl() {
         return isDefault() ? (owner != null ? owner.getUrl() : "") : getViewUrl();
     }

--- a/core/src/main/java/hudson/model/ViewGroup.java
+++ b/core/src/main/java/hudson/model/ViewGroup.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.Jenkins;
 import jenkins.views.ViewsTabBarUserProperty;
 
@@ -41,7 +42,7 @@ import jenkins.views.ViewsTabBarUserProperty;
  * @author Kohsuke Kawaguchi
  * @since 1.269
  */
-public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
+public interface ViewGroup extends Saveable, AddressableModelObject, AccessControlled {
     /**
      * Determine whether a view may be deleted.
      * @since 1.365
@@ -101,12 +102,6 @@ public interface ViewGroup extends Saveable, ModelObject, AccessControlled {
     default View getPrimaryView() {
         return null;
     }
-
-    /**
-     * Returns the path of this group, relative to the context root,
-     * like "foo/bar/zot/". Note no leading slash but trailing slash.
-     */
-    String getUrl();
 
     /**
      * {@link View} calls this method when it's renamed.

--- a/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
+++ b/core/src/main/java/hudson/model/queue/QueueTaskFilter.java
@@ -25,6 +25,7 @@
 package hudson.model.queue;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
@@ -105,6 +106,7 @@ public abstract class QueueTaskFilter implements Queue.Task {
         return base.hasAbortPermission();
     }
 
+    @NonNull
     @Override
     public String getUrl() {
         return base.getUrl();

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.concurrent.Future;
+import jenkins.model.AddressableModelObject;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
@@ -107,7 +108,7 @@ import org.kohsuke.stapler.verb.POST;
  * @see NodeProvisioner
  * @see AbstractCloudImpl
  */
-public abstract class Cloud extends Actionable implements ExtensionPoint, Describable<Cloud>, AccessControlled {
+public abstract class Cloud extends Actionable implements AddressableModelObject, ExtensionPoint, Describable<Cloud>, AccessControlled {
 
     /**
      * Uniquely identifies this {@link Cloud} instance among other instances in {@link jenkins.model.Jenkins#clouds}.

--- a/core/src/main/java/jenkins/model/Addressable.java
+++ b/core/src/main/java/jenkins/model/Addressable.java
@@ -1,0 +1,17 @@
+package jenkins.model;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An object that can be addressed via a URL in Jenkins.
+ */
+public interface Addressable {
+
+    /**
+     * @return the URL where to reach specifically this object, relative to Jenkins URL.
+     * <p>
+     * Can be empty, otherwise it must not start with leading '/' and must end with '/'.
+     */
+    @NonNull
+    String getUrl();
+}

--- a/core/src/main/java/jenkins/model/AddressableModelObject.java
+++ b/core/src/main/java/jenkins/model/AddressableModelObject.java
@@ -1,0 +1,9 @@
+package jenkins.model;
+
+import hudson.model.ModelObject;
+
+/**
+ * A model object that can be addressed by a URL.
+ */
+public interface AddressableModelObject extends Addressable, ModelObject {
+}

--- a/core/src/main/java/jenkins/model/HistoricalBuild.java
+++ b/core/src/main/java/jenkins/model/HistoricalBuild.java
@@ -29,7 +29,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.markup.MarkupFormatter;
 import hudson.model.BallColor;
 import hudson.model.BuildBadgeAction;
-import hudson.model.ModelObject;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.Queue;

--- a/core/src/main/java/jenkins/model/HistoricalBuild.java
+++ b/core/src/main/java/jenkins/model/HistoricalBuild.java
@@ -48,20 +48,12 @@ import org.kohsuke.accmod.restrictions.Beta;
  * @since 2.477
  */
 @Restricted(Beta.class)
-public interface HistoricalBuild extends ModelObject {
+public interface HistoricalBuild extends AddressableModelObject {
 
     /**
      * @return A build number
      */
     int getNumber();
-
-    /**
-     * Returns the URL of this {@link HistoricalBuild}, relative to the context root of Jenkins.
-     *
-     * @return
-     *      String like "job/foo/32/" with trailing slash but no leading slash.
-     */
-    @NonNull String getUrl();
 
     /**
      * Returns a human-readable description which is used on the main build page.

--- a/core/src/main/java/jenkins/model/IComputer.java
+++ b/core/src/main/java/jenkins/model/IComputer.java
@@ -45,7 +45,7 @@ import org.kohsuke.accmod.restrictions.Beta;
  * @since 2.480
  */
 @Restricted(Beta.class)
-public interface IComputer extends AccessControlled, IconSpec {
+public interface IComputer extends AccessControlled, AddressableModelObject, IconSpec {
     /**
      * Returns {@link Node#getNodeName() the name of the node}.
      */
@@ -65,12 +65,6 @@ public interface IComputer extends AccessControlled, IconSpec {
     boolean isOffline();
 
     /**
-     * @return the node name for UI purposes.
-     */
-    @NonNull
-    String getDisplayName();
-
-    /**
      * Returns {@code true} if the computer is accepting tasks. Needed to allow agents programmatic suspension of task
      * scheduling that does not overlap with being offline.
      *
@@ -79,12 +73,6 @@ public interface IComputer extends AccessControlled, IconSpec {
      * @see hudson.model.Node#isAcceptingTasks()
      */
     boolean isAcceptingTasks();
-
-    /**
-     * @return the URL where to reach specifically this computer, relative to Jenkins URL.
-     */
-    @NonNull
-    String getUrl();
 
     /**
      * @return {@code true} if this computer has a defined offline cause, @{code false} otherwise.

--- a/core/src/main/java/jenkins/model/IDisplayExecutor.java
+++ b/core/src/main/java/jenkins/model/IDisplayExecutor.java
@@ -34,19 +34,7 @@ import org.kohsuke.accmod.restrictions.Beta;
  * @since 2.480
  */
 @Restricted(Beta.class)
-public interface IDisplayExecutor {
-    /**
-     * @return The UI label for this executor.
-     */
-    @NonNull
-    String getDisplayName();
-
-    /**
-     * @return the URL where to reach specifically this executor, relative to Jenkins URL.
-     */
-    @NonNull
-    String getUrl();
-
+public interface IDisplayExecutor extends AddressableModelObject {
     /**
      * @return the executor this display information is for.
      */

--- a/core/src/main/java/jenkins/model/SimplePageDecorator.java
+++ b/core/src/main/java/jenkins/model/SimplePageDecorator.java
@@ -24,6 +24,7 @@
 
 package jenkins.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionPoint;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -56,7 +57,8 @@ import java.util.List;
  *
  * @since 2.128
  */
-public class SimplePageDecorator extends Descriptor<SimplePageDecorator> implements ExtensionPoint, Describable<SimplePageDecorator> {
+// TODO simply extend PageDecorator ?
+public class SimplePageDecorator extends Descriptor<SimplePageDecorator> implements ExtensionPoint, Describable<SimplePageDecorator>, Addressable {
 
     protected SimplePageDecorator()  {
         super(self());
@@ -74,6 +76,8 @@ public class SimplePageDecorator extends Descriptor<SimplePageDecorator> impleme
      * This method returns such an URL.
      */
 
+    @Override
+    @NonNull
     public final String getUrl() {
         return "descriptor/" + clazz.getName();
     }

--- a/core/src/test/java/hudson/model/MockItem.java
+++ b/core/src/test/java/hudson/model/MockItem.java
@@ -24,6 +24,7 @@
 
 package hudson.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.queue.CauseOfBlockage;
 import java.util.Collections;
 import java.util.List;
@@ -84,9 +85,10 @@ public class MockItem extends Queue.Item {
             return null;
         }
 
+        @NonNull
         @Override
         public String getUrl() {
-            return null;
+            return "";
         }
 
         @Override

--- a/core/src/test/java/hudson/model/queue/AbstractQueueTaskTest.java
+++ b/core/src/test/java/hudson/model/queue/AbstractQueueTaskTest.java
@@ -27,6 +27,7 @@ package hudson.model.queue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Queue;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -75,9 +76,10 @@ class AbstractQueueTaskTest {
             return false;
         }
 
+        @NonNull
         @Override
         public String getUrl() {
-            return null;
+            return "";
         }
 
         @Override

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -727,6 +727,7 @@ public class QueueTest {
             return true;
         }
 
+        @NonNull
         @Override public String getUrl() {
             return "test/";
         }


### PR DESCRIPTION
These new interfaces provide `getUrl` method, something that was mentioned in `ModelObject` for a long time.

I considered making `Descriptor` implement this new interface, but considering the legacy of existing implementations implementing such methods with different semantic (`JenkinsLocationConfiguration`, maybe others in plugins), I refrained from doing it.

Also considered adding it to `Actionable`. It would be natural because `Action`s implement `getUrlName` and are expected to be addressable under an `Actionable`.

Unfortunately I don't think this is doable without breaking compatibility. A new `Actionable2` could be implemented if this seems really useful.

Draft as it conflicts with #10827 which I would like to complete first.

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-26091](https://issues.jenkins.io/browse/JENKINS-26091).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Developer: objects with `getUrl` method returning the relative URL from Jenkins root now implement a consistent interface.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
