### PR TITLE
chore(pipeline): use nonspot agents on retry with Linux too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ axes.values().combinations {
     }
     int retryCount = 0
     retry(conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2) {
-      if (retryCount == 1 && platform == 'windows' ) {
+      if (retryCount == 1) {
         agentContainerLabel = agentContainerLabel + '-nonspot'
       }
       // Increment before allocating the node in case it fails

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ axes.values().combinations {
     }
     int retryCount = 0
     retry(conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2) {
-      if (retryCount == 1) {
+      if (retryCount == 0) {
         agentContainerLabel = agentContainerLabel + '-nonspot'
       }
       // Increment before allocating the node in case it fails

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ axes.values().combinations {
     }
     int retryCount = 0
     retry(conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2) {
-      if (retryCount == 0) {
+      if (retryCount == 1) {
         agentContainerLabel = agentContainerLabel + '-nonspot'
       }
       // Increment before allocating the node in case it fails


### PR DESCRIPTION
Fixes:
- https://github.com/jenkins-infra/helpdesk/issues/4906

### Testing done

With https://github.com/jenkinsci/jenkins/pull/26267/commits/58cb1f07adb0c66847aac90b8113611ade13ab1c I ensured that `maven-<jdk>-nonspot` labels are actually resulting in the use of the new nonspot agent templates I've put in place on ci.jenkins.io: https://ci.jenkins.io/job/Core/job/jenkins/job/PR-26267/4

> <img width="941" height="69" alt="image" src="https://github.com/user-attachments/assets/b55878cf-f763-4604-b5ed-689d01af0a02" />

Next build https://ci.jenkins.io/job/Core/job/jenkins/job/PR-26267/5/pipeline-overview/?selected-node=135 with the test commit reverted had its linux-21 spot agent reclaimed:
```
11:39:36  jnlp-maven-21-nz5f3 seems to be removed or offline (hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@3a33628:JNLP4-connect connection from 3.18.21.229/3.18.21.229:59752": Remote call on JNLP4-connect connection from 3.18.21.229/3.18.21.229:59752 failed. The channel is closing down or has closed down); will wait for 5 min 0 sec for it to come back online
11:39:36  Could not connect to jnlp-maven-21-nz5f3 to send interrupt signal to process
```
And retried on a nonspot agent as expected:
> <img width="1282" height="944" alt="image" src="https://github.com/user-attachments/assets/8dc88a7a-7012-4407-bce2-9374de16657d" />


### Screenshots (UI changes only)

N/A

#### Before

#### After

### Proposed changelog entries

- none (internal)

### Proposed changelog category

/label internal

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @MarkEWaite

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
