### PR TITLE
Use icon-only dismiss button for repeatable delete

### DIFF
--- a/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
+++ b/core/src/main/resources/lib/form/repeatableDeleteButton.jelly
@@ -34,8 +34,7 @@ THE SOFTWARE.
   <st:adjunct includes="lib.form.repeatable.repeatable"/>
 
   <j:set var="deleteText" value="${attrs.value ?: '%Delete'}" />
-  <button class="repeatable-delete danger" type="button" style="--width: ${deleteText.length()}ch">
+  <button class="repeatable-delete danger" type="button" tooltip="${deleteText}" aria-label="${deleteText}">
     <l:icon src="symbol-close" />
-    <span>${deleteText}</span>
   </button>
 </j:jelly>


### PR DESCRIPTION
This change updates the repeatable delete button to use an icon-only design,
removing the visible “Delete/Dismiss” text.

The goal is to align repeatable delete actions with existing Jenkins UI patterns
(e.g. dismiss buttons used in system notifications), while preserving
accessibility.

Changes included:
- Remove visible text from the repeatable delete button
- Keep tooltip text for discoverability
- Add aria-label to ensure screen reader accessibility

No functional behavior is changed; clicking the button continues to remove the
repeated block as before.

Note: When hovering over the icon-only button, the button width briefly collapses
due to existing CSS assumptions that previously relied on the presence of text.
This PR focuses only on removing visible text while maintaining accessibility.
Any CSS refinements related to hover width can be addressed separately.

Fixes #18321
