### PR TITLE
[JENKINS-49217] Export ChannelTermination#cause when it is an ExportedBean

### DIFF
--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -117,6 +117,22 @@ public abstract class OfflineCause implements IOfflineCause {
             return cause.toString();
         }
 
+        /**
+         * Returns the cause of the channel termination if it's an ExportedBean,
+         * null otherwise. This allows the API to export the cause details when
+         * the exception has the @ExportedBean annotation.
+         *
+         * @return the cause if it's exportable, null otherwise
+         * @since 2.529
+         */
+        @Exported
+        public Exception getCause() {
+            if (cause != null && cause.getClass().isAnnotationPresent(ExportedBean.class)) {
+                return cause;
+            }
+            return null;
+        }
+
         @Override public String toString() {
             return Messages.OfflineCause_connection_was_broken_simple();
         }

--- a/core/src/test/java/hudson/slaves/OfflineCauseTest.java
+++ b/core/src/test/java/hudson/slaves/OfflineCauseTest.java
@@ -3,8 +3,12 @@ package hudson.slaves;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 import org.junit.jupiter.api.Test;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 class OfflineCauseTest {
 
@@ -13,6 +17,53 @@ class OfflineCauseTest {
         String exceptionMessage = "exception message";
         OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException(exceptionMessage));
         assertThat(cause.toString(), not(containsString(exceptionMessage)));
+    }
+
+    @ExportedBean
+    static class ExportableException extends Exception {
+        private final String testMessage;
+
+        ExportableException(String message) {
+            super(message);
+            this.testMessage = message;
+        }
+
+        @Exported
+        public String getTestMessage() {
+            return testMessage;
+        }
+    }
+
+    static class NonExportableException extends Exception {
+        NonExportableException(String message) {
+            super(message);
+        }
+    }
+
+    @Test
+    void testChannelTermination_ExportsCauseWhenExportedBean() {
+        ExportableException exportableException = new ExportableException("test message");
+        OfflineCause.ChannelTermination termination = new OfflineCause.ChannelTermination(exportableException);
+
+        // The getCause() method should return the exception when it's an ExportedBean
+        assertThat(termination.getCause(), sameInstance(exportableException));
+    }
+
+    @Test
+    void testChannelTermination_DoesNotExportNonExportableException() {
+        NonExportableException nonExportableException = new NonExportableException("test message");
+        OfflineCause.ChannelTermination termination = new OfflineCause.ChannelTermination(nonExportableException);
+
+        // The getCause() method should return null when the exception is not an ExportedBean
+        assertThat(termination.getCause(), nullValue());
+    }
+
+    @Test
+    void testChannelTermination_HandlesNullCause() {
+        OfflineCause.ChannelTermination termination = new OfflineCause.ChannelTermination(null);
+
+        // The getCause() method should handle null cause
+        assertThat(termination.getCause(), nullValue());
     }
 
 }


### PR DESCRIPTION
Adds getCause() method to ChannelTermination that exports the cause field only when the exception has @ExportedBean annotation.
This allows the API to include detailed error information for exportable exceptions while maintaining backward compatibility.

See [JENKINS-49217](https://issues.jenkins.io/browse/JENKINS-49217)

## Testing done

Added unit tests covering exportable exceptions, non-exportable exceptions, and null handling.

## Proposed changelog entries

Export channel termination cause details when exception has @ExportedBean annotation

## Proposed changelog category

/label bug

## Proposed upgrade guidelines

N/A

### Submitter checklist

  - [x] The Jira issue, if it exists, is well-described.
  - [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the Proposed upgrade guidelines section only if there are breaking changes or changes that may require extra steps from users during upgrade.
  - [ ] There is automated testing or an explanation as to why this change has no tests.
  - [x] New public classes, fields, and methods are annotated with @Restricted or have @since TODO Javadocs, as appropriate.
  - [ ] New deprecations are annotated with @Deprecated(since = "TODO") or @Deprecated(forRemoval = true, since = "TODO"), if applicable.
  - [ ] New or substantially changed JavaScript is not defined inline and does not call eval to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
  - [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
  - [ ] For new APIs and extension points, there is a link to at least one consumer.

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
