### PR TITLE
Minor dropdown / notice tweaks

### DIFF
--- a/src/main/scss/components/_dropdowns.scss
+++ b/src/main/scss/components/_dropdowns.scss
@@ -148,6 +148,22 @@ $dropdown-padding: 0.375rem;
     min-width: 180px;
     user-select: none;
 
+    &:has(.jenkins-dropdown__item__description) {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      row-gap: 0.25rem;
+      text-align: left;
+      overflow: clip;
+      text-wrap: wrap;
+      max-width: 380px;
+
+      .jenkins-dropdown__item__description {
+        color: var(--text-color-secondary);
+        grid-area: 2 / 2;
+        line-height: 1.5;
+      }
+    }
+
     &__icon {
       display: inline-flex;
       align-items: center;

--- a/src/main/scss/components/_notice.scss
+++ b/src/main/scss/components/_notice.scss
@@ -19,6 +19,15 @@
     height: 2.5rem;
   }
 
+  .jenkins-dropdown {
+    text-align: left;
+  }
+
+  button > svg {
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+
   &__description {
     color: var(--text-color-secondary);
     margin-top: -0.375rem;

--- a/src/main/scss/components/_notice.scss
+++ b/src/main/scss/components/_notice.scss
@@ -14,18 +14,13 @@
   padding: calc(var(--section-padding) * 2);
   text-align: center;
 
-  svg {
+  & > svg {
     width: 2.5rem;
     height: 2.5rem;
   }
 
   .jenkins-dropdown {
     text-align: left;
-  }
-
-  button > svg {
-    width: 1.125rem;
-    height: 1.125rem;
   }
 
   &__description {


### PR DESCRIPTION
<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Improvements to dropdowns based on requirements in https://github.com/jenkinsci/credentials-plugin/pull/992

- Buttons display properly in `l:notice` now
- `l:overflowButton` in `l:notice` headings are correctly left aligned
- Add support for a description in a dropdown list

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

Applied this diff into core and then reviewed the result on a view with no jobs:

```diff
diff --git i/core/src/main/resources/hudson/model/View/noJob.jelly w/core/src/main/resources/hudson/model/View/noJob.jelly
index 23011d448e..118dc4be02 100644
--- i/core/src/main/resources/hudson/model/View/noJob.jelly
+++ w/core/src/main/resources/hudson/model/View/noJob.jelly
@@ -23,10 +23,26 @@ THE SOFTWARE.
 -->

 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:notice title="${%description_1}" icon="symbol-weather-icon-health-00to19">
-        <j:if test="${it.hasPermission(it.CONFIGURE)}">
-            ${%description_2}
-        </j:if>
-    </l:notice>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:dd="/lib/layout/dropdowns">
+  <l:notice title="${%description_1}" icon="symbol-weather-icon-health-00to19">
+    <l:overflowButton text="${%Add Credentials}"
+                      icon="symbol-add"
+                      clazz="jenkins-button--primary"
+                      tooltip="${null}">
+      <dd:header text="System"/>
+      <dd:custom>
+        <button class="jenkins-dropdown__item"
+                data-type="credentials-add-store-item"
+                data-url="/blah"
+                type="button">
+          <div class="jenkins-dropdown__item__icon">
+            <l:icon src="symbol-arrow-right"/>
+          </div>
+          <span>My domain</span>
+          <div class="jenkins-dropdown__item__description">this is a description</div>
+        </button>
+      </dd:custom>
+    </l:overflowButton>
+
+  </l:notice>
 </j:jelly>
```


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

<img width="443" height="267" alt="image" src="https://github.com/user-attachments/assets/8ca6a84b-7782-4bfb-bcf2-704627e48d67" />


#### After

<img width="444" height="270" alt="image" src="https://github.com/user-attachments/assets/7ed1ad48-f256-4327-bcec-9c74b5b381fe" />


### Proposed changelog entries

- Minor refinement of dropdowns and empty states.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
