### PR TITLE
Fix CspBuilder not applying fallback to uninitialized directive

### DIFF
--- a/core/src/test/java/jenkins/security/csp/CspBuilderTest.java
+++ b/core/src/test/java/jenkins/security/csp/CspBuilderTest.java
@@ -435,9 +435,13 @@ public class CspBuilderTest {
         builder.initialize(FetchDirective.DEFAULT_SRC, Directive.SELF);
         builder.add(Directive.SCRIPT_SRC, "example.org");
         builder.add(Directive.SCRIPT_SRC_ELEM, "example.com");
-
         assertThat(builder.build(), is("default-src 'self'; script-src 'self' example.org; script-src-elem 'self' example.com example.org;"));
 
+        builder.initialize(FetchDirective.SCRIPT_SRC);
+        assertThat(builder.build(), is("default-src 'self'; script-src example.org; script-src-elem example.com example.org;"));
+
+        builder.initialize(FetchDirective.SCRIPT_SRC_ELEM);
+        assertThat(builder.build(), is("default-src 'self'; script-src example.org; script-src-elem example.com;"));
     }
 
     private static Matcher<LogRecord> logMessageContainsString(String needle) {

--- a/core/src/test/java/jenkins/security/csp/CspBuilderTest.java
+++ b/core/src/test/java/jenkins/security/csp/CspBuilderTest.java
@@ -429,6 +429,17 @@ public class CspBuilderTest {
         assertThat(builder.build(), is("img-src example.org;"));
     }
 
+    @Test
+    void testLongChain() {
+        CspBuilder builder = new CspBuilder();
+        builder.initialize(FetchDirective.DEFAULT_SRC, Directive.SELF);
+        builder.add(Directive.SCRIPT_SRC, "example.org");
+        builder.add(Directive.SCRIPT_SRC_ELEM, "example.com");
+
+        assertThat(builder.build(), is("default-src 'self'; script-src 'self' example.org; script-src-elem 'self' example.com example.org;"));
+
+    }
+
     private static Matcher<LogRecord> logMessageContainsString(String needle) {
         return new LogMessageContainsString(containsString(needle));
     }


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jenkins/issues/23854.

### Testing done

Autotests

### Proposed changelog entries

- Fix incorrect handling of Content Security Policy inheritance chain for fetch directives. This could affect attempts to set `*-src-elem`or `*-src-attr` directives in CSP Plugin 2.x.

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
