### PR TITLE
Added some jelly documentation for `step` for numbers

### DIFF
--- a/core/src/main/resources/lib/form/number.jelly
+++ b/core/src/main/resources/lib/form/number.jelly
@@ -48,7 +48,7 @@ THE SOFTWARE.
     </st:attribute>
     <st:attribute name="min"> <![CDATA[
       The minimum of the @value. This becomes the @min of the <input> tag.
-      This will work only @clazz is 'number', 'number-required', 'non-negative-number-required',
+      This will work only if @clazz is 'number', 'number-required', 'non-negative-number-required',
         'positive-number', 'positive-number-required'.
       If specified, the @value should be greater than this value, or errors will be rendered under the text field.
       If this value contains non-digit characters, it will not work.
@@ -57,12 +57,18 @@ THE SOFTWARE.
     </st:attribute>
     <st:attribute name="max"> <![CDATA[
       The maximum of the @value. This becomes the @max of the <input> tag.
-      This will work only @clazz is 'number', 'number-required', 'non-negative-number-required',
+      This will work only if @clazz is 'number', 'number-required', 'non-negative-number-required',
         'positive-number', 'positive-number-required'.
       If specified, the @value should be less than this value, or errors will be rendered under the text field.
       If this value contains non-digit characters, it will not work.
       If @min is specified and @min is greater than this value, both @min and @max will not work.
        ]]>
+    </st:attribute>
+    <st:attribute name="step">
+      The step size of the @value. The default is 1.
+      This will work only if @clazz is 'number', 'number-required', 'non-negative-number-required',
+      'positive-number', 'positive-number-required'.
+      If this value contains non-digit characters, it will not work.
     </st:attribute>
     <!-- Tomcat doesn't like us using the attribute called 'class' -->
     <st:attribute name="clazz">

--- a/core/src/main/resources/lib/form/number.jelly
+++ b/core/src/main/resources/lib/form/number.jelly
@@ -64,11 +64,11 @@ THE SOFTWARE.
       If @min is specified and @min is greater than this value, both @min and @max will not work.
        ]]>
     </st:attribute>
-    <st:attribute name="step">
+    <st:attribute name="step"> <![CDATA[
       The step size of the @value. The default is 1. This becomes the @step of the <input> tag.
-      This will work only if @clazz is 'number', 'number-required', 'non-negative-number-required',
-      'positive-number', 'positive-number-required'.
-      If this value contains non-digit characters, it will not work.
+      The step should be an integer.
+      Otherwise the spinner of the input will change the field to non integer values.
+      ]]>
     </st:attribute>
     <!-- Tomcat doesn't like us using the attribute called 'class' -->
     <st:attribute name="clazz">

--- a/core/src/main/resources/lib/form/number.jelly
+++ b/core/src/main/resources/lib/form/number.jelly
@@ -65,7 +65,7 @@ THE SOFTWARE.
        ]]>
     </st:attribute>
     <st:attribute name="step">
-      The step size of the @value. The default is 1.
+      The step size of the @value. The default is 1. This becomes the @step of the <input> tag.
       This will work only if @clazz is 'number', 'number-required', 'non-negative-number-required',
       'positive-number', 'positive-number-required'.
       If this value contains non-digit characters, it will not work.

--- a/core/src/main/resources/lib/form/number.jelly
+++ b/core/src/main/resources/lib/form/number.jelly
@@ -66,7 +66,7 @@ THE SOFTWARE.
     </st:attribute>
     <st:attribute name="step"> <![CDATA[
       The step size of the @value. The default is 1. This becomes the @step of the <input> tag.
-      The step should be an integer.
+      The step should be an integer when using any of the validating @clazz values.
       Otherwise the spinner of the input will change the field to non integer values.
       ]]>
     </st:attribute>


### PR DESCRIPTION
When I was working with jelly files I saw that step is not recognized in IntelliJ:
<img width="1349" height="250" alt="grafik" src="https://github.com/user-attachments/assets/5a8fcb1a-a75f-438c-93ca-0fcd151ccc32" />

After this change, the documentation is shown:
<img width="1050" height="445" alt="grafik" src="https://github.com/user-attachments/assets/038c1afd-9dbe-4a34-b9c6-da999b8e6918" />


### Testing done

Only testing in IntelliJ

### Proposed changelog entries

- added documentation for `step` to jelly documentation

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label developer

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
