### PR TITLE
Implement `FieldUtils` without Commons Lang

### DIFF
--- a/core/src/main/java/org/acegisecurity/util/FieldUtils.java
+++ b/core/src/main/java/org/acegisecurity/util/FieldUtils.java
@@ -28,7 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.reflect.Field;
 
 /**
- * @deprecated use {@code org.apache.commons.lang.reflect.FieldUtils}
+ * @deprecated use {@code org.apache.commons.lang3.reflect.FieldUtils}
  */
 @Deprecated
 public final class FieldUtils {

--- a/core/src/main/java/org/acegisecurity/util/FieldUtils.java
+++ b/core/src/main/java/org/acegisecurity/util/FieldUtils.java
@@ -42,7 +42,7 @@ public final class FieldUtils {
         }
     }
 
-    public static void setProtectedFieldValue(String protectedField, Object object, Object newValue) {
+    public static void setProtectedFieldValue(@NonNull String protectedField, @NonNull Object object, @NonNull Object newValue) {
         try {
             Field field = getField(object.getClass(), protectedField);
             field.set(object, newValue);

--- a/core/src/main/java/org/acegisecurity/util/FieldUtils.java
+++ b/core/src/main/java/org/acegisecurity/util/FieldUtils.java
@@ -28,7 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.reflect.Field;
 
 /**
- * @deprecated use {@code org.apache.commons.lang3.reflect.FieldUtils}
+ * @deprecated Add a dependency to commons-lang3-api plugin and use {@code org.apache.commons.lang3.reflect.FieldUtils}
  */
 @Deprecated
 public final class FieldUtils {

--- a/core/src/main/java/org/acegisecurity/util/FieldUtils.java
+++ b/core/src/main/java/org/acegisecurity/util/FieldUtils.java
@@ -24,17 +24,19 @@
 
 package org.acegisecurity.util;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.reflect.Field;
 
 /**
- * @deprecated use {@link org.apache.commons.lang.reflect.FieldUtils}
+ * @deprecated use {@code org.apache.commons.lang.reflect.FieldUtils}
  */
 @Deprecated
 public final class FieldUtils {
 
-    public static Object getProtectedFieldValue(String protectedField, Object object) {
+    public static Object getProtectedFieldValue(@NonNull String protectedField, @NonNull Object object) {
         try {
-            return org.apache.commons.lang.reflect.FieldUtils.readField(object, protectedField, true);
+            Field field = getField(object.getClass(), protectedField);
+            return field.get(object);
         } catch (IllegalAccessException x) {
             throw new RuntimeException(x);
         }
@@ -46,12 +48,49 @@ public final class FieldUtils {
             // FieldUtils.writeField(Object, field, true) only sets accessible on *non* public fields
             // and then fails with IllegalAccessException (even if you make the field accessible in the interim!
             // for backwards compatability we need to use a few steps
-            Field field = org.apache.commons.lang.reflect.FieldUtils.getField(object.getClass(), protectedField, true);
+            Field field = getField(object.getClass(), protectedField);
             field.setAccessible(true);
             field.set(object, newValue);
         } catch (Exception x) {
             throw new RuntimeException(x);
         }
+    }
+
+    /**
+     * Return the field with the given name from the class or its superclasses.
+     * If the field is not found, an {@link IllegalArgumentException} is thrown.
+     *
+     * @param clazz the class to search for the field
+     * @param fieldName the name of the field to find
+     * @return the {@link Field} object representing the field
+     * @throws IllegalArgumentException if the field is not found
+     */
+    private static Field getField(@NonNull final Class<?> clazz, @NonNull final String fieldName) {
+        // Check class and its superclasses
+        Class<?> current = clazz;
+        while (current != null) {
+            try {
+                Field field = current.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException e) {
+                // Continue to check superclass
+            }
+            current = current.getSuperclass();
+        }
+
+        // Check interfaces
+        for (Class<?> iface : clazz.getInterfaces()) {
+            try {
+                Field field = iface.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException e) {
+                // Continue to check next interface
+            }
+        }
+
+        throw new IllegalArgumentException("Field '" + fieldName + "' not found in class " + clazz.getName());
     }
 
     // TODO other methods as needed

--- a/core/src/main/java/org/acegisecurity/util/FieldUtils.java
+++ b/core/src/main/java/org/acegisecurity/util/FieldUtils.java
@@ -44,14 +44,9 @@ public final class FieldUtils {
 
     public static void setProtectedFieldValue(String protectedField, Object object, Object newValue) {
         try {
-            // acgegi would silently fail to write to final fields
-            // FieldUtils.writeField(Object, field, true) only sets accessible on *non* public fields
-            // and then fails with IllegalAccessException (even if you make the field accessible in the interim!
-            // for backwards compatability we need to use a few steps
             Field field = getField(object.getClass(), protectedField);
-            field.setAccessible(true);
             field.set(object, newValue);
-        } catch (Exception x) {
+        } catch (IllegalAccessException x) {
             throw new RuntimeException(x);
         }
     }


### PR DESCRIPTION
While looking for remaining usages of Commons Lang in core, I found this old utility method that is still called from some tests. Reimplement it with standard Java Platform functionality so that Commons Lang can be removed in the future.

### Testing done

Ran `FieldUtilsTest`.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
