### PR TITLE
test(core): ensure display name and description survive config roundtrip

### DIFF
--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -297,6 +297,20 @@ class JobTest {
         assertEquals(1, r.getArtifactsUpTo(1).size());
     }
 
+    @Test
+    void displayNameAndDescriptionSurviveConfigRoundtrip() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("p");
+
+        project.setDisplayName("My Display Name");
+        project.setDescription("My description text");
+
+        j.configRoundtrip(project);
+
+        assertEquals("My Display Name", project.getDisplayName());
+        assertEquals("My description text", project.getDescription());
+    }
+
+
     @Issue("JENKINS-10182")
     @Test
     void emptyDescriptionReturnsEmptyPage() throws Exception {


### PR DESCRIPTION
### Summary
This pull request adds a small regression test to ensure that a job’s
display name and description are preserved across a configuration
round-trip.

### Motivation
Jenkins relies heavily on saving and reloading job configuration via
config round-trips. This test explicitly locks the expected behavior
that a job’s display name and description remain unchanged after such
a round-trip, helping prevent subtle regressions in the future.

### Testing done
- Added a unit test in `JobTest`
- Verified locally by running `mvn -pl core -DskipITs test`

### Screenshots (UI changes only)
N/A

### Proposed changelog entries
N/A (test-only change)

### Proposed changelog category
/label skip-changelog

### Proposed upgrade guidelines
N/A