### PR TITLE
Fix cloudByIndex crash when cloud name is not numeric

### DIFF
--- a/core/src/main/java/hudson/slaves/Cloud.java
+++ b/core/src/main/java/hudson/slaves/Cloud.java
@@ -337,7 +337,7 @@ public abstract class Cloud extends Actionable implements ExtensionPoint, Descri
         j.clouds.replace(this, result);
         j.save();
         // take the user back to the cloud top page.
-        return FormApply.success("../" + result.name + '/');
+        return FormApply.success(".");
 
     }
 


### PR DESCRIPTION
Title
/label bug

Fixes #26183 
Fix crash when saving cloud configuration accessed via cloudByIndex

Summary

This PR fixes an “Angry Jenkins” crash that occurs when saving a cloud configuration that is accessed via an index-based URL (cloudByIndex).
The crash was caused by an incorrect redirect that assumed clouds are always addressable by name, resulting in a NumberFormatException.


Problem

When Jenkins detects multiple clouds with the same name, it falls back to index-based routing to ensure uniqueness, for example:

/manage/cloud/cloudByIndex/1/

However, after saving the configuration, Cloud#doConfigSubmit redirected to a name-based URL:

return FormApply.success("../" + result.name + '/');

If the configuration page was accessed via cloudByIndex, this produced an invalid redirect such as:

/manage/cloud/cloudByIndex/<cloud-name>/

Stapler then attempted to parse <cloud-name> as an integer, causing a:

java.lang.NumberFormatException

and resulting in an Angry Jenkins error page.

This issue commonly occurs with cloud plugins (e.g., Google Compute Engine) where name collisions are possible due to prefixing logic.

⸻

Root Cause

The redirect logic in Cloud#doConfigSubmit assumed that clouds are always uniquely identifiable by name in the URL hierarchy and did not account for Jenkins’ index-based fallback mechanism.

⸻

Solution

Update the redirect to be hierarchy-agnostic by redirecting to the current object’s top page instead of constructing a name-based path.

Change
<img width="1003" height="171" alt="Screenshot 2026-01-25 at 7 03 07 PM" src="https://github.com/user-attachments/assets/be09a226-23bd-4363-9b6e-827c13b1e8dc" />




⸻

Why this fix is correct
	•	Hierarchy-agnostic
Works correctly whether the cloud is accessed via name or via cloudByIndex.
	•	Rename-safe
Handles cloud renames properly, since the redirect always resolves to the correct instance.
	•	Consistent with Jenkins core
Matches established patterns used elsewhere in Jenkins (e.g., ComputerSet, Run).
	•	Minimal & low-risk
One-line change, no behavior impact outside redirect handling.

⸻

Verification

Manual Testing
	1.	Duplicate name
	•	Create two clouds named gce-google
	•	Navigate to the second via cloudByIndex
	•	Save configuration
✅ Redirects correctly without crashing
	2.	Unique name
	•	Create a uniquely named cloud
	•	Save configuration
✅ Redirects to name-based status page
	3.	Rename
	•	Rename an existing cloud
	•	Save configuration
✅ Redirects to the updated cloud page

⸻

Notes on local testing

When running Jenkins locally with Java 17+ (e.g., via mvn jetty:run), the following JVM options are required due to module access restrictions:

export MAVEN_OPTS="\
--add-opens java.base/java.util=ALL-UNNAMED \
--add-opens java.base/java.lang=ALL-UNNAMED \
--add-opens java.base/java.io=ALL-UNNAMED"
mvn jetty:run

This is independent of this fix:
	•	InaccessibleObjectException → Java module access / environment issue
	•	NumberFormatException → Jenkins redirect logic bug (fixed by this PR)

⸻

Screenshots

Before: Angry Jenkins error after saving cloud configuration
<img width="1078" height="581" alt="Screenshot 2026-01-25 at 7 05 42 PM" src="https://github.com/user-attachments/assets/e6ed59b8-9f30-46ee-8443-d127231f8e21" />

After: Successful redirect to cloud status page
<img width="1082" height="603" alt="Screenshot 2026-01-25 at 7 06 30 PM" src="https://github.com/user-attachments/assets/da3c9738-b123-448b-9352-c0b5e8445f98" />


