### PR TITLE
JENKINS-18321: Use close icon for dismiss buttons in admin monitors

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 <div class="jenkins-alert jenkins-alert-warning">
   <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
     <f:submit name="yes" value="${%Tell me more}"/>
-    <f:submit name="no" value="${%Dismiss}"/>
+    <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
   </form>
   ${%blurb(app.rootDir)}
 </div>

--- a/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
     </form>
     ${%You have data stored in an older format and/or unreadable data.}
   </div>

--- a/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%More Info}"/>
       <l:isAdmin>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
       </l:isAdmin>
     </form>
     <div>${%blurb}</div>

--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
         <f:submit name="yes" value="${%Create a view now}"/>
-        <f:submit name="no" value="${%Dismiss}"/>
+        <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
       </form>
     </l:isAdmin>
     ${%blurb}

--- a/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
+++ b/core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/disable">
-      <f:submit value="${%Dismiss}"/>
+      <f:submit value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
     </form>
     ${%blurb(rootURL)}
   </div>

--- a/core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/ExcludeSessionIdAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/ExcludeSessionIdAdministrativeMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="learn" value="${%Learn more}"/>
-      <f:submit name="dismiss" value="${%Dismiss}"/>
+      <f:submit name="dismiss" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
     </form>
     ${%blurb}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsAgents/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
      <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Manage}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
      </form>
 
     ${%ExecutorsWarning}

--- a/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/ControllerExecutorsNoAgents/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="agent" value="${%Set up agent}"/>
       <f:submit name="cloud" value="${%Set up cloud}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
     </form>
     ${%ExecutorsWarning}
   </div>

--- a/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/RootUrlNotSetMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <l:isAdmin>
       <form method="post" action="${rootURL}/${it.url}/disable">
-        <f:submit value="${%Dismiss}"/>
+        <f:submit value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
       </form>
     </l:isAdmin>
     <j:set var="actionAnchor">

--- a/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/diagnostics/SecurityIsOffMonitor/message.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <div class="jenkins-alert jenkins-alert-warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
       <f:submit name="yes" value="${%Setup Security}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
     </form>
     ${%blurb}
   </div>

--- a/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
+++ b/core/src/main/resources/jenkins/model/BuiltInNodeMigration/message.jelly
@@ -3,7 +3,7 @@
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Apply Migration}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/monitor/JavaVersionRecommendationAdminMonitor/message.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
         <form id="JavaVersionRecommendationAdminMonitor" method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%More Info}"/>
             <l:isAdmin>
-                <f:submit value="${%Ignore}" name="no"/>
+                <f:submit value="${%Ignore}" name="no" icon="symbol-close-circle" primary="false"/>
             </l:isAdmin>
         </form>
         <h2>${%Recommended_Java_Version_Heading(it.javaVersion)}</h2>

--- a/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/monitor/OperatingSystemEndOfLifeAdminMonitor/message.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
         <form id="${it.id}" method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%More Info}"/>
             <l:isAdmin>
-                <f:submit value="${%Ignore}" name="no"/>
+                <f:submit value="${%Ignore}" name="no" icon="symbol-close-circle" primary="false"/>
             </l:isAdmin>
         </form>
         <h2 class="h3">${it.displayName}</h2>

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyDisabledDefaultAdministrativeMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Disable automatic generation of legacy API tokens}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
         </form>
         ${%warningMessage}
     </div>

--- a/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/apitoken/ApiTokenPropertyEnabledNewLegacyAdministrativeMonitor/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="yes" value="${%Prevent users from manually creating legacy API tokens}"/>
-            <f:submit name="no" value="${%Dismiss}"/>
+            <f:submit name="no" value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
         </form>
         ${%warningMessage}
     </div>

--- a/core/src/main/resources/jenkins/security/csp/impl/CspRecommendation/message.jelly
+++ b/core/src/main/resources/jenkins/security/csp/impl/CspRecommendation/message.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
     <div class="jenkins-alert jenkins-alert-info">
         <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
             <f:submit name="more" value="${%Learn more}"/>
-            <f:submit name="dismiss" primary="false" value="${%Dismiss}"/>
+            <f:submit name="dismiss" primary="false" value="${%Dismiss}" icon="symbol-close-circle"/>
         </form>
         ${%blurb}
     </div>

--- a/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
+++ b/core/src/main/resources/jenkins/security/csrf/CSRFAdministrativeMonitor/message.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <div class="jenkins-alert jenkins-alert-warning">
         <form method="post" action="${rootURL}/${it.url}/disable">
-            <f:submit value="${%Dismiss}"/>
+            <f:submit value="${%Dismiss}" icon="symbol-close-circle" primary="false"/>
         </form>
         <j:set var="referenceAnchor">
             <a href="https://www.jenkins.io/redirect/csrf-protection" rel="noopener noreferrer" target="_blank">${%referenceUrlContent}</a>


### PR DESCRIPTION
## Description

Fixes #18321.

Admin monitor warnings shown on **Manage Jenkins** currently use text buttons like **“Dismiss”** / **“Ignore”**. This PR updates those actions to use the standard close icon (×) via `icon="symbol-close-circle"` and makes them non-primary (`primary="false"`) for improved UX consistency.

## Screenshots (UI changes only)

### Before
- Dismiss/Ignore actions displayed as text buttons (“Dismiss” / “Ignore”).

### After
- Dismiss/Ignore actions display a close (×) icon (`symbol-close-circle`) and are styled as secondary buttons (`primary="false"`).


In Light Mode : 
<img width="1233" height="432" alt="Screenshot 2026-02-08 at 10 23 06 PM" src="https://github.com/user-attachments/assets/7bc0ebd2-f776-4457-890c-3bfc69db4da4" />



<img width="1257" height="464" alt="Screenshot 2026-02-08 at 10 23 16 PM" src="https://github.com/user-attachments/assets/c4e5b7b4-b943-4bd0-9365-2bee061a2910" />


In Dark Mode : 

<img width="1265" height="454" alt="Screenshot 2026-02-08 at 10 22 43 PM" src="https://github.com/user-attachments/assets/b0af6c74-dfae-47ca-a875-ddc6d92dd6d9" />


## Proposed changelog entries

- Use close icon (×) for dismiss/ignore actions in administrative monitor banners for improved UX consistency.

## Proposed changelog category

/label web-ui


## Testing done

- Ran Jenkins locally and validated the instance starts successfully.
- Verified the relevant views were updated by searching for the new icon usage:
  ```bash
  grep -r "icon=\"symbol-close-circle\"" core/src/main/resources/
  ```

## Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper change labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a corresponding **Proposed upgrade guidelines** section in the pull request title (see example).
- [ ] If it makes sense to backport to the LTS baseline, the change to LTS is a `_bug_` or `_improvement_`, and either the issue or pull request is labeled as `lts-candidate` to be considered.

## Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO`, as appropriate. (N/A)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. (N/A)
- [x] UI changes do not introduce regressions when enforcing the current default rules of the Content Security