### PR TITLE
Sanitize launchable build name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,8 @@ stage('Record build') {
         /*
          * TODO Add the commits of the transitive closure of the Jenkins WAR under test to this build.
          */
-        def launchableName = env.BUILD_TAG // .replaceAll('%[0-9A-F]{2}', '-') // Launchable rejects '%2F' in build name
+        // Replace URL encoded characters with '-' because Launchable rejects '%2F' in build name
+        def launchableName = env.BUILD_TAG.replaceAll('(%[0-9A-Fa-f]{2})+', '-')
         sh "launchable verify && launchable record build --name ${launchableName} --source jenkinsci/jenkins=."
         axes.values().combinations {
           def (platform, jdk) = it

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,14 +29,15 @@ stage('Record build') {
         /*
          * TODO Add the commits of the transitive closure of the Jenkins WAR under test to this build.
          */
-        sh 'launchable verify && launchable record build --name ${BUILD_TAG} --source jenkinsci/jenkins=.'
+        def launchableName = env.BUILD_TAG // .replaceAll('%[0-9A-F]{2}', '-') // Launchable rejects '%2F' in build name
+        sh "launchable verify && launchable record build --name ${launchableName} --source jenkinsci/jenkins=."
         axes.values().combinations {
           def (platform, jdk) = it
           if (platform == 'windows' && jdk != 17) {
             return // unnecessary use of hardware
           }
           def sessionFile = "launchable-session-${platform}-jdk${jdk}.txt"
-          sh "launchable record session --build ${env.BUILD_TAG} --flavor platform=${platform} --flavor jdk=${jdk} >${sessionFile}"
+          sh "launchable record session --build ${launchableName} --flavor platform=${platform} --flavor jdk=${jdk} >${sessionFile}"
           stash name: sessionFile, includes: sessionFile
         }
       }


### PR DESCRIPTION
## Sanitize launchable build name

Renovate creates branches that contain a "/", like `renovate/org.jenkins-ci.main-jenkins-test-harness-2508.x`.  It uses the created branch to create a pull request.  Sometimes the Jenkins GitHub Multibranch Pipeline plugin detects the branch and creates a job for the branch and then detects the pull request and creates a job for the pull request.  The job created for the branch uses a name that includes a '/'.  The job created for the pull request uses a name that does not include a '/'.  Eventually the job that was created for the branch will be automatically deleted because we're configured to ignore branches that are also created as pull requests.  When the job created for the branch is deleted, the evidence of the failed call to Launchable is deleted.  

The Jenkinsfile uses the BUILD_TAG to name the Launchable build.  This change sanitizes the Launchable build name so that it includes no URL escapes.

### Testing done

Confirmed that the regular expression replacement works as expected with sample strings including:

* a/b
* a%2Fb
* a%25%2Fb

Confirmed that the bug is visible by running the job on ci.jenkins.io without the fix.  The job failed.

Running the job with the fix has completed the assignment of Launchable build name

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- ~The Jira issue, if it exists, is well-described.~
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- ~New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.~
- ~New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.~
- ~New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~
- ~For dependency updates, there are links to external changelogs and, if possible, full differentials.~
- ~For new APIs and extension points, there is a link to at least one consumer.~

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).

When merged, please delete the `chore/sanitize-launchable-name` branch from the repository.  It was needed to show the bug but does not need to persist once the bug is fixed.