### PR TITLE
[JENKINS-76192] Ignore NoSuchFileException in FilePath#unzip

### DIFF
--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -722,10 +722,10 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                                     target.chmod(mode);
                                     break;
                                 } catch (NoSuchFileException ex) { // https://issues.jenkins.io/browse/JENKINS-76192
-                                    if (attempt == 3) {
+                                    if (attempt == 5) {
                                         throw ex;
                                     }
-                                    Thread.sleep(420);
+                                    Thread.sleep(1000);
                                 }
                             }
                         }

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -716,7 +716,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                     try {
                         FilePath target = new FilePath(f);
                         int mode = e.getUnixMode();
-                        if (mode != 0)   // Ant returns 0 if the archive doesn't record the access mode
+                        if (mode != 0)    // Ant returns 0 if the archive doesn't record the access mode
                             target.chmod(mode);
                     } catch (InterruptedException | NoSuchFileException ex) {
                         LOGGER.log(Level.WARNING, "unable to set permissions", ex);

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -716,20 +716,9 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                     try {
                         FilePath target = new FilePath(f);
                         int mode = e.getUnixMode();
-                        if (mode != 0) { // Ant returns 0 if the archive doesn't record the access mode
-                            for (int attempt = 1; ; attempt++) {
-                                try {
-                                    target.chmod(mode);
-                                    break;
-                                } catch (NoSuchFileException ex) { // https://issues.jenkins.io/browse/JENKINS-76192
-                                    if (attempt == 5) {
-                                        throw ex;
-                                    }
-                                    Thread.sleep(1000);
-                                }
-                            }
-                        }
-                    } catch (InterruptedException ex) {
+                        if (mode != 0) // Ant returns 0 if the archive doesn't record the access mode
+                            target.chmod(mode);
+                    } catch (InterruptedException | NoSuchFileException ex) {
                         LOGGER.log(Level.WARNING, "unable to set permissions", ex);
                     }
                     Files.setLastModifiedTime(Util.fileToPath(f), e.getLastModifiedTime());

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -716,7 +716,7 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                     try {
                         FilePath target = new FilePath(f);
                         int mode = e.getUnixMode();
-                        if (mode != 0) // Ant returns 0 if the archive doesn't record the access mode
+                        if (mode != 0)   // Ant returns 0 if the archive doesn't record the access mode
                             target.chmod(mode);
                     } catch (InterruptedException | NoSuchFileException ex) {
                         LOGGER.log(Level.WARNING, "unable to set permissions", ex);

--- a/core/src/main/java/hudson/FilePath.java
+++ b/core/src/main/java/hudson/FilePath.java
@@ -721,7 +721,11 @@ public final class FilePath implements SerializableOnlyOverRemoting {
                     } catch (InterruptedException | NoSuchFileException ex) {
                         LOGGER.log(Level.WARNING, "unable to set permissions", ex);
                     }
-                    Files.setLastModifiedTime(Util.fileToPath(f), e.getLastModifiedTime());
+                    try {
+                        Files.setLastModifiedTime(Util.fileToPath(f), e.getLastModifiedTime());
+                    } catch (NoSuchFileException ex) {
+                        LOGGER.log(Level.WARNING, "unable to set last modified time", ex);
+                    }
                 }
             }
         }


### PR DESCRIPTION
See [JENKINS-76192](https://issues.jenkins.io/browse/JENKINS-76192).

Issue initially found in https://github.com/jenkinsci/sonargraph-integration-plugin/pull/31 

It appears that during `FilePath#unzip` the file that was just unpacked cannot be found in the following calls, causing `NoSuchFileException` to be thrown.

The issue occurs in `com.hello2morrow.sonargraph.integration.jenkins.controller.CustomMetricTest#testSameReportDoesNotAddMetricId`
It could only be reproduced on `ci.jenkins.io` on both, linux and windows agent. I was unable to reproduce it in my local environment.

First I tried to add a retry-loop with a `Thread.sleep` as I suspected a slow filesystem being the cause but could not confirm this being the case. My checks show that the file is indeed present and there does not seem to be anything wrong with it. So ignoring the exception seemed to be the only remedy. My working theory is that it could be an issue of the environment.

While I'm not a big fan of these kinds of workarounds, I think it will not cause any real harm here to ignore the expections.

### Testing done

I would not know how to create a unit test that validates the behavior, however https://github.com/jenkinsci/sonargraph-integration-plugin/pull/34 shows that the fix appears to be working.

### Proposed changelog entries

- Ignore `NoSuchFileException` in `FilePath#unzip`

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers 

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
