### PR TITLE
Update Winstone to 8.1026.v31def012a_f48, add test confirming the CSP response header can be >30KB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,7 @@ THE SOFTWARE.
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <!-- TODO https://github.com/jenkinsci/winstone/pull/519 -->
-    <winstone.version>8.1026.va_a_8d171a_3851</winstone.version>
+    <winstone.version>8.1026.v31def012a_f48</winstone.version>
     <node.version>24.11.1</node.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,8 @@ THE SOFTWARE.
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.1023.v8b_42b_1b_79b_f7</winstone.version>
+    <!-- TODO https://github.com/jenkinsci/winstone/pull/519 -->
+    <winstone.version>8.1026.va_a_8d171a_3851</winstone.version>
     <node.version>24.11.1</node.version>
   </properties>
 

--- a/test/src/test/java/jenkins/security/csp/WinstoneResponseHeaderLengthTest.java
+++ b/test/src/test/java/jenkins/security/csp/WinstoneResponseHeaderLengthTest.java
@@ -1,0 +1,44 @@
+package jenkins.security.csp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.is;
+
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
+
+public class WinstoneResponseHeaderLengthTest {
+
+    @RegisterExtension
+    public RealJenkinsExtension extension = new RealJenkinsExtension().addSyntheticPlugin(new RealJenkinsExtension.SyntheticPlugin(jenkins.security.csp.winstoneResponseHeaderLengthTest.ContributorImpl.class));
+
+    @Test
+    void testLength() throws Exception {
+        extension.startJenkins();
+        String lastHeader = "";
+        try (WebClient wc = new WebClient()) {
+            // Hopefully speed this up a bit:
+            wc.getOptions().setJavaScriptEnabled(false);
+            wc.getOptions().setCssEnabled(false);
+            wc.getOptions().setDownloadImages(false);
+            wc.getPage(extension.getUrl()); // request once outside try/catch to ensure it works in principle
+            try {
+                while (true) {
+                    final HtmlPage htmlPage = wc.getPage(extension.getUrl());
+                    lastHeader = htmlPage.getWebResponse().getResponseHeaderValue("Content-Security-Policy");
+                }
+            } catch (FailingHttpStatusCodeException e) {
+                assertThat(e.getStatusCode(), is(500));
+                assertThat(e.getResponse().getContentAsString(), containsString("Error 500 Response Header Fields Too Large"));
+
+                assertThat(lastHeader, hasLength(greaterThan(30_000)));
+            }
+        }
+    }
+}

--- a/test/src/test/java/jenkins/security/csp/winstoneResponseHeaderLengthTest/ContributorImpl.java
+++ b/test/src/test/java/jenkins/security/csp/winstoneResponseHeaderLengthTest/ContributorImpl.java
@@ -1,11 +1,11 @@
 package jenkins.security.csp.winstoneResponseHeaderLengthTest;
 
 import hudson.Extension;
+import jenkins.model.Jenkins;
 import jenkins.security.csp.Contributor;
 import jenkins.security.csp.CspBuilder;
 import jenkins.security.csp.Directive;
 
-@Extension
 public class ContributorImpl implements Contributor {
     private int count = 0;
 
@@ -15,5 +15,14 @@ public class ContributorImpl implements Contributor {
         for (int i = 0; i < count; i++) {
             cspBuilder.add(Directive.IMG_SRC, "img" + i + ".example.com");
         }
+    }
+
+    @Extension
+    public static ContributorImpl getInstance() {
+        // Only load this extension if it's in the synthetic plugin, otherwise it will affect other tests
+        if (Jenkins.get().getPluginManager().whichPlugin(ContributorImpl.class) == null) {
+            return null;
+        }
+        return new ContributorImpl();
     }
 }

--- a/test/src/test/java/jenkins/security/csp/winstoneResponseHeaderLengthTest/ContributorImpl.java
+++ b/test/src/test/java/jenkins/security/csp/winstoneResponseHeaderLengthTest/ContributorImpl.java
@@ -1,0 +1,19 @@
+package jenkins.security.csp.winstoneResponseHeaderLengthTest;
+
+import hudson.Extension;
+import jenkins.security.csp.Contributor;
+import jenkins.security.csp.CspBuilder;
+import jenkins.security.csp.Directive;
+
+@Extension
+public class ContributorImpl implements Contributor {
+    private int count = 0;
+
+    @Override
+    public void apply(CspBuilder cspBuilder) {
+        count++;
+        for (int i = 0; i < count; i++) {
+            cspBuilder.add(Directive.IMG_SRC, "img" + i + ".example.com");
+        }
+    }
+}


### PR DESCRIPTION
Integrates https://github.com/jenkinsci/winstone/pull/519.

Fixes https://github.com/jenkinsci/jenkins/issues/25900 (sort of)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Proposed changelog entries

- Update Winstone to version 8.1026.v31def012a_f48 to increase the default maximum HTTP response header size to 32KB to account for very complex Content Security Policy headers.

### Proposed changelog category

/label rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
