### PR TITLE
Adjusting outdated comment about `Queue.lock` in `NodeProvisioner`

### DIFF
--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -39,7 +39,6 @@ import hudson.model.MultiStageTimeSeries;
 import hudson.model.MultiStageTimeSeries.TimeScale;
 import hudson.model.Node;
 import hudson.model.PeriodicWork;
-import hudson.model.Queue;
 import java.awt.Color;
 import java.io.IOException;
 import java.time.Duration;
@@ -208,8 +207,8 @@ public class NodeProvisioner {
      * Periodically invoked to keep track of the load.
      * Launches additional nodes if necessary.
      *
-     * Note: This method will obtain a lock on {@link #provisioningLock} first (to ensure that one and only one
-     * instance of this provisioner is running at a time) and then a lock on {@link Queue#lock}
+     * Note: This method will obtain a lock on {@link #provisioningLock} to ensure that one and only one
+     * instance of this provisioner is running at a time.
      */
     private void update() {
         long start = LOGGER.isLoggable(Level.FINER) ? System.nanoTime() : 0;


### PR DESCRIPTION
A comment introduced in 951b07789c407aa95b5f59836fc55b3c54480429 (#1596) seems to have been rendered incorrect by #5450 but was apparently forgotten there.

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
