### PR TITLE
Backporting for LTS 2.516.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.31</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.11</winstone.version>
+    <winstone.version>8.12</winstone.version>
     <node.version>22.16.0</node.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.31</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.12</winstone.version>
+    <winstone.version>8.13</winstone.version>
     <node.version>22.16.0</node.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.31</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.10</winstone.version>
+    <winstone.version>8.11</winstone.version>
     <node.version>22.16.0</node.version>
   </properties>
 

--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -57,10 +57,6 @@ function dropdown() {
         referenceParent.classList.add("model-link--open");
       }
     },
-    onHide: (instance) => {
-      const referenceParent = instance.reference.parentNode;
-      referenceParent.classList.remove("model-link--open");
-    },
   };
 }
 

--- a/src/main/js/components/dropdowns/utils.js
+++ b/src/main/js/components/dropdowns/utils.js
@@ -52,6 +52,8 @@ function generateDropdown(element, callback, immediate, options = {}) {
           }
         },
         onHide(instance) {
+          const referenceParent = instance.reference.parentNode;
+          referenceParent.classList.remove("model-link--open");
           if (
             instance.props.trigger === "mouseenter" &&
             !instance.clickToHide

--- a/src/main/scss/components/_page-header.scss
+++ b/src/main/scss/components/_page-header.scss
@@ -7,7 +7,7 @@
 
   position: sticky;
   top: 0;
-  z-index: 20;
+  z-index: 999;
   display: flex;
   align-items: center;
   gap: var(--section-padding);

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -653,7 +653,7 @@ THE SOFTWARE.
           contains a version of Jetty that is older than this, trigger Dependabot in jenkinsci/winstone and release the
           result before proceeding with the update here.
         -->
-        <version>12.0.22</version>
+        <version>12.0.23</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -653,7 +653,7 @@ THE SOFTWARE.
           contains a version of Jetty that is older than this, trigger Dependabot in jenkinsci/winstone and release the
           result before proceeding with the update here.
         -->
-        <version>12.0.23</version>
+        <version>12.0.24</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -653,7 +653,7 @@ THE SOFTWARE.
           contains a version of Jetty that is older than this, trigger Dependabot in jenkinsci/winstone and release the
           result before proceeding with the update here.
         -->
-        <version>12.0.24</version>
+        <version>12.0.25</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
```
Postponed
---------

JENKINS-75851           Minor                   <a href="https://www.jenkins.io/changelog/2.522/">https://www.jenkins.io/changelog/2.522/</a>
        Enhance breadcrumb with visual indication to show that there are dropdowns
        https://issues.jenkins.io/browse/JENKINS-75851

Fixed
-----

JENKINS-76033           Minor                   Tue, 26 Aug 2025 14:03:25 +0000
        Backport Winstone 8.13 and Jetty 12.0.25 to Jenkins 2.516.3 LTS
        https://issues.jenkins.io/browse/JENKINS-76033

JENKINS-75937           Minor                   <a href="https://www.jenkins.io/changelog/2.523/">https://www.jenkins.io/changelog/2.523/</a>
        Bottom button bar overlaps with header
        https://issues.jenkins.io/browse/JENKINS-75937

JENKINS-75927           Major                   <a href="https://www.jenkins.io/changelog/2.523/">https://www.jenkins.io/changelog/2.523/</a>
        model-link--open not removed
        https://issues.jenkins.io/browse/JENKINS-75927

JENKINS-75879           Major                   <a href="https://www.jenkins.io/changelog/2.524/">https://www.jenkins.io/changelog/2.524/</a>
        GStringTemplateEngine causes memory leak in ClassLoading
        https://issues.jenkins.io/browse/JENKINS-75879

JENKINS-75675           Minor                   <a href="https://www.jenkins.io/changelog/2.524/">https://www.jenkins.io/changelog/2.524/</a>
        Refactor class loading logic in order to reduce memory consumption
        https://issues.jenkins.io/browse/JENKINS-75675
```

Ref:
- https://github.com/jenkins-infra/release/issues/744

### Testing done

Compiled with:
```
mvn -am -pl war,bom -Pquick-build clean install
```

### Proposed changelog entries

- N/A

### Proposed changelog category

/label into-lts

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [-] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [-] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [-] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [-] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [-] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@MarkEWaite @krisstern @daniel-beck 

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
