### PR TITLE
Delete builds in QueueTest to prevent Windows test failures

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -90,8 +90,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -112,7 +110,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.BlockedBecauseOfBuildInProgress;
 import jenkins.model.Jenkins;
@@ -132,7 +129,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.MockQueueItemAuthenticator;
 import org.jvnet.hudson.test.SequenceLock;
@@ -149,8 +145,6 @@ import org.springframework.security.core.Authentication;
  */
 @WithJenkins
 public class QueueTest {
-
-    private final LogRecorder logging = new LogRecorder().record(Queue.class, Level.FINE);
 
     private JenkinsRule r;
 
@@ -172,8 +166,6 @@ public class QueueTest {
         FreeStyleProject testProject = r.createFreeStyleProject("test");
         assertNotNull(testProject.scheduleBuild2(0, new UserIdCause()));
         q.save();
-
-        System.out.println(Files.readString(r.jenkins.getRootDir().toPath().resolve("queue.xml"), StandardCharsets.UTF_8));
 
         assertEquals(1, q.getItems().length);
         q.clear();
@@ -227,8 +219,6 @@ public class QueueTest {
         FreeStyleProject testProject = r.createFreeStyleProject("test");
         assertNotNull(testProject.scheduleBuild2(0, new UserIdCause()));
         q.save();
-
-        System.out.println(Files.readString(r.jenkins.getRootDir().toPath().resolve("queue.xml"), StandardCharsets.UTF_8));
 
         assertEquals(1, q.getItems().length);
         q.clear();
@@ -372,7 +362,6 @@ public class QueueTest {
                         Started by remote host 4.3.2.1 with note: test
                         Started by remote host 1.2.3.4 with note: foo"""),
                    "Build page should combine duplicates and show counts: " + buildPage);
-        System.out.println(new XmlFile(new File(build.getRootDir(), "build.xml")).asString());
     }
 
     @Issue("JENKINS-8790")


### PR DESCRIPTION
## Delete builds in QueueTest to prevent Windows test failures

The Windows file system prevents cleanup of the builds and jobs directories while the test has them open.  Stopping the builds and deleting them is enough to close the directories and allow them to be deleted.

Also removes noisy test logging from QueueTest because no one is reading the test logs.  They add megabytes to the output and may obscure useful messages.

This pull request improves the execution time of the modified test.  The test previously required 30 seconds to complete.  It now completes in less than 2 seconds.

### Testing done

* Before this change, testGetCauseOfBlockageForNonConcurrentFreestyle failed in about 50% of runs on my 7 different Windows agents
* After this change, testGetCauseOfBlockageForNonConcurrentFreestyle passes all runs on my 7 different Windows agents

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- ~New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.~
- ~New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.~
- ~UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).~
- ~For dependency updates, there are links to external changelogs and, if possible, full differentials.~
- ~For new APIs and extension points, there is a link to at least one consumer.~

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [x] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [x] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
