### PR TITLE
WIP: Check Launchable results publication

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ properties([
 ])
 
 def axes = [
-  platforms: ['linux'],
-  jdks: [21],
+  platforms: ['linux', 'windows'],
+  jdks: [21, 25],
 ]
 
 stage('Record build') {

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -18,6 +18,8 @@
     <mina-sshd.version>2.16.0</mina-sshd.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
+    <!-- Intentionally run only one test to reduce cycle time -->
+    <test>QuotedStringTokenizerTest</test>
   </properties>
 
   <dependencyManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,8 @@ THE SOFTWARE.
     <remoting.minimum.supported.version>3176.v207ec082a_8c0</remoting.minimum.supported.version>
     <!-- Filled in by jacoco-maven-plugin -->
     <jacocoSurefireArgs />
+    <!-- Intentionally run only one test to reduce cycle time -->
+    <test>EnvVarsTest</test>
   </properties>
 
   <dependencyManagement>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -52,6 +52,8 @@ THE SOFTWARE.
 
     <!-- Filled in by maven-hpi-plugin with "-javaagent:/path/to/mockito-core-<version>.jar" -->
     <jenkins.javaAgent />
+    <!-- Intentionally run only one test to reduce cycle time -->
+    <test>hudson.AboutJenkinsTest</test>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Fast incremental build to check Launchable results publication

Do not merge.

I've seen Launchable build failures on the master branch and on two pull requests.

Perform a fast build to see if it also breaks when publishing results to Launchable.

### Testing done

None.  Rely on ci.jenkins.io

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
