### PR TITLE
[JENKINS-76114] Bring back the "All/None/Suggested" buttons in the plugin configuration wizard

### DIFF
--- a/src/main/scss/pluginSetupWizard.scss
+++ b/src/main/scss/pluginSetupWizard.scss
@@ -263,7 +263,6 @@
         top: 0;
         right: 0;
         left: 0;
-        padding: 0 10px;
         height: 2.75em;
         z-index: 100;
         background: rgb(0 0 0 / 0.03);


### PR DESCRIPTION
See [JENKINS-76114](https://issues.jenkins.io/browse/JENKINS-76114).

Since 2.527, the list of plugin in setup wizard does not show "All/None/Suggested" buttons.

Before:
<img width="1525" height="265" alt="image" src="https://github.com/user-attachments/assets/b6673d66-7e0e-41a9-bc4b-071b81f6749d" />

After:
<img width="1534" height="255" alt="image" src="https://github.com/user-attachments/assets/ecf7eaaa-43b9-4d78-bc29-81a166397996" />


### Testing done

```sh
❯ mvn -am -pl war,bom -Pquick-build clean install
❯ JENKINS_HOME=tmp java -jar war/target/jenkins.war
```

Checked that buttons are visible in both Chrome and Firefox
* large screen (width > 768px) <img width="1527" height="241" alt="image" src="https://github.com/user-attachments/assets/4ab43a4a-e43e-4db2-bd5f-cb28a4a1df0f" />
* small screen (width <= 768px) <img width="1003" height="288" alt="image" src="https://github.com/user-attachments/assets/11cf2d37-757e-459e-89b1-324d1c8a5cdd" />


### Proposed changelog entries

- Fix "All/None/Suggested" buttons visibility in plugin setup wizard.


### Proposed changelog category

/label regression-fix


### Proposed upgrade guidelines

N/A


### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
