### PR TITLE
Require Java 21 or newer

### DIFF
--- a/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
@@ -78,7 +78,6 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
 
     static {
         NavigableMap<Integer, LocalDate> supportedVersions = new TreeMap<>();
-        supportedVersions.put(17, LocalDate.of(2026, 3, 31)); // Temurin: 2027-10-31
         supportedVersions.put(21, LocalDate.of(2027, 9, 30)); // Temurin: 2029-09-30
         supportedVersions.put(25, LocalDate.of(2029, 9, 30)); // Temurin: 2031-09-30
         SUPPORTED_JAVA_VERSIONS = Collections.unmodifiableNavigableMap(supportedVersions);

--- a/core/src/main/java/jenkins/security/stapler/StaplerDispatchValidator.java
+++ b/core/src/main/java/jenkins/security/stapler/StaplerDispatchValidator.java
@@ -311,7 +311,6 @@ public class StaplerDispatchValidator implements DispatchValidator {
             }
         }
 
-        @SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC", justification = "TODO needs triage")
         private class Validator {
             // lazy load parents to avoid trying to load potentially unavailable classes
             private final Supplier<Collection<Validator>> parentsSupplier;

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.142</version>
+    <version>2.1326.v00b_e26755312</version>
     <relativePath />
   </parent>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -133,7 +133,6 @@ THE SOFTWARE.
   <build>
     <finalName>jenkins</finalName>
     <plugins>
-      <!-- TODO When Java 11 usage declines to a terminal level, this can be deleted. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -143,43 +142,10 @@ THE SOFTWARE.
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>11</version>
+                  <version>21</version>
                 </requireJavaVersion>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>11</maxJdkVersion>
-                  <excludes>
-                    <exclude>io.jenkins.tools:bridge-method-annotation</exclude>
-                    <exclude>org.jenkins-ci:annotation-indexer</exclude>
-                    <exclude>org.jenkins-ci:commons-jelly</exclude>
-                    <exclude>org.jenkins-ci:commons-jelly-tags-fmt</exclude>
-                    <exclude>org.jenkins-ci:commons-jelly-tags-xml</exclude>
-                    <exclude>org.jenkins-ci:crypto-util</exclude>
-                    <exclude>org.jenkins-ci.main:cli</exclude>
-                    <exclude>org.jenkins-ci.main:jenkins-core</exclude>
-                    <exclude>org.jenkins-ci.main:remoting</exclude>
-                    <exclude>org.jenkins-ci.main:websocket-jetty12-ee9</exclude>
-                    <exclude>org.jenkins-ci.main:websocket-spi</exclude>
-                    <exclude>org.jenkins-ci:memory-monitor</exclude>
-                    <exclude>org.jenkins-ci:symbol-annotation</exclude>
-                    <exclude>org.jenkins-ci:task-reactor</exclude>
-                    <exclude>org.jenkins-ci:version-number</exclude>
-                    <exclude>org.jvnet.hudson:commons-jelly-tags-define</exclude>
-                    <exclude>org.jvnet.winp:winp</exclude>
-                    <exclude>org.kohsuke:access-modifier-annotation</exclude>
-                    <exclude>org.kohsuke.stapler:json-lib</exclude>
-                    <exclude>org.kohsuke.stapler:stapler</exclude>
-                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
-                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
-                    <exclude>org.springframework.security:spring-security-core</exclude>
-                    <exclude>org.springframework.security:spring-security-crypto</exclude>
-                    <exclude>org.springframework.security:spring-security-web</exclude>
-                    <exclude>org.springframework:spring-aop</exclude>
-                    <exclude>org.springframework:spring-beans</exclude>
-                    <exclude>org.springframework:spring-context</exclude>
-                    <exclude>org.springframework:spring-core</exclude>
-                    <exclude>org.springframework:spring-expression</exclude>
-                    <exclude>org.springframework:spring-web</exclude>
-                  </excludes>
+                  <maxJdkVersion>21</maxJdkVersion>
                 </enforceBytecodeVersion>
               </rules>
             </configuration>
@@ -190,15 +156,15 @@ THE SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>11</release>
-          <testRelease>11</testRelease>
+          <release>21</release>
+          <testRelease>21</testRelease>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <release>11</release>
+          <release>21</release>
         </configuration>
       </plugin>
       <plugin>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -133,6 +133,7 @@ THE SOFTWARE.
   <build>
     <finalName>jenkins</finalName>
     <plugins>
+      <!-- TODO When Java 11 usage declines to a terminal level, this can be deleted. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -142,10 +143,43 @@ THE SOFTWARE.
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>21</version>
+                  <version>11</version>
                 </requireJavaVersion>
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>21</maxJdkVersion>
+                  <maxJdkVersion>11</maxJdkVersion>
+                  <excludes>
+                    <exclude>io.jenkins.tools:bridge-method-annotation</exclude>
+                    <exclude>org.jenkins-ci:annotation-indexer</exclude>
+                    <exclude>org.jenkins-ci:commons-jelly</exclude>
+                    <exclude>org.jenkins-ci:commons-jelly-tags-fmt</exclude>
+                    <exclude>org.jenkins-ci:commons-jelly-tags-xml</exclude>
+                    <exclude>org.jenkins-ci:crypto-util</exclude>
+                    <exclude>org.jenkins-ci.main:cli</exclude>
+                    <exclude>org.jenkins-ci.main:jenkins-core</exclude>
+                    <exclude>org.jenkins-ci.main:remoting</exclude>
+                    <exclude>org.jenkins-ci.main:websocket-jetty12-ee9</exclude>
+                    <exclude>org.jenkins-ci.main:websocket-spi</exclude>
+                    <exclude>org.jenkins-ci:memory-monitor</exclude>
+                    <exclude>org.jenkins-ci:symbol-annotation</exclude>
+                    <exclude>org.jenkins-ci:task-reactor</exclude>
+                    <exclude>org.jenkins-ci:version-number</exclude>
+                    <exclude>org.jvnet.hudson:commons-jelly-tags-define</exclude>
+                    <exclude>org.jvnet.winp:winp</exclude>
+                    <exclude>org.kohsuke:access-modifier-annotation</exclude>
+                    <exclude>org.kohsuke.stapler:json-lib</exclude>
+                    <exclude>org.kohsuke.stapler:stapler</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
+                    <exclude>org.springframework.security:spring-security-core</exclude>
+                    <exclude>org.springframework.security:spring-security-crypto</exclude>
+                    <exclude>org.springframework.security:spring-security-web</exclude>
+                    <exclude>org.springframework:spring-aop</exclude>
+                    <exclude>org.springframework:spring-beans</exclude>
+                    <exclude>org.springframework:spring-context</exclude>
+                    <exclude>org.springframework:spring-core</exclude>
+                    <exclude>org.springframework:spring-expression</exclude>
+                    <exclude>org.springframework:spring-web</exclude>
+                  </excludes>
                 </enforceBytecodeVersion>
               </rules>
             </configuration>
@@ -156,15 +190,15 @@ THE SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>21</release>
-          <testRelease>21</testRelease>
+          <release>11</release>
+          <testRelease>11</testRelease>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <release>21</release>
+          <release>11</release>
         </configuration>
       </plugin>
       <plugin>

--- a/war/src/main/java/executable/Main.java
+++ b/war/src/main/java/executable/Main.java
@@ -76,7 +76,7 @@ public class Main {
      * This list must remain synchronized with the one in {@code
      * JavaVersionRecommendationAdminMonitor}.
      */
-    private static final NavigableSet<Integer> SUPPORTED_JAVA_VERSIONS = new TreeSet<>(List.of(17, 21, 25));
+    private static final NavigableSet<Integer> SUPPORTED_JAVA_VERSIONS = new TreeSet<>(List.of(21, 25));
 
     /**
      * Sets custom session cookie name.

--- a/war/src/test/java/executable/MainTest.java
+++ b/war/src/test/java/executable/MainTest.java
@@ -13,26 +13,26 @@ class MainTest {
         assertJavaCheckFails(8, true);
         assertJavaCheckFails(11, false);
         assertJavaCheckFails(11, true);
+        assertJavaCheckFails(17, false);
+        assertJavaCheckFails(17, true);
     }
 
     @Test
     void supported() {
-        assertJavaCheckPasses(17, false);
-        assertJavaCheckPasses(17, true);
         assertJavaCheckPasses(21, false);
         assertJavaCheckPasses(21, true);
+        assertJavaCheckPasses(25, false);
+        assertJavaCheckPasses(25, true);
     }
 
     @Test
     void future() {
-        assertJavaCheckFails(18, false);
-        assertJavaCheckFails(19, false);
-        assertJavaCheckFails(20, false);
         assertJavaCheckFails(22, false);
-        assertJavaCheckPasses(18, true);
-        assertJavaCheckPasses(19, true);
-        assertJavaCheckPasses(20, true);
+        assertJavaCheckFails(23, false);
+        assertJavaCheckFails(24, false);
         assertJavaCheckPasses(22, true);
+        assertJavaCheckPasses(23, true);
+        assertJavaCheckPasses(24, true);
     }
 
     private static void assertJavaCheckFails(int releaseVersion, boolean enableFutureJava) {


### PR DESCRIPTION
As Java 25 is available for a couple of months now, it is time to drop support for Java 17. When this PR is merged, Jenkins will support only Java 21 and 25, or newer.

See [Java support plan](https://www.jenkins.io/blog/2023/11/06/introducing-2-2-2-java-support-plan/) and [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/SNsd_pLk4-k/m/jQDOF-3jCgAJ).

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

<!-- ### Testing done -->

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

<!-- ### Screenshots (UI changes only) -->

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

<!-- #### Before -->

<!-- #### After -->

### Proposed changelog entries

- Require Java 21 or newer.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label major-rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
