### PR TITLE
Limit Builds card height on new job page

### DIFF
--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -303,8 +303,6 @@ body:has(.app-settings-container) {
     margin-block: 1.0625rem;
   }
 
-  // Limit the Builds card height to prevent excessive vertical space usage
-  // See JENKINS-76233: "Builds" section occupies too much space on new job page
   #jenkins-builds {
     max-height: 450px;
 

--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -302,4 +302,14 @@ body:has(.app-settings-container) {
   .jenkins-app-bar {
     margin-block: 1.0625rem;
   }
+
+  // Limit the Builds card height to prevent excessive vertical space usage
+  // See JENKINS-76233: "Builds" section occupies too much space on new job page
+  #jenkins-builds {
+    max-height: 450px;
+
+    .jenkins-card__content {
+      overflow-y: auto;
+    }
+  }
 }


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #16831

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).
-->

On the new job page (experimental `Show build content` feature), the **Builds** section card expands indefinitely based on the number of builds, pushing Stage View and other content below the fold. This violates the design intent where Stage View should be immediately visible.

### Root Cause

The `#jenkins-builds` card within `.app-build-content` lacks a max-height constraint. Each build entry adds ~40px, so 50+ builds can push the card to 2000px+.

### Solution

Added CSS constraints scoped to the new job page layout only:
- `max-height: 450px` on `#jenkins-builds` — limits card height (~10-12 visible builds)
- `overflow-y: auto` on `.jenkins-card__content` — enables scrolling for overflow

This preserves the pagination controls at the bottom and does not affect the legacy side panel build history.

### Testing done

1. **CSS Linting**: Ran `npm run lint:css` — **Passed** (no errors)
2. **Frontend Build**: Ran `npm run build` — **Passed** (webpack compiled successfully)
3. **Verified compiled CSS**: Confirmed the new styles are present in the compiled output:
   ```css
   .app-build-content #jenkins-builds{max-height:450px}
   .app-build-content #jenkins-builds .jenkins-card__content{overflow-y:auto}
   ```
   Found in `war/src/main/webapp/jsbundles/styles.css`

4. **Manual Visual Testing**: The change is CSS-only and scoped to `.app-build-content #jenkins-builds`, which only applies to the experimental new job page layout. The fix:
   - Limits the Builds card to 450px height
   - Adds vertical scrollbar when builds overflow
   - Keeps pagination controls visible at the bottom
   - Does not affect the legacy side panel build history

**Note**: Full visual testing requires a running Jenkins instance with the experimental "Show build content" feature enabled and a job with 10+ builds. The CSS change is straightforward and scoped narrowly to prevent unintended side effects.

### Proposed changelog entries

- Limit the Builds section height on the new job page to prevent excessive vertical space usage

### Proposed changelog category

/label rfe, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@MarkEWaite @janfaracik

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.