### PR TITLE
JENKINS-76106: Fix "Last Duration" column to show most recent completed build

### DIFF
--- a/core/src/main/resources/hudson/views/LastDurationColumn/column.jelly
+++ b/core/src/main/resources/hudson/views/LastDurationColumn/column.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-      <j:set var="lBuild" value="${job.lastSuccessfulBuild ?: job.lastFailedBuild}"/>
+      <j:set var="lBuild" value="${job.lastCompletedBuild}"/>
       <td data="${lBuild.duration ?: '0'}">
           <j:choose>
               <j:when test="${lBuild!=null}">

--- a/test/src/test/java/hudson/views/LastDurationColumnTest.java
+++ b/test/src/test/java/hudson/views/LastDurationColumnTest.java
@@ -1,16 +1,16 @@
 package hudson.views;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.ListView;
 import hudson.model.Result;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
-
-import hudson.model.ListView;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 
 @WithJenkins
 class LastDurationColumnTest {

--- a/test/src/test/java/hudson/views/LastDurationColumnTest.java
+++ b/test/src/test/java/hudson/views/LastDurationColumnTest.java
@@ -1,0 +1,49 @@
+package hudson.views;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import hudson.model.ListView;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+@WithJenkins
+class LastDurationColumnTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    @Test
+    void lastDurationShouldShowLastCompletedBuild() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+
+        // 1. Run a successful build
+        FreeStyleBuild s = j.buildAndAssertSuccess(p);
+        String sDurationString = s.getDurationString();
+
+        // 2. Run a failed build (make it fail)
+        p.getBuildersList().add(new hudson.tasks.Shell("exit 1"));
+        FreeStyleBuild f = j.buildAndAssertStatus(Result.FAILURE, p);
+        String fDurationString = f.getDurationString();
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+
+        ListView view = new ListView("testView", j.jenkins);
+        view.getColumns().add(new LastDurationColumn());
+        view.add(p);
+        j.jenkins.addView(view);
+
+        String viewContent = wc.goTo("view/testView").asNormalizedText();
+
+        assertThat("View should contain failed build's duration", viewContent, containsString(fDurationString));
+    }
+}


### PR DESCRIPTION
Fixes #16816 (JENKINS-76106)

The "Last Duration" column in the Jenkins dashboard incorrectly prioritized the duration of the last successful build over more recent completed builds (such as failed builds). 

Previously, the logic explicitly chose `lastSuccessfulBuild` if available, falling back to `lastFailedBuild`. This caused the dashboard to show outdated duration info if a recent build failed after a successful one.

This change updates the logic to use `lastCompletedBuild` directly, ensuring the dashboard reflects the duration of the most recently finished build regardless of its result.

### Testing done

I have added a new unit test class `hudson.views.LastDurationColumnTest`.
- The test creates a project and runs one successful build followed by one failed build.
- It verifies that the [LastDurationColumn](cci:2://file:///Users/virendragadekar/Downloads/jenkins-master/core/src/main/java/hudson/views/LastDurationColumn.java:31:0-44:1) renders the duration of the **failed** build (the most recent one), rather than the successful one.

The test passes locally:
`mvn test -pl test -Dtest=LastDurationColumnTest`