### PR TITLE
Optimizations & simplifications pertaining to lazy-loading

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1119,12 +1119,15 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      *
      * @return never null
      */
+    @SuppressWarnings("deprecation")
     public PermalinkList getPermalinks() {
         PeepholePermalink.initialized();
         // TODO: shall we cache this?
         PermalinkList permalinks = new PermalinkList(Permalink.BUILTIN);
-        for (PermalinkProjectAction ppa : getActions(PermalinkProjectAction.class)) {
-            permalinks.addAll(ppa.getPermalinks());
+        for (var action : getActions()) {
+            if (action instanceof PermalinkProjectAction ppa) {
+                permalinks.addAll(ppa.getPermalinks());
+            }
         }
         return permalinks;
     }

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -192,23 +192,6 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     private long queueId = Run.QUEUE_ID_UNKNOWN;
 
     /**
-     * Previous build. Can be null.
-     * TODO JENKINS-22052 this is not actually implemented any more
-     *
-     * External code should use {@link #getPreviousBuild()}
-     */
-    @Restricted(NoExternalUse.class)
-    protected transient volatile RunT previousBuild;
-
-    /**
-     * Next build. Can be null.
-     *
-     * External code should use {@link #getNextBuild()}
-     */
-    @Restricted(NoExternalUse.class)
-    protected transient volatile RunT nextBuild;
-
-    /**
      * Pointer to the next younger build in progress. This data structure is lazily updated,
      * so it may point to the build that's already completed. This pointer is set to 'this'
      * if the computation determines that everything earlier than this build is already completed.
@@ -801,23 +784,19 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     /**
-     * Called by {@link RunMap} to drop bi-directional links in preparation for
-     * deleting a build.
+     * Called by {@link RunMap} in preparation for deleting a build.
      * @see jenkins.model.lazy.LazyBuildMixIn.RunMixIn#dropLinks
      * @since 1.556
      */
     protected void dropLinks() {
-        if (nextBuild != null)
-            nextBuild.previousBuild = previousBuild;
-        if (previousBuild != null)
-            previousBuild.nextBuild = nextBuild;
     }
 
     /**
      * @see jenkins.model.lazy.LazyBuildMixIn.RunMixIn#getPreviousBuild
      */
     public @CheckForNull RunT getPreviousBuild() {
-        return previousBuild;
+        // TODO could be implemented for benefit of ExternalRun
+        return null;
     }
 
     /**
@@ -960,7 +939,8 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * @see jenkins.model.lazy.LazyBuildMixIn.RunMixIn#getNextBuild
      */
     public @CheckForNull RunT getNextBuild() {
-        return nextBuild;
+        // TODO could be implemented for benefit of ExternalRun
+        return null;
     }
 
 


### PR DESCRIPTION
Actually three independent changes which could be filed separately if desired:

- **Avoid `TransientActionFactory` from `Job.getPermalinks`**
- **Optimizing `PeepholePermalink.RunListener` to avoid resolving old targets**
- **Simplified `RunMixIn` handling of next/previous build**

While investigating the behavior of lazy build loading in CloudBees CI in HA mode I found several reasons why running a _new_ build would wind up forcing the last (typically completed) build to be loaded into memory. I had worked on this a couple of years ago and filed #7998 but noted at that time that there were various outstanding issues. One I actually fixed recently in many cases in #11293 but forgot to mention the linkage before.

One class of problems stemmed from permalinks. https://github.com/jenkinsci/scm-api-plugin/pull/358 shows a typical stack trace. First, `Job.getPermalinks` as of #1059 was going through `TransientActionFactory`. This actually seems to have been gratuitous. `PermalinkProjectAction` (rarely implemented) says it is

> attached to `AbstractProject` (through `JobProperty.getJobActions`)

which is in fact called only by `AbstractProject.createTransientActions`, and so far as I can tell never by `WorkflowJob`. So the transient action list for a non-Pipeline project would already have had any attached `PermalinkProjectAction`, and a Pipeline project would not have supported these to begin with.

Then there was a listener checking for a build completing or being deleted and updating any relevant permalinks. This was forcing resolution of the build _previously_ referred to by the permalink, and perhaps updating the permalink. In fact this logic only needs to know the build _number_ previously targeted. Especially after the refactoring in #10042, it is straightforward to just retrieve that number, and not bother loading the `Run` itself if it was not already in memory.

Finally, #1191 specifically forced the previous build to be loaded when starting a new one. This was particularly unwanted since it happens while holding `Queue.lock`. The code here was tricky to follow and the history is a bit torturous: c32f006fe40d424309c09f6d4291b210ec5fc1c1 in #573 introducing lazy loading; f024f59058fd8475b78fbb09b23a121e695a1ae1 and b39a779444c10cf73b9ab511c66a79c2bdd40073 in #1146 supporting Pipeline; #1190; b6226ad2d1a332cb661ceb5c5f5b673771118e14 (no PR) amending that. The lazy loading system was maintaining a doubly-linked list of build references, populated on demand by the standard forward/backward search functions, with the concomitant complexity of maintaining this cache in the face of build deletion. (There appears to be no synchronization here so I suspect the list could be corrupted under certain timing conditions.) A comment implied that all this was necessary to support removing a build from `RunMap`, but I see no evidence that was ever the case. I have simplified all this to drop the data structure and just look up the next/previous build directly if and when requested, using the `AbstractLazyLoadRunMap` systems already in place to support such traversals. Note that `ExternalRun` from https://plugins.jenkins.io/external-monitor-job/ appears to have lacked next/previous links [for at least a decade](https://issues.jenkins.io/browse/JENKINS-22052) and apparently nobody complained.

### Testing done

Automated tests pass with these changes in CloudBees CI.

A CI-specific test that counts the number of builds loaded into memory by a given HA replica was able to be strengthened to confirm that only the builds actually being run by that replica were loaded. I expect the same could apply in any Jenkins controller though the setup would require `RunLoadCounter`.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
