### PR TITLE
Fix JENKINS-26001: Whitelist jenkins.io in CSP form-action

### DIFF
--- a/core/src/main/java/jenkins/security/csp/impl/BaseContributor.java
+++ b/core/src/main/java/jenkins/security/csp/impl/BaseContributor.java
@@ -47,7 +47,7 @@ public final class BaseContributor implements Contributor {
                 .initialize(FetchDirective.DEFAULT_SRC, SELF)
                 .add(Directive.STYLE_SRC, REPORT_SAMPLE)
                 .add(Directive.SCRIPT_SRC, REPORT_SAMPLE)
-                .add(Directive.FORM_ACTION, SELF)
+                .add(Directive.FORM_ACTION, SELF, "https://www.jenkins.io", "https://jenkins.io")
                 .add(Directive.BASE_URI) // 'none'
                 .add(Directive.FRAME_ANCESTORS, SELF);
     }

--- a/core/src/test/java/jenkins/security/csp/BaseContributorTest.java
+++ b/core/src/test/java/jenkins/security/csp/BaseContributorTest.java
@@ -17,7 +17,7 @@ public class BaseContributorTest {
         assertThat(csp, containsString("default-src 'self';"));
         assertThat(csp, containsString("style-src 'report-sample' 'self';"));
         assertThat(csp, containsString("script-src 'report-sample' 'self';"));
-        assertThat(csp, containsString("form-action 'self';"));
+        assertThat(csp, containsString("form-action 'self'https://www.jenkins.io https://jenkins.io;;"));
         assertThat(csp, containsString("base-uri 'none';"));
         assertThat(csp, containsString("frame-ancestors 'self';"));
     }


### PR DESCRIPTION
Fixes #26001

### Testing done

I have verified this change through both manual reproduction and automated unit testing:

**Manual Verification:**
1. Built Jenkins core and ran the WAR locally on Windows 11 using `java -jar jenkins.war`.
2. Reproduced the CSP violation by forcing a "Broken Reverse Proxy" administrative monitor (mismatching the Jenkins URL in System settings).
3. Verified via Chrome DevTools (Network tab -> Doc filter) that the `Content-Security-Policy` response header now correctly includes `https://www.jenkins.io` and `https://jenkins.io` in the `form-action` directive.
4. Confirmed that the "More Info" button successfully redirects to the documentation without any CSP violation errors in the browser console.

**Automated Verification:**
* Updated `BaseContributorTest.java` to assert that the `form-action` directive contains the newly whitelisted domains.
* Execution of `mvn test -pl core -Dtest=BaseContributorTest` resulted in `BUILD SUCCESS`.

### Screenshots (UI changes only)

N/A (Backend header change).

#### Before

#### After

### Proposed changelog entries

- Whitelist jenkins.io domains in the Content Security Policy `form-action` directive to allow administrative monitors to redirect to official documentation.

### Proposed changelog category

/label bug, csp

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@daniel-beck

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.