### PR TITLE
Fix shutdown banner not displayed on new dashboard page

### DIFF
--- a/core/src/main/resources/hudson/model/View/new-view-page.jelly
+++ b/core/src/main/resources/hudson/model/View/new-view-page.jelly
@@ -135,6 +135,8 @@ THE SOFTWARE.
       </div>
 
       <div class="app-build-content" style="padding-top: var(--section-padding)">
+        <l:shutdown-banner />
+
         <t:editableDescription permission="${it.CONFIGURE}" hideButton="true" />
 
         <j:set var="items" value="${it.items}"/>

--- a/core/src/main/resources/lib/layout/job-subpage.jelly
+++ b/core/src/main/resources/lib/layout/job-subpage.jelly
@@ -115,6 +115,7 @@ THE SOFTWARE.
           </div>
 
           <div class="app-build-content">
+            <l:shutdown-banner />
             <d:invokeBody />
           </div>
         </l:main-panel>

--- a/core/src/main/resources/lib/layout/main-panel.jelly
+++ b/core/src/main/resources/lib/layout/main-panel.jelly
@@ -23,39 +23,18 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
+<j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
   <st:documentation>
     Generates the body as the main content part of a Jenkins page.
   </st:documentation>
 
   <j:if test="${mode=='main-panel'}">
-    <j:if test="${app.isQuietingDown()}">
-      <j:choose>
-        <j:when test="${app.isPreparingSafeRestart()}">
-          <div id='safe-restart-msg'>
-            <j:choose>
-              <j:when test="${!app.getQuietDownReason().trim().isEmpty()}">
-                ${app.getQuietDownReason()}
-              </j:when>
-              <j:otherwise>
-                ${%saferestart}
-              </j:otherwise>
-            </j:choose>
-          </div>
-        </j:when>
-        <j:otherwise>
-          <div id='shutdown-msg'>
-            <j:choose>
-              <j:when test="${app.getQuietDownReason() != null}">
-                ${app.getQuietDownReason()}
-              </j:when>
-              <j:otherwise>
-                ${%shutdown}
-              </j:otherwise>
-            </j:choose>
-          </div>
-        </j:otherwise>
-      </j:choose>
+    <!-- Check if we're on a new UI page (dashboard, job, or build) to avoid rendering shutdown banner twice -->
+    <l:userExperimentalFlag var="newDashboardPage" flagClassName="jenkins.model.experimentalflags.NewDashboardPageUserExperimentalFlag" />
+    <l:userExperimentalFlag var="newJobPage" flagClassName="jenkins.model.experimentalflags.NewJobPageUserExperimentalFlag" />
+    <l:userExperimentalFlag var="newBuildPage" flagClassName="jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag" />
+    <j:if test="${!newDashboardPage and !newJobPage and !newBuildPage}">
+      <l:shutdown-banner />
     </j:if>
     <a id="skip2content" />
     <x:comment>&#10;start of main content ⇒&#10;</x:comment>

--- a/core/src/main/resources/lib/layout/run-subpage.jelly
+++ b/core/src/main/resources/lib/layout/run-subpage.jelly
@@ -82,6 +82,7 @@ THE SOFTWARE.
           </div>
 
           <div class="app-build-content">
+            <l:shutdown-banner />
             <d:invokeBody />
           </div>
         </l:main-panel>

--- a/core/src/main/resources/lib/layout/shutdown-banner.jelly
+++ b/core/src/main/resources/lib/layout/shutdown-banner.jelly
@@ -1,0 +1,62 @@
+<!--
+The MIT License
+
+Copyright (c) 2025, CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <st:documentation>
+    Displays a shutdown or safe restart banner when Jenkins is preparing for shutdown.
+
+    This component checks if Jenkins is quieting down (preparing for shutdown or safe restart)
+    and displays an appropriate banner message to inform users that no new builds can be started.
+  </st:documentation>
+
+  <j:if test="${app.isQuietingDown()}">
+    <j:choose>
+      <j:when test="${app.isPreparingSafeRestart()}">
+        <div id="safe-restart-msg">
+          <j:choose>
+            <j:when test="${!app.getQuietDownReason().trim().isEmpty()}">
+              ${app.getQuietDownReason()}
+            </j:when>
+            <j:otherwise>
+              ${%saferestart}
+            </j:otherwise>
+          </j:choose>
+        </div>
+      </j:when>
+      <j:otherwise>
+        <div id="shutdown-msg">
+          <j:choose>
+            <j:when test="${app.getQuietDownReason() != null}">
+              ${app.getQuietDownReason()}
+            </j:when>
+            <j:otherwise>
+              ${%shutdown}
+            </j:otherwise>
+          </j:choose>
+        </div>
+      </j:otherwise>
+    </j:choose>
+  </j:if>
+</j:jelly>

--- a/core/src/main/resources/lib/layout/shutdown-banner.properties
+++ b/core/src/main/resources/lib/layout/shutdown-banner.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2025, CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+shutdown=The Jenkins Controller is preparing for shutdown. No new builds can be started.
+saferestart=The Jenkins Controller is restarting safely. Running builds will finish or continue afterwards, depending on the job type. No new builds can be started.

--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -198,7 +198,10 @@ body:has(.app-settings-container) {
   &::before {
     content: "";
     position: absolute;
-    inset: -1000px calc(var(--section-padding) * -1) 0;
+
+    // Only extend upward by section-padding to cover the gap, not beyond
+    // This prevents hiding shutdown banners and system messages above the main panel
+    inset: calc(var(--section-padding) * -1) calc(var(--section-padding) * -1) 0;
     background-color: var(--background);
     border-bottom: var(--jenkins-border-width) solid var(--card-border-color);
     z-index: -1;


### PR DESCRIPTION
Fixes #25946

### Summary

When the experimental "New Dashboard Page" feature is enabled via user preferences, the shutdown/safe restart banner is not visible to users, even though space is allocated for it. This PR fixes the issue by ensuring the shutdown banner is properly displayed within the new dashboard layout.

### Root Cause

The new dashboard layout (`new-view-page.jelly`) uses a custom structure with an `app-build-bar` element. This element has a CSS `::before` pseudo-element that extends upward with a solid background, which covers the shutdown banner that `main-panel.jelly` renders at the top of the main panel. The banner was being rendered but was visually hidden behind the header background.

### Solution

1. **Created a reusable `shutdown-banner.jelly` component** - Extracted the shutdown/safe-restart banner logic into a dedicated component in `lib/layout/` for better maintainability and code reuse.

2. **Added the shutdown banner inside the content area** of the new UI pages:
   - `new-view-page.jelly` - Inside `app-build-content` div
   - `job-subpage.jelly` - Inside `app-build-content` div  
   - `run-subpage.jelly` - Inside `app-build-content` div

3. **Refactored `main-panel.jelly`** to use the new reusable component, reducing code duplication.

### Testing done

- Verified that the shutdown banner appears correctly when:
  - The new dashboard experimental flag is enabled
  - Jenkins is preparing for shutdown (`Manage Jenkins` → `Prepare for Shutdown`)
  - Jenkins is preparing for safe restart
- Verified backward compatibility: the banner continues to work correctly on the old/classic dashboard view
- Verified the banner displays the correct message (shutdown vs safe restart)
- Verified custom shutdown reasons are displayed correctly

### Proposed changelog entries

- Fix shutdown banner not being displayed on experimental new dashboard page

### Proposed changelog category

/label bug,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers @MarkEWaite