### PR TITLE
Jenkins 36720 spotbugs cleanup

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -37,6 +37,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.User;
@@ -201,7 +202,12 @@ public class BuildCommand extends CLICommand {
                     }
                     f.get();    // wait for the completion
                     stdout.println("Completed " + b.getFullDisplayName() + " : " + b.getResult());
-                    return b.getResult().ordinal;
+                    Result result = b.getResult();
+                    if (result != null) {
+                        return result.ordinal;
+                    } else {
+                        return -1;
+                    }
                 } catch (InterruptedException e) {
                     if (follow) {
                         return 125;

--- a/core/src/main/java/hudson/cli/DeleteNodeCommand.java
+++ b/core/src/main/java/hudson/cli/DeleteNodeCommand.java
@@ -26,6 +26,7 @@ package hudson.cli;
 
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.model.Computer;
 import hudson.model.Node;
 import java.util.HashSet;
 import java.util.List;
@@ -68,7 +69,11 @@ public class DeleteNodeCommand extends CLICommand {
                     throw new IllegalArgumentException("No such node '" + node_s + "'");
                 }
 
-                node.toComputer().doDoDelete();
+                Computer computer = node.toComputer();
+                if (computer == null) {
+                    throw new IllegalStateException("Node '" + node_s + "' has no computer associated with it");
+                }
+                computer.doDoDelete();
             } catch (Exception e) {
                 if (hs.size() == 1) {
                     throw e;

--- a/core/src/spotbugs/excludesFilter.xml
+++ b/core/src/spotbugs/excludesFilter.xml
@@ -61,7 +61,6 @@
       <And>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
         <Or>
-          <Class name="hudson.cli.BuildCommand"/>
           <Class name="hudson.cli.DeleteNodeCommand"/>
           <Class name="hudson.cli.UpdateNodeCommand"/>
           <Class name="hudson.cli.WaitNodeOfflineCommand"/>

--- a/core/src/spotbugs/excludesFilter.xml
+++ b/core/src/spotbugs/excludesFilter.xml
@@ -61,7 +61,7 @@
       <And>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
         <Or>
-          <Class name="hudson.cli.DeleteNodeCommand"/>
+<!--          <Class name="hudson.cli.DeleteNodeCommand"/>-->
           <Class name="hudson.cli.UpdateNodeCommand"/>
           <Class name="hudson.cli.WaitNodeOfflineCommand"/>
           <Class name="hudson.cli.WaitNodeOnlineCommand"/>


### PR DESCRIPTION
Fixes [JENKINS-36720](https://issues.jenkins.io/browse/JENKINS-36720).

### Description

This PR contributes to fixing the SpotBugs technical debt in the CLI module. In this PR, the fix is for the potential NPE in BuildCommand.java and DeleteNodeCommand.java

**Changes:**

1. **`hudson.cli.BuildCommand.java`**:
* The `run()` method was accessing `.ordinal` on `b.getResult()`.
* **Fix:** Added a null check. If the result is null, it now returns `-1` instead of throwing an NPE.


2. **`hudson.cli.DeleteNodeCommand.java`**:
* The `run()` method was calling `.doDoDelete()` on `node.toComputer()`.
* **Fix:** Added a null check. If the computer is null, it now throws an `IllegalStateException`. This allows the existing `catch` block to handle the error, print it to stderr, and continue the loop to process other nodes.


3. **`excludesFilter.xml`**:
* Removed the now-resolved exclusions for these two classes.



### Testing done

Verified that the changes compile and pass static analysis locally.

* Executed `mvn spotbugs:check` -> **BUILD SUCCESS** (0 bugs found).
* Executed `mvn test -pl core` -> **BUILD SUCCESS**.

No new unit tests were added as these are safety checks for race conditions/edge cases that are difficult to reproduce in a unit test environment without mocking internal core states.

### Screenshots (UI changes only)

N/A

### Proposed changelog entries

* Fix potential NullPointerExceptions in CLI `build` and `delete-node` commands reported by SpotBugs.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

* [x] The issue, if it exists, is well-described.
* [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [[examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
* [x] There is automated testing or an explanation as to why this change has no tests.
* [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
* [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
* [ ] UI changes do not introduce regressions when enforcing the current default rules of [[Content Security Policy Plugin](https://plugins.jenkins.io/csp/)](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [[documentation](https://www.jenkins.io/doc/developer/security/csp/)](https://www.jenkins.io/doc/developer/security/csp/)).
* [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
* [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
