### PR TITLE
Use Matrix Project Plugin in Security914Test, not Credentials Plugin

### DIFF
--- a/test/src/test/java/jenkins/security/stapler/Security914Test.java
+++ b/test/src/test/java/jenkins/security/stapler/Security914Test.java
@@ -55,12 +55,12 @@ class Security914Test {
     void cannotUseInvalidLocale_toTraverseFolder() throws Exception {
         assumeTrue(Functions.isWindows());
 
-        assertNotNull(j.getPluginManager().getPlugin("credentials"));
-        j.createWebClient().goTo("plugin/credentials/images/credentials.svg", "image/svg+xml");
+        assertNotNull(j.getPluginManager().getPlugin("matrix-project"));
+        j.createWebClient().goTo("plugin/matrix-project/images/matrixproject.svg", "image/svg+xml");
 
         JenkinsRule.WebClient wc = j.createWebClient()
                 .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/credentials/.xml").toURL());
+        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/matrix-project/.xml").toURL());
         // plugin deployed in: test\target\jenkins7375296945862059919tmp
         // rootDir is in     : test\target\jenkinsTests.tmp\jenkins1274934531848159942test
         // j.jenkins.getRootDir().getName() = jenkins1274934531848159942test
@@ -75,12 +75,12 @@ class Security914Test {
     void cannotUseInvalidLocale_toAnyFileInSystem() throws Exception {
         assumeTrue(Functions.isWindows());
 
-        assertNotNull(j.getPluginManager().getPlugin("credentials"));
-        j.createWebClient().goTo("plugin/credentials/images/credentials.svg", "image/svg+xml");
+        assertNotNull(j.getPluginManager().getPlugin("matrix-project"));
+        j.createWebClient().goTo("plugin/matrix-project/images/matrixproject.svg", "image/svg+xml");
 
         JenkinsRule.WebClient wc = j.createWebClient()
                 .withThrowExceptionOnFailingStatusCode(false);
-        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/credentials/.ini").toURL());
+        WebRequest request = new WebRequest(new URI(j.getURL() + "plugin/matrix-project/.ini").toURL());
         // ../ can be multiply to infinity, no impact, we just need to have enough to reach the root
         request.setAdditionalHeader("Accept-Language", "../../../../../../../../../../../../windows/win");
 


### PR DESCRIPTION
## Use Matrix Project Plugin in Security914Test, not Credentials Plugin

Fixes issue:

* #26088

The user interface update to the Credentials plugin in pull request:

* https://github.com/jenkinsci/credentials-plugin/issues/990

removed the image that this test used for its initial configuration.

The change was released in Credentials plugin:

* https://github.com/jenkinsci/credentials-plugin/releases/tag/1460.v48765a_c7d849

The new release of the Credentials plugin was included in Jenkins core 2.545 with pull request: 

* https://github.com/jenkinsci/jenkins/pull/26046

This change switches from the Credentials plugin to the Matrix Project plugin as the base for the test.  The assumption is that user interface changes are less likely to the Matrix Project plugin.

### Testing done

* Confirmed that the tests fail on Windows without this change
* Confirmed that the tests pass on Windows with this change

Test also passes on Linux, but I did not want to change the platform assumption for the test.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- ~New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.~
- ~New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.~
- ~UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~
- ~For dependency updates, there are links to external changelogs and, if possible, full differentials.~
- ~For new APIs and extension points, there is a link to at least one consumer.~

### Desired reviewers

@wadeck

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
