### PR TITLE
Fix clipping of authorization tables in experimental Manage Jenkins UI

### DIFF
--- a/src/main/scss/components/_section.scss
+++ b/src/main/scss/components/_section.scss
@@ -3,7 +3,12 @@
 .jenkins-section {
   border-top: var(--jenkins-border);
   padding: var(--section-padding) 0 0 0;
-  max-width: 1800px;
+  width: 100%;
+
+  .app-settings-container & {
+    max-width: none;
+    width: 100%;
+  }
 
   &:last-child {
     padding-bottom: 0;

--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -170,12 +170,14 @@ body:has(.app-settings-container) {
   min-height: calc(100vh - var(--header-height) - var(--section-padding));
 
   &__inner {
-    max-width: 900px;
-    margin: auto;
-    overflow-x: clip;
+    max-width: none;
+    width: 100%;
+    overflow-x: auto;
     padding: var(--section-padding);
-    display: flex;
-    flex-direction: column;
+
+    .app-settings-container table {
+      min-width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #26171

### Testing done

- Built Jenkins locally using `mvn -Pquick-build clean install`
- Started Jenkins with `mvn -pl war jetty:run`
- Enabled the experimental Manage Jenkins UI
- Navigated to **Manage Jenkins → Security**
- Tested **Matrix-based** and **Project-based Matrix Authorization Strategy**
- Verified wide authorization tables are no longer clipped
- Confirmed horizontal scrolling works and action buttons (Grant All / Remove All / Delete) remain accessible
- This is a CSS-only change; no backend logic was modified

### Screenshots (UI changes only)

#### Before
<!-- attach screenshot showing clipped authorization table -->
<img width="1440" height="900" alt="Screenshot 2026-01-28 at 7 44 02 AM" src="https://github.com/user-attachments/assets/bff822b1-18cd-4493-a76b-c0a933169155" />


#### After
<!-- attach screenshot showing full table with horizontal scrolling -->
<img width="1440" height="900" alt="Screenshot 2026-01-28 at 7 44 09 AM" src="https://github.com/user-attachments/assets/ab70c415-a918-468d-b0f7-c691ffd6ca95" />


### Proposed changelog entries

- Fix clipping of authorization tables in the experimental Manage Jenkins UI

### Proposed changelog category

/label bug, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue is well-described.
- [x] The changelog entry is appropriate and in the imperative mood.
- [x] There is an explanation as to why this change has no automated tests (CSS-only UI fix).
- [x] No new public APIs or Java changes were introduced.
- [x] UI changes do not introduce CSP regressions.
- [x] No dependency updates are included.

### Desired reviewers

@jenkinsci/core-pr-reviewers