### PR TITLE
Add EOL whitespace in scriptConsole_bg.properties

### DIFF
--- a/core/src/main/resources/lib/hudson/scriptConsole_bg.properties
+++ b/core/src/main/resources/lib/hudson/scriptConsole_bg.properties
@@ -27,8 +27,8 @@ Script\ Console=\
 # \ 
 # All the classes from all the plugins are visible. <code>jenkins.*</code>, <code>jenkins.model.*</code>, <code>hudson.*</code>, and <code>hudson.model.*</code> are pre-imported.
 description2=\
- Всички класове от всички приставки са видими. Следните пакети са внесени:\
- <code>jenkins.*</code>, <code>jenkins.model.*</code>, <code>hudson.*</code> и\
+ Всички класове от всички приставки са видими. Следните пакети са внесени: \
+ <code>jenkins.*</code>, <code>jenkins.model.*</code>, <code>hudson.*</code> и \
  <code>hudson.model.*</code>
 It\ is\ not\ possible\ to\ run\ scripts\ when\ slave\ is\ offline.=\
  Когато подчиненият компютър не е на линия, не може да се изпълняват скриптове.

--- a/core/src/main/resources/lib/hudson/scriptConsole_bg.properties
+++ b/core/src/main/resources/lib/hudson/scriptConsole_bg.properties
@@ -38,7 +38,7 @@ It\ is\ not\ possible\ to\ run\ scripts\ when\ slave\ is\ offline.=\
 # Use the ‘println’ command to see the output (if you use <code>System.out</code>, \
 # it will go to the server’s stdout, which is harder to see.) Example:
 description=\
- Въведете произволен скрипт на <a href="https://www.groovy-lang.org">Groovy</a>\
+ Въведете произволен скрипт на <a href="https://www.groovy-lang.org">Groovy</a> \
  и го изпълнете на сървъра. Полезно е за диагностика и коригиране на грешки.\
  За да изведете данни използвайте командата „println“. (<code>System.out</code>\
  отива на стандартния изход на сървъра, което се следи по-трудно.) Пример:

--- a/core/src/main/resources/lib/hudson/scriptConsole_bg.properties
+++ b/core/src/main/resources/lib/hudson/scriptConsole_bg.properties
@@ -39,8 +39,8 @@ It\ is\ not\ possible\ to\ run\ scripts\ when\ slave\ is\ offline.=\
 # it will go to the server’s stdout, which is harder to see.) Example:
 description=\
  Въведете произволен скрипт на <a href="https://www.groovy-lang.org">Groovy</a> \
- и го изпълнете на сървъра. Полезно е за диагностика и коригиране на грешки.\
- За да изведете данни използвайте командата „println“. (<code>System.out</code>\
+ и го изпълнете на сървъра. Полезно е за диагностика и коригиране на грешки. \
+ За да изведете данни използвайте командата „println“. (<code>System.out</code> \
  отива на стандартния изход на сървъра, което се следи по-трудно.) Пример:
 Run=\
  Изпълнение


### PR DESCRIPTION
For some reason the texts in this file have the whitespace at the end of the line removed and the words are merged together:

<img width="1944" height="712" alt="image" src="https://github.com/user-attachments/assets/101ac12e-70bd-46fb-ab17-6de57f426017" />

----

In other views the properties file has the same syntax, but looks normal - I am not sure why: https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/model/Computer/setOfflineCause_bg.properties#L28

<img width="1338" height="556" alt="image" src="https://github.com/user-attachments/assets/4687eff0-53be-4869-a08b-73bac64fbe4d" />
