### PR TITLE
Windows flake of `QueueTest.computerFailsJustAfterCreatingExecutor`

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -1546,6 +1546,9 @@ public class QueueTest {
         r.waitOnline(onlineSlave);
         r.assertBuildStatusSuccess(f);
         assertTrue(r.jenkins.getQueue().isEmpty());
+        // clean up
+        computer.disconnect(null).get();
+        r.jenkins.removeNode(onlineSlave);
     }
 
     private static class Cancelled extends CauseOfBlockage {


### PR DESCRIPTION
Test introduced in #10756 seems to be flaky on Windows, given https://github.com/jenkinsci/jenkins/pull/23890/checks?check_run_id=56961821658 in #23890.

### Testing done

Passes for locally on Linux and Windows 10. Then again, it passes locally without any change.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
