### PR TITLE
Stray `}` in `CollapsedMulti`

### DIFF
--- a/core/src/main/resources/lib/hudson/executors.properties
+++ b/core/src/main/resources/lib/hudson/executors.properties
@@ -5,5 +5,5 @@ launching=launching...
 terminate\ this\ build=Cancel
 busy={1,choice,1# {0} of {1} executor busy|1< {0} of {1} executors busy}
 CollapsedSingle={1,choice,1# ({0} of {1} executor busy)|1< ({0} of {1} executors busy)}
-CollapsedMulti={0} agents ({1} of {2} executors busy)}
+CollapsedMulti={0} agents ({1} of {2} executors busy)
 noExecutors=No executors, agents or clouds are configured.

--- a/core/src/main/resources/lib/hudson/executors_de.properties
+++ b/core/src/main/resources/lib/hudson/executors_de.properties
@@ -32,5 +32,5 @@ Computers=Master{0,choice,0#|1# + {0,number} Agent ({1} von {2} Build-Prozessore
 confirm=Möchten Sie {0} wirklich abbrechen?
 busy={0} von {1} Build-Prozessoren belegt
 CollapsedSingle={1,choice,1# ({0} von {1} Prozessor belegt)|1< ({0} von {1} Prozessoren belegt)}
-CollapsedMulti={0} Agenten ({1} von {2} Build-Prozessoren belegt)}
+CollapsedMulti={0} Agenten ({1} von {2} Build-Prozessoren belegt)
 noExecutors=Es sind keine Prozessoren, Agenten oder Clouds konfiguriert.


### PR DESCRIPTION
Glitch in #9177, actually visible in one of the screenshots there.

### Testing done

- disabled built-in node
- created two inbound agents (did not bother to connect them) each with several executors
- collapsed executor widget
- observed appearance before vs. after change

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Desired reviewers

@mawinter69

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
