### PR TITLE
Removed deprecated and unused `FormFieldValidator.NonNegativeInteger`

### DIFF
--- a/core/src/main/java/hudson/util/FormFieldValidator.java
+++ b/core/src/main/java/hudson/util/FormFieldValidator.java
@@ -633,31 +633,4 @@ public abstract class FormFieldValidator {
             error(errorMessage);
         }
     }
-
-    /**
-     * Verifies that the {@code value} parameter is an integer ≥ 0.
-     *
-     * @since 1.282
-     * @deprecated as of 1.294
-     *      Use {@link FormValidation#validateNonNegativeInteger(String)}
-     */
-    @Deprecated
-    public static class NonNegativeInteger extends FormFieldValidator {
-        public NonNegativeInteger() {
-            super(null);
-        }
-
-        @Override
-        protected void check() throws IOException, ServletException {
-            try {
-                String value = request.getParameter("value");
-                if (Integer.parseInt(value) < 0)
-                    error(hudson.model.Messages.Hudson_NotAPositiveNumber());
-                else
-                    ok();
-            } catch (NumberFormatException e) {
-                error(hudson.model.Messages.Hudson_NotANumber());
-            }
-        }
-    }
 }


### PR DESCRIPTION
Removed, long deprecated (with version 1.294) and unused `FormFieldValidator.NonNegativeInteger` according to:
-  [deprecated-and-unused](https://ci.jenkins.io/job/Reporting/job/deprecated-usage-in-plugins/3283/artifact/output/deprecated-and-unused.html)
- [GitHub search](https://github.com/search?q=org%3Ajenkinsci+NonNegativeInteger&type=code&p=1)

The localized strings are also used somewhere else, so I kept them. If this is considered **useful**, there is more unused in this file, but I think this is the safest one to start.

### Testing done

Ran a local build and a `jetty:run` in debug mode.

### Proposed changelog entries

- Remove deprecated and unused `FormFieldValidator.NonNegativeInteger`.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label developer, removed

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
