### PR TITLE
Initialize `transport` at the beginning of `opened`

### DIFF
--- a/core/src/main/java/jenkins/agents/WebSocketAgents.java
+++ b/core/src/main/java/jenkins/agents/WebSocketAgents.java
@@ -137,10 +137,10 @@ public final class WebSocketAgents extends InvisibleAction implements Unprotecte
         @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE", justification = "method signature does not permit plumbing through the return value")
         @Override
         protected void opened() {
+            transport = new Transport();
             Computer.threadPoolForRemoting.submit(() -> {
                 LOGGER.fine(() -> "setting up channel for " + agent);
                 state.fireBeforeChannel(new ChannelBuilder(agent, Computer.threadPoolForRemoting));
-                transport = new Transport();
                 try {
                     state.fireAfterChannel(state.getChannelBuilder().build(transport));
                     LOGGER.fine(() -> "set up channel for " + agent);


### PR DESCRIPTION
While testing ~500 websocket agents with CloudBees CI, noticed this race condition in `transport` initialization by the `opened` method vs the `binary` method being called slightly before.
```
WARNING	j.agents.WebSocketAgents$Session#error
java.lang.NullPointerException: Cannot invoke "jenkins.agents.WebSocketAgents$Session$Transport.receive(java.nio.ByteBuffer)" because "this.transport" is null
	at jenkins.agents.WebSocketAgents$Session.binary(WebSocketAgents.java:157)
	at jenkins.websocket.WebSockets$2.onWebSocketBinary(WebSockets.java:120)
	at jenkins.websocket.Jetty12EE9Provider$2.onWebSocketBinary(Jetty12EE9Provider.java:156)
	at Jenkins Main ClassLoader//org.eclipse.jetty.websocket.core.messages.ByteArrayMessageSink.accept(ByteArrayMessageSink.java:73)
	at …
```

The connection would be dropped at this, and agent needs to reconnect again.

### Testing done

After fixing, tested again, and no more seeing the NPE.

### Proposed changelog entries

- Fix race condition in WebSocket agent connection initialization

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A


### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jglick , @Vlatombe 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
