### PR TITLE
Test CLI._main fail

### DIFF
--- a/test/src/test/java/hudson/cli/NoClassFoundTest.java
+++ b/test/src/test/java/hudson/cli/NoClassFoundTest.java
@@ -1,0 +1,22 @@
+package hudson.cli;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+public class NoClassFoundTest {
+
+    private JenkinsRule j = new JenkinsRule();
+
+    @BeforeEach
+    public void setup(JenkinsRule j) throws Exception {
+        this.j = j;
+    }
+
+    @Test
+    void testCLI() throws Exception {
+        CLI._main(new String[]{"-http", "-s", j.getURL().toString(), "who-am-i"});
+    }
+}


### PR DESCRIPTION
I'm trying to add a test using `CLI._main`, however this is failing locally with a `NoClassFoundTest` exception.
```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 7.940 s <<< FAILURE! -- in hudson.cli.NoClassFoundTest
[ERROR] hudson.cli.NoClassFoundTest.testCLI -- Time elapsed: 7.392 s <<< ERROR!
java.lang.NoClassDefFoundError: org/glassfish/tyrus/client/exception/DeploymentHandshakeException
        at hudson.cli.NoClassFoundTest.testCLI(NoClassFoundTest.java:20)
Caused by: java.lang.ClassNotFoundException: org.glassfish.tyrus.client.exception.DeploymentHandshakeException
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
        ... 1 more
```

I'm expecting it to succeed with the CI.