### PR TITLE
Backport class loading memory usage fixes to 2.516 line

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -33,6 +33,7 @@ import hudson.PluginWrapper.Dependency;
 import hudson.model.Hudson;
 import hudson.util.CyclicGraphDetector;
 import hudson.util.CyclicGraphDetector.CycleDetectedException;
+import hudson.util.DelegatingClassLoader;
 import hudson.util.IOUtils;
 import hudson.util.MaskingClassLoader;
 import java.io.File;
@@ -559,7 +560,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
     /**
      * Used to load classes from dependency plugins.
      */
-    static final class DependencyClassLoader extends ClassLoader {
+    static final class DependencyClassLoader extends DelegatingClassLoader {
         /**
          * This classloader is created for this plugin. Useful during debugging.
          */
@@ -573,10 +574,6 @@ public class ClassicPluginStrategy implements PluginStrategy {
          * Topologically sorted list of transitive dependencies. Lazily initialized via double-checked locking.
          */
         private volatile List<PluginWrapper> transitiveDependencies;
-
-        static {
-            registerAsParallelCapable();
-        }
 
         DependencyClassLoader(ClassLoader parent, File archive, List<Dependency> dependencies, PluginManager pluginManager) {
             super("dependency ClassLoader for " + archive.getPath(), parent);

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -218,6 +218,14 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
      */
     /* private final */ static int CHECK_UPDATE_ATTEMPTS;
 
+    /**
+     * Class name prefixes to skip in the class loading
+     */
+    private static final String[] CLASS_PREFIXES_TO_SKIP = {
+            "SimpleTemplateScript",  // cf. groovy.text.SimpleTemplateEngine
+            "groovy.tmp.templates.GStringTemplateScript", // Leaks on classLoader in some cases, see JENKINS-75879
+    };
+
     static {
         try {
             // Secure initialization
@@ -2409,8 +2417,10 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
         @Override
         protected Class<?> findClass(String name) throws ClassNotFoundException {
-            if (name.startsWith("SimpleTemplateScript")) { // cf. groovy.text.SimpleTemplateEngine
-                throw new ClassNotFoundException("ignoring " + name);
+            for (String namePrefixToSkip : CLASS_PREFIXES_TO_SKIP) {
+                if (name.startsWith(namePrefixToSkip)) {
+                    throw new ClassNotFoundException("ignoring " + name);
+                }
             }
             return loaded.computeIfAbsent(name, this::computeValue).orElseThrow(() -> new ClassNotFoundException(name));
         }

--- a/core/src/main/java/hudson/util/DelegatingClassLoader.java
+++ b/core/src/main/java/hudson/util/DelegatingClassLoader.java
@@ -1,0 +1,83 @@
+package hudson.util;
+
+import java.util.Objects;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * A {@link ClassLoader} that does not define any classes itself but delegates class loading to
+ * other class loaders to avoid the JDK's per-class-name locking and lock retention.
+ *
+ * <p>This class first attempts to load classes via its {@link ClassLoader#getParent} class loader,
+ * then falls back to {@link ClassLoader#findClass} to allow for custom delegation logic.
+ *
+ * <p>In a parallel-capable {@link ClassLoader}, the JDK maintains a per-name lock object
+ * indefinitely. In Jenkins, many class loading misses across many loaders can accumulate hundreds
+ * of thousands of such locks, retaining significant memory. This loader never defines classes and
+ * bypasses {@link ClassLoader}'s default {@code loadClass} locking; it delegates to the parent
+ * first and then to {@code findClass} for custom delegation.
+ *
+ * <p>The actual defining loader (parent or a delegate) still performs the necessary synchronization
+ * and class definition. A runtime guard ({@link #verify}) throws if this loader ever becomes the
+ * defining loader.
+ *
+ * <p>Subclasses must not call {@code defineClass}; implement delegation in {@code findClass} if
+ * needed and do not mark subclasses as parallel-capable.
+ *
+ * @author Dmytro Ukhlov
+ */
+@Restricted(NoExternalUse.class)
+public abstract class DelegatingClassLoader extends ClassLoader {
+    protected DelegatingClassLoader(String name, ClassLoader parent) {
+        super(name, Objects.requireNonNull(parent));
+    }
+
+    public DelegatingClassLoader(ClassLoader parent) {
+        super(Objects.requireNonNull(parent));
+    }
+
+    /**
+     * Parent-first delegation without synchronizing on {@link #getClassLoadingLock(String)}. This
+     * prevents creation/retention of per-name lock objects in a loader that does not define
+     * classes. The defining loader downstream still serializes class definition as required.
+     *
+     * @param name The binary name of the class
+     * @param resolve If {@code true} then resolve the class
+     * @return The resulting {@link Class} object
+     * @throws ClassNotFoundException If the class could not be found
+     */
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        Class<?> c = null;
+        try {
+            c = getParent().loadClass(name);
+        } catch (ClassNotFoundException e) {
+            // ClassNotFoundException thrown if class not found
+            // from the non-null parent class loader
+        }
+
+        if (c == null) {
+            // If still not found, then invoke findClass in order
+            // to find the class.
+            c = findClass(name);
+        }
+
+        verify(c);
+        if (resolve) {
+            resolveClass(c);
+        }
+        return c;
+    }
+
+    /**
+     * Safety check to ensure this delegating loader never becomes the defining loader.
+     *
+     * <p>Fails fast if a subclass erroneously defines a class here, which would violate the
+     * delegation-only contract and could reintroduce locking/retention issues.
+     */
+    private void verify(Class<?> clazz) {
+        if (clazz.getClassLoader() == this) {
+            throw new IllegalStateException("DelegatingClassLoader must not be the defining loader: " + clazz.getName());
+        }
+    }
+}

--- a/core/src/main/java/hudson/util/ExistenceCheckingClassLoader.java
+++ b/core/src/main/java/hudson/util/ExistenceCheckingClassLoader.java
@@ -1,0 +1,60 @@
+package hudson.util;
+
+import java.util.Objects;
+import jenkins.util.URLClassLoader2;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * A {@link ClassLoader} that verifies the existence of a {@code .class} resource before attempting
+ * to load the class. Intended to sit in front of servlet container loaders we do not control.
+ *
+ * <p>This implementation overrides {@link #loadClass(String, boolean)} and uses {@link
+ * #getResource(String)} to check whether the corresponding <code>.class</code> file is available in
+ * the classpath. If the resource is not found, a {@link ClassNotFoundException} is thrown
+ * immediately.
+ *
+ * <p>Parallel-capable parent loaders retain a per-class-name lock object for every load attempt,
+ * including misses. By checking getResource(name + ".class") first and throwing {@link
+ * ClassNotFoundException} on absence, we avoid calling {@code loadClass} on misses, thus preventing
+ * the parent from populating its lock map for nonexistent classes.
+ *
+ * <p>This class is only needed in {@link hudson.PluginManager.UberClassLoader}. It is unnecessary
+ * for plugin {@link ClassLoader}s (because {@link URLClassLoader2} mitigates lock retention via
+ * {@link ClassLoader#getClassLoadingLock}) and redundant for delegators (because {@link
+ * DelegatingClassLoader} already avoids base locking).
+ *
+ * @author Dmytro Ukhlov
+ * @see ClassLoader
+ * @see #getResource(String)
+ */
+@Restricted(NoExternalUse.class)
+public final class ExistenceCheckingClassLoader extends DelegatingClassLoader {
+
+    public ExistenceCheckingClassLoader(String name, ClassLoader parent) {
+        super(name, Objects.requireNonNull(parent));
+    }
+
+    public ExistenceCheckingClassLoader(ClassLoader parent) {
+        super(Objects.requireNonNull(parent));
+    }
+
+    /**
+     * Short-circuits misses by checking for the {@code .class} resource prior to delegation.
+     * Successful loads behave exactly as the parent would; misses do not touch the parent's
+     * per-name lock map.
+     */
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        // Add support for loading of JaCoCo dynamic instrumentation classes
+        if (name.equals("java.lang.$JaCoCo")) {
+            return super.loadClass(name, resolve);
+        }
+
+        if (getResource(name.replace('.', '/') + ".class") == null) {
+            throw new ClassNotFoundException(name);
+        }
+
+        return super.loadClass(name, resolve);
+    }
+}

--- a/core/src/main/java/hudson/util/MaskingClassLoader.java
+++ b/core/src/main/java/hudson/util/MaskingClassLoader.java
@@ -42,17 +42,13 @@ import java.util.stream.Collectors;
  *
  * @author Kohsuke Kawaguchi
  */
-public class MaskingClassLoader extends ClassLoader {
+public class MaskingClassLoader extends DelegatingClassLoader {
     /**
      * Prefix of the packages that should be hidden.
      */
     private final List<String> masksClasses;
 
     private final List<String> masksResources;
-
-    static {
-        registerAsParallelCapable();
-    }
 
     public MaskingClassLoader(ClassLoader parent, String... masks) {
         this(parent, Arrays.asList(masks));

--- a/core/src/main/java/jenkins/util/URLClassLoader2.java
+++ b/core/src/main/java/jenkins/util/URLClassLoader2.java
@@ -2,6 +2,8 @@ package jenkins.util;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import jenkins.ClassLoaderReflectionToolkit;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -12,6 +14,10 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  */
 @Restricted(NoExternalUse.class)
 public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoader {
+    private static final AtomicInteger NEXT_INSTANCE_NUMBER = new AtomicInteger(0);
+
+    private final String lockObjectPrefixName = String.format(
+            "%s@%x-loadClassLock:", URLClassLoader2.class.getName(), NEXT_INSTANCE_NUMBER.getAndIncrement());
 
     static {
         registerAsParallelCapable();
@@ -69,8 +75,25 @@ public class URLClassLoader2 extends URLClassLoader implements JenkinsClassLoade
         return super.findLoadedClass(name);
     }
 
+    /**
+     * Replace the JDK's per-name lock map with a GC-collectable lock object. This is a workaround
+     * for JDK-8005233. When JDK-8005233 is resolved, this should be deleted. See also the
+     * discussion in <a
+     * href="https://mail.openjdk.org/pipermail/core-libs-dev/2025-May/146392.html">this OpenJDK
+     * thread</a>.
+     *
+     * <p>Parallel-capable {@link ClassLoader} implementations keep a distinct lock object per class
+     * name indefinitely, which can retain huge maps when there are many misses. Returning an
+     * interned {@link String} keyed by this loader and the class name preserves mutual exclusion
+     * for a given (loader, name) pair but allows the JVM to reclaim the lock when no longer
+     * referenced. Interned Strings are heap objects and GC-eligible on modern JDKs (7+).
+     *
+     * @param className the binary name of the class being loaded (must not be null)
+     * @return a lock object unique to this classloader/class pair
+     */
     @Override
     public Object getClassLoadingLock(String className) {
-        return super.getClassLoadingLock(className);
+        Objects.requireNonNull(className);
+        return (lockObjectPrefixName + className).intern();
     }
 }


### PR DESCRIPTION
Backports of JENKINS-75879 and JENKINS-75675 which, together, should fix the memory usage issues that were reported in JENKINS-75879. These shipped in yesterday's weekly, so if there are no regressions in the next week then I think it should be safe to backport these changes.

### Testing done

None; hoping that the absence of any complaints from yesterday's weekly release should be a signal that this is working.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
