### PR TITLE
Move common caching class loading functionality to the separate class

### DIFF
--- a/core/src/main/java/hudson/util/CachingClassLoader.java
+++ b/core/src/main/java/hudson/util/CachingClassLoader.java
@@ -1,0 +1,56 @@
+package hudson.util;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ *
+ * ClassLoader with internal caching of class loading results.
+ *
+ * <p>
+ * Caches both successful and failed class lookups to avoid redundant delegation
+ * and repeated class resolution attempts. Designed for performance optimization
+ * in systems that repeatedly query class presence (e.g., plugin environments,
+ * reflective loading, optional dependencies).
+ * </p>
+ *
+ * Useful for classloaders that have heavy-weight loadClass() implementations
+ *
+ * @author Dmytro Ukhlov
+ */
+@Restricted(NoExternalUse.class)
+public class CachingClassLoader extends DelegatingClassLoader {
+    private final ConcurrentHashMap<String, Object> cache = new ConcurrentHashMap<>();
+
+    public CachingClassLoader(String name, ClassLoader parent) {
+        super(name, parent);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        Object classOrEmpty = cache.computeIfAbsent(name, key -> {
+            try {
+                return super.loadClass(name, false);
+            } catch (ClassNotFoundException e) {
+                // Not found.
+                return Optional.empty();
+            }
+        });
+
+        if (classOrEmpty == Optional.empty()) {
+            throw new ClassNotFoundException(name);
+        }
+
+        Class<?> clazz = (Class<?>) classOrEmpty;
+        if (resolve) {
+            resolveClass(clazz);
+        }
+        return clazz;
+    }
+
+    public void clearCacheMisses() {
+        cache.values().removeIf(v -> v == Optional.empty());
+    }
+}


### PR DESCRIPTION
Move common class-loading caching functionality into CachingClassLoader.

Update UberClassLoader to use CachingClassLoader, so now all results of loadClass() (not just findClass()) are cached.
This improves performance, especially because UberClassLoader uses a ExistenceCheckingClassLoader wrapper for the parent class loader, which introduces overhead.

By caching class-loading results for the parent as well, we avoid redundant lookups and reduce that overhead.

### Testing done

Manual testing on local setup, jenkins ci gates.

### Proposed changelog entries

- Improve UberClassLoader class caching

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A


### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@basil, @timja

Before the changes are marked as ready-for-merge:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
