### PR TITLE
Remove the loading symbol if the submenu is empty

### DIFF
--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -254,11 +254,12 @@ function mapChildrenItemsToDropdownItems(items) {
           }
         }
       },
-      subMenu: item.subMenu && item.subMenu.items
-        ? () => {
-            return mapChildrenItemsToDropdownItems(item.subMenu.items);
-          }
-        : null,
+      subMenu:
+        item.subMenu && item.subMenu.items
+          ? () => {
+              return mapChildrenItemsToDropdownItems(item.subMenu.items);
+            }
+          : null,
     };
   });
 }

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -191,7 +191,7 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
 }
 
 /*
- * Generates the contents for the dropdown
+ * Generates the contents for the dropdown.
  */
 function mapChildrenItemsToDropdownItems(items) {
   // Handle undefined, null, or non-array items
@@ -254,11 +254,12 @@ function mapChildrenItemsToDropdownItems(items) {
           }
         }
       },
-      subMenu: item.subMenu && item.subMenu.items
-        ? () => {
-            return mapChildrenItemsToDropdownItems(item.subMenu.items);
-          }
-        : null,
+      subMenu:
+        item.subMenu && item.subMenu.items
+          ? () => {
+              return mapChildrenItemsToDropdownItems(item.subMenu.items);
+            }
+          : null,
     };
   });
 }

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -191,7 +191,7 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
 }
 
 /*
- * Generates the contents for the dropdown
+ * Generates the contents for the dropdown.
  */
 function mapChildrenItemsToDropdownItems(items) {
   // Handle undefined, null, or non-array items

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -194,6 +194,10 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
  * Generates the contents for the dropdown
  */
 function mapChildrenItemsToDropdownItems(items) {
+  // Handle undefined, null, or non-array items
+  if (!items || !Array.isArray(items)) {
+    return [];
+  }
   return items.map((item) => {
     if (item.type === "HEADER") {
       return {
@@ -250,7 +254,7 @@ function mapChildrenItemsToDropdownItems(items) {
           }
         }
       },
-      subMenu: item.subMenu
+      subMenu: item.subMenu && item.subMenu.items
         ? () => {
             return mapChildrenItemsToDropdownItems(item.subMenu.items);
           }

--- a/src/main/js/components/dropdowns/utils.js
+++ b/src/main/js/components/dropdowns/utils.js
@@ -109,7 +109,7 @@ function generateDropdownItems(items, compact) {
         tippy(
           menuItem,
           Object.assign({}, Templates.dropdown(), {
-            content: generateDropdownItems(item.subMenu()),
+            content: generateDropdownItems(item.subMenu() || []),
             trigger: "mouseenter",
             placement: "right-start",
             offset: [-8, 0],


### PR DESCRIPTION
Fixes #16760 

## Description

Fixed a bug where empty dropdown submenus would show a spinning loader forever instead of showing "No items".

When you navigate through breadcrumb menus (like Manage Jenkins → Credentials → System) and hover over items with submenus, if those submenus are empty, the spinner never stops. Now it shows "No items" like it should.

### What was wrong

The code was trying to map over `undefined` or `null` when a submenu had no items, which threw an error and left the spinner visible.

### What I changed

Added a couple of safety checks:
- In `jumplists.js`: Check if items exists and is an array before mapping
- In `utils.js`: Add a fallback to empty array if submenu returns undefined

### Testing done

Tested by:
1. Going to Manage Jenkins → Credentials → System → Global
2. Opening breadcrumb dropdowns
3. Hovering over items with empty submenus
4. Confirmed "No items" shows instead of spinner
5. Checked browser console - no errors
6. Tested normal menus still work fine

### Proposed changelog entries

- Fix endless spinner in empty dropdown submenus

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate
- [x] There is automated testing or an explanation as to why this change has no tests.
  - Manual testing done - verified the fix works visually
- [x] New public classes, fields, and methods are annotated appropriately
  - N/A
- [x] New deprecations are annotated
  - N/A
- [x] UI changes follow CSP rules
  - Just defensive checks, no inline JS
- [x] Dependency updates have changelogs
  - N/A
- [x] New APIs have consumer links
  - N/A
