### PR TITLE
Add help remove last build

### DIFF
--- a/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
+++ b/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
@@ -1,0 +1,24 @@
+<div>
+  <p>
+    When enabled, Jenkins is allowed to remove the <b>last successful</b> and
+    <b>last stable</b> build if they match the configured build discarder rules.
+  </p>
+
+  <p>
+    By default, Jenkins keeps the most recent successful and stable builds,
+    even if they are older than the configured retention limits.
+    Enabling this option overrides that behavior.
+  </p>
+
+  <p>
+    <b>Example:</b><br/>
+    If builds are configured to be deleted after 7 days, and the most recent
+    successful build is 30 days old, it will normally be kept.
+    With this option enabled, that build will also be removed.
+  </p>
+
+  <p>
+    This option is also available in Pipelines using the
+    <code>buildDiscarder(logRotator(..., removeLastBuild: true))</code> syntax.
+  </p>
+</div>


### PR DESCRIPTION
Fixes JENKINS-75463

This pull request adds missing online help documentation for the
“Remove last build” option of the LogRotator build discarder.

The help text explains the behavior, provides an example,
and references Pipeline usage.

### Testing done

- Built Jenkins locally from source.
- Verified the new help icon appears for the “Remove last build” option
  in **Manage Jenkins → Configure System → Build Discarder → Advanced**.
- Clicked the help icon and confirmed the help text renders correctly.

### Screenshots (UI changes only)

#### Before
<img width="1430" height="795" alt="Screenshot 2026-01-20 123238" src="https://github.com/user-attachments/assets/129ec63a-3863-4da6-853f-327a33c844cb" />

- No online help was available for the “Remove last build” option.

#### After
<img width="1911" height="654" alt="image" src="https://github.com/user-attachments/assets/45b914ff-3c66-49d1-917a-1c34af0e86ee" />
<img width="1919" height="693" alt="image" src="https://github.com/user-attachments/assets/67eb5994-1bdd-43c7-a342-90f0f033fb58" />


- A help icon is displayed next to the “Remove last build” option,
  showing detailed documentation when clicked.

### Proposed changelog entries

- Add online help for the “Remove last build” build discarder option.

### Proposed changelog category

/label rfe,web-ui

### Proposed upgrade guidelines

N/A
