### PR TITLE
Show saved log recorders

### DIFF
--- a/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
@@ -28,10 +28,10 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="header">
-    <j:new var="it" className="jenkins.management.SystemLogLink" />
+    <j:new var="page" className="jenkins.management.SystemLogLink" />
 
     <l:view>
-      <l:app-bar title="${it.displayName}">
+      <l:app-bar title="${page.displayName}">
         <l:isAdmin>
           <a href="new" class="jenkins-button jenkins-button--primary">
             <l:icon src="symbol-add" />
@@ -45,7 +45,7 @@ THE SOFTWARE.
       </l:app-bar>
 
       <div class="jenkins-page-description">
-        <j:out value="${it.description}" />
+        <j:out value="${page.description}" />
       </div>
     </l:view>
   </j:set>

--- a/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
+++ b/core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
@@ -28,10 +28,11 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="header">
-    <j:new var="page" className="jenkins.management.SystemLogLink" />
+    <j:set var="previousIt" value="${it}" />
+    <j:new var="it" className="jenkins.management.SystemLogLink" />
 
     <l:view>
-      <l:app-bar title="${page.displayName}">
+      <l:app-bar title="${it.displayName}">
         <l:isAdmin>
           <a href="new" class="jenkins-button jenkins-button--primary">
             <l:icon src="symbol-add" />
@@ -45,12 +46,13 @@ THE SOFTWARE.
       </l:app-bar>
 
       <div class="jenkins-page-description">
-        <j:out value="${page.description}" />
+        <j:out value="${it.description}" />
       </div>
     </l:view>
   </j:set>
 
   <l:settings-subpage header="${header}" xmlns:local="local">
+    <j:set var="it" value="${previousIt}" />
     <d:taglib uri="local">
       <d:tag name="row">
         <tr>


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jenkins/issues/23856

### Testing done

Created a log recorder and it now shows up again

### Proposed changelog entries

- Show saved log recorders again (regression in 2.537).

### Proposed changelog category

/label <update-this-with-category>

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
