### PR TITLE
Fix web UI: prevent duplicate onload processing, correct localStorage default handling, and guard tab panes access

### DIFF
--- a/src/main/js/section-to-tabs.js
+++ b/src/main/js/section-to-tabs.js
@@ -1,49 +1,52 @@
 // Converts a page's section headings into clickable tabs, see 'About Jenkins' page for example
 const tabPanes = document.querySelectorAll(".jenkins-tab-pane");
 
-// Hide tab panes
-tabPanes.forEach((tabPane) => {
-  tabPane.style.display = "none";
-});
-
-// Show the first
-tabPanes[0].style.display = "block";
-
-const tabBar = document.createElement("div");
-tabBar.className = "tabBar";
-
-// Add tabs for each tab pane
-tabPanes.forEach((tabPane, index) => {
-  const tabPaneTitle = tabPane.querySelector(".jenkins-tab-pane__title");
-  tabPaneTitle.style.display = "none";
-
-  const tab = document.createElement("div");
-  tab.className = "tab";
-
-  if (index === 0) {
-    tab.classList.add("active");
-  }
-
-  tab.addEventListener("click", function (e) {
-    e.preventDefault();
-    document.querySelectorAll(".tab").forEach((tab) => {
-      tab.classList.remove("active");
-    });
-    tab.classList.add("active");
-
-    tabPanes.forEach((tabPane) => {
-      tabPane.style.display = "none";
-    });
-    tabPanes[index].style.display = "block";
+// If there are tab panes on the page, initialize tabs; otherwise no-op
+if (tabPanes && tabPanes.length > 0) {
+  // Hide tab panes
+  tabPanes.forEach((tabPane) => {
+    tabPane.style.display = "none";
   });
 
-  const tabLink = document.createElement("a");
-  tabLink.setAttribute("href", "#");
-  tabLink.innerText = tabPaneTitle.textContent;
+  // Show the first
+  tabPanes[0].style.display = "block";
 
-  tab.append(tabLink);
+  const tabBar = document.createElement("div");
+  tabBar.className = "tabBar";
 
-  tabBar.append(tab);
-});
+  // Add tabs for each tab pane
+  tabPanes.forEach((tabPane, index) => {
+    const tabPaneTitle = tabPane.querySelector(".jenkins-tab-pane__title");
+    tabPaneTitle.style.display = "none";
 
-tabPanes[0].parentElement.insertBefore(tabBar, tabPanes[0]);
+    const tab = document.createElement("div");
+    tab.className = "tab";
+
+    if (index === 0) {
+      tab.classList.add("active");
+    }
+
+    tab.addEventListener("click", function (e) {
+      e.preventDefault();
+      document.querySelectorAll(".tab").forEach((tab) => {
+        tab.classList.remove("active");
+      });
+      tab.classList.add("active");
+
+      tabPanes.forEach((tabPane) => {
+        tabPane.style.display = "none";
+      });
+      tabPanes[index].style.display = "block";
+    });
+
+    const tabLink = document.createElement("a");
+    tabLink.setAttribute("href", "#");
+    tabLink.innerText = tabPaneTitle.textContent;
+
+    tab.append(tabLink);
+
+    tabBar.append(tab);
+  });
+
+  tabPanes[0].parentElement.insertBefore(tabBar, tabPanes[0]);
+}

--- a/src/main/js/util/localStorage.js
+++ b/src/main/js/util/localStorage.js
@@ -23,8 +23,9 @@ function setItem(name, value) {
 
 function getItem(name, defaultVal) {
   var value = storage.getItem(name);
-  if (!value) {
-    value = defaultVal;
+  // Only use default when the key is not present in storage (returns null)
+  if (value === null) {
+    return defaultVal;
   }
   return value;
 }

--- a/src/main/js/util/page.js
+++ b/src/main/js/util/page.js
@@ -18,7 +18,8 @@ function onload(selector, callback, contextEl) {
     setTimeout(scan, 50);
   }
   function scan() {
-    var elements = $(selector, contextEl).not(loadedClass);
+    // Exclude elements already processed by class marker
+    var elements = $(selector, contextEl).not("." + loadedClass);
     if (elements.length > 0) {
       elements.addClass(loadedClass);
       if (callback(elements) === true) {


### PR DESCRIPTION
## Summary of Changes

### 1. Fix `localStorage.getItem` returning incorrect defaults
The `getItem` function was using a falsy check (`!value`) to determine when to return the default value. This caused problems when a stored value was an empty string `""`, as it would incorrectly return the default instead of the actual stored value.

**Fix**: Changed to check for `null` explicitly (`value === null`), which is what `localStorage.getItem` returns when a key doesn't exist.

### 2. Fix `page.onload` not properly excluding processed elements
The `onload` function was using `.not(loadedClass)` but `loadedClass` is a string without the CSS class selector prefix. This caused jQuery's `.not()` to not work correctly.

**Fix**: Added the `.` prefix to create a proper CSS class selector (`.not("." + loadedClass)`).

### 3. Guard tab initialization when no tab panes exist
The `section-to-tabs.js` script was attempting to access `tabPanes[0]` without checking if any tab panes exist, which could cause errors on pages without tabs.

**Fix**: Wrapped the entire tab initialization logic in a guard condition that checks for the existence of tab panes.

## Testing done
- Verified localStorage correctly stores and retrieves empty strings
- Verified onload callbacks only fire once per element
- Verified pages with tabs (e.g., About Jenkins) work correctly
- Verified pages without tabs don't throw JavaScript errors

## Proposed changelog entries
N/A

## Proposed changelog category
/label skip-changelog,internal

## Proposed upgrade guidelines
N/A

## Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples). Fill in the Proposed upgrade guidelines section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see documentation).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

## Desired reviewers
@timja @daniel-beck

---

**Before the changes are marked as ready-for-merge:**

## Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or Proposed changelog entries are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a Proposed upgrade guidelines section in the pull request title (see example).
- [ ] If it would make sense to backport the change to LTS, be a Bug or Improvement, and either the issue or pull request must be labeled as `lts-candidate` to be considered.