### PR TITLE
[UX] Modernize Back to Top button in Console Output

### DIFF
--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -47,5 +47,9 @@ THE SOFTWARE.
 
     <j:set var="it" value="${it.object}" />
     <st:include page="console-log.jelly" />
+
+    <button class="jenkins-back-to-top jenkins-button" aria-label="${%Back to top}">
+      <l:icon src="symbol-chevron-up" />
+    </button>
   </l:run-subpage>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -48,8 +48,6 @@ THE SOFTWARE.
     <j:set var="it" value="${it.object}" />
     <st:include page="console-log.jelly" />
 
-    <button class="jenkins-back-to-top jenkins-button" aria-label="${%Back to top}">
-      <l:icon src="symbol-chevron-up" />
-    </button>
+    <l:backToTop />
   </l:run-subpage>
 </j:jelly>

--- a/core/src/main/resources/hudson/model/Run/console.properties
+++ b/core/src/main/resources/hudson/model/Run/console.properties
@@ -21,3 +21,4 @@
 # THE SOFTWARE.
 
 skipSome=Skipping {0,number,integer} KB.. <a href="{1}">Full Log</a>
+Back\ to\ top=Back to top

--- a/core/src/main/resources/hudson/model/Run/console.properties
+++ b/core/src/main/resources/hudson/model/Run/console.properties
@@ -21,4 +21,3 @@
 # THE SOFTWARE.
 
 skipSome=Skipping {0,number,integer} KB.. <a href="{1}">Full Log</a>
-Back\ to\ top=Back to top

--- a/core/src/main/resources/lib/layout/backToTop.jelly
+++ b/core/src/main/resources/lib/layout/backToTop.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <st:documentation>
+    Adds a "back to top" floating button that appears when the user scrolls down.
+  </st:documentation>
+  <button class="jenkins-back-to-top jenkins-button" aria-label="${%Back to top}">
+    <l:icon src="symbol-chevron-up" />
+  </button>
+</j:jelly>

--- a/core/src/main/resources/lib/layout/backToTop.properties
+++ b/core/src/main/resources/lib/layout/backToTop.properties
@@ -1,0 +1,1 @@
+Back\ to\ top=Back to top

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -7,6 +7,7 @@ import StopButtonLink from "@/components/stop-button-link";
 import ConfirmationLink from "@/components/confirmation-link";
 import Dialogs from "@/components/dialogs";
 import Defer from "@/components/defer";
+import BackToTop from "@/components/back-to-top";
 
 Dropdowns.init();
 CommandPalette.init();
@@ -17,3 +18,4 @@ Tooltips.init();
 StopButtonLink.init();
 ConfirmationLink.init();
 Dialogs.init();
+BackToTop.init();

--- a/src/main/js/components/back-to-top/index.js
+++ b/src/main/js/components/back-to-top/index.js
@@ -1,0 +1,39 @@
+function init() {
+  const backToTopButton = document.querySelector(".jenkins-back-to-top");
+
+  if (!backToTopButton) {
+    return;
+  }
+
+  const threshold = 300;
+  let ticking = false;
+
+  const updateVisibility = () => {
+    if (window.scrollY > threshold) {
+      backToTopButton.classList.add("jenkins-back-to-top--visible");
+    } else {
+      backToTopButton.classList.remove("jenkins-back-to-top--visible");
+    }
+    ticking = false;
+  };
+
+  window.addEventListener(
+    "scroll",
+    () => {
+      if (!ticking) {
+        window.requestAnimationFrame(updateVisibility);
+        ticking = true;
+      }
+    },
+    { passive: true },
+  );
+
+  backToTopButton.addEventListener("click", () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+}
+
+export default { init };

--- a/src/main/scss/components/_back-to-top.scss
+++ b/src/main/scss/components/_back-to-top.scss
@@ -1,0 +1,43 @@
+@use "../abstracts/mixins";
+
+.jenkins-back-to-top {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 900;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  padding: 0;
+  box-shadow: var(--dropdown-box-shadow);
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity var(--standard-transition),
+    visibility var(--standard-transition),
+    transform var(--standard-transition),
+    background-color var(--standard-transition);
+  transform: translateY(0.625rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &--visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  &:hover {
+    background-color: var(--button-background--hover);
+  }
+
+  &:active {
+    background-color: var(--button-background--active);
+  }
+
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}

--- a/src/main/scss/components/_index.scss
+++ b/src/main/scss/components/_index.scss
@@ -4,6 +4,7 @@
 @use "badges";
 @use "breadcrumbs";
 @use "buttons";
+@use "back-to-top";
 @use "cards";
 @use "command-palette";
 @use "content-blocks";


### PR DESCRIPTION
Fixes #26111

This pull request modernizes the Console Output navigation experience by introducing a floating, accessible “Back to Top” button.  
Long build logs currently require excessive manual scrolling; this change adds a standard UX pattern that appears dynamically and allows users to smoothly return to the top of the page without disrupting log rendering.

---

### Testing done

- Tested locally using `mvn -pl war jetty:run -Dskip.yarn` and `yarn start`
- Verified behavior on long console logs (>500 lines)
- Confirmed dynamic visibility when scrolling past threshold
- Verified smooth scroll behavior
- Tested keyboard navigation (Tab + Enter/Space)
- Tested on Chrome and Firefox
- Ran `yarn lint` and `mvn spotless:apply` successfully

---

### Screenshots (UI changes only) 

#### Before

https://github.com/user-attachments/assets/8a5cd7e0-9198-4870-b5e9-b5cee6255a55





#### After


https://github.com/user-attachments/assets/7e621c06-11fb-4968-b8e8-208a7ce20498









#### video presentation-

https://github.com/user-attachments/assets/0d45b583-58ba-4891-acf5-7e555813b79b


---

### Proposed changelog entries

- Add a floating “Back to Top” button to console output for easier navigation of long logs

---

### Proposed changelog category

/label rfe, web-ui

---

### Proposed upgrade guidelines

N/A

---

### Submitter checklist

- [x] The issue is well-described and linked.
- [x] The changelog entry is appropriate for users and written in the imperative mood.
- [x] Manual testing performed and described (UI-only change).
- [x] No new public APIs were added.
- [x] No deprecations were introduced.
- [x] JavaScript is external and CSP-safe (no inline JS, no eval).
- [x] No new dependencies were introduced.

---

---

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

### Desired reviewers

@jenkinsci/core-pr-reviewers