### PR TITLE
Enable automatic proxy configuration from JVM system properties

### DIFF
--- a/core/src/main/java/hudson/ProxyConfiguration.java
+++ b/core/src/main/java/hudson/ProxyConfiguration.java
@@ -679,7 +679,9 @@ public final class ProxyConfiguration implements Describable<ProxyConfiguration>
         if (portStr != null && !portStr.trim().isEmpty()) {
             try {
                 port = Integer.parseInt(portStr.trim());
-            } catch (NumberFormatException ignore) {}
+            } catch (NumberFormatException ignore) {
+                // ignore invalid port value and fall back to default
+            }
         }
 
         String user = SystemProperties.getString("https.proxyUser");

--- a/test/src/test/java/hudson/ProxyConfigurationSystemPropertiesTest.java
+++ b/test/src/test/java/hudson/ProxyConfigurationSystemPropertiesTest.java
@@ -113,7 +113,7 @@ class ProxyConfigurationSystemPropertiesTest {
     private void clearProxyProperties() {
         String[] keys = {
             "http.proxyHost", "http.proxyPort", "http.proxyUser", "http.proxyPassword", "http.nonProxyHosts",
-            "https.proxyHost", "https.proxyPort", "https.proxyUser", "https.proxyPassword"
+            "https.proxyHost", "https.proxyPort", "https.proxyUser", "https.proxyPassword",
         };
         for (String k : keys) {
             System.clearProperty(k);

--- a/test/src/test/java/hudson/ProxyConfigurationSystemPropertiesTest.java
+++ b/test/src/test/java/hudson/ProxyConfigurationSystemPropertiesTest.java
@@ -1,0 +1,108 @@
+package hudson;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ProxyConfigurationSystemPropertiesTest {
+
+    private Properties originalProperties;
+
+    @BeforeEach
+    void backupProperties() {
+        originalProperties = (Properties) System.getProperties().clone();
+        clearProxyProperties();
+    }
+
+    @AfterEach
+    void restoreProperties() {
+        System.setProperties(originalProperties);
+    }
+
+    @Test
+    void returnsNullWhenNoPropertiesSet() {
+        ProxyConfiguration cfg = ProxyConfiguration.createFromSystemProperties();
+        assertThat(cfg, is(nullValue()));
+    }
+
+    @Test
+    void usesHttpProperties() {
+        System.setProperty("http.proxyHost", "http.example.com");
+        System.setProperty("http.proxyPort", "8080");
+        System.setProperty("http.proxyUser", "httpUser");
+        System.setProperty("http.proxyPassword", "httpPass");
+        System.setProperty("http.nonProxyHosts", "localhost|*.internal");
+
+        ProxyConfiguration cfg = ProxyConfiguration.createFromSystemProperties();
+
+        assertThat(cfg, notNullValue());
+        assertThat(cfg.getName(), is("http.example.com"));
+        assertThat(cfg.getPort(), is(8080));
+        assertThat(cfg.getUserName(), is("httpUser"));
+        assertThat(cfg.getSecretPassword().getPlainText(), is("httpPass"));
+        assertThat(cfg.getNoProxyHost(), is("localhost|*.internal"));
+    }
+
+    @Test
+    void httpsOverridesHttpWhenPresent() {
+        System.setProperty("http.proxyHost", "http.example.com");
+        System.setProperty("http.proxyPort", "8080");
+        System.setProperty("https.proxyHost", "https.example.com");
+        System.setProperty("https.proxyPort", "8443");
+
+        ProxyConfiguration cfg = ProxyConfiguration.createFromSystemProperties();
+
+        assertThat(cfg, notNullValue());
+        assertThat(cfg.getName(), is("https.example.com"));
+        assertThat(cfg.getPort(), is(8443));
+    }
+
+    @Test
+    void invalidPortFallsBackToDefault() {
+        System.setProperty("http.proxyHost", "http.example.com");
+        System.setProperty("http.proxyPort", "NOT_A_NUMBER");
+
+        ProxyConfiguration cfg = ProxyConfiguration.createFromSystemProperties();
+
+        assertThat(cfg, notNullValue());
+        assertThat(cfg.getPort(), is(80));
+    }
+
+    @Test
+    void trimsWhitespaceFromHostAndPort() {
+        System.setProperty("http.proxyHost", "  trimmed.example.com  ");
+        System.setProperty("http.proxyPort", "  9090  ");
+
+        ProxyConfiguration cfg = ProxyConfiguration.createFromSystemProperties();
+
+        assertThat(cfg, notNullValue());
+        assertThat(cfg.getName(), is("trimmed.example.com"));
+        assertThat(cfg.getPort(), is(9090));
+    }
+
+    private void clearProxyProperties() {
+        String[] keys = {
+            "http.proxyHost", "http.proxyPort", "http.proxyUser", "http.proxyPassword", "http.nonProxyHosts",
+            "https.proxyHost", "https.proxyPort", "https.proxyUser", "https.proxyPassword"
+        };
+        for (String k : keys) {
+            System.clearProperty(k);
+        }
+    }
+
+    @Test
+    void whitespaceOnlyHostIsTreatedAsMissing() {
+        System.setProperty("http.proxyHost", "   ");
+
+        ProxyConfiguration cfg = ProxyConfiguration.createFromSystemProperties();
+
+        assertThat(cfg, is(nullValue()));
+    }
+
+}

--- a/test/src/test/java/hudson/ProxyConfigurationSystemPropertiesTest.java
+++ b/test/src/test/java/hudson/ProxyConfigurationSystemPropertiesTest.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package hudson;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/test/src/test/java/hudson/ProxyConfigurationSystemPropertiesTest.java
+++ b/test/src/test/java/hudson/ProxyConfigurationSystemPropertiesTest.java
@@ -36,17 +36,33 @@ import org.junit.jupiter.api.Test;
 
 class ProxyConfigurationSystemPropertiesTest {
 
-    private Properties originalProperties;
+    private static final String[] PROXY_KEYS = {
+        "http.proxyHost", "http.proxyPort", "http.proxyUser", "http.proxyPassword", "http.nonProxyHosts",
+        "https.proxyHost", "https.proxyPort", "https.proxyUser", "https.proxyPassword",
+    };
+
+    private Properties saved;
 
     @BeforeEach
-    void backupProperties() {
-        originalProperties = (Properties) System.getProperties().clone();
-        clearProxyProperties();
+    void saveAndClear() {
+        saved = new Properties();
+        for (String k : PROXY_KEYS) {
+            String v = System.getProperty(k);
+            if (v != null) {
+                saved.setProperty(k, v);
+            }
+            System.clearProperty(k);
+        }
     }
 
     @AfterEach
-    void restoreProperties() {
-        System.setProperties(originalProperties);
+    void restore() {
+        for (String k : PROXY_KEYS) {
+            System.clearProperty(k);
+        }
+        for (String k : saved.stringPropertyNames()) {
+            System.setProperty(k, saved.getProperty(k));
+        }
     }
 
     @Test
@@ -108,16 +124,6 @@ class ProxyConfigurationSystemPropertiesTest {
         assertThat(cfg, notNullValue());
         assertThat(cfg.getName(), is("trimmed.example.com"));
         assertThat(cfg.getPort(), is(9090));
-    }
-
-    private void clearProxyProperties() {
-        String[] keys = {
-            "http.proxyHost", "http.proxyPort", "http.proxyUser", "http.proxyPassword", "http.nonProxyHosts",
-            "https.proxyHost", "https.proxyPort", "https.proxyUser", "https.proxyPassword",
-        };
-        for (String k : keys) {
-            System.clearProperty(k);
-        }
     }
 
     @Test


### PR DESCRIPTION
Fixes ~https://github.com/jenkinsci/jenkins/issues/16780

Enable automatic proxy configuration from JVM system properties during initial setup to prevent hangs in restricted network environments. Previously, Jenkins ignored standard flags such as -Dhttp.proxyHost and -Dhttps.proxyHost until a proxy.xml file was created, which could cause connection timeouts on first startup. This change provides a fallback to those system properties when no persisted proxy configuration is present.

### Testing done

Ensured all tests still passed.

### Proposed changelog entries

Jenkins now applies standard JVM proxy system properties during the initial startup when no proxy configuration is present.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set, and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

### Desired reviewers

@jenkinsci/core-pr-reviewers
