### PR TITLE
Apply `staticanalysis.RemoveUnused*`

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -1985,8 +1985,6 @@ public final class FilePath implements SerializableOnlyOverRemoting {
         Files.setPosixFilePermissions(fileToPath(f), Util.modeToPermissions(mask));
     }
 
-    private static boolean CHMOD_WARNED = false;
-
     /**
      * Gets the file permission bit mask.
      *

--- a/core/src/main/java/hudson/LocalPluginManager.java
+++ b/core/src/main/java/hudson/LocalPluginManager.java
@@ -31,7 +31,6 @@ import jakarta.servlet.ServletContext;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 
@@ -87,6 +86,4 @@ public class LocalPluginManager extends PluginManager {
             loadDetachedPlugins();
         }
     }
-
-    private static final Logger LOGGER = Logger.getLogger(LocalPluginManager.class.getName());
 }

--- a/core/src/main/java/hudson/cli/CancelQuietDownCommand.java
+++ b/core/src/main/java/hudson/cli/CancelQuietDownCommand.java
@@ -25,7 +25,6 @@
 package hudson.cli;
 
 import hudson.Extension;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 
 /**
@@ -36,8 +35,6 @@ import jenkins.model.Jenkins;
  */
 @Extension
 public class CancelQuietDownCommand extends CLICommand {
-
-    private static final Logger LOGGER = Logger.getLogger(CancelQuietDownCommand.class.getName());
 
     @Override
     public String getShortDescription() {

--- a/core/src/main/java/hudson/cli/ClearQueueCommand.java
+++ b/core/src/main/java/hudson/cli/ClearQueueCommand.java
@@ -25,7 +25,6 @@
 package hudson.cli;
 
 import hudson.Extension;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 
 /**
@@ -36,8 +35,6 @@ import jenkins.model.Jenkins;
  */
 @Extension
 public class ClearQueueCommand extends CLICommand {
-
-    private static final Logger LOGGER = Logger.getLogger(ClearQueueCommand.class.getName());
 
     @Override
     public String getShortDescription() {

--- a/core/src/main/java/hudson/cli/ConnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/ConnectNodeCommand.java
@@ -29,7 +29,6 @@ import hudson.Extension;
 import hudson.model.Computer;
 import java.util.HashSet;
 import java.util.List;
-import java.util.logging.Logger;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.Option;
 
@@ -47,8 +46,6 @@ public class ConnectNodeCommand extends CLICommand {
 
     @Option(name = "-f", usage = "Cancel any currently pending connect operation and retry from scratch")
     public boolean force = false;
-
-    private static final Logger LOGGER = Logger.getLogger(ConnectNodeCommand.class.getName());
 
     @Override
     public String getShortDescription() {

--- a/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DisconnectNodeCommand.java
@@ -31,7 +31,6 @@ import hudson.model.ComputerSet;
 import hudson.util.EditDistance;
 import java.util.HashSet;
 import java.util.List;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.Option;
@@ -48,8 +47,6 @@ public class DisconnectNodeCommand extends CLICommand {
 
     @Option(name = "-m", usage = "Record the reason about why you are disconnecting this node")
     public String cause;
-
-    private static final Logger LOGGER = Logger.getLogger(DisconnectNodeCommand.class.getName());
 
     @Override
     public String getShortDescription() {

--- a/core/src/main/java/hudson/cli/QuietDownCommand.java
+++ b/core/src/main/java/hudson/cli/QuietDownCommand.java
@@ -25,7 +25,6 @@
 package hudson.cli;
 
 import hudson.Extension;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.kohsuke.args4j.Option;
 
@@ -37,8 +36,6 @@ import org.kohsuke.args4j.Option;
  */
 @Extension
 public class QuietDownCommand extends CLICommand {
-
-    private static final Logger LOGGER = Logger.getLogger(QuietDownCommand.class.getName());
 
     @Option(name = "-block", usage = "Block until the system really quiets down and no builds are running")
     public boolean block = false;

--- a/core/src/main/java/hudson/console/ModelHyperlinkNote.java
+++ b/core/src/main/java/hudson/console/ModelHyperlinkNote.java
@@ -10,7 +10,6 @@ import hudson.model.ModelObject;
 import hudson.model.Node;
 import hudson.model.Run;
 import hudson.model.User;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
@@ -82,6 +81,4 @@ public class ModelHyperlinkNote extends HyperlinkNote {
     }
 
     private static final long serialVersionUID = 1L;
-
-    private static final Logger LOGGER = Logger.getLogger(ModelHyperlinkNote.class.getName());
 }

--- a/core/src/main/java/hudson/model/DownloadService.java
+++ b/core/src/main/java/hudson/model/DownloadService.java
@@ -210,7 +210,6 @@ public class DownloadService {
         private final String url;
         private final long interval;
         private volatile long due = 0;
-        private volatile long lastAttempt = Long.MIN_VALUE;
 
         /**
          * Creates a new downloadable.

--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -31,7 +31,6 @@ import hudson.Extension;
 import hudson.util.EnumConverter;
 import hudson.util.RunList;
 import java.util.Objects;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
@@ -243,6 +242,4 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
             return false;
         return Objects.equals(filter, other.filter);
     }
-
-    private static final Logger LOGGER = Logger.getLogger(RunParameterDefinition.class.getName());
 }

--- a/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractAsyncNodeMonitorDescriptor.java
@@ -153,7 +153,6 @@ public abstract class AbstractAsyncNodeMonitorDescriptor<T> extends AbstractNode
      * returns computers that were not monitored as they were either offline or monitor produced {@code null} {@link Callable}.
      */
     protected static final class Result<T> {
-        private static final long serialVersionUID = -7671448355804481216L;
 
         private final @NonNull Map<Computer, T> data;
         private final @NonNull ArrayList<Computer> skipped;

--- a/core/src/main/java/hudson/node_monitors/AbstractDiskSpaceMonitor.java
+++ b/core/src/main/java/hudson/node_monitors/AbstractDiskSpaceMonitor.java
@@ -3,7 +3,6 @@ package hudson.node_monitors;
 import hudson.model.Computer;
 import hudson.node_monitors.DiskSpaceMonitorDescriptor.DiskSpace;
 import java.text.ParseException;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -94,7 +93,5 @@ public abstract class AbstractDiskSpaceMonitor extends NodeMonitor {
         ((DiskSpaceMonitorDescriptor) getDescriptor()).markNodeOfflineOrOnline(c, size, this);
         return size;
     }
-
-    private static final Logger LOGGER = Logger.getLogger(AbstractDiskSpaceMonitor.class.getName());
     private static final long DEFAULT_THRESHOLD = 1024L * 1024 * 1024;
 }

--- a/core/src/main/java/hudson/security/AccessDeniedException2.java
+++ b/core/src/main/java/hudson/security/AccessDeniedException2.java
@@ -3,7 +3,6 @@ package hudson.security;
 import io.jenkins.servlet.http.HttpServletResponseWrapper;
 import java.io.PrintWriter;
 import javax.servlet.http.HttpServletResponse;
-import jenkins.util.SystemProperties;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.Authentication;
 
@@ -14,9 +13,6 @@ import org.acegisecurity.Authentication;
  */
 @Deprecated
 public class AccessDeniedException2 extends AccessDeniedException {
-
-    /** If true, report {@code X-You-Are-In-Group} headers. Disabled due to JENKINS-39402; use {@code /whoAmI} etc. to diagnose permission issues. */
-    private static /* not final */ boolean REPORT_GROUP_HEADERS = SystemProperties.getBoolean(AccessDeniedException2.class.getName() + ".REPORT_GROUP_HEADERS");
 
     /**
      * This object represents the user being authenticated.

--- a/core/src/main/java/hudson/util/ChunkedInputStream.java
+++ b/core/src/main/java/hudson/util/ChunkedInputStream.java
@@ -34,7 +34,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.logging.Logger;
 
 /**
  * <p>Transparently coalesces chunks of a HTTP stream that uses
@@ -75,9 +74,6 @@ public class ChunkedInputStream extends InputStream {
 
     /** True if this stream is closed */
     private boolean closed = false;
-
-    /** Log object for this class. */
-    private static final Logger LOGGER = Logger.getLogger(ChunkedInputStream.class.getName());
 
     /**
      * ChunkedInputStream constructor

--- a/core/src/main/java/jenkins/cli/SafeRestartCommand.java
+++ b/core/src/main/java/jenkins/cli/SafeRestartCommand.java
@@ -27,7 +27,6 @@ package jenkins.cli;
 import hudson.Extension;
 import hudson.cli.CLICommand;
 import hudson.cli.Messages;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -42,7 +41,6 @@ import org.kohsuke.stapler.StaplerRequest2;
 @Extension
 @Restricted(NoExternalUse.class)
 public class SafeRestartCommand extends CLICommand {
-    private static final Logger LOGGER = Logger.getLogger(SafeRestartCommand.class.getName());
 
     @Option(name = "-message", usage = "Message for safe restart that will be visible to users")
     public String message = null;

--- a/core/src/main/java/jenkins/model/NodeListener.java
+++ b/core/src/main/java/jenkins/model/NodeListener.java
@@ -29,7 +29,6 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.Node;
 import java.util.List;
-import java.util.logging.Logger;
 import jenkins.util.Listeners;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -41,8 +40,6 @@ import org.kohsuke.accmod.restrictions.Beta;
  * @since 2.8
  */
 public abstract class NodeListener implements ExtensionPoint {
-
-    private static final Logger LOGGER = Logger.getLogger(NodeListener.class.getName());
 
     /**
      * Allows to veto node loading.

--- a/core/src/main/java/jenkins/security/seed/UserSeedChangeListener.java
+++ b/core/src/main/java/jenkins/security/seed/UserSeedChangeListener.java
@@ -29,8 +29,6 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import hudson.model.User;
 import java.util.List;
-import java.util.logging.Logger;
-import jenkins.security.SecurityListener;
 import jenkins.util.Listeners;
 
 /**
@@ -38,7 +36,6 @@ import jenkins.util.Listeners;
  * @since 2.160 and 2.150.2, but restricted (unavailable to plugins) before 2.406
  */
 public abstract class UserSeedChangeListener implements ExtensionPoint {
-    private static final Logger LOGGER = Logger.getLogger(SecurityListener.class.getName());
 
     /**
      * Called after a seed was changed but before the user is saved.

--- a/core/src/main/java/jenkins/slaves/restarter/SlaveRestarter.java
+++ b/core/src/main/java/jenkins/slaves/restarter/SlaveRestarter.java
@@ -3,7 +3,6 @@ package jenkins.slaves.restarter;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import java.io.Serializable;
-import java.util.logging.Logger;
 
 /**
  * Extension point to control how to restart an inbound agent when it loses the connection with the master.
@@ -40,8 +39,6 @@ public abstract class SlaveRestarter implements ExtensionPoint, Serializable {
     public static ExtensionList<SlaveRestarter> all() {
         return ExtensionList.lookup(SlaveRestarter.class);
     }
-
-    private static final Logger LOGGER = Logger.getLogger(SlaveRestarter.class.getName());
 
     private static final long serialVersionUID = 1L;
 }

--- a/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
+++ b/core/src/main/java/jenkins/telemetry/impl/UserLanguages.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Logger;
 import jenkins.telemetry.Telemetry;
 import jenkins.util.HttpServletFilter;
 import net.sf.json.JSONObject;
@@ -47,7 +46,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public class UserLanguages extends Telemetry {
 
     private static final Map<String, AtomicLong> requestsByLanguage = new ConcurrentSkipListMap<>();
-    private static Logger LOGGER = Logger.getLogger(UserLanguages.class.getName());
 
     @NonNull
     @Override

--- a/core/src/test/java/jenkins/util/MarkFindingOutputStreamTest.java
+++ b/core/src/test/java/jenkins/util/MarkFindingOutputStreamTest.java
@@ -15,7 +15,6 @@ class MarkFindingOutputStreamTest {
 
     private String mark = MarkFindingOutputStream.MARK;
     private String markHead = mark.substring(0, 5);
-    private String markTail = mark.substring(5);
 
     private ByteArrayOutputStream baos = new ByteArrayOutputStream();
     private MarkCountingOutputStream m = new MarkCountingOutputStream(baos);

--- a/core/src/test/java/jenkins/util/VirtualFileTest.java
+++ b/core/src/test/java/jenkins/util/VirtualFileTest.java
@@ -1509,7 +1509,6 @@ class VirtualFileTest {
     }
 
     private long computeEarlierSystemTime() {
-        long earlierSystemTime = 0L;
         if (Functions.isWindows()) {
             return 0L;
         }

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -619,7 +619,6 @@ class PluginManagerTest {
 
             // wait for all the download jobs to complete
             boolean done = true;
-            boolean passed = true;
             do {
                 Thread.sleep(100);
                 done = true;

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -393,8 +393,6 @@ class QuietDownCommandTest {
         final OneShotEvent finish = new OneShotEvent();
         final FreeStyleBuild build = OnlineNodeCommandTest.startBlockingAndFinishingBuild(project, finish);
         assertThat(((FreeStyleProject) j.jenkins.getItem("aProject")).getBuilds(), hasSize(1));
-
-        boolean timeoutOccurred = false;
         final FutureTask exec_task = new FutureTask(() -> {
             assertJenkinsNotInQuietMode();
             final long time_before = System.currentTimeMillis();

--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -105,7 +105,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.BlockedBecauseOfBuildInProgress;
 import jenkins.model.Jenkins;
@@ -125,7 +124,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockQueueItemAuthenticator;
 import org.jvnet.hudson.test.SequenceLock;
@@ -142,8 +140,6 @@ import org.springframework.security.core.Authentication;
  */
 @WithJenkins
 public class QueueTest {
-
-    private final LogRecorder logging = new LogRecorder().record(Queue.class, Level.FINE);
 
     private JenkinsRule r;
 

--- a/test/src/test/java/hudson/model/SimpleJobTest.java
+++ b/test/src/test/java/hudson/model/SimpleJobTest.java
@@ -2,12 +2,9 @@ package hudson.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.logging.Level;
-import jenkins.model.lazy.LazyBuildMixIn;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
@@ -15,8 +12,6 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
  */
 @WithJenkins
 class SimpleJobTest {
-
-    private final LogRecorder logging = new LogRecorder().record(LazyBuildMixIn.class, Level.FINE);
 
     private static JenkinsRule r;
 

--- a/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
+++ b/test/src/test/java/hudson/model/WorkspaceCleanupThreadTest.java
@@ -40,22 +40,18 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class WorkspaceCleanupThreadTest {
-
-    private final LogRecorder logs = new LogRecorder().record(WorkspaceCleanupThread.class, Level.ALL);
 
     private JenkinsRule r;
 

--- a/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
+++ b/test/src/test/java/hudson/model/queue/QueueTaskDispatcherTest.java
@@ -13,19 +13,15 @@ import hudson.model.Queue.Item;
 import hudson.model.TaskListener;
 import hudson.util.StreamTaskListener;
 import java.io.StringWriter;
-import java.util.logging.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class QueueTaskDispatcherTest {
-
-    private final LogRecorder logging = new LogRecorder().record(Queue.class, Level.ALL);
 
     private JenkinsRule r;
 

--- a/test/src/test/java/hudson/slaves/AgentInboundUrlTest.java
+++ b/test/src/test/java/hudson/slaves/AgentInboundUrlTest.java
@@ -26,8 +26,6 @@ package hudson.slaves;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import hudson.model.Slave;
-import java.util.logging.Level;
 import jenkins.model.Jenkins;
 import org.dom4j.Document;
 import org.dom4j.Element;
@@ -39,7 +37,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.junit.jupiter.InboundAgentExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -52,8 +49,6 @@ class AgentInboundUrlTest {
 
     @RegisterExtension
     private final InboundAgentExtension inboundAgents = new InboundAgentExtension();
-
-    private final LogRecorder logging = new LogRecorder().record(Slave.class, Level.FINE);
 
     // Override the inbound agent url
     private static final String CUSTOM_INBOUND_URL = "http://localhost:8080/jenkins";

--- a/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
+++ b/test/src/test/java/hudson/slaves/JNLPLauncherTest.java
@@ -49,7 +49,6 @@ import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import jenkins.model.Jenkins;
 import jenkins.security.SlaveToMasterCallable;
 import jenkins.slaves.RemotingWorkDirSettings;
@@ -61,7 +60,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.SimpleCommandLauncher;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -76,8 +74,6 @@ class JNLPLauncherTest {
 
     @TempDir
     private File tmpDir;
-
-    private final LogRecorder logging = new LogRecorder().record(Slave.class, Level.FINE);
 
     private JenkinsRule j;
 

--- a/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
+++ b/test/src/test/java/hudson/triggers/SafeTimerTaskTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -23,8 +22,6 @@ class SafeTimerTaskTest {
 
     @TempDir
     private File folder;
-
-    private final LogRecorder loggerRule = new LogRecorder();
 
     private JenkinsRule j;
 

--- a/test/src/test/java/hudson/util/XStream2Security383Test.java
+++ b/test/src/test/java/hudson/util/XStream2Security383Test.java
@@ -12,8 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.logging.Level;
-import jenkins.security.ClassFilterImpl;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
@@ -33,8 +30,6 @@ class XStream2Security383Test {
 
     @TempDir
     private File f;
-
-    private final LogRecorder logging = new LogRecorder().record(ClassFilterImpl.class, Level.FINE);
 
     @Mock
     private StaplerRequest2 req;

--- a/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
+++ b/test/src/test/java/jenkins/agents/WebSocketAgentsTest.java
@@ -30,21 +30,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import hudson.Functions;
 import hudson.model.FreeStyleProject;
 import hudson.model.Slave;
-import hudson.remoting.Engine;
-import hudson.slaves.SlaveComputer;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import jenkins.security.SlaveToMasterCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.junit.jupiter.BuildWatcherExtension;
 import org.jvnet.hudson.test.junit.jupiter.InboundAgentExtension;
@@ -54,19 +49,11 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 @WithJenkins
 public class WebSocketAgentsTest {
 
-    private static final Logger LOGGER = Logger.getLogger(WebSocketAgentsTest.class.getName());
-
     @RegisterExtension
     private static final BuildWatcherExtension buildWatcher = new BuildWatcherExtension();
 
     @RegisterExtension
     private final InboundAgentExtension inboundAgents = new InboundAgentExtension();
-
-    private final LogRecorder logging = new LogRecorder().
-        record(Slave.class, Level.FINE).
-        record(SlaveComputer.class, Level.FINEST).
-        record(WebSocketAgents.class, Level.FINEST).
-        record(Engine.class, Level.FINEST);
 
     private JenkinsRule r;
 

--- a/test/src/test/java/jenkins/health/HealthCheckActionTest.java
+++ b/test/src/test/java/jenkins/health/HealthCheckActionTest.java
@@ -29,20 +29,16 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.ExtensionList;
-import java.util.logging.Level;
 import net.sf.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 
 @WithJenkins
 class HealthCheckActionTest {
-
-    private final LogRecorder loggingRule = new LogRecorder().record(HealthCheckAction.class, Level.WARNING).capture(10);
 
     private JenkinsRule r;
 

--- a/test/src/test/java/jenkins/model/PeepholePermalinkTest.java
+++ b/test/src/test/java/jenkins/model/PeepholePermalinkTest.java
@@ -10,19 +10,15 @@ import hudson.model.Job;
 import hudson.model.Run;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.logging.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class PeepholePermalinkTest {
-
-    private final LogRecorder logging = new LogRecorder().record(PeepholePermalink.class, Level.FINE);
 
     private JenkinsRule j;
 

--- a/test/src/test/java/jenkins/security/ClassFilterImplTest.java
+++ b/test/src/test/java/jenkins/security/ClassFilterImplTest.java
@@ -52,19 +52,15 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import jenkins.model.GlobalConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class ClassFilterImplTest {
-
-    private final LogRecorder logging = new LogRecorder().record(ClassFilterImpl.class, Level.FINE);
 
     private JenkinsRule r;
 

--- a/test/src/test/java/jenkins/security/CustomClassFilterTest.java
+++ b/test/src/test/java/jenkins/security/CustomClassFilterTest.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import hudson.remoting.ClassFilter;
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Level;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
@@ -45,7 +44,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.WithPlugin;
 
@@ -56,8 +54,6 @@ class CustomClassFilterTest {
     static {
         System.setProperty("hudson.remoting.ClassFilter", "javax.script.SimpleBindings,!jenkins.util.TreeString");
     }
-
-    private final LogRecorder logging = new LogRecorder().record("jenkins.security", Level.FINER);
 
     @TempDir(cleanup = CleanupMode.NEVER)
     private File tmp;

--- a/test/src/test/java/jenkins/security/Security218Test.java
+++ b/test/src/test/java/jenkins/security/Security218Test.java
@@ -6,14 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.slaves.DumbSlave;
 import java.io.IOException;
-import java.util.logging.Level;
 import org.codehaus.groovy.runtime.MethodClosure;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.junit.jupiter.InboundAgentExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -26,8 +24,6 @@ class Security218Test {
 
     @RegisterExtension
     private final InboundAgentExtension inboundAgents = new InboundAgentExtension();
-
-    private final LogRecorder logging = new LogRecorder().record(ClassFilterImpl.class, Level.FINE);
 
     private JenkinsRule j;
 

--- a/test/src/test/java/jenkins/widgets/BuildListTableTest.java
+++ b/test/src/test/java/jenkins/widgets/BuildListTableTest.java
@@ -26,26 +26,21 @@ package jenkins.widgets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import hudson.model.AbstractItem;
 import hudson.model.FreeStyleProject;
 import hudson.model.ListView;
 import java.net.URI;
 import java.net.URL;
-import java.util.logging.Level;
 import org.htmlunit.html.HtmlAnchor;
 import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class BuildListTableTest {
-
-    private LogRecorder logging = new LogRecorder().record(AbstractItem.class, Level.FINER);
 
     private JenkinsRule r;
 

--- a/test/src/test/java/lib/layout/RenderOnDemandTest.java
+++ b/test/src/test/java/lib/layout/RenderOnDemandTest.java
@@ -30,10 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import hudson.model.InvisibleAction;
 import hudson.model.RootAction;
-import hudson.widgets.RenderOnDemandClosure;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
-import java.util.logging.Level;
 import org.htmlunit.ScriptResult;
 import org.htmlunit.WebClientUtil;
 import org.htmlunit.html.HtmlPage;
@@ -42,7 +40,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.MemoryAssert;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -56,7 +53,6 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 class RenderOnDemandTest {
 
     private JenkinsRule j;
-    private final LogRecorder logging = new LogRecorder().record(RenderOnDemandClosure.class, Level.FINE);
 
     @BeforeEach
     void setUp(JenkinsRule rule) {


### PR DESCRIPTION
apply:

- https://docs.openrewrite.org/recipes/staticanalysis/removeunusedprivatefields
- https://docs.openrewrite.org/recipes/staticanalysis/removeunusedlocalvariables


<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

See [JENKINS-XXXXX](https://issues.jenkins.io/browse/JENKINS-XXXXX).

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
