### PR TITLE
Show installation date for installed plugins in Plugin Manager

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -1435,7 +1435,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     /**
      * Returns the date when this plugin was installed.
      */
-		@SuppressWarnings("unused")
+    @SuppressWarnings("unused")
     @Exported
     public Date getInstallationDate() {
         if (archive == null) {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -1435,6 +1435,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     /**
      * Returns the date when this plugin was installed.
      */
+		@SuppressWarnings("unused")
     @Exported
     public Date getInstallationDate() {
         if (archive == null) {

--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -54,6 +54,7 @@ import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1429,6 +1430,18 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns the date when this plugin was installed.
+     */
+    @Exported
+    public Date getInstallationDate() {
+        if (archive == null) {
+            return null;
+        }
+        long ts = archive.lastModified();
+        return ts > 0 ? new Date(ts) : null;
     }
 
     private static final Logger LOGGER = Logger.getLogger(PluginWrapper.class.getName());

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
   Installed plugins
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:s="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:s="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%Installed plugins} - ${%Plugins}" permission="${app.SYSTEM_READ}">
     <j:set var="readOnlyMode" value="${!app.hasPermission(app.ADMINISTER)}"/>
 
@@ -78,6 +78,7 @@ THE SOFTWARE.
             <thead>
             <tr>
               <th initialSortDir="down">${%Name}</th>
+              <th>${%Installed}</th>
               <j:if test="${app.updateCenter.healthScoresAvailable}">
                 <th>
                   <j:set var="healthTooltip">${%healthTooltip}</j:set>
@@ -168,6 +169,17 @@ THE SOFTWARE.
                         ${%adoptThisPlugin}
                       </div>
                     </j:if>
+                  </td>
+                  <td class="jenkins-table__cell--tight" style="white-space:nowrap;"
+                      data="${p.installationDate != null ? p.installationDate.time : -1}">
+                      <j:choose>
+                          <j:when test="${p.installationDate != null}">
+                              <i:formatDate value="${p.installationDate}" type="both" dateStyle="medium" timeStyle="short"/>
+                          </j:when>
+                          <j:otherwise>
+                              <span class="jenkins-not-applicable">${%N/A}</span>
+                          </j:otherwise>
+                      </j:choose>
                   </td>
                   <j:if test="${app.updateCenter.healthScoresAvailable}">
                     <td class="jenkins-table__cell">
@@ -283,6 +295,10 @@ THE SOFTWARE.
                       <pre>${p.cause.message}</pre>
                     </div>
                   </td>
+                <td/>
+                <j:if test="${app.updateCenter.healthScoresAvailable}">
+                    <td/>
+                </j:if>
                   <td class="jenkins-table__cell--tight">
                     <div class="jenkins-table__cell__button-wrapper">
                       <span class="jenkins-toggle-switch">
@@ -291,7 +307,9 @@ THE SOFTWARE.
                       </span>
                     </div>
                   </td>
+                    <l:isAdmin>
                   <td/>
+                    </l:isAdmin>
                   <td/>
                 </tr>
               </j:forEach>


### PR DESCRIPTION
Fixes #16674 

Expose plugin installation date via PluginWrapper and display it in the Plugin Manager installed plugins table. The installation date is derived from the plugin archive's last modified timestamp. Adds a new "Installed" column and ensures correct sorting and table alignment, including failed plugins and uninstall-pending states.

### Testing done

Ensured all tests still passed.

### Screenshots (UI changes only)

#### Before

<img width="1470" height="833" alt="Screenshot 2026-01-30 at 12 54 59 PM" src="https://github.com/user-attachments/assets/51c45c8f-45a7-4200-b9ab-a03a2a18ee19" />

#### After

<img width="1470" height="838" alt="Screenshot 2026-01-30 at 12 37 31 PM" src="https://github.com/user-attachments/assets/66ec8998-2c1c-4268-bd2f-f6ba9ee51912" />

### Proposed changelog entries

Show installation date for plugins in the Installed Plugins page.

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Desired reviewers

@jenkinsci/core-pr-reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set, and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
