### PR TITLE
Fix primary button text color in administrative monitors

### DIFF
--- a/src/main/scss/pages/_manage-jenkins.scss
+++ b/src/main/scss/pages/_manage-jenkins.scss
@@ -1,5 +1,5 @@
-.manage-messages a,
-.manage-messages a:visited {
+.manage-messages a:not(.jenkins-button),
+.manage-messages a:visited:not(.jenkins-button) {
   color: inherit !important;
   text-decoration: none;
 }


### PR DESCRIPTION
Fixes #26205

### Testing done

- Built Jenkins locally
- Ran Jenkins using `mvn -pl war jetty:run`
- Reproduced the issue by rendering an administrative monitor message
- Verified that primary buttons inside administrative monitors retain correct styling
- Confirmed button text color is no longer overridden by admin monitor link styles
- CSS-only change; no Java or Jelly logic modified

### Screenshots (UI changes only)

#### Before
Primary button text inherits alert/link color inside administrative monitor. 
<img width="205" height="94" alt="Screenshot 2026-01-28 at 10 53 50 AM" src="https://github.com/user-attachments/assets/fb533eb5-f5c0-42d0-af60-5bfa1ceabae4" />


#### After
Primary button text is white as expected, with correct primary button styling.
<img width="157" height="79" alt="Screenshot 2026-01-28 at 10 53 57 AM" src="https://github.com/user-attachments/assets/8f87c392-7b57-4ed3-b6f0-af9d9974098f" />

### Proposed changelog entries

- Fix primary button text color in administrative monitors.

### Proposed changelog category

/label bug, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue is well-described.
- [x] The changelog entry is appropriate and in the imperative mood.
- [x] There is an explanation as to why this change has no automated tests (CSS-only UI fix).
- [x] No new public APIs or Java changes were introduced.
- [x] UI changes do not introduce CSP regressions.
- [x] No dependency updates are included.

### Desired reviewers

@jenkinsci/core-pr-reviewers