### PR TITLE
Test building from a Windows Server Core 2025 agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -218,40 +218,40 @@ axes.values().combinations {
   }
 }
 
-def athAxes = [
-  platforms: ['linux'],
-  jdks: [21],
-  browsers: ['firefox'],
-]
-athAxes.values().combinations {
-  def (platform, jdk, browser) = it
-  builds["ath-${platform}-jdk${jdk}-${browser}"] = {
-    retry(conditions: [agent(), nonresumable()], count: 2) {
-      node('docker-highmem') {
-        // Just to be safe
-        deleteDir()
-        checkout scm
+// def athAxes = [
+//   platforms: ['linux'],
+//   jdks: [21],
+//   browsers: ['firefox'],
+// ]
+// athAxes.values().combinations {
+//   def (platform, jdk, browser) = it
+//   builds["ath-${platform}-jdk${jdk}-${browser}"] = {
+//     retry(conditions: [agent(), nonresumable()], count: 2) {
+//       node('docker-highmem') {
+//         // Just to be safe
+//         deleteDir()
+//         checkout scm
 
-        withChecks(name: 'Tests', includeStage: true) {
-          infra.withArtifactCachingProxy {
-            sh "bash ath.sh ${jdk} ${browser}"
-          }
-          junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
-        }
-        /*
-         * Currently disabled, as the fact that this is a manually created subset will confuse Launchable,
-         * which expects this to be a full build. When we implement subsetting, this can be re-enabled using
-         * Launchable's subset rather than our own.
-         */
-        /*
-         withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
-         sh "launchable verify && launchable record tests --no-build --flavor platform=${platform} --flavor jdk=${jdk} --flavor browser=${browser} maven './target/ath-reports'"
-         }
-         */
-      }
-    }
-  }
-}
+//         withChecks(name: 'Tests', includeStage: true) {
+//           infra.withArtifactCachingProxy {
+//             sh "bash ath.sh ${jdk} ${browser}"
+//           }
+//           junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
+//         }
+//         /*
+//          * Currently disabled, as the fact that this is a manually created subset will confuse Launchable,
+//          * which expects this to be a full build. When we implement subsetting, this can be re-enabled using
+//          * Launchable's subset rather than our own.
+//          */
+//         /*
+//          withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
+//          sh "launchable verify && launchable record tests --no-build --flavor platform=${platform} --flavor jdk=${jdk} --flavor browser=${browser} maven './target/ath-reports'"
+//          }
+//          */
+//       }
+//     }
+//   }
+// }
 
 builds.failFast = failFast
 parallel builds

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ properties([
 ])
 
 def axes = [
-  platforms: ['linux', 'windows'],
-  jdks: [21, 25],
+  platforms: ['windows'],
+  jdks: [17],
 ]
 
 stage('Record build') {
@@ -76,6 +76,8 @@ axes.values().combinations {
       }
       // Increment before allocating the node in case it fails
       retryCount++
+      // TODO: label override here for testing on newly available non-spot Windows Server Core 2025 JDK17 VM agent template
+      agentContainerLabel = 'win-2025'
       node(agentContainerLabel) {
         // First stage is actually checking out the source. Since we're using Multibranch
         // currently, we can use "checkout scm".


### PR DESCRIPTION
This PR tests building this plugin from a Windows Server Core 2025 agent. (not for review nor merge)

Replayed to get a build from my change as I don't have permissions on this repository:
- https://ci.jenkins.io/job/Core/job/jenkins/job/PR-23872/3/

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4791#issuecomment-3585295631

### Testing done

CI (pipeline change only)

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label internal

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [-] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [-] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [-] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [-] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [-] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [-] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

None

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
