### PR TITLE
Backporting for LTS 2.516.2 - JENKINS-75931

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.132</version>
+    <version>1.136</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Backporting for LTS 2.516.2 - JENKINS-75931

Fixes https://issues.jenkins.io/browse/JENKINS-75931 core taglibs generate mismatching links and anchors

(cherry picked from commit 177c8822ec017cf3a49a174a58c080161a5c4d3e)


```console
Latest core version: jenkins-2.522

Fixed
-----

JENKINS-75931           Minor                   2.523
        core taglibs generate mismatching links and anchors
        regression
        https://issues.jenkins.io/browse/JENKINS-75931

```

From pull request:

* https://github.com/jenkinsci/jenkins/pull/10928

This is an exception to the usual LTS backport process.  We usually release changes on the weekly branch first and then backport to the LTS line.  This change is low risk, so it has been preemptively backported to the LTS line.  It has been verified with command line testing.  It will arrive in the next weekly Jenkins release.

### Testing done

Built the jellydoc and confirmed that the hyperlinks are now correct.  Commands used were:

```
mvn -am -pl war,bom -Pquick-build clean install
cd core
mvn --show-version --batch-mode -DgenerateProjectInfo=false -DgenerateSitemap=false -e clean site:site
grep -r form.*apply target
```

/label into-lts

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @daniel-back

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).


