### PR TITLE
Clarifying that `PluginServletFilter` is not in fact an `ExtensionPoint`

### DIFF
--- a/core/src/main/java/hudson/util/PluginServletFilter.java
+++ b/core/src/main/java/hudson/util/PluginServletFilter.java
@@ -25,7 +25,6 @@
 package hudson.util;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import hudson.ExtensionPoint;
 import hudson.security.SecurityRealm;
 import io.jenkins.servlet.FilterWrapper;
 import io.jenkins.servlet.ServletExceptionWrapper;
@@ -51,19 +50,16 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.CompatibleFilter;
 
 /**
- * Servlet {@link Filter} that chains multiple {@link Filter}s, provided by plugins
- *
+ * Servlet {@link Filter} that chains multiple {@link Filter}s, provided by plugins.
  * <p>
- * While this class by itself is not an extension point, I'm marking this class
- * as an extension point so that this class will be more discoverable.
- *
+ * In most cases you should rather use {@link HttpServletFilter}.
  * <p>
  * {@link SecurityRealm} that wants to contribute {@link Filter}s should first
  * check if {@link SecurityRealm#createFilter(FilterConfig)} is more appropriate.
  *
  * @see SecurityRealm
  */
-public final class PluginServletFilter implements CompatibleFilter, ExtensionPoint {
+public final class PluginServletFilter implements CompatibleFilter {
     private final List<Filter> list = new CopyOnWriteArrayList<>();
 
     private /*almost final*/ FilterConfig config;


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/11201#discussion_r2435680236 following up #7892

### Testing done

Javadoc generation passes.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
