### PR TITLE
Ignore #6149 for purposes of `git blame`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
+# Whitespace: https://github.com/jenkinsci/jenkins/pull/6149
+e27b310065b3c036b5fc9d123f1d1d99d3058c00
 # Reformatted: https://github.com/jenkinsci/jenkins/pull/6863
 e3fdfa527e4fefb4b37f04c92a2dd87b8a374b75


### PR DESCRIPTION
I noticed https://github.com/jenkinsci/jenkins/pull/6149 popping up in a lot of `Jenkins.java` lines, confusing the blame.

### Testing done

```bash
git blame core/src/main/java/jenkins/model/Jenkins.java --ignore-revs-file=.git-blame-ignore-revs | fgrep e27 | wc -l
```

is 228 before, but just 10 with this change.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
