### PR TITLE
Add top button

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -78,6 +78,12 @@ THE SOFTWARE.
       If true the drag and drop will not be activated. This just removes the drag and
       drop UI, it will not prevent users from manually submitting a different order.
     </st:attribute>
+    <st:attribute name="enableTopButton">
+      true if a new Add button, for adding new items to the heterogeneous list, should be displayed above the list.
+      Display of top button depends also on number of items. If there is no item, only one button is displayed. When at least one item is present, there are two
+      buttons displayed (only when enableTopButton is true). One above and one below.
+      Top button adds item on top of the list. Bottom button adds item at the bottom of the list.
+    </st:attribute>
   </st:documentation>
   <d:taglib uri="local">
     <d:tag name="body">
@@ -111,7 +117,12 @@ THE SOFTWARE.
   </d:taglib>
 
   <j:set var="targetType" value="${attrs.targetType?:it.class}"/>
-  <div class="jenkins-form-item hetero-list-container ${hasHeader?'with-drag-drop':''} ${attrs.oneEach?'one-each':''} ${attrs.honorOrder?'honor-order':''}">
+  <div class="jenkins-form-item hetero-list-container ${hasHeader?'with-drag-drop':''} ${attrs.oneEach?'one-each':''} ${attrs.honorOrder?'honor-order':''}" enableTopButton="${attrs.enableTopButton}">
+    <j:if test="${!empty(attrs.items) and !readOnlyMode and attrs.enableTopButton}">
+      <span>
+        <button type="button" class="jenkins-button hetero-list-add hetero-list-add-top" menualign="${attrs.menuAlign}" suffix="${attrs.name}"><l:icon src="symbol-add"/>${attrs.addCaption?:'%Add'}</button>
+      </span>
+    </j:if>
     <!-- display existing items -->
     <j:forEach var="i" items="${attrs.items}"><!-- TODO consider customizedFields: how to distinguish default items from user-configured items? -->
       <j:set var="descriptor" value="${i.descriptor}" />

--- a/core/src/main/resources/lib/form/repeatableHeteroProperty.jelly
+++ b/core/src/main/resources/lib/form/repeatableHeteroProperty.jelly
@@ -61,6 +61,12 @@ THE SOFTWARE.
       variables seen in the caller aren't visible to them. This attribute allows you
       to nominate additional variables and their values to be captured for descriptors.
     </st:attribute>
+    <st:attribute name="enableTopButton">
+      true if a new Add button, for adding new items to the heterogeneous list, should be displayed above the list.
+      Display of top button depends also on number of items. If there is no item, only one button is displayed. When at least one item is present, there are two
+      buttons displayed (only when enableTopButton is true). One above and one below.
+      Top button adds item on top of the list. Bottom button adds item at the bottom of the list.
+    </st:attribute>
   </st:documentation>
   <f:prepareDatabinding />
   <!--
@@ -73,6 +79,7 @@ THE SOFTWARE.
                  menuAlign="${attrs.menuAlign}" oneEach="${attrs.oneEach}"
                  targetType="${attrs.targetType}"
                  capture="${attrs.capture}"
+                 enableTopButton="${attrs.enableTopButton}"
           />
   <!-- TODO: there should be a mechanism to pass-through map as parameters -->
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-builders.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-builders.jelly
@@ -33,6 +33,7 @@ THE SOFTWARE.
     <f:hetero-list name="builder" hasHeader="true"
                    descriptors="${h.getBuilderDescriptors(it)}"
                    items="${it.builders}"
-                   addCaption="${%Add build step}"/>
+                   addCaption="${%Add build step}"
+                   enableTopButton="true"/>
   </f:section>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/config-publishers2.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-publishers2.jelly
@@ -35,6 +35,7 @@ THE SOFTWARE.
                    oneEach="true"
                    menuAlign="bl-tl"
                    honorOrder="true"
-                   addCaption="${%Add post-build action}"/>
+                   addCaption="${%Add post-build action}"
+                   enableTopButton="true"/>
   </f:section>
 </j:jelly>

--- a/src/main/js/components/dropdowns/hetero-list.js
+++ b/src/main/js/components/dropdowns/hetero-list.js
@@ -51,9 +51,14 @@ function generateButtons() {
       convertInputsToButtons(e);
       let allButtons = Array.from(e.querySelectorAll("BUTTON.hetero-list-add"));
       let enableTopButton = e.getAttribute("enableTopButton") === "true";
-      let topBtn = allButtons.find(b => b.classList.contains("hetero-list-add-top")) || null;
-      let btn = allButtons.filter(b => !b.classList.contains("hetero-list-add-top")).pop() || allButtons.pop();
-      
+      let topBtn =
+        allButtons.find((b) => b.classList.contains("hetero-list-add-top")) ||
+        null;
+      let btn =
+        allButtons
+          .filter((b) => !b.classList.contains("hetero-list-add-top"))
+          .pop() || allButtons.pop();
+
       // Ensure server-rendered top button has chevron icon and set up dropdown
       if (topBtn && !topBtn.querySelector("svg")) {
         let chevron = createElementFromHtml(Symbols.CHEVRON_DOWN);
@@ -247,8 +252,10 @@ function generateButtons() {
         ).length;
 
         // Find existing top button (might be server-rendered)
-        let existingTopBtn = Array.from(e.querySelectorAll("BUTTON.hetero-list-add-top"))[0];
-        
+        let existingTopBtn = Array.from(
+          e.querySelectorAll("BUTTON.hetero-list-add-top"),
+        )[0];
+
         if (selectedCount === 0) {
           // Hide top button if no items
           if (topBtn && topBtn.parentNode) {
@@ -264,7 +271,7 @@ function generateButtons() {
             // Create top button if it doesn't exist
             topBtn = btn.cloneNode(true);
             topBtn.classList.add("hetero-list-add-top");
-            
+
             // Insert at the beginning of the container
             let firstChunk = Array.from(e.children).find((child) =>
               child.classList.contains("repeated-chunk"),
@@ -294,7 +301,7 @@ function generateButtons() {
       observer.observe(e, { childList: true });
       toggleButtonState();
       updateTopButtonVisibility();
-      
+
       if (topBtn && enableTopButton && !topBtn._tippy) {
         setupTopButtonDropdown(topBtn);
       }

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -254,11 +254,12 @@ function mapChildrenItemsToDropdownItems(items) {
           }
         }
       },
-      subMenu: item.subMenu && item.subMenu.items
-        ? () => {
-            return mapChildrenItemsToDropdownItems(item.subMenu.items);
-          }
-        : null,
+      subMenu:
+        item.subMenu && item.subMenu.items
+          ? () => {
+              return mapChildrenItemsToDropdownItems(item.subMenu.items);
+            }
+          : null,
     };
   });
 }

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -191,7 +191,7 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
 }
 
 /*
- * Generates the contents for the dropdown
+ * Generates the contents for the dropdown.
  */
 function mapChildrenItemsToDropdownItems(items) {
   // Handle undefined, null, or non-array items
@@ -254,11 +254,12 @@ function mapChildrenItemsToDropdownItems(items) {
           }
         }
       },
-      subMenu: item.subMenu && item.subMenu.items
-        ? () => {
-            return mapChildrenItemsToDropdownItems(item.subMenu.items);
-          }
-        : null,
+      subMenu:
+        item.subMenu && item.subMenu.items
+          ? () => {
+              return mapChildrenItemsToDropdownItems(item.subMenu.items);
+            }
+          : null,
     };
   });
 }

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -191,7 +191,7 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
 }
 
 /*
- * Generates the contents for the dropdown
+ * Generates the contents for the dropdown.
  */
 function mapChildrenItemsToDropdownItems(items) {
   // Handle undefined, null, or non-array items

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -194,6 +194,10 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
  * Generates the contents for the dropdown
  */
 function mapChildrenItemsToDropdownItems(items) {
+  // Handle undefined, null, or non-array items
+  if (!items || !Array.isArray(items)) {
+    return [];
+  }
   return items.map((item) => {
     if (item.type === "HEADER") {
       return {
@@ -250,7 +254,7 @@ function mapChildrenItemsToDropdownItems(items) {
           }
         }
       },
-      subMenu: item.subMenu
+      subMenu: item.subMenu && item.subMenu.items
         ? () => {
             return mapChildrenItemsToDropdownItems(item.subMenu.items);
           }

--- a/src/main/js/components/dropdowns/utils.js
+++ b/src/main/js/components/dropdowns/utils.js
@@ -109,7 +109,7 @@ function generateDropdownItems(items, compact) {
         tippy(
           menuItem,
           Object.assign({}, Templates.dropdown(), {
-            content: generateDropdownItems(item.subMenu()),
+            content: generateDropdownItems(item.subMenu() || []),
             trigger: "mouseenter",
             placement: "right-start",
             offset: [-8, 0],

--- a/src/main/scss/form/_reorderable-list.scss
+++ b/src/main/scss/form/_reorderable-list.scss
@@ -225,6 +225,10 @@ div.repeated-chunk {
   margin-bottom: 1rem;
 }
 
+.hetero-list-add-top {
+  margin-bottom: 1rem;
+}
+
 .repeated-chunk + .repeatable-insertion-point + span .hetero-list-add,
 .repeated-chunk + .repeatable-insertion-point + .repeatable-add {
   margin-top: 1rem;


### PR DESCRIPTION

Fixes #16687

Adds the possibility in a hetero-list (and repeatableHeteroProperty) to add an additional dropdown button to the top of the list when there is at least one item. This is useful when it is common to have several items in such a list and the items contain configuration themselves.

Enable the flag for job parameters and build steps and post build actions in freestyle jobs.

### Testing done

**Testing Add build step:**
- Created a freestyle project and added a step → the top button appears
- Added another step with the top button → step is added to the top
- Added another step with the bottom button → step is added at the end
- Removed the last step → the top button disappears
- Created a step that contains inside its configuration another hetero-list and added one item (used the conditional build step plugin for this)
- Removing such an inner item has no influence on the outer hetero-list button

**Testing Job Parameters:**
- Added parameters to a freestyle job → top button appears when at least one parameter exists
- Added parameter using top button → parameter is added at the top
- Added parameter using bottom button → parameter is added at the bottom
- Removed all parameters → top button disappears

**Testing Add post-build action:**
- Added post-build actions → top button appears when at least one action exists
- Added action using top button → action is added at the top
- Added action using bottom button → action is added at the bottom (position where the new item is added is identical for top and bottom button due to honorOrder)

### Proposed changelog entries

- Add top button for hetero-list, e.g. "Add Parameter" and "Add build step"

### Proposed changelog category

/label rfe,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

