### PR TITLE
Avoid emitting console hyperlinks for upstream build causes

### DIFF
--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -316,8 +316,8 @@ public abstract class Cause {
             indent(listener, depth);
             listener.getLogger().println(
                 Messages.Cause_UpstreamCause_ShortDescription(
-                    ModelHyperlinkNote.encodeTo('/' + upstreamUrl, upstreamProject),
-                    ModelHyperlinkNote.encodeTo('/' + upstreamUrl + upstreamBuild, Integer.toString(upstreamBuild)))
+                    upstreamProject,
+                    Integer.toString(upstreamBuild))
             );
             if (upstreamCauses != null && !upstreamCauses.isEmpty()) {
                 indent(listener, depth);


### PR DESCRIPTION
Fixes #21106

## How was this tested?

This change was tested by looking at the build cause output for upstream triggered builds.

Previously, builds triggered from upstream included console-style hyperlinks generated by `UpstreamCause#print`, which were then reused during rendering and lead to invalid `/pollingLog` links.

Once this change is made, upstream causes are displayed as plain text, and the `/pollingLog` link is not generated for upstream build triggers.

This change does not impact SCM-trig builds, which will still produce polling log links as before.

## Why remove the link rather than repair it?

Hyperlinks generated by `UpstreamCause#print` appear to be console-oriented (`ModelHyperlinkNote`) and may not be context-aware during subsequent reuse in UI

However, repairing this connection is not easy, as it demands disambiguating console and UI rendering contexts. Moreover, this may generate even more inconsistencies.

The removal of console-style hyperlink output prevents misuse outside of a particular context and keeps changes minimal, without impacting existing behavior for SCM-triggered builds.

## Why didn’t the previous change fix the issue?

The investigation revealed that the earlier changes were targeted at addressing certain cases regarding the generation of log link but failed to take into consideration the reusage of console-style hyperlinks of `UpstreamCause#print`.

As a result, the invalid `/pollingLog` link could still appear for upstream-triggered builds. This change addresses that remaining case.
