### PR TITLE
Fix false 'Build Scheduled' notification when parent multibranch is d…

### DIFF
--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -231,7 +231,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
             // TODO JENKINS-66105 use SC_SEE_OTHER if !ScheduleResult.created
             rsp.sendRedirect(SC_CREATED, req.getContextPath() + '/' + item.getUrl());
         } else {
-            throw HttpResponses.errorWithoutStack(SC_CONFLICT, asJob().getFullName() + " is not buildable");
+            rsp.sendRedirect(".");
         }
     }
 

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -40,7 +40,6 @@ import hudson.model.BuildableItem;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Item;
-import hudson.model.ItemGroup;
 import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.ParameterDefinition;
@@ -564,19 +563,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         }
 
         default boolean isBuildable() {
-            if (isDisabled() || ((Job) this).isHoldOffBuildUntilSave()) {
-                return false;
-            }
-            // Check if parent (e.g., multibranch project) is disabled
-            // If parent is disabled, child jobs (e.g., branch jobs) should not be buildable
-            ItemGroup<? extends Item> parentGroup = ((Job) this).getParent();
-            if (parentGroup instanceof Item) {
-                Item parent = (Item) parentGroup;
-                if (parent instanceof ParameterizedJob && ((ParameterizedJob) parent).isDisabled()) {
-                    return false;
-                }
-            }
-            return true;
+            return !isDisabled() && !((Job) this).isHoldOffBuildUntilSave();
         }
 
         @Extension

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -40,6 +40,7 @@ import hudson.model.BuildableItem;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.ParameterDefinition;
@@ -231,7 +232,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
             // TODO JENKINS-66105 use SC_SEE_OTHER if !ScheduleResult.created
             rsp.sendRedirect(SC_CREATED, req.getContextPath() + '/' + item.getUrl());
         } else {
-            rsp.sendRedirect(".");
+            throw HttpResponses.errorWithoutStack(SC_CONFLICT, asJob().getFullName() + " is not buildable");
         }
     }
 
@@ -563,7 +564,19 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
         }
 
         default boolean isBuildable() {
-            return !isDisabled() && !((Job) this).isHoldOffBuildUntilSave();
+            if (isDisabled() || ((Job) this).isHoldOffBuildUntilSave()) {
+                return false;
+            }
+            // Check if parent (e.g., multibranch project) is disabled
+            // If parent is disabled, child jobs (e.g., branch jobs) should not be buildable
+            ItemGroup<? extends Item> parentGroup = ((Job) this).getParent();
+            if (parentGroup instanceof Item) {
+                Item parent = (Item) parentGroup;
+                if (parent instanceof ParameterizedJob && ((ParameterizedJob) parent).isDisabled()) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         @Extension

--- a/core/src/main/resources/hudson/views/BuildButtonColumn/icon.js
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/icon.js
@@ -14,7 +14,7 @@ Behaviour.specify(
         method: "post",
         headers: crumb.wrap({}),
       }).then((rsp) => {
-        if (rsp.ok) {
+        if (rsp.status === 201) {
           notificationBar.show(message, notificationBar.SUCCESS);
         } else {
           notificationBar.show(failure, notificationBar.ERROR);

--- a/core/src/main/resources/lib/hudson/project/configurable/configurable.js
+++ b/core/src/main/resources/lib/hudson/project/configurable/configurable.js
@@ -10,7 +10,7 @@
         method: "post",
         headers: crumb.wrap({}),
       }).then((rsp) => {
-        if (rsp.ok) {
+        if (rsp.status === 201) {
           notificationBar.show(success, notificationBar.SUCCESS);
         } else {
           notificationBar.show(failure, notificationBar.ERROR);


### PR DESCRIPTION
Fixes #16678 

### Description

When trying to trigger a build of a branch job in a disabled multibranch project, the UI incorrectly showed "Build Scheduled" notification even though the build was not actually scheduled. The queue rejected the build (returned null), but the code sent a 302 redirect which the JavaScript treated as success.

### Changes

1. **Updated `isBuildable()` method**: Now checks if the parent `ParameterizedJob` (e.g., multibranch project) is disabled before allowing builds
2. **Fixed error handling in `doBuild()`**: Changed from returning 302 redirect to throwing 409 CONFLICT when `schedule2()` returns null
3. **Fixed JavaScript response handling**: Changed from checking `rsp.ok` (which includes 302) to checking `rsp.status === 201` specifically

### Testing done

**Manual testing performed:**

1. Created a Multibranch Pipeline project
2. Disabled the multibranch project via configuration page
3. Attempted to trigger a build on a branch job within the disabled multibranch
4. **Before fix**: UI showed "Build Scheduled" notification (incorrect)
5. **After fix**: UI shows "Build failed" notification (correct)
6. Verified browser console shows proper error response (409 CONFLICT)
7. Verified that builds work correctly when multibranch is enabled
8. Verified that builds work correctly for regular (non-multibranch) projects

**Tested on:** Jenkins 2.541-SNAPSHOT

### Proposed changelog entries

- Fix false "Build Scheduled" notification when attempting to build branch jobs in disabled multibranch projects

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
  - Manual testing performed as described above. This is a UI/behavior fix that requires testing with actual multibranch projects.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
  - N/A - No new public APIs added
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
  - N/A - No deprecations added
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
  - Only changed response status check, no inline JS or eval
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
  - N/A - No dependency updates
- [x] For new APIs and extension points, there is a link to at least one consumer.
  - N/A - No new APIs added

### Desired reviewers

@timja @mawinter69 @daniel-beck 