### PR TITLE
Fix clipping in experimental Manage Jenkins matrix UI

### DIFF
--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -170,12 +170,28 @@ body:has(.app-settings-container) {
   min-height: calc(100vh - var(--header-height) - var(--section-padding));
 
   &__inner {
-    max-width: 900px;
+    width: 100%;
     margin: auto;
-    overflow-x: clip;
+    overflow-x: auto;
     padding: var(--section-padding);
-    display: flex;
-    flex-direction: column;
+    // Ensure wide tables like the authorization matrix can expand
+    table.matrix-auth-model,
+    table.matrix-auth-table,
+    .matrix-auth-table {
+      width: max-content;
+      min-width: 100%;
+
+      td:first-child {
+        min-width: 200px;
+        white-space: nowrap;
+      }
+
+      // Ensure the "Select All" / "Unselect All" buttons are visible
+      .selectall,
+      .unselectall {
+        display: inline-flex !important;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #26171
/label bug
## Summary
Fixes a layout regression in the experimental Manage Jenkins UI where
the Matrix / Project-based Matrix Authorization grid is clipped and
cannot be horizontally scrolled.

## Problem
In the experimental Manage Jenkins UI, permission columns and action
buttons (Grant All / Remove All / Delete) are clipped and inaccessible.
Unlike the classic UI, horizontal scrolling is not possible, making the
issue significantly worse.

## Solution
This PR applies a CSS-only fix to the experimental UI layout:
- Restores horizontal scrolling for wide authorization matrices
- Prevents clipping of permission columns
- Keeps action buttons accessible
- No Java or Jelly changes

## Scope
- Experimental UI only
- CSS-only change
- No impact on classic Manage Jenkins UI

## Verification
- Enabled experimental Manage Jenkins UI
- Tested Matrix and Project-based Matrix Authorization
- Verified columns are scrollable and controls accessible
<img width="677" height="542" alt="Screenshot 2026-01-25 at 10 57 14 AM" src="https://github.com/user-attachments/assets/2274aca4-fc37-4f58-89d0-119feb0d8e2c" />


## Screenshots
Before: clipped authorization grid  
<img width="1064" height="634" alt="Screenshot 2026-01-25 at 7 51 38 PM" src="https://github.com/user-attachments/assets/2fbfe47c-2f1a-4358-9e83-7d11a445cc3d" />


After: full grid accessible with horizontal scrolling
<img width="1063" height="600" alt="Screenshot 2026-01-25 at 7 25 38 PM" src="https://github.com/user-attachments/assets/d21a408c-8cf9-401c-9539-6d070b637109" />
