### PR TITLE
Removed the dismiss button and added X

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
@@ -27,7 +27,15 @@ THE SOFTWARE.
 <div class="jenkins-alert jenkins-alert-warning">
   <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
     <f:submit name="yes" value="${%Tell me more}"/>
-    <f:submit name="no" value="${%Dismiss}"/>
+      <l:isAdmin>
+        <button type="submit"
+                class="jenkins-button jenkins-button--tertiary"
+                name="no"
+                value="${%Dismiss}"
+                title="${%Dismiss}">
+          <l:icon src="symbol-close"/>
+        </button>
+      </l:isAdmin>
   </form>
   ${%blurb(app.rootDir)}
 </div>

--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
@@ -27,7 +27,15 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <l:isAdmin>
+        <button type="submit"
+                class="jenkins-button jenkins-button--tertiary"
+                name="no"
+                value="${%Dismiss}"
+                title="${%Dismiss}">
+          <l:icon src="symbol-close"/>
+        </button>
+      </l:isAdmin>
     </form>
     ${%You have data stored in an older format and/or unreadable data.}
   </div>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -28,7 +28,12 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
       <l:isAdmin>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <button type="submit"
+                class="jenkins-button jenkins-button--tertiary"
+                value="${%Dismiss}"
+                name="no">
+          <l:icon src="symbol-close"/>
+        </button>
       </l:isAdmin>
     </form>
     <div>${%blurb}</div>

--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
@@ -28,7 +28,12 @@ THE SOFTWARE.
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
         <f:submit name="yes" value="${%Create a view now}"/>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <button type="submit"
+                class="jenkins-button jenkins-button--tertiary"
+                value="${%Dismiss}"
+                name="no">
+          <l:icon src="symbol-close"/>
+        </button>
       </form>
     </l:isAdmin>
     ${%blurb}

--- a/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
+++ b/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
@@ -26,7 +26,13 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:submit value="${%Dismiss}"/>
+      <button type="submit"
+              class="jenkins-button jenkins-button--tertiary"
+              name="no"
+              value="${%Dismiss}"
+              title="${%Dismiss}">
+        <l:icon src="symbol-close"/>
+      </button>
     </form>
     ${%blurb(rootURL)}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
@@ -27,8 +27,13 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
      <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
-     </form>
+      <button type="submit"
+              class="jenkins-button jenkins-button--tertiary"
+              value="${%Dismiss}"
+              name="no">
+        <l:icon src="symbol-close"/>
+      </button>
+      </form>
 
     ${%ExecutorsWarning}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
@@ -28,7 +28,12 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="agent" value="${%Set up agent}"/>
       <f:submit name="cloud" value="${%Set up cloud}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <button type="submit"
+              class="jenkins-button jenkins-button--tertiary"
+              value="${%Dismiss}"
+              name="no">
+        <l:icon src="symbol-close"/>
+      </button>
     </form>
     ${%ExecutorsWarning}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
@@ -26,7 +26,13 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/disable">
-        <f:submit value="${%Dismiss}"/>
+        <button type="submit"
+                class="jenkins-button jenkins-button--tertiary"
+                name="no"
+                value="${%Dismiss}"
+                title="${%Dismiss}">
+          <l:icon src="symbol-close"/>
+        </button>
       </form>
     </l:isAdmin>
     <j:set var="actionAnchor">

--- a/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
@@ -27,8 +27,14 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Setup Security}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
-    </form>
+        <button type="submit"
+                class="jenkins-button jenkins-button--tertiary"
+                name="no"
+                value="${%Dismiss}"
+                title="${%Dismiss}">
+          <l:icon src="symbol-close"/>
+        </button>
+      </form>
     ${%blurb}
   </div>
 </j:jelly>

--- a/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
+++ b/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
@@ -3,7 +3,13 @@
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Apply Migration}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <button type="submit"
+                class="jenkins-button jenkins-button--tertiary"
+                name="no"
+                value="${%Dismiss}"
+                title="${%Dismiss}">
+                <l:icon src="symbol-close"/>
+            </button>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/security/csp/impl/CspRecommendation/message.jelly
+++ b/core/src/main/resources/jenkins/security/csp/impl/CspRecommendation/message.jelly
@@ -22,11 +22,18 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
     <div class="jenkins-alert jenkins-alert-info">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="more" value="${%Learn more}"/>
-            <f:submit name="dismiss" primary="false" value="${%Dismiss}"/>
+        <l:isAdmin>
+            <button type="submit"
+                    class="jenkins-button jenkins-button--tertiary"
+                    value="${%Dismiss}"
+                    name="dismiss">
+              <l:icon src="symbol-close"/>
+            </button>
+        </l:isAdmin>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
@@ -25,7 +25,14 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/disable">
-            <f:submit value="${%Dismiss}"/>
+            <l:isAdmin>
+                <button type="submit"
+                        class="jenkins-button jenkins-button--tertiary"
+                        value="${%Dismiss}"
+                        name="no">
+                <l:icon src="symbol-close"/>
+                </button>
+            </l:isAdmin>
         </form>
         <j:set var="referenceAnchor">
             <a href="https://www.jenkins.io/redirect/csrf-protection" rel="noopener noreferrer" target="_blank">${%referenceUrlContent}</a>


### PR DESCRIPTION
Fixes #18321

### Testing done
Previously: This uses Dismiss button:
<img width="1919" height="713" alt="DismissBefore" src="https://github.com/user-attachments/assets/d8a47c62-5cc3-447d-810c-722fe5820471" />
Now:
Since we have replaced the Dismiss button with X this is the after changes UI:
<img width="1890" height="823" alt="XBefore" src="https://github.com/user-attachments/assets/aa19c86b-0ced-466b-878f-7972a2fa6601" />

Tested the change of deleting physically via UI:
<img width="1899" height="831" alt="XAfter" src="https://github.com/user-attachments/assets/5010c4fc-1af2-42e0-b244-45a9b82459fb" />

Verifying the disabled or not via scripting too!
<img width="1891" height="820" alt="XVerification" src="https://github.com/user-attachments/assets/549017ed-9cb0-4cea-9fc6-a0d0e3f5b829" />

So a clear view of the changed lines in the code reflected accurately in the UI as tested both via UI and scripting
### Screenshots (UI changes only)
These are the same as attached above, added both the before and after states.. right above, not adding them again to reduce the redundancy!!


### Proposed changelog category
/label rfe,web-ui

### Proposed upgrade guidelines
N/A

### Difference between other commits and this one:
1. I have not just updated a single repeatable file instead, worked on the entire admin monitors message.jelly files which are the main reason to get the Dismiss button
2. Others solutions might be working on the css which can potentially lead to changes in other components ui behaviour
3. I have also tested the working of the (X) button via scripting which ensures that the button is triggered to the correct cause
4. The button after clicked creates a /act post request which returns 302 (as expected).

### Submitter checklist

- [X] The issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [X] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [X] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [X] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [X] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [X] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
@mention
Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
