### PR TITLE
Fix Cloud#getUrl when 2 clouds with same name exist

### DIFF
--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -341,7 +341,7 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
         j.clouds.replace(this, result);
         j.save();
         // take the user back to the cloud top page.
-        return FormApply.success("../" + result.name + '/');
+        return FormApply.success(req.getContextPath() + "/" + result.getUrl());
 
     }
 

--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -140,7 +140,11 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
      * @return Jenkins relative URL.
      */
     public @NonNull String getUrl() {
-        return "cloud/" + Util.rawEncode(name) + "/";
+        if (Jenkins.get().getCloud(name) != this) { // this cloud is not the first occurrence with this name
+            return "cloud/cloudByIndex/" + Jenkins.get().clouds.indexOf(this) + "/";
+        } else {
+            return "cloud/" + Util.rawEncode(name) + "/";
+        }
     }
 
     @Override

--- a/core/src/main/java/jenkins/agents/CloudSet.java
+++ b/core/src/main/java/jenkins/agents/CloudSet.java
@@ -113,11 +113,7 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
     @Restricted(DoNotUse.class) // stapler
     public String getCloudUrl(StaplerRequest2 request, Jenkins jenkins, Cloud cloud) {
         String context = Functions.getNearestAncestorUrl(request, jenkins);
-        if (Jenkins.get().getCloud(cloud.name) != cloud) { // this cloud is not the first occurrence with this name
-            return context + "/cloud/cloudByIndex/" + getClouds().indexOf(cloud) + "/";
-        } else {
-            return context + "/" + cloud.getUrl();
-        }
+        return context + "/" + cloud.getUrl();
     }
 
     /**

--- a/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
+++ b/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
@@ -27,9 +27,9 @@ THE SOFTWARE.
     <l:header />
     <l:side-panel>
         <l:tasks>
-            <j:set var="url" value="${h.getNearestAncestorUrl(request2,it)}"/>
-            <l:task contextMenu="false" href="${url}/" icon="symbol-computer" title="${%Status}"/>
-            <l:task href="${url}/configure" icon="symbol-settings"
+            <j:set var="url" value="${rootURL}/${it.url}"/>
+            <l:task contextMenu="false" href="${url}" icon="symbol-computer" title="${%Status}"/>
+            <l:task href="${url}configure" icon="symbol-settings"
                     title="${app.hasPermission(app.ADMINISTER) ? '%Configure' : '%View Configuration'}"/>
             <l:delete permission="${app.ADMINISTER}" title="${%Delete Cloud}" message="${%delete.cloud(it.displayName)}" urlPrefix="${url}"/>
             <t:actions />

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -64,11 +64,11 @@ THE SOFTWARE.
                   </td>
                   <td>
                     <input type="hidden" name="name" value="${cloud.name}" />
-                    <a href="${it.getCloudUrl(request2,app,cloud)}" class="jenkins-table__link model-link inside">${cloud.name}</a>
+                    <a href="../${cloud.url}" class="jenkins-table__link model-link inside">${cloud.name}</a>
                   </td>
                   <td class="jenkins-table__cell--tight">
                     <div class="jenkins-table__cell__button-wrapper">
-                      <a href="${it.getCloudUrl(request2,app,cloud)}configure" class="jenkins-button">
+                      <a href="../${cloud.url}configure" class="jenkins-button">
                         <l:icon src="symbol-settings"/>
                       </a>
                     </div>

--- a/core/src/main/resources/lib/layout/delete.jelly
+++ b/core/src/main/resources/lib/layout/delete.jelly
@@ -75,7 +75,8 @@ THE SOFTWARE.
 
   <j:set var="url" value="doDelete" />
   <j:if test="${attrs.urlPrefix != null}">
-    <j:set var="url" value="${urlPrefix}/doDelete" />
+    <j:set var="basePrefix" value="${urlPrefix.endsWith('/') ? urlPrefix.substring(0, urlPrefix.length() - 1) : urlPrefix}" />
+    <j:set var="url" value="${basePrefix}/doDelete" />
   </j:if>
 
 

--- a/test/src/test/java/hudson/slaves/CloudTest.java
+++ b/test/src/test/java/hudson/slaves/CloudTest.java
@@ -92,20 +92,22 @@ class CloudTest {
                 instanceOf(ReportingCloudAction.class)
         ));
 
-        HtmlPage page = j.createWebClient().goTo(aCloud2.getUrl());
-        String out = page.getWebResponse().getContentAsString();
-        assertThat(out, containsString("Cloud a")); // index.jelly
-        assertThat(out, containsString("Top cloud view.")); // top.jelly
-        assertThat(out, containsString("custom cloud main groovy")); // main.jelly
-        assertThat(out, containsString("Task Action")); // TaskCloudAction
-        assertThat(out, containsString("Sidepanel action box.")); // TaskCloudAction/box.jelly
-        assertThat(out, containsString("Report Here")); // ReportingCloudAction/summary.jelly
+        try (JenkinsRule.WebClient client = j.createWebClient()) {
+            HtmlPage page = client.goTo(aCloud2.getUrl());
+            String out = page.getWebResponse().getContentAsString();
+            assertThat(out, containsString("Cloud a")); // index.jelly
+            assertThat(out, containsString("Top cloud view.")); // top.jelly
+            assertThat(out, containsString("custom cloud main groovy")); // main.jelly
+            assertThat(out, containsString("Task Action")); // TaskCloudAction
+            assertThat(out, containsString("Sidepanel action box.")); // TaskCloudAction/box.jelly
+            assertThat(out, containsString("Report Here")); // ReportingCloudAction/summary.jelly
 
-        HtmlPage actionPage = page.getAnchorByText("Task Action").click();
-        URL url = actionPage.getUrl();
-        assertThat(url.getPath(), endsWith("/cloud/cloudByIndex/1/task/")); // TaskCloudAction URL
-        out = actionPage.getWebResponse().getContentAsString();
-        assertThat(out, containsString("doIndex called")); // doIndex
+            HtmlPage actionPage = page.getAnchorByText("Task Action").click();
+            URL url = actionPage.getUrl();
+            assertThat(url.getPath(), endsWith("/cloud/cloudByIndex/1/task/")); // TaskCloudAction URL
+            out = actionPage.getWebResponse().getContentAsString();
+            assertThat(out, containsString("doIndex called")); // doIndex
+        }
     }
 
     @Test
@@ -120,13 +122,25 @@ class CloudTest {
                 instanceOf(ReportingCloudAction.class)
         ));
 
-        HtmlPage page = j.createWebClient().goTo(aCloud2.getUrl());
+        // save the first cloud
+        try (JenkinsRule.WebClient client = j.createWebClient()) {
+            HtmlPage page = client.goTo(aCloud.getUrl());
 
-        HtmlPage configurePage = page.getAnchorByText("Configure").click();
-        HtmlForm form = configurePage.getFormByName("config");
-        page = form.getButtonByName("Submit").click();
-        URL url = page.getUrl();
-        assertThat(url.getPath(), endsWith("/cloud/cloudByIndex/1/")); // TaskCloudAction URL
+            HtmlPage configurePage = page.getAnchorByText("Configure").click();
+            HtmlForm form = configurePage.getFormByName("config");
+            page = form.getButtonByName("Submit").click();
+            URL url = page.getUrl();
+            assertThat(url.getPath(), endsWith("/cloud/a/"));
+
+            // save second cloud
+            page = client.goTo(aCloud2.getUrl());
+
+            configurePage = page.getAnchorByText("Configure").click();
+            form = configurePage.getFormByName("config");
+            page = form.getButtonByName("Submit").click();
+            url = page.getUrl();
+            assertThat(url.getPath(), endsWith("/cloud/cloudByIndex/1/"));
+        }
     }
 
     @Test

--- a/test/src/test/java/hudson/slaves/CloudTest.java
+++ b/test/src/test/java/hudson/slaves/CloudTest.java
@@ -154,7 +154,7 @@ class CloudTest {
     public static final class ACloud extends AbstractCloudImpl {
 
         @DataBoundConstructor
-        public ACloud(String name, String instanceCapStr) {
+        ACloud(String name, String instanceCapStr) {
             super(name, instanceCapStr);
         }
 

--- a/test/src/test/java/hudson/slaves/CloudTest.java
+++ b/test/src/test/java/hudson/slaves/CloudTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -38,7 +37,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerResponse2;
 
 @WithJenkins
-class CloudTest {
+public class CloudTest {
 
     private JenkinsRule j;
 
@@ -111,6 +110,7 @@ class CloudTest {
     }
 
     @Test
+    @Issue("#26183")
     void save() throws Exception {
         ACloud aCloud = new ACloud("a", "0");
         j.jenkins.clouds.add(aCloud);
@@ -154,7 +154,7 @@ class CloudTest {
     public static final class ACloud extends AbstractCloudImpl {
 
         @DataBoundConstructor
-        ACloud(String name, String instanceCapStr) {
+        public ACloud(String name, String instanceCapStr) {
             super(name, instanceCapStr);
         }
 
@@ -167,7 +167,7 @@ class CloudTest {
             return false;
         }
 
-        @Extension
+        @TestExtension
         public static class DescriptorImpl extends Descriptor<Cloud> {
             @Override public String getDisplayName() {
                 return "ACloud";

--- a/test/src/test/resources/hudson/slaves/CloudTest/ACloud/config.jelly
+++ b/test/src/test/resources/hudson/slaves/CloudTest/ACloud/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="name">
+    <f:textbox/>
+  </f:entry>
+  <f:entry field="instanceCapStr">
+    <f:number default="5"/>
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
The fix in #26004 was not sufficient when 2 clouds are created with the same name.
The second cloud produces a different url but in `t:actions` the url for the action is computed from `it.url` which used the non indexed url so basically going to the wrong cloud.
Similarly when saving such a cloud the form was redirecting to the wrong url

Fixes #26174 
Fixes #26183 

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done
Adjusted the tests in `CloudTest`:
- Added a new test that verifies second clouds uses a url with index
- Adjusted the ui test that an action for a second cloud has the correct url. The test fails without the fix
- Added a new test that verifies after saving the form one is redirected to the correct url

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Fix Cloud#getUrl when 2 clouds with same name exist.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
