### PR TITLE
Ignore casing in `AvatarContributor#extractDomainFromUrl`

### DIFF
--- a/core/src/main/java/jenkins/security/csp/AvatarContributor.java
+++ b/core/src/main/java/jenkins/security/csp/AvatarContributor.java
@@ -29,6 +29,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -106,9 +107,10 @@ public class AvatarContributor implements Contributor {
                 LOGGER.log(Level.FINER, "Ignoring URI without host: " + url);
                 return null;
             }
-            String domain = host;
-            final String scheme = uri.getScheme();
+            String domain = host.toLowerCase(Locale.ROOT);
+            String scheme = uri.getScheme();
             if (scheme != null) {
+                scheme = scheme.toLowerCase(Locale.ROOT);
                 if (scheme.equals("http") || scheme.equals("https")) {
                     domain = scheme + "://" + domain;
                 } else {

--- a/core/src/test/java/jenkins/security/csp/AvatarContributorTest.java
+++ b/core/src/test/java/jenkins/security/csp/AvatarContributorTest.java
@@ -80,4 +80,9 @@ public class AvatarContributorTest {
     void testExtractDomainFromUrl_Ipv4WithPort() {
         assertThat(extractDomainFromUrl("https://192.168.1.1:8080/avatar.png"), is("https://192.168.1.1:8080"));
     }
+
+    @Test
+    void testExtractDomainFromUrl_CaseInsensitivity() {
+        assertThat(extractDomainFromUrl("hTTps://EXAMPLE.com/path/to/avatar.png"), is("https://example.com"));
+    }
 }

--- a/test/src/test/java/jenkins/security/csp/AvatarContributorTest.java
+++ b/test/src/test/java/jenkins/security/csp/AvatarContributorTest.java
@@ -142,10 +142,12 @@ public class AvatarContributorTest {
 
     @Test
     void testAllow_CaseInsensitivity(JenkinsRule j) {
-        LoggerRule loggerRule = new LoggerRule().record(AvatarContributor.class, Level.CONFIG).capture(100);
+        LoggerRule loggerRule = new LoggerRule().record(AvatarContributor.class, Level.FINEST).capture(100);
         AvatarContributor.allow("hTTps://AVATARS.example.com/user/avatar.png");
+        AvatarContributor.allow("HttPS://avatars.EXAMPLE.com/user/avatar.png");
         String csp = new CspBuilder().withDefaultContributions().build();
         assertThat(csp, is("base-uri 'none'; default-src 'self'; form-action 'self'; frame-ancestors 'self'; img-src 'self' data: https://avatars.example.com; script-src 'report-sample' 'self'; style-src 'report-sample' 'self' 'unsafe-inline';"));
         assertThat(loggerRule, recorded(Level.CONFIG, is("Adding domain 'https://avatars.example.com' from avatar URL: hTTps://AVATARS.example.com/user/avatar.png")));
+        assertThat(loggerRule, recorded(Level.FINEST, is("Skipped adding duplicate domain 'https://avatars.example.com' from avatar URL: HttPS://avatars.EXAMPLE.com/user/avatar.png")));
     }
 }

--- a/test/src/test/java/jenkins/security/csp/AvatarContributorTest.java
+++ b/test/src/test/java/jenkins/security/csp/AvatarContributorTest.java
@@ -139,4 +139,13 @@ public class AvatarContributorTest {
         assertThat(loggerRule, recorded(Level.FINER, is("Ignoring URI with unsupported scheme: ftp://files.example.com/avatar.png")));
         assertThat(loggerRule, recorded(Level.FINER, is("Ignoring URI without host: data:image/png;base64,iVBORw0KG...")));
     }
+
+    @Test
+    void testAllow_CaseInsensitivity(JenkinsRule j) {
+        LoggerRule loggerRule = new LoggerRule().record(AvatarContributor.class, Level.CONFIG).capture(100);
+        AvatarContributor.allow("hTTps://AVATARS.example.com/user/avatar.png");
+        String csp = new CspBuilder().withDefaultContributions().build();
+        assertThat(csp, is("base-uri 'none'; default-src 'self'; form-action 'self'; frame-ancestors 'self'; img-src 'self' data: https://avatars.example.com; script-src 'report-sample' 'self'; style-src 'report-sample' 'self' 'unsafe-inline';"));
+        assertThat(loggerRule, recorded(Level.CONFIG, is("Adding domain 'https://avatars.example.com' from avatar URL: hTTps://AVATARS.example.com/user/avatar.png")));
+    }
 }


### PR DESCRIPTION
Amends #11269 and adds case-insensitivity to `AvatarContributor#extractDomainFromUrl`.

Neither scheme nor host are case-sensitive, so we can prevent adding duplicates here.

### Testing done

Added two tests verifying the case-insensitivity.

### Proposed changelog entries

- Ignore casing in `AvatarContributor#extractDomainFromUrl`.

### Proposed changelog category

/label rfe, developer 

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@daniel-beck 

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
