### PR TITLE
Hide build buttons in Multibranch branch/PR jobs when the Multibranch or organization folder is disabled

### DIFF
--- a/core/src/main/java/hudson/model/Build.java
+++ b/core/src/main/java/hudson/model/Build.java
@@ -83,7 +83,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  *
  * @author Kohsuke Kawaguchi
  */
-public abstract class Build<P extends Project<P, B>, B extends Build<P, B>>
+public abstract class   Build<P extends Project<P, B>, B extends Build<P, B>>
     extends AbstractBuild<P, B> {
 
     /**

--- a/core/src/main/java/hudson/model/BuildableItem.java
+++ b/core/src/main/java/hudson/model/BuildableItem.java
@@ -58,7 +58,13 @@ public interface BuildableItem extends Item, Task {
 
     boolean scheduleBuild(int quietPeriod, Cause c);
 
+    /**
+     * Whether the item is buildable.
+     *
+     * @return true, if the item can be built.
+     * @since TODO
+     */
     default boolean isBuildable() {
         return true;
-    };
+    }
 }

--- a/core/src/main/java/hudson/model/BuildableItem.java
+++ b/core/src/main/java/hudson/model/BuildableItem.java
@@ -57,4 +57,8 @@ public interface BuildableItem extends Item, Task {
     }
 
     boolean scheduleBuild(int quietPeriod, Cause c);
+
+    default boolean isBuildable() {
+        return true;
+    };
 }

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -571,9 +571,7 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
             // If parent is disabled, child jobs (e.g., branch jobs) should not be buildable
             ItemGroup<? extends Item> parentGroup = ((Job) this).getParent();
             if (parentGroup instanceof BuildableItem bi) {
-                if (!bi.isBuildable()) {
-                    return false;
-                }
+                return bi.isBuildable();
             }
             return true;
         }

--- a/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
+++ b/core/src/main/java/jenkins/model/ParameterizedJobMixIn.java
@@ -40,6 +40,7 @@ import hudson.model.BuildableItem;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.ParameterDefinition;
@@ -562,8 +563,19 @@ public abstract class ParameterizedJobMixIn<JobT extends Job<JobT, RunT> & Param
             return null;
         }
 
+        @Override
         default boolean isBuildable() {
-            return !isDisabled() && !((Job) this).isHoldOffBuildUntilSave();
+            if (isDisabled() || ((Job) this).isHoldOffBuildUntilSave()) {
+                return false;
+            }
+            // If parent is disabled, child jobs (e.g., branch jobs) should not be buildable
+            ItemGroup<? extends Item> parentGroup = ((Job) this).getParent();
+            if (parentGroup instanceof BuildableItem bi) {
+                if (!bi.isBuildable()) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         @Extension


### PR DESCRIPTION
When disabling a Multibranch project the branch/PR jobs still show the build button in the sidepanel and in the folder view the Build button column allows to start a build.

By adding the isBuildable to the BuildableItem interface we can now detect in Jobs if the parent is disabled. This will then hide the build button in the sidepanel and the column in the view.

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #16678

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done
Created a multibranch job that has one branch and one PR
disabled Multibranch project -> the jobs for the branch and PR no longer show the `Build Now` button in the sidepanel and in the view the Build Button column has no button anymore.

Did the same for an Organization folder

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After
Multibranch Job disabled:
<img width="1303" height="286" alt="image" src="https://github.com/user-attachments/assets/ae341a1b-a998-4553-bd29-398438d61ba5" />
main branch job without `Build Now`button
<img width="1613" height="350" alt="image" src="https://github.com/user-attachments/assets/f5b7dc6d-4d03-416b-8cc1-0404727b1a37" />


Multibranch Job Enabled:
<img width="1185" height="392" alt="image" src="https://github.com/user-attachments/assets/63ea6cb6-6a9f-4366-a2c2-05cca16da448" />

Multibranch project in a Disabled org:
<img width="1622" height="457" alt="image" src="https://github.com/user-attachments/assets/87d0d2b0-50ac-4f3c-a21e-7cee2df16df8" />


### Proposed changelog entries

- Hide build buttons in Multibranch branch/PR jobs when the Multibranch or organization folder is disabled

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
