### PR TITLE
Define health check for `BindException` on enforced TCP port

### DIFF
--- a/core/src/main/java/hudson/TcpSlaveAgentListener.java
+++ b/core/src/main/java/hudson/TcpSlaveAgentListener.java
@@ -50,6 +50,7 @@ import java.util.Base64;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.AgentProtocol;
+import jenkins.health.HealthCheck;
 import jenkins.model.Jenkins;
 import jenkins.model.identity.InstanceIdentityProvider;
 import jenkins.security.stapler.StaplerAccessibleType;
@@ -445,4 +446,14 @@ public final class TcpSlaveAgentListener extends Thread {
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
     @Restricted(NoExternalUse.class)
     public static Integer CLI_PORT = SystemProperties.getInteger(TcpSlaveAgentListener.class.getName() + ".port");
+
+    @Extension
+    public static final class EnforcedPortHealthCheck implements HealthCheck {
+        @Override
+        public boolean check() {
+            var j = Jenkins.get();
+            return !j.isSlaveAgentPortEnforced() || j.getSlaveAgentPort() <= 0 || j.getTcpSlaveAgentListener() != null;
+        }
+    }
+
 }


### PR DESCRIPTION
On rare occasions a CloudBees CI controller running in Kubernetes with an enforced port number of 50000 (mapped by the container to a `Service`) has been observed to fail to bind this port for unknown reasons, ultimately perhaps a Kubernetes race condition. When this happens, the controller pod is treated as healthy in terms of serving web traffic, yet it cannot be used to run any builds using TCP inbound agents (such as an in-cluster `KubernetesCloud`). This situation is tricky to detect and the remedy is to manually delete the pod and let it be restarted. This recovery should be automated.

([CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-58786))

### Testing done

Run Jenkins in various ways such as

```bash
java -Djenkins.model.Jenkins.slaveAgentPort=12345 -Djenkins.model.Jenkins.slaveAgentPortEnforce=false -jar war/target/jenkins.war
```

and then checked

```bash
curl -s http://localhost:8080/health/ | jq
```

normally printing

```json
{
  "status": true
}
```

Confirmed that the health check fails only when trying to bind a low (<1024) port like 

```bash
java -Djenkins.model.Jenkins.slaveAgentPort=123 -Djenkins.model.Jenkins.slaveAgentPortEnforce=false -jar war/target/jenkins.war
```

```json
{
  "status": false,
  "failures": [
    "hudson.TcpSlaveAgentListener$EnforcedPortHealthCheck"
  ]
}
```

where the system log explains

```
2025-10-02 20:39:53.571+0000 [id=64]	WARNING	jenkins.model.Jenkins#launchTcpSlaveAgentListener: Failed to listen to incoming agent connections through port 123. Change the port number
java.net.BindException: Permission denied
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:522)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.netBind(ServerSocketChannelImpl.java:335)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:297)
	at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:80)
	at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:72)
	at hudson.TcpSlaveAgentListener.createSocket(TcpSlaveAgentListener.java:108)
Caused: java.net.BindException: Failed to listen on port 123 because it's already in use.
	at hudson.TcpSlaveAgentListener.createSocket(TcpSlaveAgentListener.java:110)
	at hudson.TcpSlaveAgentListener.<init>(TcpSlaveAgentListener.java:94)
	at jenkins.model.Jenkins.launchTcpSlaveAgentListener(Jenkins.java:1262)
	at jenkins.model.Jenkins.<init>(Jenkins.java:1009)
	at hudson.model.Hudson.<init>(Hudson.java:100)
	at hudson.model.Hudson.<init>(Hudson.java:85)
	at hudson.WebAppMain$3.run(WebAppMain.java:249)
```

(Note that the detail message in the wrapping `BindException` is misleading in this case.)

An automated test seems awkward because this _Permission denied_ is specific to Unix systems when running as non-root. Could probably arrange to reproduce in `RealJenkinsRule` by binding a random port in the test and then starting Jenkins with that port number, but it feels excessive.

### Proposed changelog entries

- Health check for failure to bind an enforced TCP agent port.

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
