### PR TITLE
Remove errant ,

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -106,7 +106,7 @@
       ],
       "enabled": false,
       "description": "maven-metadata.xml is missing for this really old package which is required by renovate"
-    },
+    }
   ],
   "customManagers": [
     {


### PR DESCRIPTION
A block was removed from the json in cb6bc5b1d2d2846d985b1768fa75b31b7532ee4f it was the last in a series, which left an extra , at the end, causing json to get confused.

When running
```
docker run --rm -e RENOVATE_TOKEN=<token> <image> --dry-run jenkinsci/jenkins
```
I'm getting:
```
 INFO: Repository has invalid config (repository=jenkinsci/jenkins)
       "error": {
         "validationSource": ".github/renovate.json",
         "validationError": "Invalid JSON (parsing failed)",
         "validationMessage": "Syntax error near },\n  ],\n  ",
         "message": "config-validation",
         "stack": "Error: config-validation\n    at checkForRepoConfigError (/usr/local/lib/node_modules/renovate/lib/workers/repositor
y/init/merge.ts:173:17)\n    at mergeRenovateConfig (/usr/local/lib/node_modules/renovate/lib/workers/repository/init/merge.ts:213:3)\n
    at getRepoConfig (/usr/local/lib/node_modules/renovate/lib/workers/repository/init/config.ts:14:12)\n    at initRepo (/usr/local/li
b/node_modules/renovate/lib/workers/repository/init/index.ts:58:12)\n    at Object.renovateRepository (/usr/local/lib/node_modules/reno
vate/lib/workers/repository/index.ts:70:14)\n    at attributes.repository (/usr/local/lib/node_modules/renovate/lib/workers/global/inde
x.ts:184:11)\n    at start (/usr/local/lib/node_modules/renovate/lib/workers/global/index.ts:169:7)\n    at /usr/local/lib/node_modules
/renovate/lib/renovate.ts:19:22"
       }
```

Sure enough it would seem there is an extra , leftover from a commit from a few days ago. This PR is just to correct the json.