### PR TITLE
Test `/health/` not `/health`

### DIFF
--- a/test/src/test/java/jenkins/health/HealthCheckActionTest.java
+++ b/test/src/test/java/jenkins/health/HealthCheckActionTest.java
@@ -53,7 +53,7 @@ class HealthCheckActionTest {
 
     @Test
     void healthCheck() throws Exception {
-        try (var webClient = r.createWebClient()) {
+        try (var webClient = r.createWebClient().withRedirectEnabled(false)) {
             var page = webClient.goTo(healthUrl(), "application/json");
             assertThat(page.getWebResponse().getStatusCode(), is(200));
             assertEquals(JSONObject.fromObject("""
@@ -64,13 +64,14 @@ class HealthCheckActionTest {
         }
     }
 
+
     private static String healthUrl() {
-        return ExtensionList.lookupSingleton(HealthCheckAction.class).getUrlName();
+        return ExtensionList.lookupSingleton(HealthCheckAction.class).getUrlName() + "/";
     }
 
     @Test
     void healthCheckSuccessExtension() throws Exception {
-        try (var webClient = r.createWebClient()) {
+        try (var webClient = r.createWebClient().withRedirectEnabled(false)) {
             var page = webClient.goTo(healthUrl(), "application/json");
             assertThat(page.getWebResponse().getStatusCode(), is(200));
             assertEquals(JSONObject.fromObject("""
@@ -97,7 +98,7 @@ class HealthCheckActionTest {
 
     @Test
     void healthCheckFailingExtension() throws Exception {
-        try (var webClient = r.createWebClient()) {
+        try (var webClient = r.createWebClient().withRedirectEnabled(false)) {
             webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
             webClient.getOptions().setPrintContentOnFailingStatusCode(false);
             var page = webClient.goTo(healthUrl(), "application/json");


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/10522#issuecomment-3140147147

### Testing done

Test fails with redirects disabled unless URL is adjusted.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
