### PR TITLE
test(core): ensure display name and description survive config roundtrip

### DIFF
--- a/test/src/test/java/hudson/model/JobTest.java
+++ b/test/src/test/java/hudson/model/JobTest.java
@@ -297,6 +297,20 @@ class JobTest {
         assertEquals(1, r.getArtifactsUpTo(1).size());
     }
 
+    @Test
+    void displayNameAndDescriptionSurviveConfigRoundtrip() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("p");
+
+        project.setDisplayName("My Display Name");
+        project.setDescription("My description text");
+
+        j.configRoundtrip(project);
+
+        assertEquals("My Display Name", project.getDisplayName());
+        assertEquals("My description text", project.getDescription());
+    }
+
+
     @Issue("JENKINS-10182")
     @Test
     void emptyDescriptionReturnsEmptyPage() throws Exception {


### PR DESCRIPTION
### Summary
Add a regression test to ensure that a job’s display name and description
are preserved across a configuration round-trip.

### Motivation
Jenkins relies on configuration round-trips to persist job state.
This test explicitly verifies that display name and description are not
lost or altered during this process, preventing future regressions.

### Testing done
- Added a unit test in `JobTest`
- Verified locally using `mvn -pl core -DskipITs test`

### Screenshots (UI changes only)
N/A

### Proposed changelog entries
N/A (test-only change)

/label skip-changelog

### Proposed upgrade guidelines
N/A