### PR TITLE
[JENKINS-69787] Use (x) icon for dismissing admin monitors

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -27,9 +27,16 @@ THE SOFTWARE.
        data-url="${rootURL}/${it.url}/test" data-context="${rootURL}">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
-      <l:isAdmin>
-        <f:submit name="no" value="${%Dismiss}"/>
-      </l:isAdmin>
+       <l:isAdmin>
+         <button type="submit"
+          name="no"
+          class="jenkins-button jenkins-button--icon"
+          aria-label="${%Dismiss}"
+          tooltip="${%Dismiss}">
+         <l:icon src="symbol-close" />
+          </button>
+        </l:isAdmin>
+
     </form>
     <div>${%blurb}</div>
     <div class="js-context-message reverse-proxy__hidden">${%missingContextMessage(rootURL)}</div>

--- a/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
+++ b/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
@@ -34,8 +34,11 @@ THE SOFTWARE.
   <st:adjunct includes="lib.form.repeatable.repeatable"/>
 
   <j:set var="deleteText" value="${attrs.value ?: '%Delete'}" />
-  <button class="repeatable-delete danger" type="button" style="--width: ${deleteText.length()}ch">
-    <l:icon src="symbol-close" />
-    <span>${deleteText}</span>
-  </button>
+   <button
+    type="button"
+    class="repeatable-delete"
+    aria-label="${deleteText}"
+    tooltip="${deleteText}">
+  <l:icon src="symbol-close" />
+</button>
 </j:jelly>


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #69787

### Summary

Replace text-based **Dismiss** buttons in Administrative Monitor banners with a close **(×)** icon, aligning the UI with Jenkins design conventions and improving visual consistency.

This change is limited to the web UI and does not alter any backend behavior.

---

### Testing done

- Built Jenkins from source using:
mvn -DskipTests clean install
- Ran Jenkins locally using:
java -jar war/target/jenkins.war --enable-future-java
- Triggered multiple Administrative Monitors (e.g. Reverse Proxy warning, Root URL not set, Security warnings).
- Verified that:
- The dismiss action is rendered as an **(×)** icon instead of a text button.
- Hovering over the icon shows the **Dismiss** tooltip.
- The button includes an appropriate `aria-label` for accessibility.
- Clicking the icon successfully dismisses the admin monitor banner.

---



#### Before
Admin Monitor banners displayed a blue **Dismiss** text button.

#### After
Admin Monitor banners display a close **(×)** icon for dismissing.

---

### Proposed changelog entries

- Use a close (×) icon instead of a text button for dismissing administrative monitor warnings.

---

### Proposed changelog category

/label web-ui, skip-changelog

---

### Proposed upgrade guidelines

N/A

---

### Submitter checklist

- [x] The issue is well-described.
- [x] The change is limited to UI behavior and does not alter functionality.
- [x] Manual testing performed and documented.
- [x] No new public APIs introduced.
- [x] UI changes do not violate CSP rules.
- [x] No upgrade steps required.

---

### Desired reviewers

@jenkinsci/core-pr-reviewers
