### PR TITLE
Skip symlink-related tests when symlinks are unsupported

### DIFF
--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -734,9 +734,9 @@ class DirectoryBrowserSupportTest {
         Path secretTarget = secretsFolder.resolve("goal.txt");
         String secretContent = "secret";
         Files.writeString(secretTarget, secretContent, StandardCharsets.UTF_8);
-        Files.writeString(secretsFolder.toPath().resolve("public_fake1.key"), secretContent, StandardCharsets.UTF_8);
-        Files.writeString(secretsFolder.toPath().resolve("public_fake2.key"), secretContent, StandardCharsets.UTF_8);
-        Files.writeString(secretsFolder.toPath().resolve("public_fake3.key"), secretContent, StandardCharsets.UTF_8);
+        Files.writeString(secretsFolder.resolve("public_fake1.key"), secretContent, StandardCharsets.UTF_8);
+        Files.writeString(secretsFolder.resolve("public_fake2.key"), secretContent, StandardCharsets.UTF_8);
+        Files.writeString(secretsFolder.resolve("public_fake3.key"), secretContent, StandardCharsets.UTF_8);
 
         /*
          *  secrets/

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -52,7 +52,6 @@ import hudson.slaves.WorkspaceList;
 import hudson.tasks.ArtifactArchiver;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
-import hudson.util.StreamTaskListener;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -58,6 +58,8 @@ import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import hudson.util.SymlinkTestUtil;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.StandardArtifactManager;
 import jenkins.util.VirtualFile;
@@ -102,7 +104,7 @@ class ArtifactArchiverTest {
     @Issue("JENKINS-3227")
     void testEmptyDirectories() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
-        Publisher artifactArchiver = new ArtifactArchiver("dir/");
+        ArtifactArchiver artifactArchiver = new ArtifactArchiver("dir/");
         project.getPublishersList().replaceBy(Collections.singleton(artifactArchiver));
         project.getBuildersList().replaceBy(Collections.singleton(new TestBuilder() {
             @Override
@@ -217,7 +219,10 @@ class ArtifactArchiverTest {
         FreeStyleBuild b = j.buildAndAssertSuccess(p);
         FilePath ws = b.getWorkspace();
         assertNotNull(ws);
-        assumeTrue(ws.child("dir/lodge").exists(), "May not be testable on Windows:\n" + JenkinsRule.getLog(b));
+        assumeTrue(
+                SymlinkTestUtil.isSymlinkSupported(),
+                "Symlinks are not supported on this system"
+        );
         List<FreeStyleBuild.Artifact> artifacts = b.getArtifacts();
         assertEquals(1, artifacts.size());
         FreeStyleBuild.Artifact artifact = artifacts.get(0);
@@ -253,7 +258,10 @@ class ArtifactArchiverTest {
         FreeStyleBuild b = j.buildAndAssertSuccess(p);
         FilePath ws = b.getWorkspace();
         assertNotNull(ws);
-        assumeTrue(ws.child("dir/lodge").exists(), "May not be testable on Windows:\n" + JenkinsRule.getLog(b));
+        assumeTrue(
+                SymlinkTestUtil.isSymlinkSupported(),
+                "Symlinks are not supported on this system"
+        );
         List<FreeStyleBuild.Artifact> artifacts = b.getArtifacts();
         assertEquals(0, artifacts.size());
     }
@@ -377,7 +385,8 @@ class ArtifactArchiverTest {
     void testDefaultExcludesOn() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
 
-        Publisher artifactArchiver = new ArtifactArchiver("**", "", false, false, true, true);
+        ArtifactArchiver artifactArchiver =
+                new ArtifactArchiver("**", "", false, false, true, true);
         project.getPublishersList().replaceBy(Collections.singleton(artifactArchiver));
         project.getBuildersList().replaceBy(Collections.singleton(new CreateDefaultExcludesArtifact()));
 

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -50,6 +50,7 @@ import hudson.model.Run;
 import hudson.model.Slave;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
+import hudson.util.SymlinkTestUtil;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,8 +59,6 @@ import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
-import hudson.util.SymlinkTestUtil;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.StandardArtifactManager;
 import jenkins.util.VirtualFile;

--- a/test/src/test/java/hudson/util/SymlinkTestUtil.java
+++ b/test/src/test/java/hudson/util/SymlinkTestUtil.java
@@ -1,4 +1,33 @@
 package hudson.util;
 
-public class SymlinkTestUtil {
+import hudson.FilePath;
+import hudson.Functions;
+import hudson.model.TaskListener;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class SymlinkTestUtil {
+
+    private SymlinkTestUtil() {}
+
+   // Returns true if symbolic links are supported and usable on this system.
+    public static boolean isSymlinkSupported() {
+        if (Functions.isWindows()) {
+            return false;
+        }
+        try {
+            Path tempDir = Files.createTempDirectory("jenkins-symlink-test");
+            FilePath ws = new FilePath(tempDir.toFile());
+            FilePath target = ws.child("target");
+            FilePath link = ws.child("link");
+
+            target.write("test", "UTF-8");
+            link.symlinkTo(target.getName(), TaskListener.NULL);
+
+            return link.exists();
+        } catch (IOException | InterruptedException e) {
+            return false;
+        }
+    }
 }

--- a/test/src/test/java/hudson/util/SymlinkTestUtil.java
+++ b/test/src/test/java/hudson/util/SymlinkTestUtil.java
@@ -1,0 +1,4 @@
+package hudson.util;
+
+public class SymlinkTestUtil {
+}


### PR DESCRIPTION
Fixes #26097

## Testing done
- Ran `DirectoryBrowserSupportTest` locally.

## Screenshots (UI changes only)
Not applicable.

## Proposed changelog entries

- N/A – test-only change.

## Proposed changelog category

/label skip-changelog

## Proposed upgrade guidelines

- N/A – no user-facing or upgrade-impacting changes.

## Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the affected audience.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with @Restricted or have @since TODO Javadocs, as appropriate.
- [ ] New deprecations are properly annotated, if applicable.
- [ ] UI changes do not introduce regressions when enforcing Content Security Policy rules.
- [ ] For dependency updates, there are links to external changelogs. 
- [ ] For new APIs and extension points, there is a link to at least one consumer.

## Desired reviewers

* @MarkEWaite 

---

## Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or Proposed changelog entries are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the upgrade-guide-needed label is set and there is a Proposed upgrade guidelines section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a Bug or Improvement, and either the issue or pull request must be labeled as lts-candidate to be considered.
