### PR TITLE
fix-dismiss-buttons

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
@@ -27,7 +27,9 @@ THE SOFTWARE.
 <div class="jenkins-alert jenkins-alert-warning">
   <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
     <f:submit name="yes" value="${%Tell me more}"/>
-    <f:submit name="no" value="${%Dismiss}"/>
+    <button name="no" class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+      <l:icon src="symbol-close" />
+    </button>
   </form>
   ${%blurb(app.rootDir)}
 </div>

--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
@@ -27,7 +27,9 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <button name="no" class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+        <l:icon src="symbol-close" />
+      </button>
     </form>
     ${%You have data stored in an older format and/or unreadable data.}
   </div>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -28,7 +28,9 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
       <l:isAdmin>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <button name="no" class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+          <l:icon src="symbol-close" />
+        </button>
       </l:isAdmin>
     </form>
     <div>${%blurb}</div>

--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
@@ -28,7 +28,9 @@ THE SOFTWARE.
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
         <f:submit name="yes" value="${%Create a view now}"/>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <button name="no" class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+          <l:icon src="symbol-close" />
+        </button>
       </form>
     </l:isAdmin>
     ${%blurb}

--- a/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
+++ b/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
@@ -26,7 +26,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:submit value="${%Dismiss}"/>
+      <button class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+        <l:icon src="symbol-close" />
+      </button>
     </form>
     ${%blurb(rootURL)}
   </div>

--- a/core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/ExcludeSessionIdAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/ExcludeSessionIdAdministrativeMonitor/message.jelly
@@ -23,11 +23,13 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="learn" value="${%Learn more}"/>
-      <f:submit name="dismiss" value="${%Dismiss}"/>
+      <button name="dismiss" class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+        <l:icon src="symbol-close" />
+      </button>
     </form>
     ${%blurb}
   </div>

--- a/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
+++ b/core/src/main/resources/hudson/triggers/SlowTriggerAdminMonitor/message.groovy
@@ -6,12 +6,13 @@ import jenkins.model.Jenkins
 import org.apache.commons.jelly.tags.fmt.FmtTagLibrary
 
 SlowTriggerAdminMonitor tam = my
+def l = namespace(lib.LayoutTagLib)
 
 dl {
     div(class: "jenkins-alert jenkins-alert-warning") {
         form(method: "post", name: "clear", action: rootURL + "/" + tam.url + "/clear") {
-            button(name: "clear", type: "submit", class: "jenkins-button jenkins-submit-button jenkins-button--primary") {
-                raw _("Dismiss")
+            button(name: "clear", type: "submit", class: "jenkins-button jenkins-button--tertiary", title: _("Dismiss")) {
+                l.icon(src: "symbol-close")
             }
         }
 

--- a/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
+++ b/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
@@ -3,7 +3,9 @@
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Apply Migration}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <button name="no" class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+                <l:icon src="symbol-close" />
+            </button>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/message.jelly
@@ -28,7 +28,9 @@ THE SOFTWARE.
         <form id="JavaVersionRecommendationAdminMonitor" method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%More Info}"/>
             <l:isAdmin>
-                <f:submit value="${%Ignore}" name="no"/>
+                <button name="no" class="jenkins-button jenkins-button--tertiary" title="${%Ignore}">
+                    <l:icon src="symbol-close" />
+                </button>
             </l:isAdmin>
         </form>
         <h2>${%Recommended_Java_Version_Heading(it.javaVersion)}</h2>

--- a/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/message.jelly
@@ -29,7 +29,9 @@ THE SOFTWARE.
         <form id="${it.id}" method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%More Info}"/>
             <l:isAdmin>
-                <f:submit value="${%Ignore}" name="no"/>
+                <button name="no" class="jenkins-button jenkins-button--tertiary" title="${%Ignore}">
+                    <l:icon src="symbol-close" />
+                </button>
             </l:isAdmin>
         </form>
         <h2 class="h3">${it.displayName}</h2>

--- a/core/src/main/resources/jenkins/security/csp/impl/CspRecommendation/message.jelly
+++ b/core/src/main/resources/jenkins/security/csp/impl/CspRecommendation/message.jelly
@@ -22,11 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
     <div class="jenkins-alert jenkins-alert-info">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="more" value="${%Learn more}"/>
-            <f:submit name="dismiss" primary="false" value="${%Dismiss}"/>
+            <button name="dismiss" class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+                <l:icon src="symbol-close" />
+            </button>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/disable">
-            <f:submit value="${%Dismiss}"/>
+            <button class="jenkins-button jenkins-button--tertiary" title="${%Dismiss}">
+                <l:icon src="symbol-close" />
+            </button>
         </form>
         <j:set var="referenceAnchor">
             <a href="https://www.jenkins.io/redirect/csrf-protection" rel="noopener noreferrer" target="_blank">${%referenceUrlContent}</a>


### PR DESCRIPTION
Fixes [JENKINS-69787](https://issues.jenkins.io/browse/JENKINS-69787)

### Testing done

Manually verified the changes by inspecting the modified Jelly and Groovy files to ensure they use the standard `symbol-close` icon button pattern instead of text submit buttons.

Verified that the `jenkins-button--tertiary` class and `symbol-close` icon are correctly applied to the "Dismiss" (or "Ignore") actions in the following administrative monitors:
- Old Data Monitor
- Hudson Home Disk Usage Monitor
- Reverse Proxy Setup Monitor
- Too Many Jobs But No View Monitor
- Monitor Marked Node Offline
- Built-In Node Migration
- CSP Recommendation
- CSRF Administrative Monitor
- Exclude Session ID Administrative Monitor
- Slow Trigger Admin Monitor
- Operating System End of Life Admin Monitor
- Java Version Recommendation Admin Monitor

### Proposed changelog entries

- Use an (x) icon button for dismissing administrative monitors instead of a text button.

### Proposed changelog category

/label rfe, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests. (Visual UI change, manual verification)
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see documentation).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers