### PR TITLE
Check security tests on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,41 +216,6 @@ axes.values().combinations {
   }
 }
 
-def athAxes = [
-  platforms: ['linux'],
-  jdks: [21],
-  browsers: ['firefox'],
-]
-athAxes.values().combinations {
-  def (platform, jdk, browser) = it
-  builds["ath-${platform}-jdk${jdk}-${browser}"] = {
-    retry(conditions: [agent(), nonresumable()], count: 2) {
-      node('docker-highmem') {
-        // Just to be safe
-        deleteDir()
-        checkout scm
-
-        withChecks(name: 'Tests', includeStage: true) {
-          infra.withArtifactCachingProxy {
-            sh "bash ath.sh ${jdk} ${browser}"
-          }
-          junit testResults: 'target/ath-reports/TEST-*.xml', testDataPublishers: [[$class: 'AttachmentPublisher']]
-        }
-        /*
-         * Currently disabled, as the fact that this is a manually created subset will confuse Launchable,
-         * which expects this to be a full build. When we implement subsetting, this can be re-enabled using
-         * Launchable's subset rather than our own.
-         */
-        /*
-         withCredentials([string(credentialsId: 'launchable-jenkins-acceptance-test-harness', variable: 'LAUNCHABLE_TOKEN')]) {
-         sh "launchable verify && launchable record tests --no-build --flavor platform=${platform} --flavor jdk=${jdk} --flavor browser=${browser} maven './target/ath-reports'"
-         }
-         */
-      }
-    }
-  }
-}
-
 builds.failFast = failFast
 parallel builds
 infra.maybePublishIncrementals()

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -18,6 +18,7 @@
     <mina-sshd.version>2.16.0</mina-sshd.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
+    <test>QuotedStringTokenizerTest</test>
   </properties>
 
   <dependencyManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,7 @@ THE SOFTWARE.
     <remoting.minimum.supported.version>3176.v207ec082a_8c0</remoting.minimum.supported.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
+    <test>EnvVarsTest</test>
   </properties>
 
   <dependencyManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
     <remoting.minimum.supported.version>3176.v207ec082a_8c0</remoting.minimum.supported.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
-    <test>EnvVarsTest</test>
+    <test>Security*</test>
   </properties>
 
   <dependencyManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
     <remoting.minimum.supported.version>3176.v207ec082a_8c0</remoting.minimum.supported.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
-    <test>AboutJenkins</test>
+    <test>EnvVarsTest</test>
   </properties>
 
   <dependencyManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
     <remoting.minimum.supported.version>3176.v207ec082a_8c0</remoting.minimum.supported.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
-    <test>Security*</test>
+    <test>AboutJenkins</test>
   </properties>
 
   <dependencyManagement>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -52,6 +52,8 @@ THE SOFTWARE.
 
     <!-- Filled in by maven-hpi-plugin with "-javaagent:/path/to/mockito-core-<version>.jar" -->
     <jenkins.javaAgent />
+
+    <test>hudson.AboutJenkinsTest</test>
   </properties>
 
   <dependencyManagement>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -53,7 +53,7 @@ THE SOFTWARE.
     <!-- Filled in by maven-hpi-plugin with "-javaagent:/path/to/mockito-core-<version>.jar" -->
     <jenkins.javaAgent />
 
-    <test>hudson.AboutJenkinsTest</test>
+    <test>Security*</test>
   </properties>
 
   <dependencyManagement>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -53,7 +53,7 @@ THE SOFTWARE.
     <!-- Filled in by maven-hpi-plugin with "-javaagent:/path/to/mockito-core-<version>.jar" -->
     <jenkins.javaAgent />
 
-    <test>Security*</test>
+    <test>Security914*</test>
   </properties>
 
   <dependencyManagement>

--- a/test/src/test/java/jenkins/security/stapler/Security914Test.java
+++ b/test/src/test/java/jenkins/security/stapler/Security914Test.java
@@ -55,12 +55,12 @@ class Security914Test {
     void cannotUseInvalidLocale_toTraverseFolder() throws Exception {
         assumeTrue(Functions.isWindows());
 
-        assertNotNull(j.getPluginManager().getPlugin("credentials"));
-        j.createWebClient().goTo("plugin/credentials/images/credentials.svg", "image/svg+xml");
+        assertNotNull(j.getPluginManager().getPlugin("maven-plugin"));
+        j.createWebClient().goTo("plugin/maven-plugin/images/mavenmoduleset.svg", "image/svg+xml");
 
         JenkinsRule.WebClient wc = j.createWebClient()
                 .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/credentials/.xml").toURL());
+        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/maven-plugin/.xml").toURL());
         // plugin deployed in: test\target\jenkins7375296945862059919tmp
         // rootDir is in     : test\target\jenkinsTests.tmp\jenkins1274934531848159942test
         // j.jenkins.getRootDir().getName() = jenkins1274934531848159942test

--- a/test/src/test/java/jenkins/security/stapler/Security914Test.java
+++ b/test/src/test/java/jenkins/security/stapler/Security914Test.java
@@ -55,12 +55,12 @@ class Security914Test {
     void cannotUseInvalidLocale_toTraverseFolder() throws Exception {
         assumeTrue(Functions.isWindows());
 
-        assertNotNull(j.getPluginManager().getPlugin("maven-plugin"));
-        j.createWebClient().goTo("plugin/maven-plugin/images/mavenmoduleset.svg", "image/svg+xml");
+        assertNotNull(j.getPluginManager().getPlugin("matrix-project"));
+        j.createWebClient().goTo("plugin/matrix-project/images/matrixproject.svg", "image/svg+xml");
 
         JenkinsRule.WebClient wc = j.createWebClient()
                 .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/maven-plugin/.xml").toURL());
+        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/matrix-project/.xml").toURL());
         // plugin deployed in: test\target\jenkins7375296945862059919tmp
         // rootDir is in     : test\target\jenkinsTests.tmp\jenkins1274934531848159942test
         // j.jenkins.getRootDir().getName() = jenkins1274934531848159942test

--- a/test/src/test/java/jenkins/security/stapler/Security914Test.java
+++ b/test/src/test/java/jenkins/security/stapler/Security914Test.java
@@ -75,12 +75,12 @@ class Security914Test {
     void cannotUseInvalidLocale_toAnyFileInSystem() throws Exception {
         assumeTrue(Functions.isWindows());
 
-        assertNotNull(j.getPluginManager().getPlugin("credentials"));
-        j.createWebClient().goTo("plugin/credentials/images/credentials.svg", "image/svg+xml");
+        assertNotNull(j.getPluginManager().getPlugin("matrix-project"));
+        j.createWebClient().goTo("plugin/matrix-project/images/matrixproject.svg", "image/svg+xml");
 
         JenkinsRule.WebClient wc = j.createWebClient()
                 .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/credentials/.ini").toURL());
+        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/matrix-project/.ini").toURL());
         // ../ can be multiply to infinity, no impact, we just need to have enough to reach the root
         request.setAdditionalHeader("Accept-Language", "../../../../../../../../../../../../windows/win");
 


### PR DESCRIPTION
## Check security tests on master branch

Do not merge.

A few builds of the master branch have reported failures in one or more of the security tests on Windows.  Rather than wait for the long test time on Windows, this draft pull request will only run the security tests, skipping ATH and skipping other tests.

### Testing done

Confirmed that tests run locally on my Linux computer with Java 21.  Rely on ci.jenkins.io for Windows

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
