### PR TITLE
Deprecating `Extension.optional`

### DIFF
--- a/core/src/main/java/hudson/Extension.java
+++ b/core/src/main/java/hudson/Extension.java
@@ -87,7 +87,10 @@ public @interface Extension {
     /**
      * If an extension is optional, don't log any class loading errors when reading it.
      * @since 1.358
+     * @deprecated This is very difficult to use correctly and rarely what you actually wanted.
+     *             Use {@code OptionalExtension} from the {@code variant} plugin instead.
      */
+    @Deprecated
     boolean optional() default false;
 
     /**

--- a/core/src/main/java/hudson/ExtensionFinder.java
+++ b/core/src/main/java/hudson/ExtensionFinder.java
@@ -193,6 +193,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             super(Extension.class);
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         protected boolean isOptional(Extension annotation) {
             return annotation.optional();
@@ -779,6 +780,7 @@ public abstract class ExtensionFinder implements ExtensionPoint {
             }
         }
 
+        @SuppressWarnings("deprecation")
         private Level logLevel(IndexItem<Extension, Object> item) {
             return item.annotation().optional() ? Level.FINE : Level.WARNING;
         }

--- a/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/ExitLifecycle.java
@@ -25,7 +25,6 @@
 package hudson.lifecycle;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.Extension;
 import hudson.util.BootFailure;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,7 +43,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Alon Bar-Lev
  */
 @Restricted(NoExternalUse.class)
-@Extension
 public class ExitLifecycle extends Lifecycle {
 
     private static final Logger LOGGER = Logger.getLogger(ExitLifecycle.class.getName());

--- a/core/src/main/java/hudson/lifecycle/Lifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/Lifecycle.java
@@ -26,7 +26,6 @@ package hudson.lifecycle;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.ExtensionPoint;
 import hudson.Functions;
 import hudson.PluginManager;
 import hudson.Util;
@@ -62,7 +61,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Kohsuke Kawaguchi
  * @since 1.254
  */
-public abstract class Lifecycle implements ExtensionPoint {
+public abstract class Lifecycle {
     private static Lifecycle INSTANCE = null;
 
     /**

--- a/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/SystemdLifecycle.java
@@ -4,7 +4,6 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Extension;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -17,7 +16,6 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Basil Crow
  */
 @Restricted(NoExternalUse.class)
-@Extension(optional = true)
 public class SystemdLifecycle extends ExitLifecycle {
 
     private static final Logger LOGGER = Logger.getLogger(SystemdLifecycle.class.getName());

--- a/core/src/main/java/jenkins/diagnosis/HsErrPidList.java
+++ b/core/src/main/java/jenkins/diagnosis/HsErrPidList.java
@@ -34,8 +34,7 @@ import org.jenkinsci.Symbol;
  *
  * @author Kohsuke Kawaguchi
  */
-@Extension(optional = true) @Symbol("hsErrPid")
-// TODO why would an extension using a built-in extension point need to be marked optional?
+@Extension @Symbol("hsErrPid")
 public class HsErrPidList extends AdministrativeMonitor {
     /**
      * hs_err_pid files that we think belong to us.


### PR DESCRIPTION
Plugin developers often grab for this flag because it is easy to find, but it is almost always the wrong choice. It means the extension loader will still try to load the extension; it will just be _less_ noisy (still printing a warning to the log, one line rather than a stack trace!) if it fails. And it is actually tricky to get it to fail. You have to arrange for the initialization of the extension class (and perhaps also the constructor, I do not recall) to fail. So if your plugin has an `optional` dep on a plugin `xxx-api` and you write

```java
@Extension(optional = true)
public class MyImpl implements XXXExtensionPoint {
    @Override
    public XXXType someXXXMethod() {
        // …
    }
}
```

then that is fine, because types from `xxx-api` are required in the signature of `MyImpl`, so the `NoClassDefFoundError` will be caught by the extension loader and this extension will be skipped. But people often try to do something like the following:

```java
@Extension(optional = true)
public class MyListener extends RunListener {
    @Override
    public void onStarted(Run build) {
        if (build instanceof XXXBuild xxxBuild) {
            // …
        }
    }
}
```

This will be quietly registered even when `xxx-api` is disabled—and then throw `NoClassDefFoundError`s every time it is used! That is because the HotSpot linker is lazy: even though some method bodies refer to an inaccessible type, they are not linked until the first time the method is run.

You _can_ use `optional = true` correctly if you think carefully about what you are doing, and write tests with `RealJenkinsRule.omitPlugins` to prove that it behaves as expected. But you might as well just use `@OptionalExtension` which is much easier to reason about (and avoids the one-line warning to boot).

### Testing done

None.

### Proposed changelog entries

- Deprecating the `Extension.optional` attribute.

### Proposed changelog category

/label developer

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
