### PR TITLE
[JENKINS-76295] Allow SSH build agents to connect

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -119,7 +119,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.21.0</version>
+        <version>2.20.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
## [JENKINS-76295] Allow SSH build agents to connect

[JENKINS-76295](https://issues.jenkins.io/browse/JENKINS-76295) reports that SSH build agents fail to connect after [commons-io 2.21.0](https://commons.apache.org/proper/commons-io/changes.html#a2.21.0) was included from pull request:

* #11276 

This reverts commit ab45729395499a92acf117862cdc36b9686a3c51.

### Testing done

* Confirmed that Jenkins 2.537 fails to start an SSH build agent on Debian 13
* Confirmed that with this change reverted, the SSH build agent starts as expected on Debian 13
* Confirmed that all tests pass on Fedora Linux 43 with Java 21.0.9
* Confirmed that all tests pass on Red Hat Enterprise Linux 8.10 with Java 25.0.1
* Confirmed that 1 test fails (once) on Ubuntu 22.04 with Java 21.0.9

No automated tests are included in this pull request because the pull request needs to be evaluated quickly so that we can create a new release.  I hope to create an automated test that shows the issue, but don't want to delay the release while creating the automated test.

I plan to merge this even if the ci.jenkins.io jobs do not all pass, since I've checked it in 

### Proposed changelog entries

- Allow SSH build agents to connect.

### Proposed changelog category

/label major-bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- ~New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.~
- ~New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.~
- ~UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- ~For new APIs and extension points, there is a link to at least one consumer.~

### Desired reviewers

@mawinter69, @jglick

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- ~If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).~
- ~If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).~
