### PR TITLE
Add help for "remove last build" in Manage Jenkins

### DIFF
--- a/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
+++ b/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
@@ -1,24 +1,29 @@
 <div>
   <p>
-    When enabled, Jenkins is allowed to remove the <b>last successful</b> and
-    <b>last stable</b> build if they match the configured build discarder rules.
+    When enabled, Jenkins is allowed to remove the
+    <b>last successful</b>
+    and
+    <b>last stable</b>
+    build if they match the configured build discarder rules.
   </p>
 
   <p>
-    By default, Jenkins keeps the most recent successful and stable builds,
-    even if they are older than the configured retention limits.
-    Enabling this option overrides that behavior.
+    By default, Jenkins keeps the most recent successful and stable builds, even
+    if they are older than the configured retention limits. Enabling this option
+    overrides that behavior.
   </p>
 
   <p>
-    <b>Example:</b><br/>
+    <b>Example:</b>
+    <br />
     If builds are configured to be deleted after 7 days, and the most recent
-    successful build is 30 days old, it will normally be kept.
-    With this option enabled, that build will also be removed.
+    successful build is 30 days old, it will normally be kept. With this option
+    enabled, that build will also be removed.
   </p>
 
   <p>
     This option is also available in Pipelines using the
-    <code>buildDiscarder(logRotator(..., removeLastBuild: true))</code> syntax.
+    <code>buildDiscarder(logRotator(..., removeLastBuild: true))</code>
+    syntax.
   </p>
 </div>

--- a/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
+++ b/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
@@ -21,11 +21,11 @@
     enabled, that build will also be removed.
   </p>
 
-  <p>
-    This option is also available in Pipelines using the
-    <code>options {
-        buildDiscarder logRotator(removeLastBuild: true)
-        }</code>
-    syntax.
-  </p>
+  <p>This option is also available in Pipelines with:</p>
+
+  <pre>
+options {
+    buildDiscarder logRotator(removeLastBuild: true)
+}
+  </pre>
 </div>

--- a/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
+++ b/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
@@ -1,0 +1,24 @@
+<div>
+  <p>
+    When enabled, Jenkins is allowed to remove the <b>last successful</b> and
+    <b>last stable</b> build if they match the configured build discarder rules.
+  </p>
+
+  <p>
+    By default, Jenkins keeps the most recent successful and stable builds,
+    even if they are older than the configured retention limits.
+    Enabling this option overrides that behavior.
+  </p>
+
+  <p>
+    <b>Example:</b><br/>
+    If builds are configured to be deleted after 7 days, and the most recent
+    successful build is 30 days old, it will normally be kept.
+    With this option enabled, that build will also be removed.
+  </p>
+
+  <p>
+    This option is also available in Pipelines using the
+    <code>buildDiscarder(logRotator(..., removeLastBuild: true))</code> syntax.
+  </p>
+</div>

--- a/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
+++ b/core/src/main/resources/hudson/tasks/LogRotator/help-removeLastBuild.html
@@ -23,7 +23,9 @@
 
   <p>
     This option is also available in Pipelines using the
-    <code>buildDiscarder(logRotator(..., removeLastBuild: true))</code>
+    <code>options {
+        buildDiscarder logRotator(removeLastBuild: true)
+        }</code>
     syntax.
   </p>
 </div>


### PR DESCRIPTION
Fixes #16688

This pull request adds missing online help documentation for the
“Remove last build” option of the LogRotator build discarder.

The help text explains the behavior, provides an example,
and references Pipeline usage.

### Testing done

- Built Jenkins locally from source
- Verified the new help icon appears for the **“Remove last build”** option in  
  **Manage Jenkins → Configure System → Build Discarder → Advanced**
- Clicked the help icon and confirmed the help text renders correctly

### Screenshots (UI changes only)

#### Before
<img width="1430" height="795" alt="image" src="https://github.com/user-attachments/assets/14425d99-5f2a-49ff-b3bd-9a4def1b2644" />
No online help was available for the “Remove last build” option.

#### After
<img width="1911" height="654" alt="image" src="https://github.com/user-attachments/assets/7bf19676-f31c-41e8-bc32-02e7c182487f" />
<img width="1919" height="693" alt="image" src="https://github.com/user-attachments/assets/2923c3ea-7085-45d7-83fe-0ac2d23ed43f" />
A help icon is displayed next to the “Remove last build” option, showing detailed documentation when clicked.

### Proposed changelog entries

- Add online help for the “Remove last build” build discarder option.

### Proposed changelog category

/label rfe,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] UI changes do not introduce regressions with Content Security Policy.

### Maintainer checklist

- [ ] At least two approvals
- [ ] No unresolved conversations
- [ ] Changelog entries look correct
- [ ] Proper labels set

### Desired reviewers

@jenkinsci/core-pr-reviewers
