### PR TITLE
Add CSP-compliant variant of undocumented validateButton script feature

### DIFF
--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -560,7 +560,7 @@ public class ApiTokenProperty extends UserProperty {
                 p.changeApiToken();
             }
 
-            rsp.setHeader("script", "document.getElementById('apiToken').value='" + p.getApiToken() + "'");
+            rsp.setHeader("X-Jenkins-ValidateButton-Callback", "{\"callback\":\"changeTokenCallback\",\"arguments\":[\"" + p.getApiTokenInsecure() + "\"]}");
             return HttpResponses.html(p.hasPermissionToSeeToken()
                     ? Messages.ApiTokenProperty_ChangeToken_Success()
                     : Messages.ApiTokenProperty_ChangeToken_SuccessHidden());

--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.js
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.js
@@ -32,8 +32,9 @@ Behaviour.specify(
   },
 );
 
+// eslint-disable-next-line no-unused-vars
 function changeTokenCallback(newValue) {
-  document.getElementById('apiToken').value = newValue;
+  document.getElementById("apiToken").value = newValue;
 }
 
 function revokeToken(anchorRevoke) {

--- a/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.js
+++ b/core/src/main/resources/jenkins/security/ApiTokenProperty/resources.js
@@ -32,6 +32,10 @@ Behaviour.specify(
   },
 );
 
+function changeTokenCallback(newValue) {
+  document.getElementById('apiToken').value = newValue;
+}
+
 function revokeToken(anchorRevoke) {
   const tokenRow = anchorRevoke.closest(".token-card");
   const confirmMessage = anchorRevoke.getAttribute("data-confirm");

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2636,6 +2636,16 @@ function validateButton(checkUrl, paramList, button) {
       target.innerHTML = `<div class="validation-error-area" />`;
       updateValidationArea(target.children[0], responseText);
       layoutUpdateCallback.call();
+      let json = rsp.headers.get("X-Jenkins-ValidateButton-Callback");
+      if (json != null) {
+        let callInfo = JSON.parse(json)
+        let callback = callInfo['callback'];
+        let args = callInfo['arguments'];
+        if (window[callback] && typeof window[callback] === 'function') {
+          window[callback](...args);
+        }
+      }
+
       var s = rsp.headers.get("script");
       try {
         geval(s);

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2638,10 +2638,10 @@ function validateButton(checkUrl, paramList, button) {
       layoutUpdateCallback.call();
       let json = rsp.headers.get("X-Jenkins-ValidateButton-Callback");
       if (json != null) {
-        let callInfo = JSON.parse(json)
-        let callback = callInfo['callback'];
-        let args = callInfo['arguments'];
-        if (window[callback] && typeof window[callback] === 'function') {
+        let callInfo = JSON.parse(json);
+        let callback = callInfo["callback"];
+        let args = callInfo["arguments"];
+        if (window[callback] && typeof window[callback] === "function") {
           window[callback](...args);
         }
       }

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2642,7 +2642,7 @@ function validateButton(checkUrl, paramList, button) {
         let callback = callInfo["callback"];
         let args = callInfo["arguments"];
         if (window[callback] && typeof window[callback] === "function") {
-          window[callback](...args);
+          window[callback].apply(window, args);
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jenkins/issues/18688

With CSP protection enabled (https://plugins.jenkins.io/csp/ or https://github.com/jenkinsci/jenkins/pull/11269), so that `script-src` does not allow `'unsafe-inline'`, it is not possible to regenerate a _legacy API token_. In new instances, this token has been disabled by default for many years.

> <img width="2630" height="475" alt="Screenshot 2025-11-24 at 18 19 42" src="https://github.com/user-attachments/assets/716231f7-814d-4955-ac84-be464f53557f" />

The reason is a seemingly undocumented feature of `f:validateButton`: If you provide an inline script in the `script` HTTP response header to the validation `method`, that script is executed: https://github.com/jenkinsci/jenkins/blob/110014cf69390b52860aa74e350a64670bb5a25e/war/src/main/webapp/scripts/hudson-behavior.js#L2639-L2644

There seem to be just two plugins (`gitlab-plugin` and `gitee`) and this core functionality using this feature.

This PR adds a new, equally undocumented feature: Set the `X-Jenkins-ValidateButton-Callback` HTTP response header to a JSON object with the String `callback` and the list `arguments` to have a global function of that name be invoked with those arguments.

### Testing done

Manually generated a token while CSP plugin was installed and "Report Only" was unchecked, it worked as if there was no CSP enforcement.

### Proposed changelog entries

- Bugfix: Make "Change API Token" for legacy API tokens work when Content Security Policy is enforced and prohibits inline JavaScript.
- Developer: Add `X-Jenkins-ValidateButton-Callback` (a JSON object with `callback` and `arguments` keys) as a replacement for the CSP-incompatible `script` HTTP response header for `f:validateButton`.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the Jira issue in the changelog entry.
Include the Jira issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).
