### PR TITLE
Warn users in March 2029 of Java 25 end of support September 2029

### DIFF
--- a/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
@@ -80,6 +80,7 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
         NavigableMap<Integer, LocalDate> supportedVersions = new TreeMap<>();
         supportedVersions.put(17, LocalDate.of(2026, 3, 31)); // Temurin: 2027-10-31
         supportedVersions.put(21, LocalDate.of(2027, 9, 30)); // Temurin: 2029-09-30
+        supportedVersions.put(25, LocalDate.of(2029, 9, 30)); // Temurin: 2031-09-30
         SUPPORTED_JAVA_VERSIONS = Collections.unmodifiableNavigableMap(supportedVersions);
     }
 


### PR DESCRIPTION
## Warn users of Java 25 end of support September 2029

Beginning in March 2029, users will be warned that Java 25 will be reaching its end of support in the Jenkins project.

Amends pull request:

* https://github.com/jenkinsci/jenkins/pull/11148

The [2+2+2 Java support plan](https://www.jenkins.io/blog/2023/11/06/introducing-2-2-2-java-support-plan/) states that we drop support for a Java line after two years so that we're only supporting two Java versions at a time.

Also refer to the (incomplete) [Jenkins Enhancement Proposal pull request](https://github.com/jenkinsci/jep/pull/400).

### Testing done

* None.  Relying on the existing behavior that I've seen from the Java 17 administrative monitor.  It is now shown to users to warn them that we plan to drop Java 17 support by the end of March 2026

### Proposed changelog entries

- N/A

### Proposed changelog category

Skipping changelog because users won't see any result from this change for several years.  Don't confuse them by publishing it in the changelog.

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- ~There is automated testing or an explanation as to why this change has no tests.~
- ~New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.~
- ~New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.~
- ~UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~
- ~For dependency updates, there are links to external changelogs and, if possible, full differentials.~
- ~For new APIs and extension points, there is a link to at least one consumer.~

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
