### PR TITLE
Use client-side redirects in admin monitors for Chrome

### DIFF
--- a/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/ReverseProxySetupMonitor.java
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.security.stapler.StaplerDispatchable;
+import jenkins.util.ClientHttpRedirect;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -127,7 +128,7 @@ public class ReverseProxySetupMonitor extends AdministrativeMonitor {
             // of course the irony is that this redirect won't work
             return HttpResponses.redirectViaContextPath("/manage");
         } else {
-            return new HttpRedirect("https://www.jenkins.io/redirect/troubleshooting/broken-reverse-proxy");
+            return new ClientHttpRedirect("https://www.jenkins.io/redirect/troubleshooting/broken-reverse-proxy");
         }
     }
 

--- a/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
+++ b/core/src/main/java/hudson/security/csrf/DefaultCrumbIssuer.java
@@ -24,15 +24,17 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.security.HexStringConfidentialKey;
+import jenkins.util.ClientHttpRedirect;
 import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
-import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.POST;
 import org.springframework.security.core.Authentication;
 
@@ -181,15 +183,14 @@ public class DefaultCrumbIssuer extends CrumbIssuer {
         }
 
         @POST
-        public void doAct(StaplerRequest2 req, StaplerResponse2 rsp, @QueryParameter String learn, @QueryParameter String dismiss) throws IOException, ServletException {
+        public HttpResponse doAct(StaplerRequest2 req, @QueryParameter String learn, @QueryParameter String dismiss) throws IOException, ServletException {
             if (learn != null) {
-                rsp.sendRedirect("https://www.jenkins.io/redirect/csrf-protection/");
-                return;
+                return new ClientHttpRedirect("https://www.jenkins.io/redirect/csrf-protection/");
             }
             if (dismiss != null) {
                 disable(true);
             }
-            rsp.forwardToPreviousPage(req);
+            return HttpResponses.forwardToPreviousPage();
         }
     }
 

--- a/core/src/main/java/hudson/util/HttpResponses.java
+++ b/core/src/main/java/hudson/util/HttpResponses.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import jenkins.util.ClientHttpRedirect;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.HttpResponse;
@@ -49,6 +50,16 @@ import org.kohsuke.stapler.StaplerResponse2;
 public class HttpResponses extends org.kohsuke.stapler.HttpResponses {
     public static HttpResponse staticResource(File f) throws IOException {
         return staticResource(f.toURI().toURL());
+    }
+
+    /**
+     * Redirect to the given URL via a client-side JS/meta tag redirect.
+     * @param url the URL to redirect to
+     * @return the HttpResponse
+     * @since TODO
+     */
+    public static HttpResponse clientRedirectTo(String url) {
+        return new ClientHttpRedirect(url);
     }
 
     /**

--- a/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
+++ b/core/src/main/java/jenkins/monitor/JavaVersionRecommendationAdminMonitor.java
@@ -38,12 +38,12 @@ import java.util.Locale;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import jenkins.model.Jenkins;
+import jenkins.util.ClientHttpRedirect;
 import jenkins.util.SystemProperties;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
@@ -138,7 +138,7 @@ public class JavaVersionRecommendationAdminMonitor extends AdministrativeMonitor
             disable(true);
             return HttpResponses.forwardToPreviousPage();
         } else {
-            return new HttpRedirect("https://jenkins.io/redirect/java-support/");
+            return new ClientHttpRedirect("https://jenkins.io/redirect/java-support/");
         }
     }
 

--- a/core/src/main/java/jenkins/util/ClientHttpRedirect.java
+++ b/core/src/main/java/jenkins/util/ClientHttpRedirect.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.util;
+
+import hudson.Util;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
+
+/**
+ * An HTTP response that redirects the client to the given URL.
+ * Unlike {@link org.kohsuke.stapler.HttpRedirect}, this implements a client-side redirect (using meta tag and/or JavaScript).
+ * This allows the redirect to work even when Content Security Policy is enforced in Chrome
+ * (which applies {@code form-action} to redirects after form submission).
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/form-action">MDN documentation on form-action</a>
+ * @see <a href="https://github.com/w3c/webappsec-csp/issues/8">Content Security Policy issue discussing this behavior</a>
+ * @since TODO
+ */
+public record ClientHttpRedirect(String redirectUrl) implements HttpResponse {
+    @Override
+    public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object o) throws IOException, ServletException {
+        rsp.setContentType("text/html;charset=UTF-8");
+        Util.printRedirect(req.getContextPath(), redirectUrl, redirectUrl, rsp.getWriter());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jenkins/issues/26001

I considered multiple options to address this issue:

* Amend CSP rules to allow redirects. At least core always sends to `www.jenkins.io`, so that would be easy.
* Change the buttons with form submission to links and directly go there.
* Keep the buttons but attach JS to navigate to the site.
* Change how the direct is done, from HTTP 302 with `Location` header to client-side JS/`meta` tag.

The first one is easy but limited: Any URLs outside www.jenkins.io would be unsupported. Even if there aren't many problems like this across plugins, relaxing rules does not set a good example for plugin developers.

The second one was my favorite until I found https://github.com/jenkinsci/jenkins/issues/26205. It's still my favorite option for plugins though, and has as additional benefit that it's straightforward to open the link in a new window.

The third seems unnecessarily complicated on the view, so I dismissed it quickly.

This implementation uses the fourth option. For use in plugins, they would need to increase the core dependency, or reimplement the `HttpResponse` calling `Util#printRedirect` themselves. The latter seems reasonable, with just using a (currently broken looking) link probably the easiest.

FWIW there is currently no caller for `HttpResponses#clientRedirectTo`, so technically not ideal. It seems like a natural addition to that API though, and mirrors existing methods. Adding it there would help discoverability.

In terms of plugins, a quick GH code search found just:

* [dimensionsscm](https://github.com/jenkinsci/dimensionsscm-plugin/blob/67bf937de370f4d331ce64c883e4540152069234/src/main/java/hudson/plugins/dimensionsscm/MissingJarsAdministrativeMonitor.java#L51) is currently incompatible with CSP enforcement anyway, so that just adds another one to the list.
* [analysis-core](https://github.com/jenkinsci/analysis-core-plugin/blob/07ea7c8ec8d3802cf07f221b24fcbf363111973d/src/main/java/hudson/plugins/analysis/core/UpgradeNotifier.java#L43) is suspended since 2020.
* [scis-ad](https://github.com/jenkinsci/scis-ad-plugin/blob/62eafad2b93a5505f76909119f5c43109919ddf3/src/main/java/hudson/plugins/scis_ad/ScisSupportOffer.java#L26) is suspended since 2011, redirects to a dead domain.

Even if my search is not complete, I would expect this to be a problem in few plugins, and it's fairly easily resolved with a link.

### Testing done

Clicked the buttons in Chrome once the monitors showed:

* The reverse proxy monitor is always active in `jetty:run`, since it fails with "HTTP ERROR 400 Ambiguous URI path separator".
* `hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID = true` in script console
* Locally patched `JavaVersionRecommendationAdminMonitor` so it's already due.



I skipped autotests, because the new code is just a minor adapter around existing code doing the actual work.

### Screenshots (UI changes only)

n/a

#### Before

#### After

### Proposed changelog entries

- Make redirects to documentation on www.jenkins.io work in the built-in administrative monitors when using Chrome and enforcing Content Security Policy.

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
