### PR TITLE
Avoid warning about `labelAtomSet` during `Slave.readResolve`

### DIFF
--- a/core/src/main/java/hudson/model/Slave.java
+++ b/core/src/main/java/hudson/model/Slave.java
@@ -27,6 +27,7 @@ package hudson.model;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.DescriptorExtensionList;
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -102,6 +103,7 @@ import org.kohsuke.stapler.StaplerResponse2;
  *
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "DESERIALIZATION_GADGET", justification = "unhappy about existence of readResolve?")
 public abstract class Slave extends Node implements Serializable {
 
     private static final Logger LOGGER = Logger.getLogger(Slave.class.getName());


### PR DESCRIPTION
#8448 introduced a warning which it turns out is produced spuriously

```
java.lang.Exception: Stack trace
	at java.base/java.lang.Thread.dumpStack(Thread.java:2210)
	at hudson.model.Slave.warnPlugin(Slave.java:394)
	at hudson.model.Slave.getLabelAtomSet(Slave.java:386)
	at hudson.model.Node.getAssignedLabels(Node.java:338)
	at hudson.model.Slave._setLabelString(Slave.java:373)
	at hudson.model.Slave.readResolve(Slave.java:641)
```

This call to `getLabelAtomSet` occurs before `labelAtomSet` has been initialized, so it is normal to initialize it there.

### Testing done

Warning reproduced in a CloudBees CI functional test before fix but not after.

### Proposed changelog entries

- Stop printing incorrect message from `Slave.warnPlugin`.

### Proposed changelog category

/label regression-fix

### Proposed upgrade guidelines

N/A

### Desired reviewers

@Vlatombe

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
