### PR TITLE
Move TimeZoneProperty to user preferences page

### DIFF
--- a/core/src/main/java/hudson/model/TimeZoneProperty.java
+++ b/core/src/main/java/hudson/model/TimeZoneProperty.java
@@ -114,7 +114,7 @@ public class TimeZoneProperty extends UserProperty {
 
         @Override
         public @NonNull UserPropertyCategory getUserPropertyCategory() {
-            return UserPropertyCategory.get(UserPropertyCategory.Account.class);
+            return UserPropertyCategory.get(UserPropertyCategory.Preferences.class);
         }
     }
 


### PR DESCRIPTION
The TimeZoneProperty is currently on the account settings page. I think it betters fits on the `Preferences` page. Alternatively it could also be on the `Appearance` page thought that setting could also be used by plugins for other non UI things.

### Testing done

Tested that property is on the right page and still works.

### Proposed changelog entries

- Move the user time zone configuration to the user preferences page.

### Proposed changelog category

/label rfe,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
