### PR TITLE
Use display name in directory browser breadcrumbs

### DIFF
--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -35,10 +35,7 @@ THE SOFTWARE.
         <div class="parentPath">
           <form>
             <a href="${topPath}">
-              <j:choose>
-                <j:when test="${empty(it.owner.name)}">${%Root}</j:when>
-                <j:otherwise>${it.owner.displayName}</j:otherwise>
-              </j:choose>
+              ${it.owner.displayName}
             </a> /
             <j:forEach var="p" items="${parentPath}">
               <a href="${p.href}">${p.title}</a>

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -34,14 +34,12 @@ THE SOFTWARE.
       <!-- parent path -->
         <div class="parentPath">
           <form>
-            <j:choose>
-              <j:when test="${request2.originalRequestURI.contains('/artifact/')}">
-                <a href="${rootURL}/${it.owner.url}artifact/">${%Root}</a> /
-              </j:when>
-              <j:otherwise>
-                <a href="${topPath}">${it.owner.name}</a> /
-              </j:otherwise>
-            </j:choose>
+            <a href="${topPath}">
+              <j:choose>
+                <j:when test="${empty(it.owner.name)}">${%Root}</j:when>
+                <j:otherwise>${it.owner.displayName}</j:otherwise>
+              </j:choose>
+            </a> /
             <j:forEach var="p" items="${parentPath}">
               <a href="${p.href}">${p.title}</a>
               /

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -34,7 +34,14 @@ THE SOFTWARE.
       <!-- parent path -->
         <div class="parentPath">
           <form>
-            <a href="${topPath}">${it.owner.name}</a> /
+            <j:choose>
+              <j:when test="${request2.originalRequestURI.contains('/artifact/')}">
+                <a href="${it.owner.url}artifact/">${%Root}</a> /
+              </j:when>
+              <j:otherwise>
+                <a href="${topPath}">${it.owner.name}</a> /
+              </j:otherwise>
+            </j:choose>
             <j:forEach var="p" items="${parentPath}">
               <a href="${p.href}">${p.title}</a>
               /

--- a/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
           <form>
             <j:choose>
               <j:when test="${request2.originalRequestURI.contains('/artifact/')}">
-                <a href="${it.owner.url}artifact/">${%Root}</a> /
+                <a href="${rootURL}/${it.owner.url}artifact/">${%Root}</a> /
               </j:when>
               <j:otherwise>
                 <a href="${topPath}">${it.owner.name}</a> /


### PR DESCRIPTION
### Fixes #16765

### Testing done
Verified locally. The breadcrumb now correctly shows the display name instead of the internal name, which looks much better for jobs with custom display names.

### UI Screenshots

After the change

<img width="1850" height="971" alt="Screenshot from 2025-12-12 04-13-50" src="https://github.com/user-attachments/assets/b4c0abfe-75b8-4f8c-be55-27be5c592a8e" />


Before the change

<img width="1850" height="926" alt="image" src="https://github.com/user-attachments/assets/819eecfa-4f82-4c3e-84bb-54fc11decc5d" />

### Proposed changelog entries
* Use display name in directory browser breadcrumb.

### Proposed changelog category
* Improvement

### Proposed upgrade guidelines
N/A

### Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples). Fill in the Proposed upgrade guidelines section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with @Restricted or have @since TODO Javadocs, as appropriate.
- [ ] New deprecations are annotated with @Deprecated(since = "TODO") or @Deprecated(forRemoval = true, since = "TODO"), if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call eval to ease future introduction of Content Security Policy (CSP) directives (see documentation).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

Desired reviewers
@timja @mawinter69 @daniel-beck @MarkEWaite 