### PR TITLE
Optimize `MappingWorksheet` to avoid calling `Task.getEstimatedDuration`

### DIFF
--- a/test/src/test/java/hudson/model/queue/LoadPredictorTest.java
+++ b/test/src/test/java/hudson/model/queue/LoadPredictorTest.java
@@ -37,6 +37,7 @@ import hudson.model.Queue.BuildableItem;
 import hudson.model.Queue.JobOffer;
 import hudson.model.Queue.Task;
 import hudson.model.Queue.WaitingItem;
+import hudson.slaves.DumbSlave;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -106,7 +107,7 @@ class LoadPredictorTest {
     }
 
     private Computer createMockComputer(int nExecutors) throws Exception {
-        Node n = mock(Node.class);
+        Node n = mock(DumbSlave.class);
         Computer c = mock(Computer.class);
         when(c.getNode()).thenReturn(n);
 


### PR DESCRIPTION
Amends the rather old 0ff811ff021fbe80564253d09f9ce942fe5d6f98 by trying to avoid calling `Queue.Task.getEstimatedDuration()` unless it is actually helpful to do so. Follows up my #7998 which did make this call faster in many cases; still, flame graphs show that in a heavily loaded controller, a major source of contention on the `Queue` lock is the `MappingWorksheet` constructor and the calculations it performs.

* Quite often, this code is entered when there are no `JobOffer`s at all, so the loop will not run and there is no purpose in even asking for the estimated duration.
* When using cloud agents, https://github.com/jenkinsci/jenkins/blob/320a149f7640d31f4fb7c4ee8eee81124cd6c588/core/src/main/java/hudson/model/queue/LoadPredictor.java#L40-L42 simply makes no sense. Each item added to the queue triggers creation of an agent which will run its task. There is no reason to waste time doing anything fancier.
* When at least one permanent agent is under consideration for the item, the more expensive historical behavior is preserved, in case someone finds it useful. (It seems dubious to me.) I am treating `DumbSlave` as the definition of _permanent agent_; use of https://github.com/jenkinsci/jenkins/blob/320a149f7640d31f4fb7c4ee8eee81124cd6c588/core/src/main/java/hudson/slaves/AbstractCloudSlave.java#L40 is optional (see https://github.com/jenkinsci/ec2-plugin/pull/1015 for example).

### Testing done

Original performance problem observed sometimes under load in a CloudBees CI high availability controller. The patch appears to help, though running a controlled experiment is difficult.

So for only tested semi-interactively using functional tests in CloudBees CI representing various scenarios of cloud agents only, permanent agents only, or a mixture but the specific queue item is requesting a cloud agent label, and confirming that the appropriate `FINE` log message is printed. Other than the fairly low-level mock test, I did not find any existing functional tests that would confirm the purpose and effectiveness of the `MappingWorksheet` logic in the context of a real `Queue.maintain`.

### Proposed changelog entries

- Performance improvement for queue item scheduling.

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
