### PR TITLE
Allow entirely disabling CSP headers

### DIFF
--- a/core/src/main/java/jenkins/security/csp/CspHeader.java
+++ b/core/src/main/java/jenkins/security/csp/CspHeader.java
@@ -24,6 +24,7 @@
 
 package jenkins.security.csp;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 
@@ -35,7 +36,8 @@ import org.kohsuke.accmod.restrictions.Beta;
 @Restricted(Beta.class)
 public enum CspHeader {
     ContentSecurityPolicy("Content-Security-Policy"),
-    ContentSecurityPolicyReportOnly("Content-Security-Policy-Report-Only");
+    ContentSecurityPolicyReportOnly("Content-Security-Policy-Report-Only"),
+    None(null);
 
     private final String headerName;
 
@@ -43,6 +45,7 @@ public enum CspHeader {
         this.headerName = headerName;
     }
 
+    @CheckForNull
     public String getHeaderName() {
         return headerName;
     }

--- a/core/src/main/java/jenkins/security/csp/impl/CspDecorator.java
+++ b/core/src/main/java/jenkins/security/csp/impl/CspDecorator.java
@@ -105,10 +105,11 @@ public class CspDecorator extends PageDecorator {
     }
 
     /**
-     * Determines the name of the HTTP header to set.
+     * Determines the name of the HTTP header to set, or {@code null} if none.
      *
      * @return the name of the HTTP header to set.
      */
+    @CheckForNull
     public String getContentSecurityPolicyHeaderName() {
         final Optional<CspHeaderDecider> decider = CspHeaderDecider.getCurrentDecider();
         if (decider.isPresent()) {

--- a/core/src/main/java/jenkins/security/csp/impl/SystemPropertyHeaderDecider.java
+++ b/core/src/main/java/jenkins/security/csp/impl/SystemPropertyHeaderDecider.java
@@ -25,7 +25,9 @@
 package jenkins.security.csp.impl;
 
 import hudson.Extension;
+import hudson.Util;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -50,7 +52,8 @@ public class SystemPropertyHeaderDecider implements CspHeaderDecider {
         final String systemProperty = SystemProperties.getString(SYSTEM_PROPERTY_NAME);
         if (systemProperty != null) {
             LOGGER.log(Level.FINEST, "Using system property: {0}", new Object[]{ systemProperty });
-            return Arrays.stream(CspHeader.values()).filter(h -> h.getHeaderName().equals(systemProperty)).findFirst();
+            final String expected = Util.fixEmptyAndTrim(systemProperty);
+            return Arrays.stream(CspHeader.values()).filter(h -> Objects.equals(expected, h.getHeaderName())).findFirst();
         }
         return Optional.empty();
     }

--- a/core/src/main/resources/jenkins/security/csp/impl/CspDecorator/httpHeaders.jelly
+++ b/core/src/main/resources/jenkins/security/csp/impl/CspDecorator/httpHeaders.jelly
@@ -23,6 +23,9 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-    <st:setHeader name="${it.getContentSecurityPolicyHeaderName()}" value="${it.getContentSecurityPolicyHeaderValue(request2)}" />
-    <st:setHeader name="Reporting-Endpoints" value="${it.getReportingEndpointsHeaderValue(request2)}" />
+    <j:set var="cspHeaderName" value="${it.getContentSecurityPolicyHeaderName()}"/>
+    <j:if test="${cspHeaderName != null}">
+        <st:setHeader name="${cspHeaderName}" value="${it.getContentSecurityPolicyHeaderValue(request2)}" />
+        <st:setHeader name="Reporting-Endpoints" value="${it.getReportingEndpointsHeaderValue(request2)}" />
+    </j:if>
 </j:jelly>

--- a/core/src/main/resources/jenkins/security/csp/impl/SystemPropertyHeaderDecider/message.jelly
+++ b/core/src/main/resources/jenkins/security/csp/impl/SystemPropertyHeaderDecider/message.jelly
@@ -23,5 +23,14 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:description>${%blurb(it.headerName)}</f:description>
+    <f:description>
+        <j:choose>
+            <j:when test="${it.headerName != null}">
+                ${%blurb(it.headerName)}
+            </j:when>
+            <j:otherwise>
+                ${%blurbUnset}
+            </j:otherwise>
+        </j:choose>
+    </f:description>
 </j:jelly>

--- a/core/src/main/resources/jenkins/security/csp/impl/SystemPropertyHeaderDecider/message.properties
+++ b/core/src/main/resources/jenkins/security/csp/impl/SystemPropertyHeaderDecider/message.properties
@@ -1,2 +1,4 @@
 blurb = Content Security Policy is configured to use the HTTP header <code>{0}</code> based on the system property <code>jenkins.security.csp.CspHeader.headerName</code>. \
-    It cannot be configured through the UI while this system property specifies a header name.
+    It cannot be configured through the UI while this system property is set.
+blurbUnset = Content Security Policy is disabled based on the system property <code>jenkins.security.csp.CspHeader.headerName</code>. \
+    It cannot be configured through the UI while this system property is set.


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jenkins/issues/23914.

### Testing done

Autotest, basic manual test.

### Proposed changelog entries

- Allow entirely disabling CSP headers to work around unusual Jenkins configurations resulting in excessive HTTP response header lengths.

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
