### PR TITLE
Fix references to RealJenkinsRule.Endpoint

### DIFF
--- a/core/src/main/java/jenkins/util/SetContextClassLoader.java
+++ b/core/src/main/java/jenkins/util/SetContextClassLoader.java
@@ -41,8 +41,8 @@ import java.io.ObjectInputStream;
  * unclear, {@link #SetContextClassLoader(ClassLoader)} can be used as a fallback with {@link
  * PluginManager.UberClassLoader} as the argument, though this is not as safe since lookups could be
  * ambiguous in case two unrelated plugins both bundle the same library. In functional tests, {@code
- * RealJenkinsRule.Endpoint} can be used to reference a class loader that has access to the plugins
- * defined in the test scenario.
+ * jenkinsRule.getPluginManager().uberClassLoader} can be used to reference a class loader that has
+ * access to the plugins defined in the test scenario.
  *
  * <p>See <a
  * href="https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#context-class-loaders">the

--- a/test/src/test/java/jenkins/util/SetContextClassLoaderTest.java
+++ b/test/src/test/java/jenkins/util/SetContextClassLoaderTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RealJenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
 
 class SetContextClassLoaderTest {
@@ -20,7 +19,7 @@ class SetContextClassLoaderTest {
     }
 
     private static void _positive(JenkinsRule r) throws ClassNotFoundException {
-        try (SetContextClassLoader sccl = new SetContextClassLoader(RealJenkinsRule.Endpoint.class)) {
+        try (SetContextClassLoader sccl = new SetContextClassLoader(r.getPluginManager().uberClassLoader)) {
             assertEquals("hudson.tasks.Mailer$UserProperty", getUserPropertyClass().getName());
         }
     }


### PR DESCRIPTION
Addresses https://github.com/jenkinsci/jenkins/pull/25975#discussion_r2653728144 and https://github.com/jenkinsci/jenkins/pull/25975#discussion_r2653741870

### Testing done

None, waiting for CI build.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Fix references to `RealJenkinsRule.Endpoint`

### Proposed changelog category

/label internal, developer, skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jglick 

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
