### PR TITLE
Make `CLICommand.getClientCharset` `public`

### DIFF
--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -497,7 +497,7 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
         this.encoding = encoding;
     }
 
-    protected @NonNull Charset getClientCharset() throws IOException, InterruptedException {
+    public @NonNull Charset getClientCharset() throws IOException, InterruptedException {
         if (encoding != null) {
             return encoding;
         }


### PR DESCRIPTION
Without this, you cannot run the `CLICommandInvoker` test utility from inside a controller JVM using `RealJenkinsRule`:

```
org.jvnet.hudson.test.RealJenkinsRule$StepException: Remote step in … threw an exception: java.lang.IllegalAccessError: class hudson.cli.CLICommandInvoker tried to access protected method 'java.nio.charset.Charset hudson.cli.CLICommand.getClientCharset()' (hudson.cli.CLICommandInvoker is in unnamed module of loader java.net.URLClassLoader @c4e6ff3; hudson.cli.CLICommand is in unnamed module of loader org.eclipse.jetty.ee9.webapp.WebAppClassLoader @563e4951)
	at org.jvnet.hudson.test.RealJenkinsRule.runRemotely(RealJenkinsRule.java:1295)
	at org.jvnet.hudson.test.RealJenkinsRule.runRemotely(RealJenkinsRule.java:1254)
	at org.jvnet.hudson.test.RealJenkinsRule.runRemotely(RealJenkinsRule.java:1351)
	at …
Caused by: java.lang.IllegalAccessError: class hudson.cli.CLICommandInvoker tried to access protected method 'java.nio.charset.Charset hudson.cli.CLICommand.getClientCharset()' (hudson.cli.CLICommandInvoker is in unnamed module of loader java.net.URLClassLoader @c4e6ff3; hudson.cli.CLICommand is in unnamed module of loader org.eclipse.jetty.ee9.webapp.WebAppClassLoader @563e4951)
	at hudson.cli.CLICommandInvoker.invoke(CLICommandInvoker.java:148)
	at …
	at org.jvnet.hudson.test.RealJenkinsRule$Endpoint.lambda$doStep$0(RealJenkinsRule.java:1645)
	at …
```

### Testing done

Allows a test in CloudBees CI to run which otherwise failed with the error above.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
