### PR TITLE
Add sidepanels for nodes and load statistics based on user preferences

### DIFF
--- a/core/src/main/java/hudson/model/ComputerSet.java
+++ b/core/src/main/java/hudson/model/ComputerSet.java
@@ -62,6 +62,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.ModelObjectWithChildren;
 import jenkins.model.ModelObjectWithContextMenu.ContextMenu;
 import jenkins.security.ExtendedReadRedaction;
+import jenkins.users.SidePanelUserProperty;
 import jenkins.util.Timer;
 import jenkins.widgets.HasWidgets;
 import net.sf.json.JSONObject;
@@ -547,6 +548,17 @@ public final class ComputerSet extends AbstractModelObject implements Describabl
             LOGGER.log(Level.SEVERE, "Failed to instantiate " + d.clazz, e);
         }
         return null;
+    }
+
+    // jelly only
+    @Restricted(DoNotUse.class)
+    public boolean isShowSidePanel() {
+        User user = User.current();
+        if (user == null) {
+            return false;
+        }
+        SidePanelUserProperty property = user.getProperty(SidePanelUserProperty.class);
+        return property != null && property.isShowNodesSidePanel();
     }
 
     @Extension(ordinal = -1)

--- a/core/src/main/java/jenkins/console/ConsoleUrlProviderGlobalConfiguration.java
+++ b/core/src/main/java/jenkins/console/ConsoleUrlProviderGlobalConfiguration.java
@@ -53,7 +53,7 @@ import org.kohsuke.stapler.StaplerRequest2;
 @Extension
 @Symbol("consoleUrlProvider")
 @Restricted(NoExternalUse.class)
-public class ConsoleUrlProviderGlobalConfiguration extends GlobalConfiguration {
+public class  ConsoleUrlProviderGlobalConfiguration extends GlobalConfiguration {
     private static final Logger LOGGER = Logger.getLogger(ConsoleUrlProviderGlobalConfiguration.class.getName());
 
     private List<ConsoleUrlProvider> providers;

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -292,6 +292,7 @@ import jenkins.security.stapler.StaplerFilteredActionListener;
 import jenkins.security.stapler.StaplerNotDispatchable;
 import jenkins.security.stapler.TypedFilter;
 import jenkins.slaves.WorkspaceLocator;
+import jenkins.users.SidePanelUserProperty;
 import jenkins.util.JenkinsJVM;
 import jenkins.util.Listeners;
 import jenkins.util.SystemProperties;
@@ -1344,6 +1345,17 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     @CheckForNull
     public Boolean isNoUsageStatistics() {
         return noUsageStatistics;
+    }
+
+    // jelly only
+    @Restricted(DoNotUse.class)
+    public boolean isShowLoadstatsSidePanel() {
+        User user = User.current();
+        if (user == null) {
+            return false;
+        }
+        SidePanelUserProperty property = user.getProperty(SidePanelUserProperty.class);
+        return property != null && property.isShowLoadstatsSidePanel();
     }
 
     /**

--- a/core/src/main/java/jenkins/users/SidePanelUserProperty.java
+++ b/core/src/main/java/jenkins/users/SidePanelUserProperty.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Markus Winter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.users;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+import hudson.model.userproperty.UserPropertyCategory;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * User property to control the visibility of the side panel in the user interface of various Jenkins pages.
+ */
+public class SidePanelUserProperty extends UserProperty {
+
+    private boolean showNodesSidePanel;
+
+    private boolean showLoadstatsSidePanel;
+
+    @DataBoundConstructor
+    public SidePanelUserProperty() {
+        this.showNodesSidePanel = false;
+    }
+
+    public boolean isShowNodesSidePanel() {
+        return showNodesSidePanel;
+    }
+
+    @DataBoundSetter
+    public void setShowNodesSidePanel(boolean showNodesSidePanel) {
+        this.showNodesSidePanel = showNodesSidePanel;
+    }
+
+    public boolean isShowLoadstatsSidePanel() {
+        return showLoadstatsSidePanel;
+    }
+
+    @DataBoundSetter
+    public void setShowLoadstatsSidePanel(boolean showLoadstatsSidePanel) {
+        this.showLoadstatsSidePanel = showLoadstatsSidePanel;
+    }
+
+    @Extension
+    @Symbol("SidePanel")
+    public static class DescriptorImpl extends UserPropertyDescriptor {
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.SidePanelUserProperty_DisplayName();
+        }
+
+        @Override
+        public UserProperty newInstance(User user) {
+            return new SidePanelUserProperty();
+        }
+
+        @Override
+        public @NonNull UserPropertyCategory getUserPropertyCategory() {
+            return UserPropertyCategory.get(UserPropertyCategory.Preferences.class);
+        }
+    }
+}

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -27,7 +27,16 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
-<l:layout title="${%Nodes}" type="one-column">
+  <j:set var="showSidePanel" value="${it.showSidePanel}"/>
+<l:layout title="${%Nodes}" type="${showSidePanel ? 'two-column' : 'one-column'}">
+  <j:if test="${showSidePanel}">
+    <l:side-panel>
+      <j:forEach var="w" items="${it.widgets}">
+        <st:include it="${w}" page="index" />
+      </j:forEach>
+    </l:side-panel>
+  </j:if>
+
   <!-- no need for additional breadcrumb here as we're on an index page already including breadcrumb -->
   <l:main-panel>
     <l:app-bar title="${%Nodes}">

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -113,6 +113,7 @@ ComputerSet.SlaveAlreadyExists=Agent called ‘{0}’ already exists
 ComputerSet.SpecifySlaveToCopy=Specify which agent to copy
 ComputerSet.DisplayName=Nodes
 ComputerSet.may_not_copy_as_it_contains_secrets_and_=May not copy {0} as it contains secrets and {1} has {2}/{3} but not /{4}
+ComputerSet.SidePanelUserProperty.DisplayName=Show Side Panel with widgets on Nodes page
 
 Descriptor.From=(from <a href="{1}" rel="noopener noreferrer" target="_blank">{0}</a>)
 

--- a/core/src/main/resources/jenkins/users/Messages.properties
+++ b/core/src/main/resources/jenkins/users/Messages.properties
@@ -1,0 +1,1 @@
+SidePanelUserProperty.DisplayName=Settings for side panels

--- a/core/src/main/resources/jenkins/users/SidePanelUserProperty/config.jelly
+++ b/core/src/main/resources/jenkins/users/SidePanelUserProperty/config.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+Copyright (c) 2025, Markus Winter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,22 +23,11 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <j:set var="showSidePanel" value="${it.showLoadstatsSidePanel}"/>
-  <l:layout title="${it.displayName} ${%Load Statistics}" type="${showSidePanel ? 'two-column' : 'one-column'}">
-    <j:set var="primaryView" value="${it.primaryView}"/>
-    <j:if test="${showSidePanel and primaryView != null}">
-      <l:side-panel>
-        <j:forEach var="w" items="${primaryView.widgets}">
-          <j:set var="view" value="${primaryView}" /><!-- expose the view that's rendering this sidepanel to the widget -->
-          <st:include it="${w}" page="index.jelly" />
-        </j:forEach>
-      </l:side-panel>
-    </j:if>
-    <l:breadcrumb title="${%Load Statistics}"/>
-    <l:main-panel>
-      <j:set var="prefix" value="overallLoad" />
-      <st:include page="main.jelly" from="${it.overallLoad}" />
-    </l:main-panel>
-  </l:layout>
+<j:jelly xmlns:j="jelly:core"  xmlns:f="/lib/form">
+  <f:entry>
+    <f:checkbox name="showNodesSidePanel" checked="${instance.showNodesSidePanel}" title="${%Show side panel on nodes page}"/>
+  </f:entry>
+  <f:entry>
+    <f:checkbox name="showLoadstatsSidePanel" checked="${instance.showLoadstatsSidePanel}" title="${%Show side panel on global load statistics}"/>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Some users consider the sidepanels on the nodes page and the global load statistics page useful.
This change adds a user property that allows to enable the side panel on these 2 pages.
The sidepanels only contain the widgets with queue and nodes but no menu entries

<img width="964" height="468" alt="image" src="https://github.com/user-attachments/assets/8e0a966d-574e-436c-8916-d4f1dda21dbb" />
<img width="1065" height="477" alt="image" src="https://github.com/user-attachments/assets/0f2ef1d7-59e3-4fb4-a987-afc578ff5767" />

<!-- Comment:
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue ID you created in Jira.
Note that if you want your changes backported into LTS, you need to create a Jira issue. See https://www.jenkins.io/download/lts/#backporting-process for more information.
-->

<!-- Comment:
If the issue is not fully described in Jira, add more information here (justification, pull request links, etc.).

 * We do not require Jira issues for minor improvements.
 * Bug fixes should have a Jira issue to facilitate the backporting process.
 * Major new features should have a Jira issue.
-->

### Testing done

Manual testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Add sidepanels for nodes and load statistics based on user preference

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe,web-ui

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
