### PR TITLE
Fix card overflow for queue and build containers

### DIFF
--- a/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
+++ b/core/src/main/resources/hudson/widgets/HistoryWidget/index.jelly
@@ -44,6 +44,7 @@ THE SOFTWARE.
        data-page-entry-oldest="${page.oldestOnPage}"
        data-page-has-up="${page.hasUpPage}"
        data-page-has-down="${page.hasDownPage}">
+  <div class="jenkins-build-history-card">
     <l:card id="jenkins-builds" title="Builds" controls="${controls}" expandable="${it.baseUrl}/buildTimeTrend">
       <l:search-bar placeholder="${%find}"
                     clazz="${page.runs.isEmpty() and page.queueItems.isEmpty() ? 'jenkins-hidden' : ''}"/>
@@ -75,5 +76,5 @@ THE SOFTWARE.
       <!--after that component has been rendered to get the correct value to use in `builds-card.js`-->
       <div id="properties" page-next-build="${it.nextBuildNumberToFetch ?: it.owner.nextBuildNumber}"/>
     </l:card>
-  </div>
+  </div></div>
 </j:jelly>

--- a/src/main/scss/components/_cards.scss
+++ b/src/main/scss/components/_cards.scss
@@ -36,6 +36,10 @@ $card-padding: 1rem;
     padding: 0 $card-padding $card-padding;
     overflow-y: auto;
 
+    .jenkins-build-history-card & {
+      overflow: visible;
+    }
+
     &:empty {
       display: none;
     }


### PR DESCRIPTION
Fixes #26193

### Testing done
- Built Jenkins locally using `mvn -am -pl war,bom -Pquick-build install`
- Ran Jenkins with `java -jar war/target/jenkins.war`
- Reproduced the issue in queue and build-related views where card content was clipped or misaligned
- Verified that cards containing queue and build containers render correctly without clipping
- Frontend lint verified locally using `corepack yarn lint`

### Screenshots (UI changes only)
#### Before
Queue/build card content is clipped due to overflow handling.
<img width="348" height="549" alt="Screenshot from 2026-02-06 00-58-29" src="https://github.com/user-attachments/assets/139ea92d-c8d4-4c6a-ba2e-eb7d0236ff77" />


#### After
Queue/build card content is fully visible with correct layout.
<img width="497" height="553" alt="Screenshot from 2026-02-06 01-02-59" src="https://github.com/user-attachments/assets/bc733e6b-b77e-4a1f-8d81-4163dab596a3" />
<img width="497" height="553" alt="Screenshot from 2026-02-06 01-03-03" src="https://github.com/user-attachments/assets/cefbda47-a0bb-44f4-99ac-9cb64e3c0507" />


### Proposed changelog entries

- Fix card overflow regression affecting queue and build views.

### Proposed changelog category
/label bug, web-ui

### Proposed upgrade guidelines

N/A


### Submitter checklist

- [x] The issue is well-described.
- [x] The changelog entry is appropriate and in the imperative mood.
- [x] There is an explanation as to why this change has no automated tests.
- [x] No new public APIs or Java changes were introduced.
- [x] UI changes do not introduce CSP regressions.
- [x] No dependency updates are included.

### Desired reviewers

@jenkinsci/core-pr-reviewers