### PR TITLE
show parameters of a run with readOnlyMode

### DIFF
--- a/core/src/main/resources/hudson/model/BooleanParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/BooleanParameterValue/value.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <j:set var="escapeEntryTitleAndDescription" value="false"/>
     <f:entry description="${it.formattedDescription}">
-        <f:checkbox title="${h.escape(it.name)}" name="value" checked="${it.value}" readonly="true" />
+      <f:checkbox title="${h.escape(it.name)}" name="value" checked="${it.value}"/>
     </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/BooleanParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/BooleanParameterValue/value.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
     <j:set var="escapeEntryTitleAndDescription" value="false"/>
     <f:entry description="${it.formattedDescription}">
+      <j:set var="readOnlyMode" value="true"/>
       <f:checkbox title="${h.escape(it.name)}" name="value" checked="${it.value}"/>
     </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/ParametersAction/index.jelly
+++ b/core/src/main/resources/hudson/model/ParametersAction/index.jelly
@@ -35,6 +35,7 @@ THE SOFTWARE.
     <l:main-panel>
 	  <t:buildCaption it="${build}">${title}</t:buildCaption>
       <j:set var="escapeEntryTitleAndDescription" value="true" /> <!-- SECURITY-353 defense unless overridden -->
+      <j:set var="readOnlyMode" value="true"/>
       <j:forEach var="parameterValue" items="${it.parameters}">
 	    <st:include it="${parameterValue}" page="value.jelly" />
       </j:forEach>

--- a/core/src/main/resources/hudson/model/StringParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/StringParameterValue/value.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
          xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <j:set var="escapeEntryTitleAndDescription" value="false"/>
   <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+    <j:set var="readOnlyMode" value="true"/>
     <f:textbox name="value" value="${it.value}"/>
   </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/StringParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/StringParameterValue/value.jelly
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
-	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-        <j:set var="escapeEntryTitleAndDescription" value="false"/>
-        <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
-		<f:textbox name="value" value="${it.value}" readonly="true" />
-	</f:entry>
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  <j:set var="escapeEntryTitleAndDescription" value="false"/>
+  <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+    <f:textbox name="value" value="${it.value}"/>
+  </f:entry>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/TextParameterValue/value.jelly
+++ b/core/src/main/resources/hudson/model/TextParameterValue/value.jelly
@@ -26,8 +26,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-        <j:set var="escapeEntryTitleAndDescription" value="false"/>
-        <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
-		<f:textarea name="value" value="${it.value}" readonly="readonly" />
-	</f:entry>
+    <j:set var="escapeEntryTitleAndDescription" value="false"/>
+    <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+      <j:set var="readOnlyMode" value="true"/>
+      <f:textarea name="value" value="${it.value}"/>
+    </f:entry>
 </j:jelly>

--- a/core/src/main/resources/lib/form/checkbox.jelly
+++ b/core/src/main/resources/lib/form/checkbox.jelly
@@ -83,9 +83,9 @@ THE SOFTWARE.
            name="${name}"
            value="${attrs.value}"
            title="${attrs.tooltip}"
-           onclick="${attrs.readonly=='true' ? 'return false;' : attrs.onclick}" id="${attrs.id}" class="${attrs.class} ${attrs.negative!=null ? 'negative' : null} ${attrs.checkUrl!=null?'validated':''}"
+           onclick="${attrs.readonly=='true' ? null : attrs.onclick}" id="${attrs.id}" class="${attrs.class} ${attrs.negative!=null ? 'negative' : null} ${attrs.checkUrl!=null?'validated':''}"
            checkUrl="${attrs.checkUrl}" checkDependsOn="${attrs.checkDependsOn}" json="${attrs.json}"
-           disabled="${readOnlyMode ? 'true' : null}"
+           disabled="${readOnlyMode or attrs.readonly=='true' ? 'true' : null}"
            checked="${value ? 'true' : null}"/>
     <label class="attach-previous ${attrs.title == null ? 'js-checkbox-label-empty' : ''}"
            title="${attrs.tooltip}">${attrs.title}</label>

--- a/core/src/main/resources/lib/form/radio.jelly
+++ b/core/src/main/resources/lib/form/radio.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
- <st:documentation> <![CDATA[
+  <st:documentation> <![CDATA[
     <input type="radio"> tag that takes true/false for @checked, which is more Jelly friendly.
 
     Note that Safari doesn't support onchange.
@@ -38,7 +38,13 @@ THE SOFTWARE.
     <st:attribute name="checked" />
     <st:attribute name="value" />
     <st:attribute name="id" />
-    <st:attribute name="onclick" />
+    <st:attribute name="onclick" deprecated="true">
+      Inline JavaScript to execute when the checkbox is clicked.
+      Deprecated because this attribute is incompatible with adding Content-Security-Policy to the Jenkins UI in the future.
+      Set 'id' or 'class' attributes as appropriate to look up this element in external Javascript files (e.g. adjuncts)
+      to add the desired behavior there (DOMContentLoaded event in static forms, Behaviour.specify if this element may be
+      dynamically added). See https://github.com/jenkinsci/jenkins/pull/6852 for an example.
+    </st:attribute>
     <st:attribute name="title">
       If specified, this human readable text will follow the radio, and clicking this text also
       toggles the radio.

--- a/test/src/test/java/hudson/model/ParametersTest.java
+++ b/test/src/test/java/hudson/model/ParametersTest.java
@@ -267,7 +267,7 @@ class ParametersTest {
         assertAll(
                 () -> assertThat("parameters page should escape param name", text2, containsString("&lt;param name&gt;")),
                 () -> assertThat("parameters page should not leave param name unescaped", text2, not(containsString("<param name>"))),
-                () -> assertThat("parameters page should escape param value", text2, containsString("&lt;param value&gt;")),
+                () -> assertThat("parameters page should escape param value", text2, containsString("&lt;param value>")),
                 () -> assertThat("parameters page should not leave param value unescaped", text2, not(containsString("<param value>"))),
                 () -> assertThat("parameters page should mark up param description", text2, containsString("<b>[</b>param description<b>]</b>")),
                 () -> assertThat("parameters page should not leave param description unescaped", text2, not(containsString("<param description>")))


### PR DESCRIPTION
Display the parameters that have been used for a run with `readOnlyMode` instead of using the readonly attribute. This is the recommended way.

Also removes the inline javascript when a checkbox sets `readonly="true"`. This is only used in very few places and should not have an effect on plugins. A f:checkbox that still uses `readonly` will then be rendered `disabled`

Before:
<img width="537" height="834" alt="image" src="https://github.com/user-attachments/assets/cb364a82-7e2a-44a9-a7ff-736fafbe1eb9" />

After:
<img width="780" height="861" alt="image" src="https://github.com/user-attachments/assets/1de51dd5-a4bc-4168-bdeb-76b30e7d8263" />

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done
Interactive testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Show parameters of a run in read only mode.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe,web-ui

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
