### PR TITLE
Clearer documentation for `ExtensionPoint`

### DIFF
--- a/core/src/main/java/hudson/ExtensionPoint.java
+++ b/core/src/main/java/hudson/ExtensionPoint.java
@@ -36,17 +36,14 @@ import jenkins.model.Jenkins;
  * in Jenkins that can be implemented by plugins.
  *
  * <p>
- * See respective interfaces/classes for more about how to register custom
- * implementations to Jenkins. See {@link Extension} for how to have
- * Jenkins auto-discover your implementations.
+ * Use {@link Extension} to register an implementation.
+ * Use {@link ExtensionList} to look for implementations.
  *
  * <p>
  * This interface is used for auto-generating
  * documentation.
  *
  * @author Kohsuke Kawaguchi
- * @see Plugin
- * @see Extension
  */
 public interface ExtensionPoint {
     /**


### PR DESCRIPTION
Amending d4c6a4b06cb5aa6823ed0b5fb3a6e11abb1d2029 as suggested in https://github.com/jenkinsci/jenkins/pull/11201#discussion_r2441255120.

### Testing done

Javadoc generation passes.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
