### PR TITLE
Skip runScriptOnOfflineComputer on Windows ci.jenkins.io

### DIFF
--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -559,6 +559,7 @@ public class JenkinsTest {
 
     @Test
     void runScriptOnOfflineComputer() throws Exception {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "TODO: Test fails on CI Windows VM since transition to AWS");
         DumbSlave slave = j.createSlave(true);
         j.disconnectSlave(slave);
 


### PR DESCRIPTION
## Skip runScriptOnOfflineComputer on Windows ci.jenkins.io

Test was slightly flaky before ci.jenkins.io transitioned from Azure to AWS agents.  Since the transition, the test fails much more frequently.  The failures are not pointing to a real problem, but a change in the infrastructure.

Infra help desk issue that is investigating:

* https://github.com/jenkins-infra/helpdesk/issues/4730

Let's not waste time or resources retrying this test on Windows in CI.

### Launchable flakiness report

<img width="900" height="1071" alt="screencapture-app-launchableinc-organizations-jenkins-workspaces-jenkins-data-test-paths-class-jenkins-model-JenkinsTest-2025-08-21-15_00_31-edit" src="https://github.com/user-attachments/assets/bae71d83-5c4e-41ed-9685-f0183d105044" />

### Testing done

* Ran JenkinsTest#runScriptOnOfflineComputer on 5 different Windows computers before making this change.  Execution times ranged from 21 sec to 45 sec (depending on the age of the Windows computer).  None of those tests failed.
* Confirmed that the test is skipped on those Windows computers after making this change

Those Windows computers are running a mix of Windows 10 and Windows 11 with local SSD disc drives.  They each have at least 16 GB of RAM.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
