### PR TITLE
Revert "Update dependency org.jenkins-ci.main:jenkins-test-harness to v2505"

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -192,7 +192,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2505.v4a_e1e6f69d4e</version>
+      <version>2493.vcc1b_74b_c433f</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Reverts jenkinsci/jenkins#11106

As per https://github.com/jenkinsci/jenkins-test-harness/issues/1031