### PR TITLE
Fix category headers showing as raw HTML on New Item page

### DIFF
--- a/src/main/js/add-item.js
+++ b/src/main/js/add-item.js
@@ -135,8 +135,8 @@ document.addEventListener("DOMContentLoaded", () => {
         $items.append(drawItem(elem));
       });
 
-      $catHeader.append(title);
-      $catHeader.append(description);
+      $catHeader.append(createElementFromHtml(title));
+      $catHeader.append(createElementFromHtml(description));
       $category.append($catHeader);
       $category.append($items);
 


### PR DESCRIPTION
Fixes #26053

When the `flat` class is removed from the items container on the New Item page, category titles and descriptions show up as raw HTML text (like `<h2>Freestyle projects</h2>`) instead of being rendered as proper HTML elements.

This is a regression from PR #10208 which migrated the page from jQuery to vanilla JavaScript. The problem is that jQuery's `.append()` automatically parses HTML strings, but vanilla JS `.append()` treats strings as plain text nodes.

**The fix:** I wrapped the title and description strings with `createElementFromHtml()` before appending them. This function is already imported and used elsewhere in the same file (lines 123, 128, 129), so it follows the existing pattern.

### Testing done

I tested this by:
- Running `node --check` on the file - no syntax errors
- Confirming `createElementFromHtml()` is imported at the top and already used the same way elsewhere in the file
- Successfully building the frontend with `npm run dev` 
- The change is just 2 lines, wrapping existing variables with the helper function

### Screenshots (UI changes only)

#### Before
Categories display as literal HTML strings (`<h2>Freestyle projects</h2><p>This is the central feature...</p>`) instead of rendered elements. This happens when the `flat` class is removed from `div#items` as documented in issue #26053.
<img width="1470" height="787" alt="Screenshot 2026-01-05 at 11 35 43 AM" src="https://github.com/user-attachments/assets/f5672507-e113-4ac7-b1a9-b6c80b32cbd6" />

#### After
Categories render correctly with properly formatted h2 headings and paragraph text.
<img width="1470" height="765" alt="Screenshot 2026-01-05 at 11 37 10 AM" src="https://github.com/user-attachments/assets/083f0dd6-1eff-48ec-9cdf-9a2bd4e5d4f7" />

### Proposed changelog entries

- N/A

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval`.

### Desired reviewers

@daniel-beck @jenkinsci/core-pr-reviewers