### PR TITLE
Add `rewrite` support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,21 +95,38 @@ which will open the workspace in IntelliJ IDEA using JetBrains Gateway.
 
 ### Linting
 
-For linting we use a number of tools:
+For linting we use a number of tools.
+
+Backend:
 
 - [checkstyle](https://checkstyle.sourceforge.io/)
+- [rewrite](https://github.com/openrewrite/rewrite)
+- [spotbugs](https://github.com/spotbugs/spotbugs)
+- [spotless](https://github.com/diffplug/spotless)
+
+Frontend:
+
 - [eslint](https://eslint.org/)
 - [prettier](https://prettier.io/)
-- [spotless](https://github.com/diffplug/spotless)
 - [stylelint](https://stylelint.io/)
 
 These are all configured to run as part of the Maven build, although they will be skipped if you are building with the `quick-build` profile.
 
 To automatically fix backend issues, run:
 
+#### spotless
+
 ```sh
 mvn spotless:apply
 ```
+
+#### rewrite
+
+```sh
+mvn rewrite:run
+```
+
+#### yarn
 
 To view frontend issues, after [optionally adding Node and Yarn to your path](#running-the-yarn-frontend-build), run:
 
@@ -117,10 +134,16 @@ To view frontend issues, after [optionally adding Node and Yarn to your path](#r
 yarn lint
 ```
 
-To fix frontend issues, after [optionally adding Node and Yarn to your path](#running-the-yarn-frontend-build), run:
+To automatically fix frontend issues, run:
 
 ```sh
 yarn lint:fix
+```
+
+#### prettier
+
+```sh
+ prettier --write .
 ```
 
 ## Testing changes

--- a/pom.xml
+++ b/pom.xml
@@ -286,11 +286,10 @@ THE SOFTWARE.
           </dependencies>
           <executions>
             <execution>
-              <id>validate</id>
               <goals>
                 <goal>check</goal>
               </goals>
-              <phase>validate</phase>
+              <phase>verify</phase>
             </execution>
           </executions>
         </plugin>
@@ -299,10 +298,53 @@ THE SOFTWARE.
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.8.13</version>
         </plugin>
+        <plugin>
+          <groupId>org.openrewrite.maven</groupId>
+          <artifactId>rewrite-maven-plugin</artifactId>
+          <version>6.15.0</version>
+          <configuration>
+            <activeRecipes>
+              <recipe>org.jenkins.openrewrite.DefinitionOfDone</recipe>
+            </activeRecipes>
+            <exclusions>
+              <exclusion>**ApiTokenStats.java</exclusion>
+              <exclusion>**DownloadFromUrlInstaller.java</exclusion>
+              <exclusion>**NodesTest.java</exclusion>
+              <exclusion>**generated-test-sources**</exclusion>
+            </exclusions>
+            <exportDatatables>true</exportDatatables>
+            <failOnDryRunResults>true</failOnDryRunResults>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.openrewrite.recipe</groupId>
+              <artifactId>rewrite-static-analysis</artifactId>
+              <version>2.15.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.openrewrite.recipe</groupId>
+              <artifactId>rewrite-third-party</artifactId>
+              <version>0.24.3</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <!--move to CI-->
+            <execution>
+              <goals>
+                <goal>dryRun</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.openrewrite.maven</groupId>
+        <artifactId>rewrite-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
@@ -328,7 +370,7 @@ THE SOFTWARE.
         <configuration>
           <!-- work around for a bug in javadoc plugin that causes the release to fail. see MRELEASE-271 -->
           <preparationGoals>clean install</preparationGoals>
-          <goals>-DskipTests -Dspotbugs.skip -Dmaven.checkstyle.skip -Dspotless.check.skip generate-resources javadoc:javadoc deploy</goals>
+          <goals>-DskipTests -Dspotbugs.skip -Dmaven.checkstyle.skip -Dspotless.check.skip -DrewriteSkip generate-resources javadoc:javadoc deploy</goals>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>
           <tagNameFormat>jenkins-@{project.version}</tagNameFormat>

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,14 @@
+type: specs.openrewrite.org/v1beta/recipe
+name: org.jenkins.openrewrite.DefinitionOfDone
+displayName: Definition of Done
+description: Automatically code cleanup to comply common convention.
+recipeList:
+  - org.openrewrite.staticanalysis.ModifierOrder
+#  - org.openrewrite.java.RemoveUnusedImports
+#  - org.openrewrite.staticanalysis.LowercasePackage
+#  - org.openrewrite.staticanalysis.MissingOverrideAnnotation
+#  - org.openrewrite.staticanalysis.RemoveUnusedLocalVariables
+#  - org.openrewrite.staticanalysis.RemoveUnusedPrivateFields
+#  - org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods
+#  - tech.picnic.errorprone.refasterrules.BugCheckerRulesRecipes
+#  - tech.picnic.errorprone.refasterrules.FileRulesRecipes # security fixes


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).







## Add `rewrite` support for `errorprone.refasterrules`

I’d like to propose integrating [Google’s Error Prone](https://github.com/google/error-prone) and its Picnic extension (demonstrated in [Automating Away Bugs with Error Prone | PlatformCon 2023](https://www.youtube.com/watch?v=6llnrUtVlrE)) to enable automated bug fixes via `rewrite` rules. This would complement Checkstyle’s static analysis capabilities by addressing semantic bugs rather than stylistic issues.

## Motivation
Error Prone’s `refaster`/`rewrite` rules can automatically:
- Fix common bug patterns (e.g., `String.equals()` misuse)
- Modernize code (e.g., JDK migration helpers)
- Enforce best practices (e.g., null-check improvements)

Real-world adoptions show tangible benefits:
- [Apache Kafka’s integration](https://github.com/apache/kafka/pull/20219)
- [Spotless’s implementation](https://github.com/diffplug/spotless/pull/2576)

## Proposal
1. Add support for `errorprone.refasterrules`-based rewrites
2. Implement with opt-in adoption (no breaking changes)
3. Include suppression mechanisms for API constraints

## Discussion Points
- Need consensus on:
  - Scope of auto-fixes
  - Preferred suppression strategy
  - Integration approach

## Next Steps
I’m happy to:
- Prepare a PoC demonstrating the value
- Collaborate on implementation strategy
- Address any concerns about compatibility



relates to:

- https://github.com/checkstyle/checkstyle/issues/16543
- https://github.com/checkstyle/checkstyle/issues/17487