### PR TITLE
Test HTMLUnit 4.21.0 in Jenkins test harness

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -192,7 +192,9 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>2538.vcca_5b_74c18a_2</version>
+      <!-- TODO: https://github.com/jenkinsci/jenkins-test-harness/pull/1139 -->
+      <!-- TODO: https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/203 -->
+      <version>2541.v93f803705b_29</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
## Test HTMLUnit 4.21.0 in Jenkins test harness

Do not merge.

HTMLUnit 4.19.0 and 4.20.0 were unable to process some of the JavaScript used in the Jenkins test harness.  Issue:

* https://github.com/HtmlUnit/htmlunit/issues/1064

Resolved in [HTMLUnit 4.21.0](https://github.com/HtmlUnit/htmlunit/releases/tag/4.21.0)

Pull requests:

* https://github.com/jenkinsci/jenkins-test-harness/pull/1139
* https://github.com/jenkinsci/jenkins-test-harness-htmlunit/pull/203

### Testing done

* Checked that automated tests pass for 3 sample test classes.  Rely on ci.jenkins.io to test the rest

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
