### PR TITLE
Remove redundant stream()

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17

--- a/ath.sh
+++ b/ath.sh
@@ -6,7 +6,7 @@ set -o xtrace
 cd "$(dirname "$0")"
 
 # https://github.com/jenkinsci/acceptance-test-harness/releases
-export ATH_VERSION=6319.v9da_e005f2fd2
+export ATH_VERSION=6344.v66fc2b_88977b_
 
 if [[ $# -eq 0 ]]; then
 	export JDK=17

--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -36,6 +36,7 @@
 
 package hudson.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -139,6 +140,9 @@ public class QuotedStringTokenizer
 
     /* ------------------------------------------------------------ */
     @Override
+    @SuppressFBWarnings(
+            value = {"SF_DEAD_STORE_DUE_TO_SWITCH_FALLTHROUGH", "SF_SWITCH_FALLTHROUGH"},
+            justification = "TODO needs triage")
     public boolean hasMoreTokens()
     {
         // Already found a token

--- a/core/src/main/java/hudson/util/jna/RegistryKey.java
+++ b/core/src/main/java/hudson/util/jna/RegistryKey.java
@@ -17,6 +17,7 @@ Lesser General Public License for more details.
 package hudson.util.jna;
 
 import com.sun.jna.ptr.IntByReference;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.TreeMap;
@@ -89,6 +90,7 @@ public class RegistryKey implements AutoCloseable {
         return convertBufferToInt(getValue(valueName));
     }
 
+    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH", justification = "TODO needs triage")
     private byte[] getValue(String valueName) {
         IntByReference pType, lpcbData;
         byte[] lpData = new byte[1];
@@ -149,6 +151,7 @@ public class RegistryKey implements AutoCloseable {
     /**
      * Does a specified value exist?
      */
+    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH", justification = "TODO needs triage")
     public boolean valueExists(String name) {
         IntByReference pType, lpcbData;
         byte[] lpData = new byte[1];
@@ -223,6 +226,7 @@ public class RegistryKey implements AutoCloseable {
      *
      * @return TreeMap with name and value pairs
      */
+    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH", justification = "TODO needs triage")
     public TreeMap<String, Object> getValues() {
         int dwIndex, result;
         char[] lpValueName;

--- a/core/src/main/java/jenkins/agents/CloudSet.java
+++ b/core/src/main/java/jenkins/agents/CloudSet.java
@@ -141,7 +141,7 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
     @Override
     public ModelObjectWithContextMenu.ContextMenu doChildrenContextMenu(StaplerRequest2 request, StaplerResponse2 response) throws Exception {
         ModelObjectWithContextMenu.ContextMenu m = new ModelObjectWithContextMenu.ContextMenu();
-        Jenkins.get().clouds.stream().forEach(m::add);
+        Jenkins.get().clouds.forEach(m::add);
         return m;
     }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "stylelint": "16.23.1",
     "stylelint-checkstyle-reporter": "1.1.1",
     "stylelint-config-standard-scss": "15.0.1",
-    "webpack": "5.101.2",
+    "webpack": "5.101.3",
     "webpack-cli": "6.0.1",
     "webpack-remove-empty-scripts": "1.1.1"
   },

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.138</version>
+    <version>1.139</version>
     <relativePath />
   </parent>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -84,7 +84,7 @@ THE SOFTWARE.
         <!-- RequireUpperBoundDeps between bootstrap5-api and echarts-api -->
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>font-awesome-api</artifactId>
-        <version>7.0.0-1</version>
+        <version>7.0.0-844.vb_f7825b_7f5da_</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
@@ -99,7 +99,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>plugin-util-api</artifactId>
-        <version>6.1154.ved7e7d3035a_5</version>
+        <version>6.1157.vc75ef7129d86</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -372,7 +372,7 @@ THE SOFTWARE.
                 <artifactItem>
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>prism-api</artifactId>
-                  <version>1.30.0-1</version>
+                  <version>1.30.0-600.v0b_eeeb_e43a_f9</version>
                   <type>hpi</type>
                   <outputDirectory>${project.build.outputDirectory}/plugins</outputDirectory>
                   <destFileName>prism-api.jpi</destFileName>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -256,7 +256,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>3.2.7</version>
+      <version>3.2.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -250,7 +250,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>515.vd788654779b_1</version>
+      <version>522.va_995fa_cfb_8b_d</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -332,7 +332,7 @@ THE SOFTWARE.
                   <!-- dependency of checks-api, echarts-api, font-awesome-api, and junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>plugin-util-api</artifactId>
-                  <version>6.1154.ved7e7d3035a_5</version>
+                  <version>6.1157.vc75ef7129d86</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -369,7 +369,7 @@ THE SOFTWARE.
                   <!-- dependency of junit -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>echarts-api</artifactId>
-                  <version>6.0.0-1</version>
+                  <version>6.0.0-1137.vfd5f348e1952</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>
@@ -407,7 +407,7 @@ THE SOFTWARE.
                   <!-- dependency of bootstrap5-api and echarts-api -->
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>font-awesome-api</artifactId>
-                  <version>7.0.0-1</version>
+                  <version>7.0.0-844.vb_f7825b_7f5da_</version>
                   <type>hpi</type>
                 </artifactItem>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -283,7 +283,7 @@ THE SOFTWARE.
                   <!-- detached after 1.493 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>mailer</artifactId>
-                  <version>515.vd788654779b_1</version>
+                  <version>522.va_995fa_cfb_8b_d</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -290,7 +290,7 @@ THE SOFTWARE.
                   <!-- detached after 1.535 -->
                   <groupId>org.jenkins-ci.plugins</groupId>
                   <artifactId>matrix-auth</artifactId>
-                  <version>3.2.7</version>
+                  <version>3.2.8</version>
                   <type>hpi</type>
                 </artifactItem>
                 <artifactItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4376,7 +4376,7 @@ __metadata:
     stylelint-checkstyle-reporter: "npm:1.1.1"
     stylelint-config-standard-scss: "npm:15.0.1"
     tippy.js: "npm:6.3.7"
-    webpack: "npm:5.101.2"
+    webpack: "npm:5.101.3"
     webpack-cli: "npm:6.0.1"
     webpack-remove-empty-scripts: "npm:1.1.1"
     window-handle: "npm:1.0.1"
@@ -7062,9 +7062,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.101.2":
-  version: 5.101.2
-  resolution: "webpack@npm:5.101.2"
+"webpack@npm:5.101.3":
+  version: 5.101.3
+  resolution: "webpack@npm:5.101.3"
   dependencies:
     "@types/eslint-scope": "npm:^3.7.7"
     "@types/estree": "npm:^1.0.8"
@@ -7096,7 +7096,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 10c0/e27091bd0d51ff17ecdaf18dae00dca57475e9152d7fc50d7c65e098629a63c7b3bf4e275ae76d111aed37b95f956b2df19aeeac27b0351fa2572e71f019dcb5
+  checksum: 10c0/3c204d4f1df0ef2774ae043f62e4db56c11b7a0594e82fbb1fbbaf69893570f3bf08a8b5d2d5a0302ce6346132bf3eb9dbde81e4fab3d68307b2e506d606f064
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removed stream() since clouds are already iterable, replaced with direct call to forEach()


### Testing done
N/A

### Proposed changelog entries

- /label skip-changelog

### Proposed upgrade guidelines
- N/A

Submitter checklist
 - [ ] The Jira issue, if it exists, is well-described.
  - [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the Proposed upgrade guidelines section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with @Restricted or have @since TODO Javadocs, as appropriate.
- [ ] New deprecations are annotated with @Deprecated(since = "TODO") or @Deprecated(forRemoval = true, since = "TODO"), if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call eval to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.


### Desired reviewers
N/A

Before the changes are marked as ready-for-merge:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or Proposed changelog entries are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the upgrade-guide-needed label is set and there is a Proposed upgrade guidelines section in the pull request title (see https://github.com/jenkinsci/jenkins/pull/4387).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a Bug or Improvement, and be labeled as lts-candidate to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).