### PR TITLE
Add `detectOfflineLinks` set to `false` in `maven-javadoc-plugin` configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,9 @@ THE SOFTWARE.
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
     <winstone.version>8.13.1</winstone.version>
     <node.version>24.9.0</node.version>
+
+    <!-- Avoid "Execution attach-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.3:jar failed: Null charset name" javadoc error -->
+    <detectOfflineLinks>false</detectOfflineLinks>
   </properties>
 
   <!--
@@ -158,6 +161,7 @@ THE SOFTWARE.
           <configuration>
             <quiet>true</quiet>
             <splitindex>true</splitindex>
+            <detectOfflineLinks>${detectOfflineLinks}</detectOfflineLinks>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This PR adds this configuration in the main pom.xml to avoid the following error encountered with https://github.com/jenkinsci/jenkins/pull/11130:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.3:jar (attach-javadocs) on project jenkins-war: Execution attach-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.3:jar failed: Null charset name -> [Help 1] org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.3:jar (attach-javadocs) on project jenkins-war: Execution attach-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.3:jar failed: Null charset name
```

Refs:
- https://github.com/jenkinsci/jenkins/pull/11130#issuecomment-3351854076
- https://github.com/apache/maven-javadoc-plugin/issues/1241#issuecomment-3214956373

### Testing done

- Ran `mvn --batch-mode --show-version --errors --no-transfer-progress -Pdebug -Penable-jacoco --update-snapshots -Dmaven.test.failure.ignore -DforkCount=2 -Dspotbugs.failOnError=false -Dcheckstyle.failOnViolation=false -Dset.changelist help:evaluate -Dexpression=changelist -DskipTests clean install` locally and confirmed the error is gone with this change.

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [-] The Jira issue, if it exists, is well-described.
- [-] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [-] There is automated testing or an explanation as to why this change has no tests.
- [-] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [-] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [-] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [-] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [-] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @MarkEWaite @olamy @jglick @daniel-beck 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
