### PR TITLE
Fix word breaking in pre tags and help classes

### DIFF
--- a/src/main/scss/base/_style.scss
+++ b/src/main/scss/base/_style.scss
@@ -290,7 +290,8 @@ pre.console {
   display: none; /* hidden until loaded */
   padding: 1rem;
   margin: 1rem 0;
-  word-break: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
   border-radius: var(--form-input-border-radius);
   background-color: var(--button-background);
   border: var(--jenkins-border--subtle);

--- a/src/main/scss/base/_style.scss
+++ b/src/main/scss/base/_style.scss
@@ -148,7 +148,7 @@ td.tab {
 
 pre {
   white-space: pre-wrap;
-  word-wrap: word-break;
+  overflow-wrap: break-word;
   margin: 0 0 var(--section-padding);
   padding: 0.8rem 1rem;
   border-radius: var(--form-input-border-radius);
@@ -160,7 +160,7 @@ pre {
   line-height: 1.66;
 
   a {
-    word-wrap: word-break;
+    overflow-wrap: break-word;
   }
 }
 

--- a/src/main/scss/base/_style.scss
+++ b/src/main/scss/base/_style.scss
@@ -290,7 +290,7 @@ pre.console {
   display: none; /* hidden until loaded */
   padding: 1rem;
   margin: 1rem 0;
-  word-break: word-break;
+  word-break: break-word;
   border-radius: var(--form-input-border-radius);
   background-color: var(--button-background);
   border: var(--jenkins-border--subtle);


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

`word-wrap` is an alias for `overflow-wrap` and only has the supported values `normal | break-word | anywhere | [initial | inherit | unset | revert | revert-layer]`[^1].
I am assuming the intention in the `pre` styling was to have it set up to break on each word.  
I have made the same assumption with the `word-break` property for the `.help` which only supports the values `normal | break-all | keep-all | manual | auto-phrase | break-word | [initial | inherit | unset | revert | revert-layer]`[^2].

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Manual visual regression check

| Before | After |
|---|---|
| <img width="1242" height="511" alt="image" src="https://github.com/user-attachments/assets/fc37d2fd-1b03-4f3f-8ee7-84cf58c18692" /> | <img width="1278" height="579" alt="image" src="https://github.com/user-attachments/assets/d67f461f-e936-4c3d-b0d1-68889a377897" /> |
| <img width="523" height="891" alt="image" src="https://github.com/user-attachments/assets/206f4f6d-9d2b-4c26-9f49-2ad48cd76334" /> | <img width="480" height="833" alt="image" src="https://github.com/user-attachments/assets/144b871b-fbfe-45d3-b8d3-3ea026547d35" /> |

### Proposed changelog entries

- Correct `word-wrap` and `word-break` CSS properties to use supported values.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui, bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#syntax
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#syntax
