### PR TITLE
Fix console parallel stages overflow

### DIFF
--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -303,3 +303,11 @@ body:has(.app-settings-container) {
     margin-block: 1.0625rem;
   }
 }
+
+// Fix for JENKINS-76029: Prevent pipeline branch labels from overflowing into sidebar
+// The Pipeline plugin uses ::before pseudo-elements with position:absolute and translateX(-100%)
+// to place labels in the left margin. Override this to display inline instead.
+.console-output [class*="pipeline-node-"]::before {
+  position: static !important;
+  transform: none !important;
+}


### PR DESCRIPTION
Fixes #16806 

When parallel pipeline stages have long names, the branch labels in the console output overflow into the left sidebar, making them hard to read and overlapping with navigation items.

The Pipeline plugin uses `::before` pseudo-elements with `position: absolute` and `transform: translateX(-100%)` to position these labels in the left margin. This fix overrides that behavior to display labels inline instead.

### Testing done

Created a pipeline job with parallel stages having long names and ran it multiple times. Checked the console output page before and after the fix:

- Before: Labels like [run echo hello world from step 1] were positioned in the left margin and overflowed into the sidebar
- After: Labels appear inline with the console text, no more overflow

Also verified that regular console output (non-pipeline) still works correctly.

### Screenshots 

#### Before

<img width="1855" height="927" alt="Screenshot from 2026-01-17 05-01-17" src="https://github.com/user-attachments/assets/7e03ba13-5ed6-4d34-9e7b-c6c542b37129" />


#### After

<img width="1855" height="927" alt="Screenshot from 2026-01-17 05-33-06" src="https://github.com/user-attachments/assets/b1886e18-ee2d-42a7-bc68-8f6c69306d5c" />

### Proposed changelog entries

- Fix pipeline parallel branch labels overflowing into sidebar in console output

### Proposed changelog category

/label bug,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @MarkEWaite @mawinter69 