### PR TITLE
[JENKINS-76028] Add NavigableMap support for CopyOnWriteMap.Tree

### DIFF
--- a/core/src/main/java/hudson/util/CopyOnWriteMap.java
+++ b/core/src/main/java/hudson/util/CopyOnWriteMap.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.NavigableSet;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -82,7 +83,7 @@ public abstract class CopyOnWriteMap<K, V> implements Map<K, V> {
     /**
      * Atomically replaces the entire map by the copy of the specified map.
      */
-    public void replaceBy(Map<? extends K, ? extends V> data) {
+    public synchronized void replaceBy(Map<? extends K, ? extends V> data) {
         Map<K, V> d = copy();
         d.clear();
         d.putAll(data);
@@ -224,7 +225,7 @@ public abstract class CopyOnWriteMap<K, V> implements Map<K, V> {
     /**
      * {@link CopyOnWriteMap} backed by {@link TreeMap}.
      */
-    public static final class Tree<K, V> extends CopyOnWriteMap<K, V> implements SortedMap<K, V> {
+    public static final class Tree<K, V> extends CopyOnWriteMap<K, V> implements NavigableMap<K, V> {
         private final Comparator<K> comparator;
 
         public Tree(Map<K, V> core, Comparator<K> comparator) {
@@ -259,12 +260,104 @@ public abstract class CopyOnWriteMap<K, V> implements Map<K, V> {
         }
 
         @Override
-        public NavigableMap<K, V> getView() {
+        protected NavigableMap<K, V> getView() {
             return (NavigableMap<K, V>) super.getView();
         }
 
+        @Override
+        public synchronized Entry<K, V> pollFirstEntry() {
+            TreeMap<K, V> d = copy();
+            Entry<K, V> res = d.pollFirstEntry();
+            update(d);
+            return res;
+        }
+
+        @Override
+        public synchronized Entry<K, V> pollLastEntry() {
+            TreeMap<K, V> d = copy();
+            Entry<K, V> res = d.pollLastEntry();
+            update(d);
+            return res;
+        }
+
+        @Override
+        public Entry<K, V> lowerEntry(K key) {
+            return getView().lowerEntry(key);
+        }
+
+        @Override
+        public K lowerKey(K key) {
+            return getView().lowerKey(key);
+        }
+
+        @Override
+        public Entry<K, V> floorEntry(K key) {
+            return getView().floorEntry(key);
+        }
+
+        @Override
+        public K floorKey(K key) {
+            return getView().floorKey(key);
+        }
+
+        @Override
+        public Entry<K, V> ceilingEntry(K key) {
+            return getView().ceilingEntry(key);
+        }
+
+        @Override
+        public K ceilingKey(K key) {
+            return getView().ceilingKey(key);
+        }
+
+        @Override
+        public Entry<K, V> higherEntry(K key) {
+            return getView().higherEntry(key);
+        }
+
+        @Override
+        public K higherKey(K key) {
+            return getView().higherKey(key);
+        }
+
+        @Override
+        public Entry<K, V> firstEntry() {
+            return getView().firstEntry();
+        }
+
+        @Override
+        public Entry<K, V> lastEntry() {
+            return getView().lastEntry();
+        }
+
+        @Override
         public NavigableMap<K, V> descendingMap() {
             return getView().descendingMap();
+        }
+
+        @Override
+        public NavigableSet<K> navigableKeySet() {
+            return getView().navigableKeySet();
+        }
+
+        @Override
+        public NavigableSet<K> descendingKeySet() {
+            return getView().descendingKeySet();
+        }
+
+        @Override
+        public NavigableMap<K, V> subMap(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
+            return getView().subMap(fromKey, fromInclusive, toKey, toInclusive);
+        }
+
+        @Override
+        public NavigableMap<K, V> headMap(K toKey, boolean inclusive) {
+            return getView().headMap(toKey, inclusive);
+        }
+
+        @Override
+        public NavigableMap<K, V> tailMap(K fromKey, boolean inclusive) {
+            return getView().tailMap(fromKey, inclusive);
         }
 
         @Override


### PR DESCRIPTION
See [JENKINS-76028](https://issues.jenkins.io/browse/JENKINS-76028).

Optimise AbstractLazyLoadRunMap's search, firstKey, lastKey methods using NavigableMap features

Simplify wrapping with BuildReferenceMapAdapter by introducing single configuration class BuildReferenceMapAdapter.Resolver

Make CopyOnWriteMap.Tree.getView method protected (was public)

### Testing done

Manual testing on a local setup, jenkins PR automation tests

### Proposed changelog entries

- Expose NavigableMap interface from CopyOnWrite.Tree map
- Optimise AbstractLazyLoadRunMap.search() method

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jglick, @timja

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
