### PR TITLE
Better error response from `doBuildWithParameters`

### DIFF
--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -24,6 +24,7 @@
 
 package jenkins.model;
 
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_CONFLICT;
 import static jakarta.servlet.http.HttpServletResponse.SC_CREATED;
 
@@ -201,7 +202,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         }
 
         if (!asJob().isBuildable()) {
-            throw HttpResponses.error(SC_CONFLICT, new IOException(asJob().getFullName() + " is not buildable"));
+            throw HttpResponses.errorWithoutStack(SC_CONFLICT, asJob().getFullName() + " is not buildable");
         }
 
         // if a build is parameterized, let that take over
@@ -238,12 +239,12 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
 
         ParametersDefinitionProperty pp = asJob().getProperty(ParametersDefinitionProperty.class);
         if (!asJob().isBuildable()) {
-            throw HttpResponses.error(SC_CONFLICT, new IOException(asJob().getFullName() + " is not buildable!"));
+            throw HttpResponses.errorWithoutStack(SC_CONFLICT, asJob().getFullName() + " is not buildable");
         }
         if (pp != null) {
             pp.buildWithParameters(req, rsp, delay);
         } else {
-            throw new IllegalStateException("This build is not parameterized!");
+            throw HttpResponses.errorWithoutStack(SC_BAD_REQUEST, asJob().getFullName() + " is not parameterized");
         }
     }
 

--- a/test/src/test/java/jenkins/model/ParameterizedJobMixInTest.java
+++ b/test/src/test/java/jenkins/model/ParameterizedJobMixInTest.java
@@ -81,9 +81,22 @@ class ParameterizedJobMixInTest {
 
         FailingHttpStatusCodeException fex = assertThrows(
                 FailingHttpStatusCodeException.class,
-                () -> webClient.getPage(webClient.addCrumb(new WebRequest(new URL(j.getURL(), project.getUrl() + "build?delay=0"), HttpMethod.POST))),
+                () -> webClient.getPage(webClient.addCrumb(new WebRequest(new URL(j.getURL(), project.getUrl() + "buildWithParameters?FOO=x"), HttpMethod.POST))),
                 "should fail when invoking disabled project");
-        assertThat("Should fail with conflict", fex.getStatusCode(), is(409));
+        assertThat("Should fail with conflict", fex.getStatusCode(), is(HttpServletResponse.SC_CONFLICT));
+    }
+
+    @Test
+    void doBuildWithParameters_shouldFailWhenInvokingNonParameterizedProject() throws Exception {
+        final FreeStyleProject project = j.createFreeStyleProject();
+
+        final JenkinsRule.WebClient webClient = j.createWebClient();
+
+        FailingHttpStatusCodeException fex = assertThrows(
+                FailingHttpStatusCodeException.class,
+                () -> webClient.getPage(webClient.addCrumb(new WebRequest(new URL(j.getURL(), project.getUrl() + "buildWithParameters?FOO=x"), HttpMethod.POST))),
+                "should fail when invoking non-parameterized project");
+        assertThat("Should fail with bad request", fex.getStatusCode(), is(HttpServletResponse.SC_BAD_REQUEST));
     }
 
     @Test


### PR DESCRIPTION
I noticed a long stack trace in system logs

```
WARNING Error while serving https://…/job/…/buildWithParameters
java.lang.IllegalStateException: This build is not parameterized!
	at jenkins.model.ParameterizedJobMixIn.doBuildWithParameters(ParameterizedJobMixIn.java:246)
	at jenkins.model.ParameterizedJobMixIn$ParameterizedJob.doBuildWithParameters(ParameterizedJobMixIn.java:446)
	at …
```

rather than a sensible HTTP response.

### Testing done

Test without fix produces a 500 response with giant stack trace. With fix, a 400 with a polite message.

### Proposed changelog entries

- Friendlier HTTP response for an attempt to `buildWithParameters` a disabled or non-parameterized job.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
