### PR TITLE
Add user preference for build timestamp format

### DIFF
--- a/core/src/main/java/jenkins/model/DateTimePreference.java
+++ b/core/src/main/java/jenkins/model/DateTimePreference.java
@@ -1,0 +1,71 @@
+package jenkins.model;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+import hudson.model.userproperty.UserPropertyCategory;
+import hudson.util.ListBoxModel;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * User property that stores the preferred date and time format.
+ *
+ * <p>
+ * This property allows users to control how timestamps are rendered in the Jenkins UI.
+ * The format can either follow the browser's locale (the default behavior) or be
+ * explicitly set to a specific representation such as 12-hour, 24-hour, or ISO-8601.
+ * </p>
+ *
+ */
+public class DateTimePreference extends UserProperty {
+
+    private final String timeFormat;
+
+    @DataBoundConstructor
+    public DateTimePreference(String timeFormat) {
+        this.timeFormat = timeFormat == null ? "auto" : timeFormat;
+    }
+
+    @SuppressWarnings("unused")
+    public String getTimeFormat() {
+        return timeFormat;
+    }
+
+    @Extension
+    @Symbol("dateTimePreference")
+    public static final class DescriptorImpl extends UserPropertyDescriptor {
+
+        @Override
+        public UserProperty newInstance(User user) {
+            return new DateTimePreference("auto");
+        }
+
+        @Override
+        public @NonNull String getDisplayName() {
+            return "Date and Time Format";
+        }
+
+        @Override
+        public @NonNull UserPropertyCategory getUserPropertyCategory() {
+            return UserPropertyCategory.get(UserPropertyCategory.Preferences.class);
+        }
+
+        @Override
+        public String getId() {
+            return DateTimePreference.class.getName();
+        }
+
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillTimeFormatItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("Auto (Browser Default)", "auto");
+            items.add("12-hour (6:05 PM)", "12h");
+            items.add("24-hour (18:05)", "24h");
+            items.add("ISO-8601 (2025-01-30 18:05)", "iso8601");
+            return items;
+        }
+    }
+}

--- a/core/src/main/resources/jenkins/model/DateTimePreference/DescriptorImpl/config.jelly
+++ b/core/src/main/resources/jenkins/model/DateTimePreference/DescriptorImpl/config.jelly
@@ -1,0 +1,32 @@
+<!--
+The MIT License
+
+Copyright (c) 2024 Jan Faracik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Time Format}"
+             field="timeFormat"
+             description="${%Controls how build timestamps are displayed. This does not affect the UI language.}">
+        <f:select />
+    </f:entry>
+</j:jelly>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2723,7 +2723,9 @@ Behaviour.specify(
     }
 
     const date = new Date(parseInt(timestampVal));
-    if (isNaN(date.getTime())) return;
+    if (isNaN(date.getTime())) {
+      return;
+    }
 
     if (formatPref === "iso8601") {
       try {
@@ -2736,7 +2738,7 @@ Behaviour.specify(
           hour12: false,
         });
         element.innerText = isoFormatter.format(date);
-      } catch (e) {
+      } catch {
         const pad = (n) => String(n).padStart(2, "0");
         element.innerText =
           date.getFullYear() +

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2709,3 +2709,45 @@ var layoutUpdateCallback = {
     }
   },
 };
+
+Behaviour.specify(".jenkins-build-timestamp", 'time-formatter', 0, function(element) {
+  const timestampVal = element.getAttribute('data-timestamp');
+  const formatPref = element.getAttribute('data-format');
+
+  if (!timestampVal || formatPref === 'auto') {
+    return;
+  }
+
+  const date = new Date(parseInt(timestampVal));
+  if (isNaN(date.getTime())) return;
+
+  if (formatPref === 'iso8601') {
+    try {
+      const isoFormatter = new Intl.DateTimeFormat('sv-SE', {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', hour12: false
+      });
+      element.innerText = isoFormatter.format(date);
+    } catch(e) {
+      const pad = n => String(n).padStart(2, '0');
+      element.innerText = date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate()) + ' ' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+    }
+    return;
+  }
+
+  let options = {};
+  if (formatPref === '24h') {
+    options = { hour: 'numeric', minute: '2-digit', hour12: false };
+  } else if (formatPref === '12h') {
+    options = { hour: 'numeric', minute: '2-digit', hour12: true };
+  }
+
+  try {
+    const formatter = new Intl.DateTimeFormat(undefined, options);
+    element.innerText = formatter.format(date);
+  } catch (e) {
+    if (window.console && console.debug) {
+      console.debug("Failed to format Jenkins timestamp", e);
+    }
+  }
+});


### PR DESCRIPTION
Fixes ~https://github.com/jenkinsci/jenkins/issues/16804

This change introduces backend support for a user preference that controls build timestamp formatting by adding a UserProperty descriptor and a fillItems endpoint. The backend implementation is complete and verified. However, the preference is not yet reflected in the UI due to Jenkins core JavaScript behavior issues encountered during development, despite multiple attempts to integrate it. A separate follow-up issue can be raised to track the UI-side work.

Steps to verify it:-
1. Run the war file locally
2. Go to this link: http://localhost:8080/descriptorByName/jenkins.model.DateTimePreference/fillTimeFormatItems
3. Confirm that the endpoint returns a ListBoxModel containing all supported timestamp format options.


### Testing done

Ensured all tests still passed.

### Proposed changelog entries

Internal support for configurable build timestamp formatting.

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set, and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
