### PR TITLE
chore(GHA/publish-release-artifacts) merge into a single package for RH/SuSE

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -114,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ${{ steps.fetch-deb.outputs.file-name }}
-  redhat:
+  rpm:
     permissions:
       contents: write # to upload release asset (softprops/action-gh-release)
 
@@ -128,15 +128,15 @@ jobs:
         run: |
           PROJECT_VERSION=${{ needs.determine-version.outputs.project-version }}
           echo $PROJECT_VERSION
-          FILE_NAME=jenkins-${PROJECT_VERSION}-1.1.noarch.rpm
+          FILE_NAME=jenkins-${PROJECT_VERSION}-1.noarch.rpm
           IS_LTS=${{ needs.determine-version.outputs.is-lts }}
 
           echo "file-name=$FILE_NAME" >> $GITHUB_OUTPUT
 
-          REPO=redhat
+          REPO=rpm
           if [ ${IS_LTS} = 'true' ]
           then
-            REPO=redhat-stable
+            REPO=rpm-stable
           fi
 
           echo $REPO
@@ -186,39 +186,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ${{ steps.fetch-msi.outputs.file-name }}
-  suse:
-    permissions:
-      contents: write # to upload release asset (softprops/action-gh-release)
-
-    runs-on: ubuntu-latest
-    needs: determine-version
-    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
-    steps:
-      - name: Fetch suse rpm
-        id: fetch-suse-rpm
-        if: always()
-        run: |
-          PROJECT_VERSION=${{ needs.determine-version.outputs.project-version }}
-          echo $PROJECT_VERSION
-          # we need opensuse to the file 
-          OUTPUT_FILE_NAME=jenkins-${PROJECT_VERSION}-1.2-opensuse.noarch.rpm
-          IS_LTS=${{ needs.determine-version.outputs.is-lts }}
-          echo "file-name=$OUTPUT_FILE_NAME" >> $GITHUB_OUTPUT
-
-          REPO=opensuse
-          if [ ${IS_LTS} = 'true' ]
-          then
-            REPO=opensuse-stable
-          fi
-
-          echo $REPO
-
-          wget -q https://get.jenkins.io/${REPO}/jenkins-${PROJECT_VERSION}-1.2.noarch.rpm -O ${OUTPUT_FILE_NAME}
-      - name: Upload Release Asset
-        id: upload-suse-rpm
-        if: always()
-        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: ${{ steps.fetch-suse-rpm.outputs.file-name }}

--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -136,7 +136,8 @@ jobs:
           REPO=rpm
           if [ ${IS_LTS} = 'true' ]
           then
-            REPO=rpm-stable
+            REPO=redhat-stable
+            FILE_NAME=jenkins-${PROJECT_VERSION}-1.1.noarch.rpm
           fi
 
           echo $REPO


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/packaging/pull/430 for details

this change updates the artifacts upload GHA workflow to merge the Redhat and OpenSuse packages into a single unified RPM package


In draft until the planning is fully decided in https://github.com/jenkinsci/packaging/pull/430