### PR TITLE
Add support for archiving empty directories in TarArchiver

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -46,7 +46,6 @@ import hudson.util.FormValidation;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
-import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -237,7 +236,9 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
     public boolean isFollowSymlinks() {
         return followSymlinks;
     }
+
     public boolean isIncludeEmptyDirs() { return includeEmptyDirs; }
+
     @DataBoundSetter public final void setFollowSymlinks(boolean followSymlinks) {
         this.followSymlinks = followSymlinks;
     }

--- a/core/src/main/java/hudson/util/DirScanner.java
+++ b/core/src/main/java/hudson/util/DirScanner.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;

--- a/core/src/main/java/hudson/util/DirScanner.java
+++ b/core/src/main/java/hudson/util/DirScanner.java
@@ -10,7 +10,10 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.OpenOption;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
@@ -141,12 +144,28 @@ public abstract class DirScanner implements Serializable {
             fs.setDefaultexcludes(useDefaultExcludes);
 
             if (dir.exists()) {
+                Set<String> allPaths = new TreeSet<>();
+
                 DirectoryScanner ds = fs.getDirectoryScanner(new Project());
-                for (String f : ds.getIncludedFiles()) {
-                    File file = new File(dir, f);
-                    scanSingle(file, f, visitor);
+                for (String d : ds.getIncludedDirectories()) {
+                    if (!d.isEmpty()) allPaths.add(d);
                 }
+
+                allPaths.addAll(List.of(ds.getIncludedFiles()));
+
+                for (String path : allPaths) {
+                    File file = new File(dir, path);
+
+                    // skip non-empty dirs
+                    String [] contents = file.list();
+                    if (contents != null && contents.length > 0) continue;
+
+                    scanSingle(file, path, visitor);
+                }
+
+
             }
+
         }
 
         private static final long serialVersionUID = 1L;

--- a/core/src/main/java/hudson/util/DirScanner.java
+++ b/core/src/main/java/hudson/util/DirScanner.java
@@ -154,11 +154,6 @@ public abstract class DirScanner implements Serializable {
 
                 for (String path : allPaths) {
                     File file = new File(dir, path);
-
-                    // skip non-empty dirs
-                    String [] contents = file.list();
-                    if (contents != null && contents.length > 0) continue;
-
                     scanSingle(file, path, visitor);
                 }
 

--- a/core/src/main/java/jenkins/util/VirtualFile.java
+++ b/core/src/main/java/jenkins/util/VirtualFile.java
@@ -327,9 +327,8 @@ public abstract class VirtualFile implements Comparable<VirtualFile>, Serializab
 
         private static void collectFiles(VirtualFile d, Collection<String> names, String prefix) throws IOException {
             for (VirtualFile child : d.list()) {
-                if (child.isFile()) {
-                    names.add(prefix + child.getName());
-                } else if (child.isDirectory()) {
+                names.add(prefix + child.getName());
+                if (child.isDirectory()) {
                     collectFiles(child, names, prefix + child.getName() + "/");
                 }
             }

--- a/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
+++ b/core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
@@ -49,6 +49,9 @@ THE SOFTWARE.
     <f:entry field="followSymlinks" >
       <f:checkbox title="${%followSymlinks}" default="false"/>
     </f:entry>
+    <f:entry title="Include empty directories" field="includeEmptyDirs">
+        <f:checkbox />
+    </f:entry>
   </f:advanced>
 </j:jelly>
 

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -877,7 +877,7 @@ class FilePathTest {
         // Compress archive
         final FilePath tmpDirPath = new FilePath(srcFolder);
         int tarred = tmpDirPath.tar(Files.newOutputStream(archive.toPath()), "**");
-        assertEquals(3, tarred, "One file should have been compressed");
+        assertEquals(4, tarred, "One file should have been compressed");
 
         // Decompress
         final File dstFolder = newFolder(temp, "dst");

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -139,16 +139,16 @@ class VirtualFileTest {
             System.err.println("testing " + vf.getClass().getName());
             assertEquals("[.hg/config.txt, sub/mid.txt, sub/subsub/lowest.txt, top.txt]", new TreeSet<>(vf.list("**/*.txt", null, false)).toString());
             assertEquals("[sub/mid.txt, sub/subsub/lowest.txt, top.txt]", new TreeSet<>(vf.list("**/*.txt", null, true)).toString());
-            assertEquals("[.hg/config.txt, sub/mid.txt, sub/subsub/lowest.txt, top.txt, very/deep/path/here]", new TreeSet<>(vf.list("**", null, false)).toString());
+            assertEquals("[.hg, .hg/config.txt, sub, sub/mid.txt, sub/subsub, sub/subsub/lowest.txt, top.txt, very, very/deep, very/deep/path, very/deep/path/here]", new TreeSet<>(vf.list("**", null, false)).toString());
             assertEquals("[]", new TreeSet<>(vf.list("", null, false)).toString());
-            assertEquals("[sub/mid.txt, sub/subsub/lowest.txt]", new TreeSet<>(vf.list("sub/", null, false)).toString());
-            assertEquals("[sub/mid.txt]", new TreeSet<>(vf.list("sub/", "sub/subsub/", false)).toString());
-            assertEquals("[sub/mid.txt]", new TreeSet<>(vf.list("sub/", "sub/subsub/**", false)).toString());
-            assertEquals("[sub/mid.txt]", new TreeSet<>(vf.list("sub/", "**/subsub/", false)).toString());
+            assertEquals("[sub, sub/mid.txt, sub/subsub, sub/subsub/lowest.txt]", new TreeSet<>(vf.list("sub/", null, false)).toString());
+            assertEquals("[sub, sub/mid.txt]", new TreeSet<>(vf.list("sub/", "sub/subsub/", false)).toString());
+            assertEquals("[sub, sub/mid.txt]", new TreeSet<>(vf.list("sub/", "sub/subsub/**", false)).toString());
+            assertEquals("[sub, sub/mid.txt]", new TreeSet<>(vf.list("sub/", "**/subsub/", false)).toString());
             assertEquals("[.hg/config.txt, sub/mid.txt]", new TreeSet<>(vf.list("**/mid*,**/conf*", null, false)).toString());
-            assertEquals("[sub/mid.txt, sub/subsub/lowest.txt]", new TreeSet<>(vf.list("sub/", "**/notthere/", false)).toString());
+            assertEquals("[sub, sub/mid.txt, sub/subsub, sub/subsub/lowest.txt]", new TreeSet<>(vf.list("sub/", "**/notthere/", false)).toString());
             assertEquals("[top.txt]", new TreeSet<>(vf.list("*.txt", null, false)).toString());
-            assertEquals("[sub/subsub/lowest.txt, top.txt, very/deep/path/here]", new TreeSet<>(vf.list("**", "**/mid*,**/conf*", false)).toString());
+            assertEquals("[.hg, sub, sub/subsub, sub/subsub/lowest.txt, top.txt, very, very/deep, very/deep/path, very/deep/path/here]", new TreeSet<>(vf.list("**", "**/mid*,**/conf*", false)).toString());
         }
     }
     /** Roughly analogous to {@code org.jenkinsci.plugins.compress_artifacts.ZipStorage}. */
@@ -245,6 +245,11 @@ class VirtualFileTest {
         VirtualFile virtualRoot = VirtualFile.forFile(root);
         Collection<String> children = virtualRoot.list("**", null, true, LinkOption.NOFOLLOW_LINKS);
         assertThat(children, containsInAnyOrder(
+                "a",
+                "a/aa",
+                "a/ab",
+                "b",
+                "b/ba",
                 "a/aa/aaa",
                 "a/aa/aa.txt",
                 "a/ab/ab.txt",

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -269,6 +269,7 @@ class VirtualFileTest {
         assertThat(children, containsInAnyOrder(
                 "a",
                 "a/aa",
+                "a/aa/aaa",
                 "a/ab",
                 "b/ba",
                 "a/aa/aa.txt",

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -267,6 +267,10 @@ class VirtualFileTest {
         VirtualFile virtualRoot = VirtualFile.forFilePath(new FilePath(root));
         Collection<String> children = virtualRoot.list("**", null, true, LinkOption.NOFOLLOW_LINKS);
         assertThat(children, containsInAnyOrder(
+                "a",
+                "a/aa",
+                "a/ab",
+                "b/ba",
                 "a/aa/aa.txt",
                 "a/ab/ab.txt",
                 "b/ba/ba.txt"
@@ -518,7 +522,7 @@ class VirtualFileTest {
         VirtualFile symlinkVirtualPath = VirtualFile.forFilePath(symlinkPath);
         VirtualFile symlinkChildVirtualPath = symlinkVirtualPath.child("aa");
         Collection<String> children = symlinkChildVirtualPath.list("**", null, true, LinkOption.NOFOLLOW_LINKS);
-        assertThat(children, contains("aa.txt"));
+        assertThat(children, containsInAnyOrder( "aaa", "aa.txt"));
     }
 
     @Test
@@ -533,7 +537,7 @@ class VirtualFileTest {
         VirtualFile symlinkVirtualFile = VirtualFile.forFile(symlinkFile);
         VirtualFile symlinkChildVirtualFile = symlinkVirtualFile.child("aa");
         Collection<String> children = symlinkChildVirtualFile.list("**", null, true, LinkOption.NOFOLLOW_LINKS);
-        assertThat(children, contains("aa.txt"));
+        assertThat(children, containsInAnyOrder( "aaa", "aa.txt"));
     }
 
     @Test

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -245,6 +245,7 @@ class VirtualFileTest {
         VirtualFile virtualRoot = VirtualFile.forFile(root);
         Collection<String> children = virtualRoot.list("**", null, true, LinkOption.NOFOLLOW_LINKS);
         assertThat(children, containsInAnyOrder(
+                "a/aa/aaa",
                 "a/aa/aa.txt",
                 "a/ab/ab.txt",
                 "b/ba/ba.txt"
@@ -288,7 +289,7 @@ class VirtualFileTest {
         assertTrue(unzipPath.isDirectory());
         assertTrue(unzipPath.child("a").child("aa").child("aa.txt").exists());
         assertTrue(unzipPath.child("a").child("ab").child("ab.txt").exists());
-        assertFalse(unzipPath.child("a").child("aa").child("aaa").exists());
+        assertTrue(unzipPath.child("a").child("aa").child("aaa").exists());
         assertFalse(unzipPath.child("a").child("_b").exists());
         assertTrue(unzipPath.child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child("b").child("_a").exists());
@@ -318,7 +319,7 @@ class VirtualFileTest {
         assertTrue(unzipPath.child(prefix).isDirectory());
         assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aa.txt").exists());
         assertTrue(unzipPath.child(prefix).child("a").child("ab").child("ab.txt").exists());
-        assertFalse(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
+        assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
         assertFalse(unzipPath.child(prefix).child("a").child("_b").exists());
         assertTrue(unzipPath.child(prefix).child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child(prefix).child("b").child("_a").exists());
@@ -346,7 +347,7 @@ class VirtualFileTest {
         assertTrue(unzipPath.isDirectory());
         assertTrue(unzipPath.child("a").child("aa").child("aa.txt").exists());
         assertTrue(unzipPath.child("a").child("ab").child("ab.txt").exists());
-        assertFalse(unzipPath.child("a").child("aa").child("aaa").exists());
+        assertTrue(unzipPath.child("a").child("aa").child("aaa").exists());
         assertFalse(unzipPath.child("a").child("_b").exists());
         assertTrue(unzipPath.child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child("b").child("_a").exists());
@@ -376,7 +377,7 @@ class VirtualFileTest {
         assertTrue(unzipPath.child(prefix).isDirectory());
         assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aa.txt").exists());
         assertTrue(unzipPath.child(prefix).child("a").child("ab").child("ab.txt").exists());
-        assertFalse(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
+        assertTrue(unzipPath.child(prefix).child("a").child("aa").child("aaa").exists());
         assertFalse(unzipPath.child(prefix).child("a").child("_b").exists());
         assertTrue(unzipPath.child(prefix).child("b").child("ba").child("ba.txt").exists());
         assertFalse(unzipPath.child(prefix).child("b").child("_a").exists());

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -696,7 +696,9 @@ class DirectoryBrowserSupportTest {
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
             assertThat(entryNames, containsInAnyOrder(
                     p.getName() + "/intermediateFolder/public2.key",
-                    p.getName() + "/public1.key"
+                    p.getName() + "/public1.key",
+                    p.getName() + "/intermediateFolder/",
+                    p.getName() + "/intermediateFolder/otherFolder/"
             ));
         }
         { // workaround for JENKINS-19947 is still supported, i.e. no parent folder
@@ -706,7 +708,9 @@ class DirectoryBrowserSupportTest {
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
             assertThat(entryNames, containsInAnyOrder(
                     "intermediateFolder/public2.key",
-                    "public1.key"
+                    "public1.key",
+                    "intermediateFolder/",
+                    "intermediateFolder/otherFolder/"
             ));
         }
         { // all the outside folders / files are not included in the zip
@@ -714,14 +718,16 @@ class DirectoryBrowserSupportTest {
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
-            assertThat(entryNames, contains("intermediateFolder/public2.key"));
+            assertThat(entryNames, containsInAnyOrder(
+                    "intermediateFolder/otherFolder/",
+                    "intermediateFolder/public2.key"));
         }
         { // workaround for JENKINS-19947 is still supported, i.e. no parent folder, even inside a sub-folder
             Page zipPage = wc.goTo(p.getUrl() + "ws/intermediateFolder/**/*zip*/intermediateFolder.zip", null);
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
-            assertThat(entryNames, contains("public2.key"));
+            assertThat(entryNames, containsInAnyOrder( "otherFolder/", "public2.key"));
         }
     }
 
@@ -926,7 +932,10 @@ class DirectoryBrowserSupportTest {
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
             assertThat(entryNames, containsInAnyOrder(
                     p.getName() + "/intermediateFolder/public2.key",
-                    p.getName() + "/public1.key"
+                    p.getName() + "/public1.key",
+                    p.getName() + "/intermediateFolder/",
+                    p.getName() + "/intermediateFolder/otherFolder/"
+
             ));
         }
         { // all the outside folders / files are not included in the zip
@@ -934,7 +943,9 @@ class DirectoryBrowserSupportTest {
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
-            assertThat(entryNames, contains("intermediateFolder/public2.key"));
+            assertThat(entryNames, containsInAnyOrder(
+                    "intermediateFolder/otherFolder/",
+                    "intermediateFolder/public2.key"));
         }
         // Explicitly delete everything including junctions, which TemporaryDirectoryAllocator.dispose may have trouble with:
         new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds("cmd", "/c", "rmdir", "/s", "/q", j.jenkins.getRootDir().getAbsolutePath()).start().join();
@@ -996,7 +1007,14 @@ class DirectoryBrowserSupportTest {
             assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
             List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
-            assertThat(entryNames, hasSize(0));
+            assertThat(entryNames, hasSize(6));
+            assertThat(entryNames, containsInAnyOrder(
+                    "test0/a1/",
+                    "test0/b1/",
+                    "test0/b1/b2/",
+                    "test0/c1/",
+                    "test0/c1/c2/",
+                    "test0/c1/c2/c3/"));
         }
         {
             Page zipPage = wc.goTo(p.getUrl() + "ws/a1/*zip*/a1.zip", null);
@@ -1277,8 +1295,10 @@ class DirectoryBrowserSupportTest {
         assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
         List<String> entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
-        assertThat(entryNames, hasSize(2));
+        assertThat(entryNames, hasSize(4));
         assertThat(entryNames, containsInAnyOrder(
+                "test0/anotherDir/insideDir/",
+                "test0/anotherDir/",
                 "test0/anotherDir/one.txt",
                 "test0/anotherDir/insideDir/two.txt"
         ));
@@ -1287,8 +1307,9 @@ class DirectoryBrowserSupportTest {
         assertThat(zipPage.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
 
         entryNames = getListOfEntriesInDownloadedZip((UnexpectedPage) zipPage);
-        assertThat(entryNames, hasSize(2));
+        assertThat(entryNames, hasSize(3));
         assertThat(entryNames, containsInAnyOrder(
+                "anotherDir/insideDir/",
                 "anotherDir/one.txt",
                 "anotherDir/insideDir/two.txt"
         ));


### PR DESCRIPTION

See [JENKINS-73837](https://issues.jenkins.io/browse/JENKINS-73837).

### Testing done

A test was already created as a part of acceptance criteria https://github.com/jenkinsci/jenkins/pull/9809 and it is passing after the changes.

Other relevant existing tests (to my knowledge) have been modified to accept new behavior.


### Proposed changelog category

/label rfe


### Proposed upgrade guidelines

N/A


### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@MarkEWaite 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
