### PR TITLE
[JENKINS-69787] Use icon-based dismiss buttons in admin monitors

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <div class="jenkins-alert jenkins-alert-warning">
   <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
     <f:submit name="yes" value="${%Tell me more}"/>
-    <f:submit name="no" value="${%Dismiss}"/>
+    <f:dismissButton name="no"/>
   </form>
   ${%blurb(app.rootDir)}
 </div>

--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:dismissButton name="no"/>
     </form>
     ${%You have data stored in an older format and/or unreadable data.}
   </div>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
       <l:isAdmin>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <f:dismissButton name="no"/>
       </l:isAdmin>
     </form>
     <div>${%blurb}</div>

--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
         <f:submit name="yes" value="${%Create a view now}"/>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <f:dismissButton name="no"/>
       </form>
     </l:isAdmin>
     ${%blurb}

--- a/core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/ExcludeSessionIdAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/ExcludeSessionIdAdministrativeMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="learn" value="${%Learn more}"/>
-      <f:submit name="dismiss" value="${%Dismiss}"/>
+      <f:dismissButton name="dismiss"/>
     </form>
     ${%blurb}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
      <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:dismissButton name="no"/>
      </form>
 
     ${%ExecutorsWarning}

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="agent" value="${%Set up agent}"/>
       <f:submit name="cloud" value="${%Set up cloud}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:dismissButton name="no"/>
     </form>
     ${%ExecutorsWarning}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/disable">
-        <f:submit value="${%Dismiss}"/>
+        <f:dismissButton/>
       </form>
     </l:isAdmin>
     <j:set var="actionAnchor">

--- a/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Setup Security}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:dismissButton name="no"/>
     </form>
     ${%blurb}
   </div>

--- a/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
+++ b/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
@@ -3,7 +3,7 @@
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Apply Migration}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:dismissButton name="no"/>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Disable automatic generation of legacy API tokens}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:dismissButton name="no"/>
         </form>
         ${%warningMessage}
     </div>

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Prevent users from manually creating legacy API tokens}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:dismissButton name="no"/>
         </form>
         ${%warningMessage}
     </div>

--- a/core/src/main/resources/jenkins/security/csp/impl/CspRecommendation/message.jelly
+++ b/core/src/main/resources/jenkins/security/csp/impl/CspRecommendation/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
     <div class="jenkins-alert jenkins-alert-info">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="more" value="${%Learn more}"/>
-            <f:submit name="dismiss" primary="false" value="${%Dismiss}"/>
+            <f:dismissButton name="dismiss"/>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/disable">
-            <f:submit value="${%Dismiss}"/>
+            <f:dismissButton/>
         </form>
         <j:set var="referenceAnchor">
             <a href="https://www.jenkins.io/redirect/csrf-protection" rel="noopener noreferrer" target="_blank">${%referenceUrlContent}</a>

--- a/core/src/main/resources/lib/form/dismissButton.jelly
+++ b/core/src/main/resources/lib/form/dismissButton.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc.
+Copyright (c) 2024
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,11 +23,28 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <div class="jenkins-alert jenkins-alert-warning">
-    <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:dismissButton/>
-    </form>
-    ${%blurb(rootURL)}
-  </div>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <st:documentation> <![CDATA[
+    Icon-based dismiss button for administrative monitors.
+    Uses symbol-close icon for visual consistency with other Jenkins UI elements.
+    ]]>
+    <st:attribute name="name" use="optional">
+      Name attribute for the submit button (e.g., "no", "dismiss").
+      If not specified, the button will submit without a name attribute.
+    </st:attribute>
+  </st:documentation>
+
+  <j:set var="buttonName" value="${attrs.name}" />
+  <j:choose>
+    <j:when test="${buttonName != null}">
+      <button type="submit" name="${buttonName}" class="jenkins-button jenkins-button--tertiary" tooltip="${%Dismiss}">
+        <l:icon src="symbol-close" />
+      </button>
+    </j:when>
+    <j:otherwise>
+      <button type="submit" class="jenkins-button jenkins-button--tertiary" tooltip="${%Dismiss}">
+        <l:icon src="symbol-close" />
+      </button>
+    </j:otherwise>
+  </j:choose>
 </j:jelly>

--- a/core/src/main/resources/lib/form/dismissButton.properties
+++ b/core/src/main/resources/lib/form/dismissButton.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2024
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Dismiss=Dismiss


### PR DESCRIPTION
- Created reusable dismissButton.jelly component with symbol-close icon
- Updated 15 admin monitor message files to use icon button instead of text
- Replaced <f:submit value=${%Dismiss}/> with <f:dismissButton/>
- Improved UX consistency with repeatableDeleteButton pattern
- Maintained accessibility with tooltip support
- Preserves form submission behavior and name attributes

The new dismissButton component:
- Uses symbol-close icon for visual consistency
- Includes tooltip with localized 'Dismiss' text
- Supports optional name attribute for form handling
- Applies jenkins-button--tertiary styling

Files updated:
- hudson/node_monitors/MonitorMarkedNodeOffline
- hudson/security/csrf/DefaultCrumbIssuer/ExcludeSessionIdAdministrativeMonitor
- hudson/diagnosis/HudsonHomeDiskUsageMonitor
- hudson/diagnosis/ReverseProxySetupMonitor
- hudson/diagnosis/TooManyJobsButNoView
- hudson/diagnosis/OldDataMonitor
- jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor
- jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor
- jenkins/security/csrf/CSRFAdministrativeMonitor
- jenkins/security/csp/impl/CspRecommendation
- jenkins/model/BuiltInNodeMigration
- jenkins/diagnostics/SecurityIsOffMonitor
- jenkins/diagnostics/RootUrlNotSetMonitor
- jenkins/diagnostics/ControllerExecutorsNoAgents
- jenkins/diagnostics/ControllerExecutorsAgents

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #<issue-number>

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
