### PR TITLE
Prototype 2.541.1 backport 1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ properties([
 ])
 
 def axes = [
-  platforms: ['linux', 'windows'],
+  platforms: ['linux'],
   jdks: [21, 25],
 ]
 
@@ -128,7 +128,12 @@ axes.values().combinations {
             }
             withChecks(name: 'Tests', includeStage: true) {
               realtimeJUnit(healthScaleFactor: 20.0, testResults: '*/target/surefire-reports/*.xml') {
+                // Only use with replay, not with a commit
+                // sh 'curl -O  https://home.markwaite.net/~mwaite/test-pom.patch && git apply test-pom.patch && git diff'
+                // mavenOptions.add(0, "-Dignore.dirt")
                 infra.runMaven(mavenOptions, jdk)
+                // Only use with replay, not with a commit
+                // sh 'git checkout -- */pom.xml'
                 if (isUnix()) {
                   sh 'git add . && git diff --exit-code HEAD'
                 }
@@ -211,41 +216,6 @@ axes.values().combinations {
             }
           }
         }
-      }
-    }
-  }
-}
-
-def athAxes = [
-  platforms: ['linux'],
-  jdks: [21],
-  browsers: ['firefox'],
-]
-athAxes.values().combinations {
-  def (platform, jdk, browser) = it
-  builds["ath-${platform}-jdk${jdk}-${browser}"] = {
-    retry(conditions: [agent(), nonresumable()], count: 2) {
-      node('docker-highmem') {
-        // Just to be safe
-        deleteDir()
-        checkout scm
-
-        withChecks(name: 'Tests', includeStage: true) {
-          infra.withArtifactCachingProxy {
-            sh "bash ath.sh ${jdk} ${browser}"
-          }
-          junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
-        }
-        /*
-         * Currently disabled, as the fact that this is a manually created subset will confuse Launchable,
-         * which expects this to be a full build. When we implement subsetting, this can be re-enabled using
-         * Launchable's subset rather than our own.
-         */
-        /*
-         withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
-         sh "launchable verify && launchable record tests --no-build --flavor platform=${platform} --flavor jdk=${jdk} --flavor browser=${browser} maven './target/ath-reports'"
-         }
-         */
       }
     }
   }

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -18,6 +18,7 @@
     <mina-sshd.version>2.16.0</mina-sshd.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
+    <test>QuotedStringTokenizerTest</test>
   </properties>
 
   <dependencyManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,7 @@ THE SOFTWARE.
     <remoting.minimum.supported.version>3107.v665000b_51092</remoting.minimum.supported.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
+    <test>EnvVarsTest</test>
   </properties>
 
   <dependencyManagement>

--- a/core/src/main/java/jenkins/security/csp/CspHeader.java
+++ b/core/src/main/java/jenkins/security/csp/CspHeader.java
@@ -24,6 +24,7 @@
 
 package jenkins.security.csp;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 
@@ -35,7 +36,8 @@ import org.kohsuke.accmod.restrictions.Beta;
 @Restricted(Beta.class)
 public enum CspHeader {
     ContentSecurityPolicy("Content-Security-Policy"),
-    ContentSecurityPolicyReportOnly("Content-Security-Policy-Report-Only");
+    ContentSecurityPolicyReportOnly("Content-Security-Policy-Report-Only"),
+    None(null);
 
     private final String headerName;
 
@@ -43,6 +45,7 @@ public enum CspHeader {
         this.headerName = headerName;
     }
 
+    @CheckForNull
     public String getHeaderName() {
         return headerName;
     }

--- a/core/src/main/java/jenkins/security/csp/impl/CspDecorator.java
+++ b/core/src/main/java/jenkins/security/csp/impl/CspDecorator.java
@@ -105,10 +105,11 @@ public class CspDecorator extends PageDecorator {
     }
 
     /**
-     * Determines the name of the HTTP header to set.
+     * Determines the name of the HTTP header to set, or {@code null} if none.
      *
      * @return the name of the HTTP header to set.
      */
+    @CheckForNull
     public String getContentSecurityPolicyHeaderName() {
         final Optional<CspHeaderDecider> decider = CspHeaderDecider.getCurrentDecider();
         if (decider.isPresent()) {

--- a/core/src/main/java/jenkins/security/csp/impl/SystemPropertyHeaderDecider.java
+++ b/core/src/main/java/jenkins/security/csp/impl/SystemPropertyHeaderDecider.java
@@ -25,7 +25,9 @@
 package jenkins.security.csp.impl;
 
 import hudson.Extension;
+import hudson.Util;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -50,7 +52,8 @@ public class SystemPropertyHeaderDecider implements CspHeaderDecider {
         final String systemProperty = SystemProperties.getString(SYSTEM_PROPERTY_NAME);
         if (systemProperty != null) {
             LOGGER.log(Level.FINEST, "Using system property: {0}", new Object[]{ systemProperty });
-            return Arrays.stream(CspHeader.values()).filter(h -> h.getHeaderName().equals(systemProperty)).findFirst();
+            final String expected = Util.fixEmptyAndTrim(systemProperty);
+            return Arrays.stream(CspHeader.values()).filter(h -> Objects.equals(expected, h.getHeaderName())).findFirst();
         }
         return Optional.empty();
     }

--- a/core/src/main/java/jenkins/telemetry/impl/ContentSecurityPolicy.java
+++ b/core/src/main/java/jenkins/telemetry/impl/ContentSecurityPolicy.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.telemetry.impl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import jenkins.security.csp.AdvancedConfigurationDescriptor;
+import jenkins.security.csp.Contributor;
+import jenkins.security.csp.CspBuilder;
+import jenkins.security.csp.CspHeader;
+import jenkins.security.csp.CspHeaderDecider;
+import jenkins.security.csp.impl.CspConfiguration;
+import jenkins.telemetry.Telemetry;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Collect information about Content Security Policy configuration.
+ *
+ */
+@Restricted(NoExternalUse.class)
+@Extension
+public class ContentSecurityPolicy extends Telemetry {
+
+    private static final Logger LOGGER = Logger.getLogger(ContentSecurityPolicy.class.getName());
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Content Security Policy";
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getStart() {
+        return LocalDate.of(2025, 12, 1);
+    }
+
+    @NonNull
+    @Override
+    public LocalDate getEnd() {
+        return LocalDate.of(2026, 6, 1);
+    }
+
+    @Override
+    public JSONObject createContent() {
+        final JSONObject data = new JSONObject();
+        data.put("enforce", ExtensionList.lookupSingleton(CspConfiguration.class).isEnforce());
+        final Optional<CspHeaderDecider> decider = CspHeaderDecider.getCurrentDecider();
+        data.put("decider", decider.map(Object::getClass).map(Class::getName).orElse(null));
+        data.put("header", decider.map(CspHeaderDecider::decide).filter(Optional::isPresent).map(Optional::get).map(CspHeader::getHeaderName).orElse(null));
+
+        Set<String> contributors = new TreeSet<>();
+        ExtensionList.lookup(Contributor.class).stream().map(Contributor::getClass).map(Class::getName).forEach(contributors::add);
+        data.put("contributors", contributors);
+
+        Set<String> configurations = new TreeSet<>();
+        ExtensionList.lookup(AdvancedConfigurationDescriptor.class).stream().map(AdvancedConfigurationDescriptor::getClass).map(Class::getName).forEach(configurations::add);
+        data.put("configurations", configurations);
+
+        try {
+            Map<String, Map<String, Integer>> directivesSize = new CspBuilder().withDefaultContributions().getMergedDirectives().stream()
+                    .map(d -> Map.entry(d.name(), Map.of("entries", d.values().size(), "chars", String.join(" ", d.values()).length())))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            data.put("directivesSize", directivesSize);
+        } catch (RuntimeException ex) {
+            LOGGER.log(Level.FINE, "Error during directive processing", ex);
+        }
+
+        data.put("components", buildComponentInformation());
+        return data;
+    }
+}

--- a/core/src/main/java/jenkins/telemetry/impl/JavaSystemProperties.java
+++ b/core/src/main/java/jenkins/telemetry/impl/JavaSystemProperties.java
@@ -70,13 +70,13 @@ public class JavaSystemProperties extends Telemetry {
     @NonNull
     @Override
     public LocalDate getStart() {
-        return LocalDate.of(2023, 12, 17);
+        return LocalDate.of(2026, 1, 4);
     }
 
     @NonNull
     @Override
     public LocalDate getEnd() {
-        return LocalDate.of(2024, 4, 1);
+        return LocalDate.of(2026, 4, 1);
     }
 
     @Override

--- a/core/src/main/resources/hudson/model/Run/console-log.jelly
+++ b/core/src/main/resources/hudson/model/Run/console-log.jelly
@@ -29,7 +29,7 @@
     </j:when>
     <!-- output is completed now. -->
     <j:otherwise>
-      <pre class="console-output">
+      <pre id="out" class="console-output">
         <st:getOutput var="output" />
         <j:whitespace>${it.writeLogTo(offset,output)}</j:whitespace>
       </pre>

--- a/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
+++ b/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
@@ -27,10 +27,11 @@ THE SOFTWARE.
     <l:header />
     <l:side-panel>
         <l:tasks>
-            <l:task contextMenu="false" href="." icon="symbol-computer" title="${%Status}"/>
-            <l:task href="configure" icon="symbol-settings"
+            <j:set var="url" value="${h.getNearestAncestorUrl(request2,it)}"/>
+            <l:task contextMenu="false" href="${url}/" icon="symbol-computer" title="${%Status}"/>
+            <l:task href="${url}/configure" icon="symbol-settings"
                     title="${app.hasPermission(app.ADMINISTER) ? '%Configure' : '%View Configuration'}"/>
-            <l:delete permission="${app.ADMINISTER}" title="${%Delete Cloud}" message="${%delete.cloud(it.displayName)}"/>
+            <l:delete permission="${app.ADMINISTER}" title="${%Delete Cloud}" message="${%delete.cloud(it.displayName)}" urlPrefix="${url}"/>
             <t:actions />
         </l:tasks>
         <j:forEach var="action" items="${it.allActions}">

--- a/core/src/main/resources/jenkins/security/csp/impl/CspDecorator/httpHeaders.jelly
+++ b/core/src/main/resources/jenkins/security/csp/impl/CspDecorator/httpHeaders.jelly
@@ -23,6 +23,9 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
-    <st:setHeader name="${it.getContentSecurityPolicyHeaderName()}" value="${it.getContentSecurityPolicyHeaderValue(request2)}" />
-    <st:setHeader name="Reporting-Endpoints" value="${it.getReportingEndpointsHeaderValue(request2)}" />
+    <j:set var="cspHeaderName" value="${it.getContentSecurityPolicyHeaderName()}"/>
+    <j:if test="${cspHeaderName != null}">
+        <st:setHeader name="${cspHeaderName}" value="${it.getContentSecurityPolicyHeaderValue(request2)}" />
+        <st:setHeader name="Reporting-Endpoints" value="${it.getReportingEndpointsHeaderValue(request2)}" />
+    </j:if>
 </j:jelly>

--- a/core/src/main/resources/jenkins/security/csp/impl/SystemPropertyHeaderDecider/message.jelly
+++ b/core/src/main/resources/jenkins/security/csp/impl/SystemPropertyHeaderDecider/message.jelly
@@ -23,5 +23,14 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:description>${%blurb(it.headerName)}</f:description>
+    <f:description>
+        <j:choose>
+            <j:when test="${it.headerName != null}">
+                ${%blurb(it.headerName)}
+            </j:when>
+            <j:otherwise>
+                ${%blurbUnset}
+            </j:otherwise>
+        </j:choose>
+    </f:description>
 </j:jelly>

--- a/core/src/main/resources/jenkins/security/csp/impl/SystemPropertyHeaderDecider/message.properties
+++ b/core/src/main/resources/jenkins/security/csp/impl/SystemPropertyHeaderDecider/message.properties
@@ -1,2 +1,4 @@
 blurb = Content Security Policy is configured to use the HTTP header <code>{0}</code> based on the system property <code>jenkins.security.csp.CspHeader.headerName</code>. \
-    It cannot be configured through the UI while this system property specifies a header name.
+    It cannot be configured through the UI while this system property is set.
+blurbUnset = Content Security Policy is disabled based on the system property <code>jenkins.security.csp.CspHeader.headerName</code>. \
+    It cannot be configured through the UI while this system property is set.

--- a/core/src/main/resources/jenkins/telemetry/impl/ContentSecurityPolicy/description.jelly
+++ b/core/src/main/resources/jenkins/telemetry/impl/ContentSecurityPolicy/description.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    This trial collects basic information about the current configuration of Content Security Policy (CSP):
+    <ul>
+        <li>Whether the user-facing configuration option is set to enforce CSP</li>
+        <li>The active <code>CspHeaderDecider</code>, which roughly corresponds to how Jenkins is run and whether system properties related to CSP are set</li>
+        <li>The current Content Security Policy header (<code>Content-Security-Policy</code> or <code>Content-Security-Policy-Report-Only</code>)</li>
+        <li>Which <code>Contributor</code>s are known, i.e., extensions that contribute to the CSP rules</li>
+        <li>Which <code>AdvancedConfiguration</code>s are known, i.e., extensions that add CSP configuration options</li>
+        <li>Which directives (e.g., <code>img-src</code>) are set, and the length in bytes of their values</li>
+    </ul>
+
+    <p>
+        <strong>This trial does not collect the actual CSP rules.</strong>
+    </p>
+    <p>
+        Additionally this trial collects the list of installed plugins, their version, and the version of Jenkins.
+        This data will be used to understand how widely CSP protection is used.
+    </p>
+</j:jelly>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.1023.v8b_42b_1b_79b_f7</winstone.version>
+    <winstone.version>8.1026.v31def012a_f48</winstone.version>
     <node.version>24.11.1</node.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.1026.v31def012a_f48</winstone.version>
+    <winstone.version>8.1027.v84c818db_a_b_b_b_</winstone.version>
     <node.version>24.11.1</node.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ THE SOFTWARE.
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
-    <winstone.version>8.1027.v84c818db_a_b_b_b_</winstone.version>
+    <winstone.version>8.1029.vd3071f6b_5988</winstone.version>
     <node.version>24.11.1</node.version>
   </properties>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -52,6 +52,8 @@ THE SOFTWARE.
 
     <!-- Filled in by maven-hpi-plugin with "-javaagent:/path/to/mockito-core-<version>.jar" -->
     <jenkins.javaAgent />
+
+    <test>hudson.AboutJenkinsTest</test>
   </properties>
 
   <dependencyManagement>

--- a/test/src/test/java/jenkins/security/csp/WinstoneResponseHeaderLengthTest.java
+++ b/test/src/test/java/jenkins/security/csp/WinstoneResponseHeaderLengthTest.java
@@ -1,0 +1,44 @@
+package jenkins.security.csp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.is;
+
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
+
+public class WinstoneResponseHeaderLengthTest {
+
+    @RegisterExtension
+    public RealJenkinsExtension extension = new RealJenkinsExtension().addSyntheticPlugin(new RealJenkinsExtension.SyntheticPlugin(jenkins.security.csp.winstoneResponseHeaderLengthTest.ContributorImpl.class));
+
+    @Test
+    void testLength() throws Exception {
+        extension.startJenkins();
+        String lastHeader = "";
+        try (WebClient wc = new WebClient()) {
+            // Hopefully speed this up a bit:
+            wc.getOptions().setJavaScriptEnabled(false);
+            wc.getOptions().setCssEnabled(false);
+            wc.getOptions().setDownloadImages(false);
+            wc.getPage(extension.getUrl()); // request once outside try/catch to ensure it works in principle
+            try {
+                while (true) {
+                    final HtmlPage htmlPage = wc.getPage(extension.getUrl());
+                    lastHeader = htmlPage.getWebResponse().getResponseHeaderValue("Content-Security-Policy");
+                }
+            } catch (FailingHttpStatusCodeException e) {
+                assertThat(e.getStatusCode(), is(500));
+                assertThat(e.getResponse().getContentAsString(), containsString("Error 500 Response Header Fields Too Large"));
+
+                assertThat(lastHeader, hasLength(greaterThan(30_000)));
+            }
+        }
+    }
+}

--- a/test/src/test/java/jenkins/security/csp/winstoneResponseHeaderLengthTest/ContributorImpl.java
+++ b/test/src/test/java/jenkins/security/csp/winstoneResponseHeaderLengthTest/ContributorImpl.java
@@ -1,0 +1,28 @@
+package jenkins.security.csp.winstoneResponseHeaderLengthTest;
+
+import hudson.Extension;
+import jenkins.model.Jenkins;
+import jenkins.security.csp.Contributor;
+import jenkins.security.csp.CspBuilder;
+import jenkins.security.csp.Directive;
+
+public class ContributorImpl implements Contributor {
+    private int count = 0;
+
+    @Override
+    public void apply(CspBuilder cspBuilder) {
+        count++;
+        for (int i = 0; i < count; i++) {
+            cspBuilder.add(Directive.IMG_SRC, "img" + i + ".example.com");
+        }
+    }
+
+    @Extension
+    public static ContributorImpl getInstance() {
+        // Only load this extension if it's in the synthetic plugin, otherwise it will affect other tests
+        if (Jenkins.get().getPluginManager().whichPlugin(ContributorImpl.class) == null) {
+            return null;
+        }
+        return new ContributorImpl();
+    }
+}

--- a/test/src/test/java/jenkins/telemetry/impl/ContentSecurityPolicyTest.java
+++ b/test/src/test/java/jenkins/telemetry/impl/ContentSecurityPolicyTest.java
@@ -1,0 +1,68 @@
+package jenkins.telemetry.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import hudson.ExtensionList;
+import hudson.model.FreeStyleProject;
+import jenkins.security.csp.AvatarContributor;
+import jenkins.security.csp.Contributor;
+import jenkins.security.csp.CspBuilder;
+import jenkins.security.csp.CspHeader;
+import jenkins.security.csp.Directive;
+import jenkins.security.csp.impl.BaseContributor;
+import jenkins.security.csp.impl.CompatibleContributor;
+import jenkins.security.csp.impl.DevelopmentHeaderDecider;
+import jenkins.security.csp.impl.UserAvatarContributor;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+public class ContentSecurityPolicyTest {
+
+    @Test
+    void basics(JenkinsRule j) { // arg required to actually get a Jenkins
+        final ContentSecurityPolicy csp = ExtensionList.lookupSingleton(ContentSecurityPolicy.class);
+        final JSONObject content = csp.createContent();
+        assertThat(content.get("enforce"), is(false));
+        assertThat(content.get("decider"), is(DevelopmentHeaderDecider.class.getName()));
+        assertThat(content.get("header"), is(CspHeader.ContentSecurityPolicy.getHeaderName()));
+        assertThat(content.getJSONArray("contributors"),
+                containsInAnyOrder(BaseContributor.class.getName(), CompatibleContributor.class.getName(), AvatarContributor.class.getName(), UserAvatarContributor.class.getName()));
+        assertThat(content.getJSONArray("configurations"), is(empty()));
+        final JSONObject directivesSize = content.getJSONObject("directivesSize");
+        assertThat(directivesSize.keySet(), containsInAnyOrder(Directive.DEFAULT_SRC, Directive.SCRIPT_SRC, Directive.STYLE_SRC, Directive.IMG_SRC, Directive.FORM_ACTION, Directive.BASE_URI, Directive.FRAME_ANCESTORS));
+        assertThat(directivesSize.getJSONObject(Directive.IMG_SRC).get("entries"), is(2));
+        assertThat(directivesSize.getJSONObject(Directive.IMG_SRC).get("chars"), is(12)); // 'self' data:
+        assertThat(directivesSize.getJSONObject(Directive.SCRIPT_SRC).get("entries"), is(2));
+        assertThat(directivesSize.getJSONObject(Directive.SCRIPT_SRC).get("chars"), is(22)); // 'self' 'report-sample'
+    }
+
+
+    @Test
+    void withContributors(JenkinsRule j) throws Exception {
+        final FreeStyleProject freeStyleProject = j.createFreeStyleProject();
+
+        final ContentSecurityPolicy csp = ExtensionList.lookupSingleton(ContentSecurityPolicy.class);
+        final JSONObject content = csp.createContent();
+        final JSONObject directivesSize = content.getJSONObject("directivesSize");
+        assertThat(directivesSize.keySet(), containsInAnyOrder(Directive.DEFAULT_SRC, Directive.SCRIPT_SRC, Directive.STYLE_SRC, Directive.IMG_SRC, Directive.FORM_ACTION, Directive.BASE_URI, Directive.FRAME_ANCESTORS));
+        assertThat(directivesSize.getJSONObject(Directive.IMG_SRC).get("entries"), is(3));
+        assertThat(directivesSize.getJSONObject(Directive.IMG_SRC).get("chars"), is(28)); // 'self' data: img.example.com
+        assertThat(directivesSize.getJSONObject(Directive.SCRIPT_SRC).get("entries"), is(2));
+        assertThat(directivesSize.getJSONObject(Directive.SCRIPT_SRC).get("chars"), is(22)); // 'self' 'report-sample'
+    }
+
+    @TestExtension("withContributors")
+    public static class TestContributor implements Contributor {
+        @Override
+        public void apply(CspBuilder cspBuilder) {
+            cspBuilder.add(Directive.IMG_SRC, "img.example.com");
+        }
+    }
+}

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -661,7 +661,7 @@ THE SOFTWARE.
           contains a version of Jetty that is older than this, trigger Dependabot in jenkinsci/winstone and release the
           result before proceeding with the update here.
         -->
-        <version>12.1.4</version>
+        <version>12.1.5</version>
         <configuration>
           <!--
             Reload webapp when you hit ENTER. (See JETTY-282 for more)


### PR DESCRIPTION
## Prototype of 2.541.1 based on current (wrong) stable-2.541

Draft - do not merge.  Needs much more analysis to confirm it is correct and complete

Backports the following issues and matching pull requests:

* #23900  
    * #23901 
* #23914 
  * #23915 
* #25900 
  * #23909
  * #25901 
* #25958 
  * #25968 
* #25976 
  * #25953 
* #26002 
  * #26004
* #26040 
  * #26038

### Testing done

None.  Using ci.jenkins.io to build it so that I can do more checks later.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
