### PR TITLE
Fix clipping of authorization tables in experimental Manage Jenkins UI

### DIFF
--- a/src/main/scss/components/_section.scss
+++ b/src/main/scss/components/_section.scss
@@ -3,7 +3,12 @@
 .jenkins-section {
   border-top: var(--jenkins-border);
   padding: var(--section-padding) 0 0 0;
-  max-width: 1800px;
+  width: 100%;
+
+  .app-settings-container & {
+    max-width: none;
+    width: 100%;
+  }
 
   &:last-child {
     padding-bottom: 0;

--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -170,12 +170,17 @@ body:has(.app-settings-container) {
   min-height: calc(100vh - var(--header-height) - var(--section-padding));
 
   &__inner {
-    max-width: 900px;
-    margin: auto;
-    overflow-x: clip;
+    max-width: none;
+    width: 100%;
+    overflow-x: auto;
     padding: var(--section-padding);
-    display: flex;
-    flex-direction: column;
+     // Ensure wide tables can scroll
+    // 1. Allows tables to grow
+    // 2. Leaves column sizing to browser
+    // 3. Doesn't affect non-settings pages
+    .app-settings-container table {
+      min-width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #26171

### Testing done
- Enabled the experimental Manage Jenkins UI
- Navigated to Manage Jenkins → Security
- Tested Matrix-based and Project-based Matrix Authorization Strategy
- Verified wide authorization tables are no longer clipped
- Confirmed horizontal scrolling works and action buttons remain accessible

### Screenshots (UI changes only)

#### Before
<!-- clipped authorization table -->
<img width="1440" height="900" alt="Screenshot 2026-01-26 at 10 42 55 AM" src="https://github.com/user-attachments/assets/70758c3e-2d94-45d8-a25a-593563a9bef7" />


#### After
<!-- full-width table with horizontal scrolling -->
<img width="1440" height="900" alt="Screenshot 2026-01-26 at 10 42 43 AM" src="https://github.com/user-attachments/assets/4a565c3a-0600-4b03-b00c-a4311fdee76a" />

### Proposed changelog entries
- Fix clipping of authorization tables in the experimental Manage Jenkins UI

### Proposed changelog category
/label bug, web-ui

### Proposed upgrade guidelines
N/A