### PR TITLE
[JENKINS-75991] Fix name of reason query parameter in online help for quietDown

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/_api.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
 
   <h2>Restarting Jenkins</h2>
   <p>
-    Jenkins will enter into the "quiet down" mode by sending a POST request with optional <code>reason</code> query parameter to <a href="../quietDown">this URL</a>.
+    Jenkins will enter into the "quiet down" mode by sending a POST request with optional <code>message</code> query parameter as the reason to <a href="../quietDown">this URL</a>.
     You can also send another request to this URL to update the reason.
     You can cancel this mode by sending a POST request to <a href="../cancelQuietDown">this URL</a>. On environments
     where Jenkins can restart itself (such as when Jenkins is installed as a Windows service), POSTing to


### PR DESCRIPTION
The name of the query parameter to indicate the quietDown reason changed from "reason" to "message" in commit df4972fb70e37fa2a9a15d574d2d35ba17899fb7 (part of JENKINS-70059). This updates the documentation as served as HTML at /api accordingly.

See [JENKINS-75991](https://issues.jenkins.io/browse/JENKINS-75991).

### Testing done

Confirmed with the current Jenkins release that when the query parameter `reason` is provided, the value of the parameter is ignored.  Confirmed with the current Jenkins release that the query parameter `message` is honored when it is provided in the POST request.

<img width="1037" height="269" alt="screencapture-rhel-8-a-markwaite-net-8080-api-2025-08-14-05_24_23-edit" src="https://github.com/user-attachments/assets/d8e91152-70a2-42a7-935a-e3482bf15484" />


Documentation change, no automated test.

### Proposed changelog entries

- Fix incorrect parameter name in `quietDown` API online help.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).