### PR TITLE
Fix anchor links being obscured by header

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -115,6 +115,15 @@ THE SOFTWARE.
     <j:if test="${attrs.nogrid==null or attrs.nogrid.equals(false)}">
       <link rel="stylesheet" href="${resURL}/css/responsive-grid.css" type="text/css" />
     </j:if>
+    <style>
+      /*
+       * Prevent anchor targets from being hidden behind the fixed Jenkins header
+       * See: https://github.com/jenkinsci/jenkins/issues/16803
+       */
+      :target {
+        scroll-margin-top: 4rem;
+      }
+    </style>
     <j:if test="${attrs.css!=null}">
       <link rel="stylesheet" href="${resURL}${attrs.css}" type="text/css" />
     </j:if>

--- a/core/src/main/resources/lib/layout/skeleton/skeleton.css
+++ b/core/src/main/resources/lib/layout/skeleton/skeleton.css
@@ -95,10 +95,3 @@ body:has(.jenkins-form-skeleton) {
     margin: 0 !important;
   }
 }
-/*
- * Prevent anchor targets from being hidden behind the Jenkins header
- * See: https://github.com/jenkinsci/jenkins/issues/16803
- */
-[id] {
-  scroll-margin-top: 4rem;
-}

--- a/core/src/main/resources/lib/layout/skeleton/skeleton.css
+++ b/core/src/main/resources/lib/layout/skeleton/skeleton.css
@@ -96,9 +96,9 @@ body:has(.jenkins-form-skeleton) {
   }
 }
 /*
- * Fix anchor links being obscured by the fixed Jenkins header
+ * Prevent anchor targets from being hidden behind the Jenkins header
  * See: https://github.com/jenkinsci/jenkins/issues/16803
  */
-html {
-  scroll-padding-top: 64px;
+[id] {
+  scroll-margin-top: 4rem;
 }

--- a/core/src/main/resources/lib/layout/skeleton/skeleton.css
+++ b/core/src/main/resources/lib/layout/skeleton/skeleton.css
@@ -95,3 +95,10 @@ body:has(.jenkins-form-skeleton) {
     margin: 0 !important;
   }
 }
+/*
+ * Fix anchor links being obscured by the fixed Jenkins header
+ * See: https://github.com/jenkinsci/jenkins/issues/16803
+ */
+html {
+  scroll-padding-top: 64px;
+}


### PR DESCRIPTION
Fixes #16803

### Testing done
-Started Jenkins locally from the built WAR
-Navigated to configuration pages using anchor URLs
-Verified that anchored sections are fully visible and not obscured by the fixed header

### Screenshots (UI changes only)
<img width="1411" height="1045" alt="Screenshot 2026-01-11 at 12 10 28 AM" src="https://github.com/user-attachments/assets/779c237c-d361-456e-969c-457333ae23fd" />

### Proposed changelog entries
N/A – UI-only CSS fix with no user-facing functional change.

### Proposed changelog category
(skip)

### Proposed upgrade guidelines
N/A – no upgrade or migration impact.

### Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the affected audience.
- [x] There is automated testing or an explanation as to why this change has no tests.
This is a CSS-only layout fix; Jenkins does not have automated coverage for anchor scroll positioning.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
