### PR TITLE
[JENKINS-16341] Pick up `BoundObjectTable` fix

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <commons-fileupload2.version>2.0.0-M4</commons-fileupload2.version>
     <groovy.version>2.4.21</groovy.version>
     <jelly.version>1.1-jenkins-20250731</jelly.version>
-    <stapler.version>2033.va_95221851a_23</stapler.version>
+    <stapler.version>2036.v69a_e0454da_b_9</stapler.version>
   </properties>
 
   <dependencyManagement>

--- a/core/src/main/java/jenkins/util/ProgressiveRendering.java
+++ b/core/src/main/java/jenkins/util/ProgressiveRendering.java
@@ -134,23 +134,12 @@ public abstract class ProgressiveRendering {
                     ((ScheduledExecutorService) executorService).schedule(new Runnable() {
                         @Override public void run() {
                             LOG.log(Level.FINE, "some time has elapsed since {0} finished, so releasing", boundId);
-                            release();
+                            boundObjectTable.release(boundId);
                         }
                     }, timeout() /* add some grace period for browser/network overhead */ * 2, TimeUnit.MILLISECONDS);
                 }
             }
         });
-    }
-
-    /** {@link BoundObjectTable#releaseMe} just cannot work the way we need it to. */
-    private void release() {
-        try {
-            Method release = BoundObjectTable.Table.class.getDeclaredMethod("release", String.class);
-            release.setAccessible(true);
-            release.invoke(boundObjectTable, boundId);
-        } catch (Exception x) {
-            LOG.log(Level.WARNING, "failed to unbind " + boundId, x);
-        }
     }
 
     /**
@@ -281,7 +270,7 @@ public abstract class ProgressiveRendering {
         r.put("status", statusJSON);
         if (statusJSON instanceof String) { // somehow completed
             LOG.log(Level.FINE, "finished in news so releasing {0}", boundId);
-            release();
+            boundObjectTable.release(boundId);
         }
         lastNewsTime = System.currentTimeMillis();
         LOG.log(Level.FINER, "news from {0}", uri);


### PR DESCRIPTION
See [JENKINS-16341](https://issues.jenkins.io/browse/JENKINS-16341).

Like https://github.com/jenkinsci/jenkins/pull/11084, picks up https://github.com/jenkinsci/stapler/pull/663, but also cleans up from https://github.com/jenkinsci/jenkins/commit/aac8c239721ed52caacbff389a29d5db2c1e3a00 as in https://github.com/jenkinsci/stapler/pull/663#discussion_r2075943073.

### Testing done

After `jetty:run`, `/view/all/builds` shows something.

### Proposed changelog entries

- Try harder to release controller memory after using some JavaScript features.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
