### PR TITLE
Apply security fixes featuring `refasterrules.FileRulesRecipes`

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -680,7 +680,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
     }
 
     private static void unzip(File dir, InputStream in) throws IOException {
-        File tmpFile = File.createTempFile("tmpzip", null); // uses java.io.tmpdir
+        File tmpFile = Files.createTempFile("tmpzip", null).toFile(); // uses java.io.tmpdir
         try {
             // TODO why does this not simply use ZipInputStream?
             IOUtils.copy(in, tmpFile);
@@ -1582,7 +1582,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
 
         @Override
         public String invoke(File dir, VirtualChannel channel) throws IOException {
-            File f = File.createTempFile(prefix, suffix, dir);
+            File f = Files.createTempFile(dir.toPath(), prefix, suffix).toFile();
             return f.getName();
         }
     }
@@ -1660,7 +1660,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
 
             File f;
             try {
-                f = File.createTempFile(prefix, suffix, dir);
+                f = Files.createTempFile(dir.toPath(), prefix, suffix).toFile();
             } catch (IOException e) {
                 throw new IOException("Failed to create a temporary directory in " + dir, e);
             }

--- a/core/src/main/java/hudson/Main.java
+++ b/core/src/main/java/hudson/Main.java
@@ -143,7 +143,7 @@ public class Main {
         }
 
         // write the output to a temporary file first.
-        File tmpFile = File.createTempFile("jenkins", "log");
+        File tmpFile = Files.createTempFile("jenkins", "log").toFile();
         try {
             int ret;
             try (OutputStream os = Files.newOutputStream(tmpFile.toPath());

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -88,7 +88,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.security.CodeSource;
 import java.time.Duration;
@@ -1396,7 +1396,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     if ("file".equals(loc.getProtocol())) {
                         File file;
                         try {
-                            file = Paths.get(loc.toURI()).toFile();
+                            file = Path.of(loc.toURI()).toFile();
                         } catch (InvalidPathException | URISyntaxException e) {
                             LOGGER.log(Level.WARNING, "could not inspect " + loc, e);
                             return null;
@@ -1962,7 +1962,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             }
 
             // first copy into a temporary file name
-            File t = File.createTempFile("uploaded", ".jpi", tmpDir);
+            File t = Files.createTempFile(tmpDir.toPath(), "uploaded", ".jpi").toFile();
             tmpDir.deleteOnExit();
             t.deleteOnExit();
             // TODO Remove this workaround after FILEUPLOAD-293 is resolved.

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -1306,7 +1306,7 @@ public class Util {
     @CheckReturnValue
     private static boolean createSymlinkAtomic(@NonNull Path pathForSymlink, @NonNull File fileForSymlink, @NonNull Path target, @NonNull String symlinkPath) {
         try {
-            File symlink = File.createTempFile("symtmp", null, fileForSymlink);
+            File symlink = Files.createTempFile(fileForSymlink.toPath(), "symtmp", null).toFile();
             tryToDeleteSymlink(symlink);
             Path tempSymlinkPath = symlink.toPath();
             Files.createSymbolicLink(tempSymlinkPath, target);

--- a/core/src/main/java/hudson/WebAppMain.java
+++ b/core/src/main/java/hudson/WebAppMain.java
@@ -224,7 +224,7 @@ public class WebAppMain implements ServletContextListener {
             // even if the temp directory doesn't exist.
             // check that and report an error
             try {
-                File f = File.createTempFile("test", "test");
+                File f = Files.createTempFile("test", "test").toFile();
                 boolean result = f.delete();
                 if (!result) {
                     LOGGER.log(FINE, "Temp file test.test could not be deleted.");

--- a/core/src/main/java/hudson/cli/InstallPluginCommand.java
+++ b/core/src/main/java/hudson/cli/InstallPluginCommand.java
@@ -169,7 +169,7 @@ public class InstallPluginCommand extends CLICommand {
     }
 
     private static File getTmpFile() throws Exception {
-        return File.createTempFile("download", ".jpi.tmp", Jenkins.get().getPluginManager().rootDir);
+        return Files.createTempFile(Jenkins.get().getPluginManager().rootDir.toPath(), "download", ".jpi.tmp").toFile();
     }
 
     private static File moveToFinalLocation(File tmpFile) throws Exception {

--- a/core/src/main/java/hudson/scm/SCM.java
+++ b/core/src/main/java/hudson/scm/SCM.java
@@ -516,7 +516,7 @@ public abstract class SCM implements Describable<SCM>, ExtensionPoint {
                         BuildListener.class,
                         File.class)) {
             if (changelogFile == null) {
-                changelogFile = File.createTempFile("changelog", ".xml");
+                changelogFile = Files.createTempFile("changelog", ".xml").toFile();
                 try {
                     if (!checkout((AbstractBuild) build, launcher, workspace, (BuildListener) listener, changelogFile)) {
                         throw new AbortException();

--- a/core/src/main/java/hudson/util/AtomicFileWriter.java
+++ b/core/src/main/java/hudson/util/AtomicFileWriter.java
@@ -155,7 +155,7 @@ public class AtomicFileWriter extends Writer {
 
         try {
             // JENKINS-48407: NIO's createTempFile creates file with 0600 permissions, so we use pre-NIO for this...
-            tmpPath = File.createTempFile(destPath.getFileName() + "-atomic", "tmp", dir.toFile()).toPath();
+            tmpPath = Files.createTempFile(dir, destPath.getFileName() + "-atomic", "tmp");
         } catch (IOException e) {
             throw new IOException("Failed to create a temporary file in " + dir, e);
         }

--- a/core/src/main/java/hudson/util/RemotingDiagnostics.java
+++ b/core/src/main/java/hudson/util/RemotingDiagnostics.java
@@ -184,7 +184,7 @@ public final class RemotingDiagnostics {
     private static class GetHeapDump extends MasterToSlaveCallable<FilePath, IOException> {
             @Override
             public FilePath call() throws IOException {
-                final File hprof = File.createTempFile("hudson-heapdump", ".hprof");
+                final File hprof = Files.createTempFile("hudson-heapdump", ".hprof").toFile();
                 Files.delete(Util.fileToPath(hprof));
                 try {
                     MBeanServer server = ManagementFactory.getPlatformMBeanServer();

--- a/core/src/main/java/jenkins/install/SetupWizard.java
+++ b/core/src/main/java/jenkins/install/SetupWizard.java
@@ -245,7 +245,7 @@ public class SetupWizard extends PageDecorator {
                 }
 
                 try {
-                    plainText = Files.readString(apiTokenFile, StandardCharsets.UTF_8);
+                    plainText = Files.readString(apiTokenFile);
                     LOGGER.log(Level.INFO, "API Token generated using contents of file: {0}", apiTokenFile.toAbsolutePath());
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, String.format("The API Token cannot be retrieved from the file: %s", apiTokenFile), e);
@@ -483,7 +483,7 @@ public class SetupWizard extends PageDecorator {
         File state = getUpdateStateFile();
         if (state.exists()) {
             try {
-                String version = Files.readString(Util.fileToPath(state), StandardCharsets.UTF_8);
+                String version = Files.readString(Util.fileToPath(state));
                 if (version == null || version.isBlank()) {
                     version = "1.0";
                 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -3449,7 +3449,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
         if (replacedValue.contains("doCheckRawBuildsDir-Marker:foo")) {
             // make sure platform can handle colon
             try {
-                File tmp = File.createTempFile("Jenkins-doCheckRawBuildsDir", "foo:bar");
+                File tmp = Files.createTempFile("Jenkins-doCheckRawBuildsDir", "foo:bar").toFile();
                 Files.delete(tmp.toPath());
             } catch (IOException | InvalidPathException e) {
                 throw (InvalidBuildsDir) new InvalidBuildsDir(newBuildsDirValue +  " contains ${ITEM_FULLNAME} but your system does not support it (JENKINS-12251). Use ${ITEM_FULL_NAME} instead").initCause(e);

--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -137,7 +137,7 @@ class FilePathTest {
 
     @Test
     void copyTo() throws Exception {
-        File tmp = File.createTempFile("junit", null, temp);
+        File tmp = Files.createTempFile(temp.toPath(), "junit", null).toFile();
         FilePath f = new FilePath(french, tmp.getPath());
         try (OutputStream out = OutputStream.nullOutputStream()) {
             f.copyTo(out);
@@ -155,9 +155,9 @@ class FilePathTest {
     @Test
     void noFileLeakInCopyTo() throws Exception {
         for (int j = 0; j < 2500; j++) {
-            File tmp = File.createTempFile("junit", null, temp);
+            File tmp = Files.createTempFile(temp.toPath(), "junit", null).toFile();
             FilePath f = new FilePath(tmp);
-            File tmp2 = File.createTempFile("junit", null, temp);
+            File tmp2 = Files.createTempFile(temp.toPath(), "junit", null).toFile();
             FilePath f2 = new FilePath(british, tmp2.getPath());
 
             f.copyTo(f2);
@@ -182,7 +182,7 @@ class FilePathTest {
     @Issue("JENKINS-7871")
     @Test
     void noRaceConditionInCopyTo() throws Exception {
-        final File tmp = File.createTempFile("junit", null, temp);
+        final File tmp = Files.createTempFile(temp.toPath(), "junit", null).toFile();
 
            int fileSize = 90000;
 
@@ -262,7 +262,7 @@ class FilePathTest {
         // should return number of files processed, whether or not they were copied or already current
         File src = newFolder(temp, "src");
         File dst = newFolder(temp, "dst");
-            File.createTempFile("foo", ".tmp", src);
+        Files.createTempFile(src.toPath(), "foo", ".tmp").toFile();
             FilePath fp = new FilePath(src);
             assertEquals(1, fp.copyRecursiveTo(new FilePath(dst)));
             // copy again should still report 1
@@ -872,7 +872,7 @@ class FilePathTest {
         givenSomeContentInFile(pomFile, 2049);
         FileUtils.copyFileToDirectory(pomFile, srcFolder);
 
-        final File archive = File.createTempFile("archive.tar", null, temp);
+        final File archive = Files.createTempFile(temp.toPath(), "archive.tar", null).toFile();
 
         // Compress archive
         final FilePath tmpDirPath = new FilePath(srcFolder);
@@ -890,7 +890,7 @@ class FilePathTest {
     @Test
     void chmod() throws Exception {
         assumeFalse(Functions.isWindows());
-        File f = File.createTempFile("file", null, temp);
+        File f = Files.createTempFile(temp.toPath(), "file", null).toFile();
         FilePath fp = new FilePath(f);
         int prevMode = fp.mode();
         assertEquals(0400, chmodAndMode(fp, 0400));
@@ -1214,7 +1214,7 @@ class FilePathTest {
     void isDescendant_throwIfAbsolutePathGiven() throws Exception {
         FilePath rootFolder = new FilePath(newFolder(temp, "root"));
         rootFolder.mkdirs();
-        assertThrows(IllegalArgumentException.class, () -> rootFolder.isDescendant(File.createTempFile("junit", null, temp).getAbsolutePath()));
+        assertThrows(IllegalArgumentException.class, () -> rootFolder.isDescendant(Files.createTempFile(temp.toPath(), "junit", null).toFile().getAbsolutePath()));
     }
 
     @Test

--- a/core/src/test/java/hudson/LauncherTest.java
+++ b/core/src/test/java/hudson/LauncherTest.java
@@ -100,7 +100,7 @@ class LauncherTest {
     void remoteKill() throws Exception {
         assumeFalse(Functions.isWindows());
 
-        File tmp = File.createTempFile("junit", null, temp);
+        File tmp = Files.createTempFile(temp.toPath(), "junit", null).toFile();
 
             FilePath f = new FilePath(french, tmp.getPath());
             Launcher l = f.createLauncher(StreamTaskListener.fromStderr());

--- a/core/src/test/java/hudson/UtilTest.java
+++ b/core/src/test/java/hudson/UtilTest.java
@@ -263,7 +263,7 @@ class UtilTest {
             // JENKINS-12331: either a bug in createSymlink or this isn't supposed to work:
             //assertTrue(Util.isSymlink(new File(d,"anotherDir/link")));
 
-            File external = File.createTempFile("something", "");
+            File external = Files.createTempFile("something", "").toFile();
             try {
                 Util.createSymlink(d, external.getAbsolutePath(), "outside", l);
                 assertEquals(external.getAbsolutePath(), Util.resolveSymlink(new File(d, "outside")));

--- a/core/src/test/java/hudson/model/ComputerTest.java
+++ b/core/src/test/java/hudson/model/ComputerTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import hudson.FilePath;
 import hudson.security.ACL;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -24,7 +25,7 @@ class ComputerTest {
 
     @Test
     void testRelocate() throws Exception {
-        File d = File.createTempFile("jenkins", "test");
+        File d = Files.createTempFile("jenkins", "test").toFile();
         FilePath dir = new FilePath(d);
         try {
             dir.delete();

--- a/core/src/test/java/hudson/model/LoadStatisticsTest.java
+++ b/core/src/test/java/hudson/model/LoadStatisticsTest.java
@@ -76,7 +76,7 @@ class LoadStatisticsTest {
         JFreeChart chart = ls.createTrendChart(TimeScale.SEC10).createChart();
         BufferedImage image = chart.createBufferedImage(400, 200);
 
-        File tempFile = File.createTempFile("chart-", "png");
+        File tempFile = Files.createTempFile("chart-", "png").toFile();
         try (OutputStream os = Files.newOutputStream(tempFile.toPath(), StandardOpenOption.DELETE_ON_CLOSE)) {
             ImageIO.write(image, "PNG", os);
         } finally {

--- a/core/src/test/java/hudson/util/AtomicFileWriterTest.java
+++ b/core/src/test/java/hudson/util/AtomicFileWriterTest.java
@@ -67,7 +67,7 @@ class AtomicFileWriterTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        af = File.createTempFile("junit", null, tmp);
+        af = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(af.toPath(), PREVIOUS, Charset.defaultCharset());
         afw = new AtomicFileWriter(af.toPath(), Charset.defaultCharset());
     }
@@ -147,7 +147,7 @@ class AtomicFileWriterTest {
 
     @Test
     void badPath() throws Exception {
-        final File newFile = File.createTempFile("junit", null, tmp);
+        final File newFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         File parentExistsAndIsAFile = new File(newFile, "badChild");
 
         assertTrue(newFile.exists());
@@ -163,7 +163,7 @@ class AtomicFileWriterTest {
     @Test
     void checkPermissionsRespectUmask() throws IOException {
 
-        final File newFile = File.createTempFile("junit", null, tmp);
+        final File newFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         boolean posixSupported = isPosixSupported(newFile);
 
         assumeTrue(posixSupported);

--- a/core/src/test/java/hudson/util/FileChannelWriterTest.java
+++ b/core/src/test/java/hudson/util/FileChannelWriterTest.java
@@ -49,6 +49,6 @@ class FileChannelWriterTest {
     }
 
     private void assertContent(String string) throws IOException {
-        assertThat(Files.readString(file, StandardCharsets.UTF_8), equalTo(string));
+        assertThat(Files.readString(file), equalTo(string));
     }
 }

--- a/core/src/test/java/hudson/util/TextFileTest.java
+++ b/core/src/test/java/hudson/util/TextFileTest.java
@@ -18,7 +18,7 @@ class TextFileTest {
 
     @Test
     void head() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+        File f = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         FileUtils.copyURLToFile(getClass().getResource("ascii.txt"), f);
 
         TextFile t = new TextFile(f);
@@ -29,7 +29,7 @@ class TextFileTest {
 
     @Test
     void shortHead() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+        File f = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(f.toPath(), "hello", Charset.defaultCharset());
 
         TextFile t = new TextFile(f);
@@ -38,7 +38,7 @@ class TextFileTest {
 
     @Test
     void tail() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+        File f = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         FileUtils.copyURLToFile(getClass().getResource("ascii.txt"), f);
         String whole = Files.readString(f.toPath(), Charset.defaultCharset());
         TextFile t = new TextFile(f);
@@ -48,7 +48,7 @@ class TextFileTest {
 
     @Test
     void shortTail() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+        File f = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(f.toPath(), "hello", Charset.defaultCharset());
 
         TextFile t = new TextFile(f);
@@ -63,7 +63,7 @@ class TextFileTest {
      */
     @Test
     void tailShiftJIS() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+        File f = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
 
         TextFile t = new TextFile(f);
 

--- a/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
+++ b/core/src/test/java/hudson/util/io/RewindableRotatingFileOutputStreamTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -23,7 +24,7 @@ class RewindableRotatingFileOutputStreamTest {
 
     @Test
     void rotation() throws IOException, InterruptedException {
-        File base = File.createTempFile("test.log", null, tmp);
+        File base = Files.createTempFile(tmp.toPath(), "test.log", null).toFile();
         RewindableRotatingFileOutputStream os = new RewindableRotatingFileOutputStream(base, 3);
         PrintWriter w = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8), true);
         for (int i = 0; i <= 4; i++) {

--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -64,10 +64,10 @@ class TarArchiverTest {
     void permission() throws Exception {
         assumeFalse(Functions.isWindows());
 
-        File tar = File.createTempFile("test", "tar");
-        File zip = File.createTempFile("test", "zip");
+        File tar = Files.createTempFile("test", "tar").toFile();
+        File zip = Files.createTempFile("test", "zip").toFile();
 
-        FilePath dir = new FilePath(File.createTempFile("test", "dir"));
+        FilePath dir = new FilePath(Files.createTempFile("test", "dir").toFile());
 
         try {
             dir.delete();
@@ -135,7 +135,7 @@ class TarArchiverTest {
     @Issue("JENKINS-73837")
     @Test
     void emptyDirectory() throws Exception {
-        Path tar = File.createTempFile("test.tar", null, tmp).toPath();
+        Path tar = Files.createTempFile(tmp.toPath(), "test.tar", null);
         Path root = newFolder(tmp, "junit").toPath();
         Files.createDirectory(root.resolve("foo"));
         Files.createDirectory(root.resolve("bar"));

--- a/core/src/test/java/hudson/util/io/ZipArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/ZipArchiverTest.java
@@ -86,7 +86,7 @@ class ZipArchiverTest {
     @Issue("JENKINS-49296")
     @Test
     void emptyDirectory() throws Exception {
-        Path zip = File.createTempFile("test.zip", null, tmp).toPath();
+        Path zip = Files.createTempFile(tmp.toPath(), "test.zip", null);
         Path root = newFolder(tmp, "junit").toPath();
         Files.createDirectory(root.resolve("foo"));
         Files.createDirectory(root.resolve("bar"));

--- a/core/src/test/java/jenkins/model/lazy/FakeMapBuilder.java
+++ b/core/src/test/java/jenkins/model/lazy/FakeMapBuilder.java
@@ -41,7 +41,7 @@ public class FakeMapBuilder {
 
     public FakeMapBuilder() {
         try {
-            dir = File.createTempFile("lazyload", "test");
+            dir = Files.createTempFile("lazyload", "test").toFile();
             dir.delete();
             dir.mkdirs();
         } catch (IOException e) {

--- a/core/src/test/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitorTest.java
+++ b/core/src/test/java/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitorTest.java
@@ -167,7 +167,7 @@ class OperatingSystemEndOfLifeAdminMonitorTest {
 
     @Test
     void testReadOperatingSystemListOnWarningDate() throws Exception {
-        File dataFile = File.createTempFile("junit", null, tmp);
+        File dataFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(dataFile.toPath(), "PRETTY_NAME=\"Test OS\"");
         JSONObject eolIn6Months = new JSONObject();
         eolIn6Months.put("pattern", "Test OS");

--- a/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
+++ b/core/src/test/java/jenkins/security/DefaultConfidentialStoreTest.java
@@ -51,7 +51,7 @@ class DefaultConfidentialStoreTest {
         // data storage should have some stuff
         assertTrue(new File(tmp, "test").exists());
 
-        assertThrows(MalformedInputException.class, () -> Files.readString(tmp.toPath().resolve("test"), StandardCharsets.UTF_8)); // the data shouldn't be a plain text, obviously
+        assertThrows(MalformedInputException.class, () -> Files.readString(tmp.toPath().resolve("test"))); // the data shouldn't be a plain text, obviously
 
         if (!Functions.isWindows()) {
             assertEquals(0700, new FilePath(tmp).mode() & 0777); // should be read only

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -111,7 +111,7 @@ class VirtualFileTest {
     @Issue("JENKINS-26810")
     @Test
     void mode() throws Exception {
-        File f = File.createTempFile("junit", null, tmp);
+        File f = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         VirtualFile vf = VirtualFile.forFile(f);
         FilePath fp = new FilePath(f);
         VirtualFile vfp = VirtualFile.forFilePath(fp);

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -116,7 +116,7 @@ class PathRemoverTest {
 
     @Test
     void testForceRemoveFile() throws IOException {
-        File file = File.createTempFile("junit", null, tmp);
+        File file = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         touchWithFileName(file);
 
         PathRemover remover = PathRemover.newSimpleRemover();
@@ -191,7 +191,7 @@ class PathRemoverTest {
     @Test
     void testForceRemoveFile_SymbolicLink() throws IOException {
         assumeFalse(Functions.isWindows());
-        File file = File.createTempFile("junit", null, tmp);
+        File file = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         touchWithFileName(file);
         Path link = Files.createSymbolicLink(tmp.toPath().resolve("test-link"), file.toPath());
 
@@ -206,7 +206,7 @@ class PathRemoverTest {
     @Issue("JENKINS-55448")
     void testForceRemoveFile_DotsInPath() throws IOException {
         Path folder = newFolder(tmp, "junit-" + System.currentTimeMillis()).toPath();
-        File test = File.createTempFile("test", null, tmp);
+        File test = Files.createTempFile(tmp.toPath(), "test", null).toFile();
         touchWithFileName(test);
         Path path = folder.resolve("../" + test.getName());
 

--- a/test/src/test/java/hudson/cli/CLIActionTest.java
+++ b/test/src/test/java/hudson/cli/CLIActionTest.java
@@ -28,6 +28,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -93,7 +94,7 @@ class CLIActionTest {
         config.setTokenGenerationOnCreationEnabled(true);
 
         logging.record(PlainCLIProtocol.class, Level.FINE);
-        File jar = File.createTempFile("jenkins-cli.jar", null, tmp);
+        File jar = Files.createTempFile(tmp.toPath(), "jenkins-cli.jar", null).toFile();
         FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to(ADMIN));
@@ -147,7 +148,7 @@ class CLIActionTest {
     void authenticationFailed() throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().toAuthenticated());
-        var jar = File.createTempFile("jenkins-cli.jar", null, tmp);
+        var jar = Files.createTempFile(tmp.toPath(), "jenkins-cli.jar", null).toFile();
         FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
         var baos = new ByteArrayOutputStream();
         var exitStatus = new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
@@ -160,7 +161,7 @@ class CLIActionTest {
     @Issue("JENKINS-41745")
     @Test
     void encodingAndLocale() throws Exception {
-        File jar = File.createTempFile("jenkins-cli.jar", null, tmp);
+        File jar = Files.createTempFile(tmp.toPath(), "jenkins-cli.jar", null).toFile();
         FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         assertEquals(0, new Launcher.LocalLauncher(StreamTaskListener.fromStderr()).launch().cmds(
@@ -176,7 +177,7 @@ class CLIActionTest {
     @Test
     void interleavedStdio() throws Exception {
         logging.record(PlainCLIProtocol.class, Level.FINE).record(FullDuplexHttpService.class, Level.FINE);
-        File jar = File.createTempFile("jenkins-cli.jar", null, tmp);
+        File jar = Files.createTempFile(tmp.toPath(), "jenkins-cli.jar", null).toFile();
         FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PipedInputStream pis = new PipedInputStream();
@@ -204,7 +205,7 @@ class CLIActionTest {
     @Issue("SECURITY-754")
     @Test
     void noPreAuthOptionHandlerInfoLeak() throws Exception {
-        File jar = File.createTempFile("jenkins-cli.jar", null, tmp);
+        File jar = Files.createTempFile(tmp.toPath(), "jenkins-cli.jar", null).toFile();
         FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.addView(new AllView("v1"));
@@ -246,7 +247,7 @@ class CLIActionTest {
     @Test
     void largeTransferWebSocket() throws Exception {
         logging.record(CLIAction.class, Level.FINE);
-        File jar = File.createTempFile("jenkins-cli.jar", null, tmp);
+        File jar = Files.createTempFile(tmp.toPath(), "jenkins-cli.jar", null).toFile();
         FileUtils.copyURLToFile(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
         long size = /*999_*/999_999;
         try (OutputStream nos = OutputStream.nullOutputStream(); CountingOutputStream cos = new CountingOutputStream(nos)) {

--- a/test/src/test/java/hudson/cli/CLIEnvVarTest.java
+++ b/test/src/test/java/hudson/cli/CLIEnvVarTest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +49,7 @@ class CLIEnvVarTest {
     @BeforeEach
     void grabCliJar() throws IOException {
         home = newFolder(tmp, "junit");
-        jar = File.createTempFile("jenkins-cli.jar", null, tmp);
+        jar = Files.createTempFile(tmp.toPath(), "jenkins-cli.jar", null).toFile();
         FileUtils.copyURLToFile(r.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
     }
 

--- a/test/src/test/java/hudson/cli/CLITest.java
+++ b/test/src/test/java/hudson/cli/CLITest.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -86,7 +87,7 @@ class CLITest {
     }
 
     private void grabCliJar() throws IOException {
-        jar = File.createTempFile("jenkins-cli.jar", null, tmp);
+        jar = Files.createTempFile(tmp.toPath(), "jenkins-cli.jar", null).toFile();
         FileUtils.copyURLToFile(r.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
     }
 

--- a/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
+++ b/test/src/test/java/hudson/diagnosis/OldDataMonitorTest.java
@@ -35,6 +35,7 @@ import hudson.model.Saveable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -130,7 +131,7 @@ class OldDataMonitorTest {
 
         ensureEntry.await();
         // test will hang here due to JENKINS-24763
-        File xml = File.createTempFile("OldDataMonitorTest.slowDiscard", "xml");
+        File xml = Files.createTempFile("OldDataMonitorTest.slowDiscard", "xml").toFile();
         xml.deleteOnExit();
         OldDataMonitor.changeListener
                 .onChange(() -> {},

--- a/test/src/test/java/hudson/model/AbstractItemTest.java
+++ b/test/src/test/java/hudson/model/AbstractItemTest.java
@@ -70,7 +70,7 @@ class AbstractItemTest {
         }
         // update on disk representation
         Path path = p.getConfigFile().getFile().toPath();
-        Files.writeString(path, Files.readString(path, StandardCharsets.UTF_8).replaceAll("Hello World", "Good Evening"), StandardCharsets.UTF_8);
+        Files.writeString(path, Files.readString(path).replaceAll("Hello World", "Good Evening"), StandardCharsets.UTF_8);
 
         TestSaveableListener testSaveableListener = ExtensionList.lookupSingleton(TestSaveableListener.class);
         testSaveableListener.setSaveable(p);

--- a/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
+++ b/test/src/test/java/hudson/model/ComputerConfigDotXmlTest.java
@@ -52,7 +52,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import jenkins.model.Jenkins;
 import org.htmlunit.FailingHttpStatusCodeException;
@@ -221,7 +220,7 @@ class ComputerConfigDotXmlTest {
         FailingHttpStatusCodeException e = assertThrows(FailingHttpStatusCodeException.class, () -> wc.getPage(req));
         assertThat(e.getStatusCode(), equalTo(400));
         File configDotXml = new File(rule.jenkins.getRootDir(), "config.xml");
-        String configDotXmlContents = Files.readString(configDotXml.toPath(), StandardCharsets.UTF_8);
+        String configDotXmlContents = Files.readString(configDotXml.toPath());
 
         assertThat(configDotXmlContents, not(containsString("<name>../</name>")));
     }

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -68,7 +68,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -347,7 +346,7 @@ class DirectoryBrowserSupportTest {
 
     private File download(UnexpectedPage page) throws IOException {
 
-        File file = File.createTempFile("DirectoryBrowserSupport", "zipDownload");
+        File file = Files.createTempFile("DirectoryBrowserSupport", "zipDownload").toFile();
         file.delete();
         try (InputStream is = page.getInputStream();
              OutputStream os = Files.newOutputStream(file.toPath())) {
@@ -1112,8 +1111,8 @@ class DirectoryBrowserSupportTest {
         if (resourceUrl == null) {
             fail("The resource with fileName " + fileNameInResources + " is not present in the resources of the test");
         }
-        Path resourcePath = Paths.get(resourceUrl.toURI());
-        return Files.readString(resourcePath, StandardCharsets.UTF_8);
+        Path resourcePath = Path.of(resourceUrl.toURI());
+        return Files.readString(resourcePath);
     }
 
     @Test

--- a/test/src/test/java/hudson/model/FileParameterValuePersistenceTest.java
+++ b/test/src/test/java/hudson/model/FileParameterValuePersistenceTest.java
@@ -40,7 +40,7 @@ class FileParameterValuePersistenceTest {
             FreeStyleProject p = j.createFreeStyleProject("p");
             p.addProperty(new ParametersDefinitionProperty(new FileParameterDefinition(FILENAME, "The file.")));
             p.getBuildersList().add(Functions.isWindows() ? new BatchFile("type " + FILENAME) : new Shell("cat " + FILENAME));
-            File test = File.createTempFile("junit", null, tmp);
+            File test = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
             Files.writeString(test.toPath(), CONTENTS, StandardCharsets.UTF_8);
             try (JenkinsRule.WebClient wc = j.createWebClient()) {
                 // ParametersDefinitionProperty/index.jelly sends a 405
@@ -71,7 +71,7 @@ class FileParameterValuePersistenceTest {
         j.assertLogContains(CONTENTS, b);
         Path saved = b.getRootDir().toPath().resolve("fileParameters").resolve(FILENAME);
         assertTrue(Files.isRegularFile(saved));
-        assertEquals(CONTENTS, Files.readString(saved, StandardCharsets.UTF_8));
+        assertEquals(CONTENTS, Files.readString(saved));
         assertTrue(b.getWorkspace().child(FILENAME).exists());
         try (JenkinsRule.WebClient wc = j.createWebClient()) {
             HtmlPage page = wc.goTo(p.getUrl() + "ws");

--- a/test/src/test/java/hudson/model/FileParameterValueTest.java
+++ b/test/src/test/java/hudson/model/FileParameterValueTest.java
@@ -87,7 +87,7 @@ class FileParameterValueTest {
         assertThat(root.child("root-level.txt").exists(), equalTo(false));
 
         String uploadedContent = "test-content";
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), uploadedContent, StandardCharsets.UTF_8);
 
         FreeStyleBuild build = p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -127,7 +127,7 @@ class FileParameterValueTest {
         assertThat(root.child("pwned").exists(), equalTo(false));
 
         String uploadedContent = "test-content";
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), uploadedContent, StandardCharsets.UTF_8);
 
         FreeStyleBuild build = p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -154,7 +154,7 @@ class FileParameterValueTest {
         assertThat(root.child("pwned").exists(), equalTo(false));
 
         String uploadedContent = "test-content";
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), uploadedContent, StandardCharsets.UTF_8);
 
         FreeStyleBuild build = p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -192,7 +192,7 @@ class FileParameterValueTest {
         assertThat(root.child("root-level.txt").exists(), equalTo(false));
 
         String uploadedContent = "test-content";
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), uploadedContent, StandardCharsets.UTF_8);
 
         FreeStyleBuild build = p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -221,7 +221,7 @@ class FileParameterValueTest {
         )));
 
         String uploadedContent = "test-content";
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), uploadedContent, StandardCharsets.UTF_8);
 
         FreeStyleBuild build = p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -249,7 +249,7 @@ class FileParameterValueTest {
         )));
 
         String uploadedContent = "test-content";
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), uploadedContent, StandardCharsets.UTF_8);
 
         FreeStyleBuild build = p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -283,7 +283,7 @@ class FileParameterValueTest {
         root.child("root-level.txt").write(initialContent, StandardCharsets.UTF_8.name());
 
         String uploadedContent = "test-content";
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), uploadedContent, StandardCharsets.UTF_8);
 
         FreeStyleBuild build = p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -308,9 +308,9 @@ class FileParameterValueTest {
                 new FileParameterDefinition("parent/child2.txt", null)
         )));
 
-        File uploadedFile1 = File.createTempFile("junit", null, tmp);
+        File uploadedFile1 = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile1.toPath(), "test1", StandardCharsets.UTF_8);
-        File uploadedFile2 = File.createTempFile("junit", null, tmp);
+        File uploadedFile2 = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile2.toPath(), "test2", StandardCharsets.UTF_8);
 
         FreeStyleBuild build = j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -349,7 +349,7 @@ class FileParameterValueTest {
                 new FileParameterDefinition("weird..name.txt", null)
         )));
 
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), "test1", StandardCharsets.UTF_8);
 
         FreeStyleBuild build = j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(
@@ -377,7 +377,7 @@ class FileParameterValueTest {
                 new FileParameterDefinition("~name", null)
         )));
 
-        File uploadedFile = File.createTempFile("junit", null, tmp);
+        File uploadedFile = Files.createTempFile(tmp.toPath(), "junit", null).toFile();
         Files.writeString(uploadedFile.toPath(), "test1", StandardCharsets.UTF_8);
 
         FreeStyleBuild build = j.assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(

--- a/test/src/test/java/hudson/model/FreestyleJobPublisherTest.java
+++ b/test/src/test/java/hudson/model/FreestyleJobPublisherTest.java
@@ -8,7 +8,6 @@ import hudson.model.utils.IOExceptionPublisher;
 import hudson.model.utils.ResultWriterPublisher;
 import hudson.model.utils.TrueFalsePublisher;
 import hudson.tasks.ArtifactArchiver;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +49,7 @@ class FreestyleJobPublisherTest {
         FreeStyleBuild b = j.buildAndAssertStatus(Result.FAILURE, p);
         Path path = b.getArtifactsDir().toPath().resolve("result.txt");
         assertTrue(Files.exists(path), "ArtifactArchiver is executed even prior publisher fails");
-        assertEquals(Files.readString(path, StandardCharsets.UTF_8), Result.FAILURE.toString(), "Publisher, after publisher with return false status, must see FAILURE status");
+        assertEquals(Files.readString(path), Result.FAILURE.toString(), "Publisher, after publisher with return false status, must see FAILURE status");
     }
 
     /**
@@ -74,7 +73,7 @@ class FreestyleJobPublisherTest {
         j.assertLogContains("Threw AbortException from publisher!", b); // log must contain exact error message
         Path path = b.getArtifactsDir().toPath().resolve("result.txt");
         assertTrue(Files.exists(path), "ArtifactArchiver is executed even prior publisher fails");
-        assertEquals(Files.readString(path, StandardCharsets.UTF_8), Result.FAILURE.toString(), "Third publisher must see FAILURE status");
+        assertEquals(Files.readString(path), Result.FAILURE.toString(), "Third publisher must see FAILURE status");
     }
 
     /**
@@ -98,6 +97,6 @@ class FreestyleJobPublisherTest {
         j.assertLogContains("Threw IOException from publisher!", b); // log must contain exact error message
         Path path = b.getArtifactsDir().toPath().resolve("result.txt");
         assertTrue(Files.exists(path), "ArtifactArchiver is executed even prior publisher fails");
-        assertEquals(Files.readString(path, StandardCharsets.UTF_8), Result.FAILURE.toString(), "Third publisher must see FAILURE status");
+        assertEquals(Files.readString(path), Result.FAILURE.toString(), "Third publisher must see FAILURE status");
     }
 }

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -89,7 +89,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -166,7 +165,7 @@ public class QueueTest {
         assertNotNull(testProject.scheduleBuild2(0, new UserIdCause()));
         q.save();
 
-        System.out.println(Files.readString(r.jenkins.getRootDir().toPath().resolve("queue.xml"), StandardCharsets.UTF_8));
+        System.out.println(Files.readString(r.jenkins.getRootDir().toPath().resolve("queue.xml")));
 
         assertEquals(1, q.getItems().length);
         q.clear();
@@ -221,7 +220,7 @@ public class QueueTest {
         assertNotNull(testProject.scheduleBuild2(0, new UserIdCause()));
         q.save();
 
-        System.out.println(Files.readString(r.jenkins.getRootDir().toPath().resolve("queue.xml"), StandardCharsets.UTF_8));
+        System.out.println(Files.readString(r.jenkins.getRootDir().toPath().resolve("queue.xml")));
 
         assertEquals(1, q.getItems().length);
         q.clear();

--- a/test/src/test/java/hudson/model/UpdateSiteTest.java
+++ b/test/src/test/java/hudson/model/UpdateSiteTest.java
@@ -41,10 +41,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,7 +87,7 @@ public class UpdateSiteTest {
             if (url == null) {
                 url = extract(resourceName);
             }
-            return url != null ? Files.readString(Paths.get(url.toURI()), StandardCharsets.UTF_8) : null;
+            return url != null ? Files.readString(Path.of(url.toURI())) : null;
         } catch (URISyntaxException e) {
             return null;
         }

--- a/test/src/test/java/hudson/model/UsageStatisticsTest.java
+++ b/test/src/test/java/hudson/model/UsageStatisticsTest.java
@@ -40,7 +40,7 @@ import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.security.KeyFactory;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -191,7 +191,7 @@ class UsageStatisticsTest {
     private void compareWithFile(String fileName, Object object) throws IOException, URISyntaxException {
 
         Class clazz = this.getClass();
-        String fileContent = Files.readString(Paths.get(clazz.getResource(clazz.getSimpleName() + "/" + fileName).toURI()), StandardCharsets.UTF_8);
+        String fileContent = Files.readString(Path.of(clazz.getResource(clazz.getSimpleName() + "/" + fileName).toURI()));
         fileContent = fileContent.replace("JVMVENDOR", System.getProperty("java.vm.vendor"));
         fileContent = fileContent.replace("JVMNAME", System.getProperty("java.vm.name"));
         fileContent = fileContent.replace("JVMVERSION", System.getProperty("java.version"));

--- a/test/src/test/java/hudson/model/UserPropertyTest.java
+++ b/test/src/test/java/hudson/model/UserPropertyTest.java
@@ -204,7 +204,7 @@ class UserPropertyTest {
         }
 
         private File getUserFile() throws IOException {
-            userFile =  File.createTempFile("user", ".txt");
+            userFile =  Files.createTempFile("user", ".txt").toFile();
             userFile.deleteOnExit();
             if (!userFile.exists()) {
                 userFile.createNewFile();

--- a/test/src/test/java/hudson/slaves/PingThreadTest.java
+++ b/test/src/test/java/hudson/slaves/PingThreadTest.java
@@ -134,7 +134,7 @@ class PingThreadTest {
                 .atMost(10, TimeUnit.SECONDS)
                 .until(() -> {
                     try {
-                        String status = Files.readString(Paths.get("/proc/" + pid + "/stat"), StandardCharsets.UTF_8);
+                        String status = Files.readString(Paths.get("/proc/" + pid + "/stat"));
                         char actualState = status.charAt(status.lastIndexOf(')') + 2);
                         return actualState == expectedState;
                     } catch (NoSuchFileException e) {

--- a/test/src/test/java/hudson/util/XStream2Security383Test.java
+++ b/test/src/test/java/hudson/util/XStream2Security383Test.java
@@ -64,7 +64,7 @@ class XStream2Security383Test {
     @Test
     @Issue("SECURITY-383")
     void testXmlLoad() throws Exception {
-        File exploitFile = File.createTempFile("junit", null, f);
+        File exploitFile = Files.createTempFile(f.toPath(), "junit", null).toFile();
         try {
             // be extra sure there's no file already
             if (exploitFile.exists() && !exploitFile.delete()) {
@@ -91,7 +91,7 @@ class XStream2Security383Test {
     @Test
     @Issue("SECURITY-383")
     void testPostJobXml() throws Exception {
-        File exploitFile = File.createTempFile("junit", null, f);
+        File exploitFile = Files.createTempFile(f.toPath(), "junit", null).toFile();
         try {
             // be extra sure there's no file already
             if (exploitFile.exists() && !exploitFile.delete()) {

--- a/test/src/test/java/jenkins/model/JenkinsBuildsAndWorkspacesDirectoriesTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsBuildsAndWorkspacesDirectoriesTest.java
@@ -156,7 +156,7 @@ class JenkinsBuildsAndWorkspacesDirectoriesTest {
 
             // Now screw up the value by writing into the file directly, like one could do using external XML manipulation tools
             final Path configFile = rule.jenkins.getRootDir().toPath().resolve("config.xml");
-            final String screwedUp = Files.readString(configFile, StandardCharsets.UTF_8).
+            final String screwedUp = Files.readString(configFile).
                     replaceFirst("<buildsDir>.*</buildsDir>", "<buildsDir>eeeeeeeeek</buildsDir>");
             Files.writeString(configFile, screwedUp, StandardCharsets.UTF_8);
         });
@@ -240,7 +240,7 @@ class JenkinsBuildsAndWorkspacesDirectoriesTest {
 
             // ** HACK AROUND JENKINS-50422: manually restarting ** //
             // Check the disk (cannot just restart normally with the rule, )
-            assertThat(Files.readString(j.jenkins.getRootDir().toPath().resolve("config.xml"), StandardCharsets.UTF_8),
+            assertThat(Files.readString(j.jenkins.getRootDir().toPath().resolve("config.xml")),
                        containsString("<buildsDir>" + newBuildsDirValueBySysprop + "</buildsDir>"));
 
             String rootDirBeforeRestart = j.jenkins.getRootDir().toString();
@@ -253,7 +253,7 @@ class JenkinsBuildsAndWorkspacesDirectoriesTest {
             }
 
             assertEquals(rootDirBeforeRestart, j.jenkins.getRootDir().toString());
-            assertThat(Files.readString(j.jenkins.getRootDir().toPath().resolve("config.xml"), StandardCharsets.UTF_8),
+            assertThat(Files.readString(j.jenkins.getRootDir().toPath().resolve("config.xml")),
                        containsString("<buildsDir>" + newBuildsDirValueBySysprop + "</buildsDir>"));
             assertEquals(newBuildsDirValueBySysprop, j.jenkins.getRawBuildsDir());
             // ** END HACK ** //

--- a/test/src/test/java/jenkins/model/JenkinsLocationConfigurationTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLocationConfigurationTest.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicReference;
@@ -75,7 +74,7 @@ class JenkinsLocationConfigurationTest {
             assertNull(JenkinsLocationConfiguration.getOrDie().getUrl());
 
             Path configFile = j.jenkins.getRootDir().toPath().resolve("jenkins.model.JenkinsLocationConfiguration.xml");
-            String configFileContent = Files.readString(configFile, StandardCharsets.UTF_8);
+            String configFileContent = Files.readString(configFile);
             assertThat(configFileContent, containsString("JenkinsLocationConfiguration"));
             assertThat(configFileContent, not(containsString("javascript:alert(123);//")));
         });
@@ -103,7 +102,7 @@ class JenkinsLocationConfigurationTest {
                 assertEquals(expectedUrl + "/", JenkinsLocationConfiguration.getOrDie().getUrl());
 
                 Path configFile = j.jenkins.getRootDir().toPath().resolve("jenkins.model.JenkinsLocationConfiguration.xml");
-                String configFileContent = Files.readString(configFile, StandardCharsets.UTF_8);
+                String configFileContent = Files.readString(configFile);
                 assertThat(configFileContent, containsString("JenkinsLocationConfiguration"));
                 assertThat(configFileContent, containsString(expectedUrl));
             } finally {

--- a/test/src/test/java/jenkins/security/stapler/StaticRoutingDecisionProvider2Test.java
+++ b/test/src/test/java/jenkins/security/stapler/StaticRoutingDecisionProvider2Test.java
@@ -32,7 +32,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -182,14 +181,14 @@ class StaticRoutingDecisionProvider2Test {
 
         wl.save();
         assertTrue(Files.exists(whitelistUserControlledList));
-        assertThat(Files.readString(whitelistUserControlledList, StandardCharsets.UTF_8), is(""));
+        assertThat(Files.readString(whitelistUserControlledList), is(""));
 
         wl.add("white-1");
 
         assertThat(wl.decide("white-1"), is(RoutingDecisionProvider.Decision.ACCEPTED));
 
         assertTrue(Files.exists(whitelistUserControlledList));
-        assertThat(Files.readString(whitelistUserControlledList, StandardCharsets.UTF_8), containsString("white-1"));
+        assertThat(Files.readString(whitelistUserControlledList), containsString("white-1"));
         {
             StaticRoutingDecisionProvider temp = new StaticRoutingDecisionProvider();
             assertThat(temp.decide("white-1"), is(RoutingDecisionProvider.Decision.ACCEPTED));
@@ -199,7 +198,7 @@ class StaticRoutingDecisionProvider2Test {
 
         assertThat(wl.decide("white-1"), is(RoutingDecisionProvider.Decision.ACCEPTED));
         assertThat(wl.decide("black-2"), is(RoutingDecisionProvider.Decision.REJECTED));
-        assertThat(Files.readString(whitelistUserControlledList, StandardCharsets.UTF_8), allOf(
+        assertThat(Files.readString(whitelistUserControlledList), allOf(
                 containsString("white-1"),
                 containsString("!black-2")
         ));
@@ -214,7 +213,7 @@ class StaticRoutingDecisionProvider2Test {
 
         assertThat(wl.decide("white-1"), is(RoutingDecisionProvider.Decision.ACCEPTED));
         assertThat(wl.decide("black-2"), is(RoutingDecisionProvider.Decision.UNKNOWN));
-        assertThat(Files.readString(whitelistUserControlledList, StandardCharsets.UTF_8), allOf(
+        assertThat(Files.readString(whitelistUserControlledList), allOf(
                 containsString("white-1"),
                 not(containsString("black-2"))
         ));
@@ -229,7 +228,7 @@ class StaticRoutingDecisionProvider2Test {
 
         assertThat(wl.decide("white-1"), is(RoutingDecisionProvider.Decision.UNKNOWN));
         assertThat(wl.decide("black-2"), is(RoutingDecisionProvider.Decision.UNKNOWN));
-        assertThat(Files.readString(whitelistUserControlledList, StandardCharsets.UTF_8), allOf(
+        assertThat(Files.readString(whitelistUserControlledList), allOf(
                 not(containsString("white-1")),
                 not(containsString("black-2"))
         ));

--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -41,6 +41,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -254,7 +255,7 @@ public class Main {
         // is deployed.
         File tempFile;
         try {
-            tempFile = File.createTempFile("dummy", "dummy");
+            tempFile = Files.createTempFile("dummy", "dummy").toFile();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -402,7 +403,7 @@ public class Main {
         }
         File myself;
         try {
-            myself = File.createTempFile("jenkins", ".jar", directory);
+            myself = Files.createTempFile(directory.toPath(), "jenkins", ".jar").toFile();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -429,7 +430,7 @@ public class Main {
         // put this jar in a file system so that we can load jars from there
         File tmp;
         try {
-            tmp = File.createTempFile(fileName, suffix, directory);
+            tmp = Files.createTempFile(directory.toPath(), fileName, suffix).toFile();
         } catch (IOException e) {
             String tmpdir = directory == null ? System.getProperty("java.io.tmpdir") : directory.getAbsolutePath();
             throw new UncheckedIOException("Jenkins failed to create a temporary file in " + tmpdir + ": " + e, e);


### PR DESCRIPTION
potential security change related to:

https://github.com/checkstyle/checkstyle/pull/17490#discussion_r2265236105 

@Stephan202  is this any good ?



<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
