### PR TITLE
Fix CSP form-action violation in ReverseProxySetupMonitor

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout">
   <div id="redirect-error" class="jenkins-alert jenkins-alert-danger reverse-proxy__hidden"
        data-url="${rootURL}/${it.url}/test" data-context="${rootURL}">
-    <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
+    <form method="get" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
       <l:isAdmin>
         <f:submit name="no" value="${%Dismiss}"/>


### PR DESCRIPTION
Fixes #25999

### Summary
Replace POST action to the `administrativeMonitor/.../act` endpoint with a
CSP-safe navigation to **Manage Jenkins → Configure System**.

This avoids violating the `form-action 'self'` Content Security Policy
directive when Jenkins is accessed behind a reverse proxy.

### Problem
Submitting the Reverse Proxy Setup Monitor form sends a POST request to:

/administrativeMonitor/hudson.diagnosis.ReverseProxySetupMonitor/act

This violates Jenkins CSP rules (`form-action 'self'`) and the browser blocks
the request.

### Solution
The monitor now navigates users to the **Manage Jenkins configuration page**
instead of submitting a POST request, ensuring CSP compliance.

---

### Testing done
- Manually verified the Reverse Proxy Setup Monitor banner
- Clicked **More Info**
- Confirmed navigation to *Manage Jenkins → Configure System*
- Verified no CSP errors in browser console

### Screenshots (UI changes only)

#### Before
- Clicking **More Info** triggers a blocked POST request due to CSP

#### After
- Clicking **More Info** safely navigates to Manage Jenkins configuration

---

### Proposed changelog entries
- Fix Reverse Proxy Setup Monitor CSP violation by using safe navigation

### Proposed changelog category
/label bug, web-ui

### Proposed upgrade guidelines
N/A
