### PR TITLE
Backporting for LTS 2.516.2 - JENKINS-75851

### DIFF
--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -47,19 +47,21 @@ THE SOFTWARE.
   </st:documentation>
 
   <j:if test="${mode=='breadcrumbs'}">
+    <j:set var="baseUrl" value="${request2.originalRequestURI}" />
     <j:set var="hasLink" value="${attrs.href != null}" />
-    <li id="${attrs.id}" class="jenkins-breadcrumbs__list-item" data-type="breadcrumb-item" aria-current="${hasLink ? null : 'page'}">
+    <j:set var="isCurrent" value="${baseUrl == attrs.href}" />
+    <li aria-current="${(isCurrent or !hasLink)? 'page' : null}"  id="${attrs.id}" class="jenkins-breadcrumbs__list-item" data-type="breadcrumb-item">
       <j:choose>
-        <j:when test="${!hasLink}">
-          <span>${attrs.title}</span>
+        <j:when test="${!hasLink or isCurrent}">
+          <span title="${attrs.title}">${attrs.title}</span>
         </j:when>
         <j:otherwise>
-            <a href="${attrs.href}">
+            <a title="${attrs.title}" href="${attrs.href}">
               ${attrs.title}
             </a>
           <j:if test="${attrs.hasMenu or attrs.hasChildrenMenu}">
-            <div tabindex="0" class="dropdown-indicator" data-href="${attrs.href}" data-model="${attrs.hasMenu}" data-children="${attrs.hasChildrenMenu}" >
-              <l:icon class="icon-sm" src="symbol-chevron-down" />
+            <div data-iscurrent="${isCurrent}" data-href="${attrs.href}" data-base="${baseUrl}" tabindex="0" class="dropdown-indicator" data-model="${attrs.hasMenu}" data-children="${attrs.hasChildrenMenu}" >
+              <l:icon class="icon-sm jenkins-!-text-color-secondary" src="symbol-chevron-down" />
             </div>
           </j:if>
         </j:otherwise>

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -50,7 +50,7 @@ THE SOFTWARE.
     <j:set var="baseUrl" value="${request2.originalRequestURI}" />
     <j:set var="hasLink" value="${attrs.href != null}" />
     <j:set var="isCurrent" value="${baseUrl == attrs.href}" />
-    <j:set var="shouldShowTitle" value="${attrs.title.length() > 25}" />
+    <j:set var="shouldShowTitle" value="${attrs.title.length() > 26}" />
 
     <li aria-current="${(isCurrent or !hasLink)? 'page' : null}"  id="${attrs.id}" class="jenkins-breadcrumbs__list-item" data-type="breadcrumb-item">
       <j:choose>

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -71,18 +71,18 @@ THE SOFTWARE.
         <j:otherwise>
           <j:choose>
             <j:when test="${shouldShowTitle}">
-              <a aria-label="path element" tooltip="${attrs.title}" href="${attrs.href}">
+              <a tooltip="${attrs.title}" href="${attrs.href}">
                 ${attrs.title}
               </a>
             </j:when>
             <j:otherwise>
-              <a aria-label="path element" href="${attrs.href}">
+              <a href="${attrs.href}">
                 ${attrs.title}
               </a>
             </j:otherwise>
           </j:choose>
           <j:if test="${attrs.hasMenu or attrs.hasChildrenMenu}">
-            <div aria-label="dropdown menu for path" data-iscurrent="${isCurrent}" data-href="${attrs.href}" data-base="${baseUrl}" tabindex="0" class="dropdown-indicator" data-model="${attrs.hasMenu}" data-children="${attrs.hasChildrenMenu}" >
+            <div aria-label="dropdown menu for ${attrs.title}" data-iscurrent="${isCurrent}" data-href="${attrs.href}" data-base="${baseUrl}" tabindex="0" class="dropdown-indicator" data-model="${attrs.hasMenu}" data-children="${attrs.hasChildrenMenu}" >
               <l:icon class="icon-sm jenkins-!-text-color-secondary" src="symbol-chevron-down" />
             </div>
           </j:if>

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -50,11 +50,15 @@ THE SOFTWARE.
     <j:set var="baseUrl" value="${request2.originalRequestURI}" />
     <j:set var="hasLink" value="${attrs.href != null}" />
     <j:set var="isCurrent" value="${baseUrl == attrs.href}" />
+    <j:set var="isSystem" value="${baseUrl.contains('manage/configure')}" />
     <j:set var="shouldShowTitle" value="${attrs.title.length() > 26}" />
 
-    <li aria-current="${(isCurrent or !hasLink)? 'page' : null}"  id="${attrs.id}" class="jenkins-breadcrumbs__list-item" data-type="breadcrumb-item">
+    <li aria-current="${(isCurrent or !hasLink)? 'page' : null}"
+        id="${attrs.id}" class="jenkins-breadcrumbs__list-item"
+        data-type="breadcrumb-item" data-has-menu="${attrs.hasMenu}"
+    >
       <j:choose>
-        <j:when test="${!hasLink or isCurrent}">
+        <j:when test="${(!hasLink and !attrs.hasMenu)  or (isCurrent and !isSystem)}">
           <j:choose>
             <j:when test="${shouldShowTitle}">
               <span tooltip="${attrs.title}">${attrs.title}</span>
@@ -67,18 +71,18 @@ THE SOFTWARE.
         <j:otherwise>
           <j:choose>
             <j:when test="${shouldShowTitle}">
-              <a tooltip="${attrs.title}" href="${attrs.href}">
+              <a aria-label="path element" tooltip="${attrs.title}" href="${attrs.href}">
                 ${attrs.title}
               </a>
             </j:when>
             <j:otherwise>
-              <a href="${attrs.href}">
+              <a aria-label="path element" href="${attrs.href}">
                 ${attrs.title}
               </a>
             </j:otherwise>
           </j:choose>
           <j:if test="${attrs.hasMenu or attrs.hasChildrenMenu}">
-            <div data-iscurrent="${isCurrent}" data-href="${attrs.href}" data-base="${baseUrl}" tabindex="0" class="dropdown-indicator" data-model="${attrs.hasMenu}" data-children="${attrs.hasChildrenMenu}" >
+            <div aria-label="dropdown menu for path" data-iscurrent="${isCurrent}" data-href="${attrs.href}" data-base="${baseUrl}" tabindex="0" class="dropdown-indicator" data-model="${attrs.hasMenu}" data-children="${attrs.hasChildrenMenu}" >
               <l:icon class="icon-sm jenkins-!-text-color-secondary" src="symbol-chevron-down" />
             </div>
           </j:if>

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -54,9 +54,14 @@ THE SOFTWARE.
           <span>${attrs.title}</span>
         </j:when>
         <j:otherwise>
-          <a href="${attrs.href}" class="${attrs.hasMenu ? 'hoverable-model-link' : ''} ${attrs.hasChildrenMenu ? 'hoverable-children-model-link' : ''}">
-            ${attrs.title}
-          </a>
+            <a href="${attrs.href}">
+              ${attrs.title}
+            </a>
+          <j:if test="${attrs.hasMenu or attrs.hasChildrenMenu}">
+            <div tabindex="0" class="dropdown-indicator" data-href="${attrs.href}" data-model="${attrs.hasMenu}" data-children="${attrs.hasChildrenMenu}" >
+              <l:icon class="icon-sm" src="symbol-chevron-down" />
+            </div>
+          </j:if>
         </j:otherwise>
       </j:choose>
     </li>

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -50,15 +50,33 @@ THE SOFTWARE.
     <j:set var="baseUrl" value="${request2.originalRequestURI}" />
     <j:set var="hasLink" value="${attrs.href != null}" />
     <j:set var="isCurrent" value="${baseUrl == attrs.href}" />
+    <j:set var="shouldShowTitle" value="${attrs.title.length() > 25}" />
+
     <li aria-current="${(isCurrent or !hasLink)? 'page' : null}"  id="${attrs.id}" class="jenkins-breadcrumbs__list-item" data-type="breadcrumb-item">
       <j:choose>
         <j:when test="${!hasLink or isCurrent}">
-          <span title="${attrs.title}">${attrs.title}</span>
+          <j:choose>
+            <j:when test="${shouldShowTitle}">
+              <span tooltip="${attrs.title}">${attrs.title}</span>
+            </j:when>
+            <j:otherwise>
+              <span>${attrs.title}</span>
+            </j:otherwise>
+          </j:choose>
         </j:when>
         <j:otherwise>
-            <a title="${attrs.title}" href="${attrs.href}">
-              ${attrs.title}
-            </a>
+          <j:choose>
+            <j:when test="${shouldShowTitle}">
+              <a tooltip="${attrs.title}" href="${attrs.href}">
+                ${attrs.title}
+              </a>
+            </j:when>
+            <j:otherwise>
+              <a href="${attrs.href}">
+                ${attrs.title}
+              </a>
+            </j:otherwise>
+          </j:choose>
           <j:if test="${attrs.hasMenu or attrs.hasChildrenMenu}">
             <div data-iscurrent="${isCurrent}" data-href="${attrs.href}" data-base="${baseUrl}" tabindex="0" class="dropdown-indicator" data-model="${attrs.hasMenu}" data-children="${attrs.hasChildrenMenu}" >
               <l:icon class="icon-sm jenkins-!-text-color-secondary" src="symbol-chevron-down" />

--- a/core/src/main/resources/lib/layout/breadcrumb.jelly
+++ b/core/src/main/resources/lib/layout/breadcrumb.jelly
@@ -50,7 +50,7 @@ THE SOFTWARE.
     <j:set var="baseUrl" value="${request2.originalRequestURI}" />
     <j:set var="hasLink" value="${attrs.href != null}" />
     <j:set var="isCurrent" value="${baseUrl == attrs.href}" />
-    <j:set var="isSystem" value="${baseUrl.contains('manage/configure')}" />
+    <j:set var="inPageNav" value="${attrs.id.contains('inpage-nav')}" />
     <j:set var="shouldShowTitle" value="${attrs.title.length() > 26}" />
 
     <li aria-current="${(isCurrent or !hasLink)? 'page' : null}"
@@ -58,7 +58,7 @@ THE SOFTWARE.
         data-type="breadcrumb-item" data-has-menu="${attrs.hasMenu}"
     >
       <j:choose>
-        <j:when test="${(!hasLink and !attrs.hasMenu)  or (isCurrent and !isSystem)}">
+        <j:when test="${(!hasLink and !attrs.hasMenu)  or (isCurrent and !inPageNav)}">
           <j:choose>
             <j:when test="${shouldShowTitle}">
               <span tooltip="${attrs.title}">${attrs.title}</span>

--- a/src/main/js/components/dropdowns/inpage-jumplist.js
+++ b/src/main/js/components/dropdowns/inpage-jumplist.js
@@ -5,7 +5,7 @@ import { toId } from "@/util/dom";
  * sections on the page (if using <f:breadcrumb-config-outline />)
  */
 function init() {
-  const inpageNavigationBreadcrumb = document.querySelector("#inpage-nav");
+  const inpageNavigationBreadcrumb = document.querySelector("#inpage-nav div");
 
   if (inpageNavigationBreadcrumb) {
     const chevron = document.createElement("li");

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -122,12 +122,14 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
     };
 
     const fetchSection = function (urlSuffix) {
-      const response = fetch(Path.combinePath(href, urlSuffix));
-      const json = response.json();
-      const items = Utils.generateDropdownItems(
-        mapChildrenItemsToDropdownItems(json.items),
-      );
-      return items;
+      return fetch(Path.combinePath(href, urlSuffix))
+        .then((response) => response.json())
+        .then((json) => {
+          const items = Utils.generateDropdownItems(
+            mapChildrenItemsToDropdownItems(json.items),
+          );
+          return items;
+        });
     };
 
     const promises = [];

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -132,7 +132,7 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
 
     const promises = [];
 
-    if (hasModelLink) {
+    if (hasModelLink === "true") {
       promises.push(
         fetchSection("contextMenu").then((section) => {
           const dContainer = section;
@@ -146,7 +146,7 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
       );
     }
 
-    if (hasChildrenLink) {
+    if (hasChildrenLink === "true") {
       promises.push(
         fetchSection("childrenContextMenu").then((section) => {
           const dContainer = section;

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -121,9 +121,9 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
       children: null,
     };
 
-    const fetchSection = async function (urlSuffix) {
-      const response = await fetch(Path.combinePath(href, urlSuffix));
-      const json = await response.json();
+    const fetchSection = function (urlSuffix) {
+      const response = fetch(Path.combinePath(href, urlSuffix));
+      const json = response.json();
       const items = Utils.generateDropdownItems(
         mapChildrenItemsToDropdownItems(json.items),
       );

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -45,7 +45,7 @@ function generateDropdowns() {
           element.classList.contains("hoverable-children-model-link"),
           element.href,
         ),
-        false,
+        element.items != null,
         {
           trigger: "mouseenter",
           offset: [-16, 10],
@@ -68,7 +68,7 @@ function generateDropdowns() {
           element.getAttribute("data-children"),
           element.getAttribute("data-href"),
         ),
-        false,
+        element.items != null,
         {
           trigger: "click focus",
           offset: [-16, 10],

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -1,10 +1,22 @@
-import Path from "@/util/path";
-import behaviorShim from "@/util/behavior-shim";
 import Utils from "@/components/dropdowns/utils";
+import behaviorShim from "@/util/behavior-shim";
+import { createElementFromHtml } from "@/util/dom";
+import Path from "@/util/path";
 
 function init() {
   generateJumplistAccessors();
   generateDropdowns();
+}
+function generateDropdownChevron(element) {
+  const isFirefox = navigator.userAgent.indexOf("Firefox") !== -1;
+  // Firefox adds unwanted lines when copying buttons in text, so use a span instead
+  const dropdownChevron = document.createElement(isFirefox ? "span" : "button");
+  dropdownChevron.className = "jenkins-menu-dropdown-chevron";
+  dropdownChevron.dataset.href = element.href;
+  dropdownChevron.addEventListener("click", (event) => {
+    event.preventDefault();
+  });
+  element.appendChild(dropdownChevron);
 }
 
 /*
@@ -12,17 +24,7 @@ function init() {
  */
 function generateJumplistAccessors() {
   behaviorShim.specify("A.model-link", "-jumplist-", 999, (link) => {
-    const isFirefox = navigator.userAgent.indexOf("Firefox") !== -1;
-    // Firefox adds unwanted lines when copying buttons in text, so use a span instead
-    const dropdownChevron = document.createElement(
-      isFirefox ? "span" : "button",
-    );
-    dropdownChevron.className = "jenkins-menu-dropdown-chevron";
-    dropdownChevron.dataset.href = link.href;
-    dropdownChevron.addEventListener("click", (event) => {
-      event.preventDefault();
-    });
-    link.appendChild(dropdownChevron);
+    generateDropdownChevron(link);
   });
 }
 
@@ -37,77 +39,38 @@ function generateDropdowns() {
     (element) =>
       Utils.generateDropdown(
         element,
-        (instance) => {
-          const href = element.href;
-
-          if (element.items) {
-            instance.setContent(Utils.generateDropdownItems(element.items));
-            return;
-          }
-
-          const hasModelLink = element.classList.contains(
-            "hoverable-model-link",
-          );
-          const hasChildrenLink = element.classList.contains(
-            "hoverable-children-model-link",
-          );
-
-          const sections = {
-            model: null,
-            children: null,
-          };
-
-          const fetchSection = function (urlSuffix) {
-            return fetch(Path.combinePath(href, urlSuffix))
-              .then((response) => response.json())
-              .then((json) => {
-                const items = mapChildrenItemsToDropdownItems(json.items);
-                const section = document.createElement("div");
-                section.appendChild(Utils.generateDropdownItems(items));
-                return section;
-              });
-          };
-
-          const promises = [];
-
-          if (hasModelLink) {
-            promises.push(
-              fetchSection("contextMenu").then((section) => {
-                sections.model = section;
-              }),
-            );
-          }
-
-          if (hasChildrenLink) {
-            promises.push(
-              fetchSection("childrenContextMenu").then((section) => {
-                sections.children = section;
-              }),
-            );
-          }
-
-          Promise.all(promises)
-            .then(() => {
-              const container = document.createElement("div");
-              container.className = "jenkins-dropdown__split-container";
-              if (sections.model) {
-                container.appendChild(sections.model);
-              }
-              if (sections.children) {
-                container.appendChild(sections.children);
-              }
-              instance.setContent(container);
-            })
-            .catch((error) => {
-              console.log(`Dropdown fetch failed: ${error}`);
-            })
-            .finally(() => {
-              instance.loaded = true;
-            });
-        },
+        createDropdownContent(
+          element,
+          element.classList.contains("hoverable-model-link"),
+          element.classList.contains("hoverable-children-model-link"),
+          element.href,
+        ),
         false,
         {
           trigger: "mouseenter",
+          offset: [-16, 10],
+          animation: "tooltip",
+          touch: false,
+        },
+      ),
+  );
+
+  behaviorShim.specify(
+    ".dropdown-indicator",
+    "-clickable-dropdown-",
+    1000,
+    (element) =>
+      Utils.generateDropdown(
+        element,
+        createDropdownContent(
+          element,
+          element.getAttribute("data-model"),
+          element.getAttribute("data-children"),
+          element.getAttribute("data-href"),
+        ),
+        false,
+        {
+          trigger: "click focus",
           offset: [-16, 10],
           animation: "tooltip",
           touch: false,
@@ -145,6 +108,84 @@ function generateDropdowns() {
           .finally(() => (instance.loaded = true));
       }),
   );
+}
+
+function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
+  return (instance) => {
+    if (element.items) {
+      instance.setContent(Utils.generateDropdownItems(element.items));
+      return;
+    }
+    const sections = {
+      model: null,
+      children: null,
+    };
+
+    const fetchSection = async function (urlSuffix) {
+      const response = await fetch(Path.combinePath(href, urlSuffix));
+      const json = await response.json();
+      const items = Utils.generateDropdownItems(
+        mapChildrenItemsToDropdownItems(json.items),
+      );
+      return items;
+    };
+
+    const promises = [];
+
+    if (hasModelLink) {
+      promises.push(
+        fetchSection("contextMenu").then((section) => {
+          const dContainer = section;
+          dContainer.prepend(
+            createElementFromHtml(
+              `<p class="jenkins-dropdown__heading">Actions</p>`,
+            ),
+          );
+          sections.model = dContainer;
+        }),
+      );
+    }
+
+    if (hasChildrenLink) {
+      promises.push(
+        fetchSection("childrenContextMenu").then((section) => {
+          const dContainer = section;
+          // add a header for the section
+          dContainer.prepend(
+            createElementFromHtml(
+              `<p class="jenkins-dropdown__heading">Navigation</p>`,
+            ),
+          );
+          sections.children = dContainer;
+        }),
+      );
+    }
+
+    Promise.all(promises)
+      .then(() => {
+        const container = document.createElement("div");
+        container.className = "jenkins-dropdown__split-container";
+        if (sections.model && !sections.children) {
+          container.appendChild(sections.model);
+        } else if (!sections.model && sections.children) {
+          container.appendChild(sections.children);
+        } else if (sections.model && sections.children) {
+          // use the first dropdown and add the second dropdowns choices this way the a11y stays intact
+          const dropbox = sections.model;
+          Array.from(sections.children.children).forEach((item) => {
+            dropbox.appendChild(item);
+          });
+          container.appendChild(dropbox);
+        }
+        instance.setContent(container);
+      })
+      .catch((error) => {
+        console.log(`Dropdown fetch failed: ${error}`);
+      })
+      .finally(() => {
+        instance.loaded = true;
+      });
+  };
 }
 
 /*

--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -86,7 +86,7 @@ function menuItem(options) {
   const item = createElementFromHtml(`
       <${tag} class="jenkins-dropdown__item ${itemOptions.clazz ? xmlEscape(itemOptions.clazz) : ""}"
         ${itemOptions.url ? `href="${xmlEscape(itemOptions.url)}"` : ""} ${itemOptions.id ? `id="${xmlEscape(itemOptions.id)}"` : ""}
-        ${itemOptions.title ? `title="${xmlEscape(itemOptions.title)}"` : ""}>
+        ${itemOptions.tooltip ? `data-html-tooltip="${xmlEscape(itemOptions.tooltip)}"` : ""}>
           ${
             itemOptions.icon
               ? `<div class="jenkins-dropdown__item__icon">${

--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -84,7 +84,9 @@ function menuItem(options) {
   const tag = itemOptions.type === "link" ? "a" : "button";
 
   const item = createElementFromHtml(`
-      <${tag} class="jenkins-dropdown__item ${itemOptions.clazz ? xmlEscape(itemOptions.clazz) : ""}" ${itemOptions.url ? `href="${xmlEscape(itemOptions.url)}"` : ""} ${itemOptions.id ? `id="${xmlEscape(itemOptions.id)}"` : ""}>
+      <${tag} class="jenkins-dropdown__item ${itemOptions.clazz ? xmlEscape(itemOptions.clazz) : ""}"
+        ${itemOptions.url ? `href="${xmlEscape(itemOptions.url)}"` : ""} ${itemOptions.id ? `id="${xmlEscape(itemOptions.id)}"` : ""}
+        ${itemOptions.title ? `title="${xmlEscape(itemOptions.title)}"` : ""}>
           ${
             itemOptions.icon
               ? `<div class="jenkins-dropdown__item__icon">${

--- a/src/main/js/components/header/breadcrumbs-overflow.js
+++ b/src/main/js/components/header/breadcrumbs-overflow.js
@@ -40,7 +40,7 @@ export default function computeBreadcrumbs() {
         if (href) {
           href = href.href;
         }
-        if(e.textContent.length>26) {
+        if (e.textContent.length > 26) {
           tooltip = e.textContent;
         }
 

--- a/src/main/js/components/header/breadcrumbs-overflow.js
+++ b/src/main/js/components/header/breadcrumbs-overflow.js
@@ -42,6 +42,7 @@ export default function computeBreadcrumbs() {
 
         return {
           type: "link",
+          clazz: "jenkins-breadcrumbs__overflow-item",
           title: e.textContent,
           label: e.textContent,
           url: href,

--- a/src/main/js/components/header/breadcrumbs-overflow.js
+++ b/src/main/js/components/header/breadcrumbs-overflow.js
@@ -42,6 +42,7 @@ export default function computeBreadcrumbs() {
 
         return {
           type: "link",
+          title: e.textContent,
           label: e.textContent,
           url: href,
         };
@@ -51,7 +52,7 @@ export default function computeBreadcrumbs() {
     },
     true,
     {
-      trigger: "mouseenter focus",
+      trigger: "click focus",
       offset: [0, 10],
       animation: "tooltip",
     },

--- a/src/main/js/components/header/breadcrumbs-overflow.js
+++ b/src/main/js/components/header/breadcrumbs-overflow.js
@@ -36,16 +36,18 @@ export default function computeBreadcrumbs() {
     (instance) => {
       const mappedItems = items.map((e) => {
         let href = e.querySelector("a");
+        let tooltip;
         if (href) {
+          tooltip = href.getAttribute("tooltip");
           href = href.href;
         }
 
         return {
           type: "link",
           clazz: "jenkins-breadcrumbs__overflow-item",
-          title: e.textContent,
           label: e.textContent,
           url: href,
+          tooltip,
         };
       });
 

--- a/src/main/js/components/header/breadcrumbs-overflow.js
+++ b/src/main/js/components/header/breadcrumbs-overflow.js
@@ -38,8 +38,10 @@ export default function computeBreadcrumbs() {
         let href = e.querySelector("a");
         let tooltip;
         if (href) {
-          tooltip = href.getAttribute("tooltip");
           href = href.href;
+        }
+        if(e.textContent.length>26) {
+          tooltip = e.textContent;
         }
 
         return {

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -24,13 +24,14 @@
         pointer-events: all !important;
       }
 
-      & > a {
+      & > a,
+      .dropdown-indicator {
         @include mixins.item($border: false);
 
         --item-background: transparent;
-        --item-background--hover: transparent;
-        --item-background--active: transparent;
-        --item-box-shadow--focus: transparent;
+        --item-background--hover: var(--button-background--hover);
+        --item-background--active: var(--button-background--active);
+        --item-box-shadow--focus: var(--button-box-shadow--focus);
 
         transition: opacity var(--standard-transition);
 
@@ -70,8 +71,8 @@
       &::before {
         content: "";
         position: relative;
-        width: 1rem;
-        height: 1.25rem;
+        width: 16px;
+        height: 20px;
         flex-shrink: 0;
         mask-size: contain;
         mask-position: center;
@@ -86,23 +87,6 @@
         @media (prefers-contrast: more) {
           background: var(--text-color);
         }
-      }
-
-      &:has(a)::after {
-        content: "";
-        position: relative !important;
-
-        /* create a small triangle */
-        width: 0;
-        height: 0;
-        border: 0.4em solid currentColor !important; /* ▼ by default */
-        transform: rotate(270deg);
-        transition: transform 0.25s ease; /* smooth rotation */
-        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'%3E%3Ctitle%3EChevron Forward%3C/title%3E%3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='48' d='M184 112l144 144-144 144'/%3E%3C/svg%3E");
-      }
-
-      &:has(a[aria-expanded="true"])::after {
-        transform: rotate(90deg);
       }
     }
   }

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -53,10 +53,6 @@
       & > a,
       span {
         position: relative;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 1rem;
         font-size: var(--font-size-sm);
         font-weight: var(--font-bold-weight);
         margin: 0;
@@ -65,6 +61,10 @@
         text-decoration: none;
         text-wrap: nowrap;
         flex-shrink: 0;
+        overflow: hidden;
+        max-width: 25ch;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       // '/' separator between two items

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -87,17 +87,20 @@
           background: var(--text-color);
         }
       }
-      &::after{
+
+      &::after {
         content: "";
         position: relative !important;
+
         /* create a small triangle */
         width: 0;
         height: 0;
-        border: 0.4em solid currentColor !important;  /* ▼ by default */
+        border: 0.4em solid currentColor !important; /* ▼ by default */
         transform: rotate(270deg);
-        transition: transform 0.25s ease;      /* smooth rotation */
-        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'%3E%3Ctitle%3EChevron Forward%3C/title%3E%3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='48' d='M184 112l144 144-144 144'/%3E%3C/svg%3E")
+        transition: transform 0.25s ease; /* smooth rotation */
+        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'%3E%3Ctitle%3EChevron Forward%3C/title%3E%3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='48' d='M184 112l144 144-144 144'/%3E%3C/svg%3E");
       }
+
       &:has(a[aria-expanded="true"])::after {
         transform: rotate(90deg);
       }

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -27,6 +27,7 @@
 
       .dropdown-indicator {
         margin-right: 4px;
+        display: flex;
       }
 
       & > a,

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -87,6 +87,20 @@
           background: var(--text-color);
         }
       }
+      &::after{
+        content: "";
+        position: relative !important;
+        /* create a small triangle */
+        width: 0;
+        height: 0;
+        border: 0.4em solid currentColor !important;  /* ▼ by default */
+        transform: rotate(270deg);
+        transition: transform 0.25s ease;      /* smooth rotation */
+        mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'%3E%3Ctitle%3EChevron Forward%3C/title%3E%3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='48' d='M184 112l144 144-144 144'/%3E%3C/svg%3E")
+      }
+      &:has(a[aria-expanded="true"])::after {
+        transform: rotate(90deg);
+      }
     }
   }
 }

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -88,7 +88,7 @@
         }
       }
 
-      &::after {
+      &:has(a)::after {
         content: "";
         position: relative !important;
 

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -3,25 +3,30 @@
 .jenkins-breadcrumbs {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  margin-left: 0.625rem;
+  gap: 0.5rem;
+  margin-left: -2rem;
   overflow: hidden;
 
   &__list {
-    display: contents;
+    display: flex;
 
     & > * {
       z-index: 1;
     }
 
     &-item {
-      display: contents;
+      display: flex;
+      align-items: center;
 
       a::before {
         content: "";
         position: absolute;
         inset: -0.5rem -0.75rem !important;
         pointer-events: all !important;
+      }
+
+      .dropdown-indicator {
+        margin-right: 4px;
       }
 
       & > a,
@@ -56,7 +61,7 @@
         font-size: var(--font-size-sm);
         font-weight: var(--font-bold-weight);
         margin: 0;
-        padding: 0;
+        padding: 4px 8px;
         color: inherit;
         text-decoration: none;
         text-wrap: nowrap;
@@ -69,23 +74,15 @@
 
       // '/' separator between two items
       &::before {
-        content: "";
+        content: "/";
         position: relative;
-        width: 16px;
-        height: 20px;
         flex-shrink: 0;
-        mask-size: contain;
-        mask-position: center;
-        mask-repeat: no-repeat;
-        mask-image: url("data:image/svg+xml,%3Csvg width='10' height='20' viewBox='0 0 10 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 18L8 2' stroke='black' stroke-width='1.5px' stroke-linecap='round'/%3E%3C/svg%3E%0A");
-        background: color-mix(
-          in sRGB,
-          var(--text-color-secondary) 30%,
-          transparent
-        );
+        color: color-mix(in sRGB, var(--text-color-secondary) 30%, transparent);
+        padding-left: 4px;
+        padding-right: 4px;
 
         @media (prefers-contrast: more) {
-          background: var(--text-color);
+          color: var(--text-color);
         }
       }
     }

--- a/src/main/scss/components/_dropdowns.scss
+++ b/src/main/scss/components/_dropdowns.scss
@@ -129,7 +129,6 @@ $dropdown-padding: 0.375rem;
     @include mixins.item($border: false);
 
     appearance: none;
-    display: inline-flex;
     align-items: center;
     justify-content: flex-start;
     border: none;
@@ -144,10 +143,14 @@ $dropdown-padding: 0.375rem;
     border-radius: calc($dropdown-border-radius - $dropdown-padding);
     cursor: pointer;
     min-height: 36px;
-    white-space: nowrap;
     gap: 1.2ch;
     min-width: 180px;
     user-select: none;
+    display: block;
+    overflow: hidden;
+    max-width: 25ch;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     &__icon {
       display: inline-flex;

--- a/src/main/scss/components/_dropdowns.scss
+++ b/src/main/scss/components/_dropdowns.scss
@@ -281,10 +281,11 @@ $dropdown-padding: 0.375rem;
     }
   }
 }
-.jenkins-breadcrumbs__overflow-item{
-    display: block;
-    overflow: hidden;
-    max-width: 25ch;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+
+.jenkins-breadcrumbs__overflow-item {
+  display: block;
+  overflow: hidden;
+  max-width: 25ch;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/main/scss/components/_dropdowns.scss
+++ b/src/main/scss/components/_dropdowns.scss
@@ -129,6 +129,7 @@ $dropdown-padding: 0.375rem;
     @include mixins.item($border: false);
 
     appearance: none;
+    display: inline-flex;
     align-items: center;
     justify-content: flex-start;
     border: none;
@@ -143,14 +144,10 @@ $dropdown-padding: 0.375rem;
     border-radius: calc($dropdown-border-radius - $dropdown-padding);
     cursor: pointer;
     min-height: 36px;
+    white-space: nowrap;
     gap: 1.2ch;
     min-width: 180px;
     user-select: none;
-    display: block;
-    overflow: hidden;
-    max-width: 25ch;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 
     &__icon {
       display: inline-flex;
@@ -283,4 +280,11 @@ $dropdown-padding: 0.375rem;
       border-left: var(--jenkins-border--subtle);
     }
   }
+}
+.jenkins-breadcrumbs__overflow-item{
+    display: block;
+    overflow: hidden;
+    max-width: 25ch;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }


### PR DESCRIPTION
```console
Latest core version: jenkins-2.521

Postponed
---------

JENKINS-75637           Major                   <a href="https://www.jenkins.io/changelog/2.520/">https://www.jenkins.io/changelog/2.520/</a>
        System configuration no longer has breadcrumb navigation (regression in 2.507)
        regression
        https://issues.jenkins.io/browse/JENKINS-75637

JENKINS-75931           Minor                   <a href="https://github.com/jenkinsci/jellydoc-maven-plugin/releases/tag/226.v2eddb_617a_307">https://github.com/jenkinsci/jellydoc-maven-plugin/releases/tag/226.v2eddb_617a_307</a>
        core taglibs generate mismatching links and anchors
        regression
        https://issues.jenkins.io/browse/JENKINS-75931

Fixed
-----

JENKINS-75851           Minor                   Mon, 4 Aug 2025 05:43:49 +0000
        Enhance breadcrumb with visual indication to show that there are dropdowns
        https://issues.jenkins.io/browse/JENKINS-75851

```

Cherry picked individual commits from pull request:

* https://github.com/jenkinsci/jenkins/pull/10803

One open question relates to the contents of src/main/js/components/dropdowns/inpage-jumplist.js on the stable-2.516 branch.  It is different than the contents of src/main/js/components/dropdowns/inpage-jumplist.js at the point where this pull request was merged.

### Testing done

Interactive testing to confirm the breadcrumbs behaved as expected.  Confirmed that long job names are truncated and the hover text shows the full name.  Created views and confirmed they were available from the navigation.

Compared contents of modified files with the command:

```
git diff ee48c485e05e43b7fbfd402d55954190210abdef..37715de5af42de9624c67573e1194445f306917d -- core/src/main/resources/lib/layout/breadcrumb.jelly src/main/js/components/dropdowns/inpage-jumplist.js src/main/js/components/dropdowns/jumplists.js src/main/js/components/dropdowns/templates.js src/main/js/components/header/breadcrumbs-overflow.js src/main/scss/components/_breadcrumbs.scss src/main/scss/components/_dropdowns.scss
```

The comparison shows:

```
diff --git a/src/main/js/components/dropdowns/inpage-jumplist.js b/src/main/js/components/dropdowns/inpage-jumplist.js
index 0397f6fca2..b0f89f7de9 100644
--- a/src/main/js/components/dropdowns/inpage-jumplist.js
+++ b/src/main/js/components/dropdowns/inpage-jumplist.js
@@ -8,7 +8,9 @@ function init() {
   const inpageNavigationBreadcrumb = document.querySelector("#inpage-nav div");
 
   if (inpageNavigationBreadcrumb) {
-    inpageNavigationBreadcrumb.items = Array.from(
+    const chevron = document.createElement("li");
+    chevron.classList.add("children");
+    chevron.items = Array.from(
       document.querySelectorAll(
         "form > div > .jenkins-section > .jenkins-section__title",
       ),
@@ -16,6 +18,8 @@ function init() {
       section.id = toId(section.textContent);
       return { label: section.textContent, url: "#" + section.id };
     });
+
+    inpageNavigationBreadcrumb.after(chevron);
   }
 }
 
diff --git a/src/main/scss/components/_breadcrumbs.scss b/src/main/scss/components/_breadcrumbs.scss
index b04d87cfe8..89cdfae514 100644
--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -100,6 +100,7 @@
   outline: none;
   cursor: pointer;
   padding: 0;
+  pointer-events: none;
   transition: var(--standard-transition);
   background: transparent;
   top: 4px;
```

/label into-lts

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@scherler @timja @MarkEWaite @basil @NotMyFault 

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

