### PR TITLE
Fix api token rendering

### DIFF
--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/config.jelly
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/config.jelly
@@ -62,7 +62,7 @@ THE SOFTWARE.
         </d:tag>
     </d:taglib>
     <div class="jenkins-hidden" id="api-token-row-template" xmlns:local="local">
-        <div class="token-card jenkins-card" id="${token.uuid}">
+        <div class="token-card" id="${token.uuid}">
             <div class="token-card-inner">
                 <div class="token-card__title">
                     <span class="token-name">${token.name}</span>
@@ -122,7 +122,7 @@ THE SOFTWARE.
                             <j:set var="legacyClazz" value="legacy-token" />
                             <j:set var="legacyToolTip" value="${%LegacyToken}" />
                         </j:if>
-                        <div class="token-card jenkins-card ${legacyClazz}" id="${token.uuid}">
+                        <div class="token-card ${legacyClazz}" id="${token.uuid}">
                             <div class="token-card-inner">
                                 <div class="token-card__title ${legacyClazz}" tooltip="${legacyToolTip}">
                                         <j:if test="${token.isLegacy}">

--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.css
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.css
@@ -56,7 +56,6 @@
   pointer-events: none;
 }
 
-
 .token-card__title,
 .token-stats,
 .token-never-used,

--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.css
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.css
@@ -26,10 +26,41 @@
   max-width: 700px;
 }
 
+#api-tokens {
+  width: 100%;
+}
+
+#api-token-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.token-card {
+  flex-direction: row;
+  display: flex;
+  gap: 0.5rem;
+  border-radius: var(--form-input-border-radius);
+  background: var(--card-background);
+  position: relative;
+}
+
+.token-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: var(--card-border-width) solid var(--card-border-color);
+  z-index: 1;
+  pointer-events: none;
+}
+
+
 .token-card__title,
 .token-stats,
 .token-never-used,
-.token-list .jenkins-card,
+.token-list,
 .token-controls {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
Change #11141 added display: flex with direction column to jenkins-card. This broke the styling of the api token display
This makes the api tokens more independent from jenkins-card

Before:
<img width="938" height="488" alt="image" src="https://github.com/user-attachments/assets/d0c44113-ad0a-477a-8ec3-30801d19cb63" />


After:
<img width="929" height="439" alt="image" src="https://github.com/user-attachments/assets/659ccf33-6dd7-4ca7-8b38-b2116865fde9" />

### Testing done

Interactive testing

### Proposed changelog entries

- Fix api token rendering.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
