### PR TITLE
Fix link to polling log of upstream build caused by an SCM trigger after a Jenkins restart

### DIFF
--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -200,6 +200,11 @@ public abstract class Cause {
         }
 
         @Override
+        public void onLoad(@NonNull Run<?, ?> build) {
+            onLoad(build.getParent(), build.getNumber());
+        }
+
+        @Override
         public void onLoad(@NonNull Job<?, ?> _job, int _buildNumber) {
             Item i = Jenkins.get().getItemByFullName(this.upstreamProject);
             if (!(i instanceof Job j)) {

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -29,12 +29,14 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.XmlFile;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.BuildTrigger;
+import hudson.triggers.SCMTrigger;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -268,6 +270,18 @@ class CauseTest {
             assertFalse(content.contains("Simple cause: <img"));
             assertTrue(content.contains("Simple cause: &lt;img"));
         }
+    }
+
+    @Test
+    @LocalData
+    void upstreamCauseOnLoad() throws Exception {
+        final Item item = j.jenkins.getItemByFullName("downstream");
+        assertThat(item, instanceOf(FreeStyleProject.class));
+        FreeStyleProject down = (FreeStyleProject) item;
+        final FreeStyleBuild build = down.getBuildByNumber(1);
+        Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) build.getCauses().getFirst();
+        SCMTrigger.SCMTriggerCause scmCause = (SCMTrigger.SCMTriggerCause) upstreamCause.getUpstreamCauses().getFirst();
+        assertNotNull(scmCause.getRun());
     }
 
     public static class SimpleCause extends Cause {

--- a/test/src/test/resources/hudson/model/CauseTest/jobs/downstream/builds/1/build.xml
+++ b/test/src/test/resources/hudson/model/CauseTest/jobs/downstream/builds/1/build.xml
@@ -1,0 +1,32 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<build>
+    <actions>
+        <hudson.model.CauseAction>
+            <causeBag class="linked-hash-map">
+                <entry>
+                    <hudson.model.Cause_-UpstreamCause>
+                        <upstreamProject>upstream</upstreamProject>
+                        <upstreamUrl>job/upstream/</upstreamUrl>
+                        <upstreamBuild>1</upstreamBuild>
+                        <upstreamCauses>
+                            <hudson.triggers.SCMTrigger_-SCMTriggerCause/>
+                        </upstreamCauses>
+                    </hudson.model.Cause_-UpstreamCause>
+                    <int>1</int>
+                </entry>
+            </causeBag>
+        </hudson.model.CauseAction>
+    </actions>
+    <queueId>6</queueId>
+    <timestamp>1595937941553</timestamp>
+    <startTime>1595937941557</startTime>
+    <result>SUCCESS</result>
+    <duration>2</duration>
+    <charset>UTF-8</charset>
+    <keepLog>false</keepLog>
+    <builtOn></builtOn>
+    <workspace>/var/jenkins_home/workspace/downstream</workspace>
+    <hudsonVersion>2.249</hudsonVersion>
+    <scm class="hudson.scm.NullChangeLogParser"/>
+    <culprits class="com.google.common.collect.EmptyImmutableSortedSet"/>
+</build>

--- a/test/src/test/resources/hudson/model/CauseTest/jobs/downstream/config.xml
+++ b/test/src/test/resources/hudson/model/CauseTest/jobs/downstream/config.xml
@@ -1,0 +1,18 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <authToken>test</authToken>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders/>
+    <publishers/>
+    <buildWrappers/>
+</project>

--- a/test/src/test/resources/hudson/model/CauseTest/jobs/upstream/builds/1/build.xml
+++ b/test/src/test/resources/hudson/model/CauseTest/jobs/upstream/builds/1/build.xml
@@ -1,0 +1,25 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<build>
+    <actions>
+        <hudson.model.CauseAction>
+            <causeBag class="linked-hash-map">
+                <entry>
+                    <hudson.triggers.SCMTrigger_-SCMTriggerCause/>
+                    <int>1</int>
+                </entry>
+            </causeBag>
+        </hudson.model.CauseAction>
+    </actions>
+    <queueId>5</queueId>
+    <timestamp>1595937941553</timestamp>
+    <startTime>1595937941557</startTime>
+    <result>SUCCESS</result>
+    <duration>2</duration>
+    <charset>UTF-8</charset>
+    <keepLog>false</keepLog>
+    <builtOn></builtOn>
+    <workspace>/var/jenkins_home/workspace/upstream</workspace>
+    <hudsonVersion>2.249</hudsonVersion>
+    <scm class="hudson.scm.NullChangeLogParser"/>
+    <culprits class="com.google.common.collect.EmptyImmutableSortedSet"/>
+</build>

--- a/test/src/test/resources/hudson/model/CauseTest/jobs/upstream/config.xml
+++ b/test/src/test/resources/hudson/model/CauseTest/jobs/upstream/config.xml
@@ -1,0 +1,18 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <authToken>test</authToken>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders/>
+    <publishers/>
+    <buildWrappers/>
+</project>


### PR DESCRIPTION
fixes #21106

When a run was caused by an upstream change that itself was triggered by an SCMTriggerCause, the link on the run to the pollingLog of the upstream build was lost after a Jenkins restart.
The root cause of the problem is the fix for #23334 which removed the `onLoad(Run build)` from the upstream cause which effectively prevents loading of upstream causes after a restart. The `onLoad(Job, job, int buildNumber)` was then actually never called.
The fix should not reintroduce the issue from #23334, as the `DeeplyNestedUpstreamCause` will at one point jump in and prevent further loading of more builds.

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done
Added a test that fails without the fix and succeeds afterwards.
Also verified manually:
1. Create a job `downstream` that does nothing
2. Create a job `upstream`, that uses Git SCM with any small github project
3. add a post build step that triggers a build of downstream
4. configured Poll SCM to run every minute
5. wait for the `upstream` and `downstream` jobs to have run
6. The downstream build now has a working link in it's SCMTrigger cause
7. Restart Jenkins and visit the downstream build
8. The downstream build still has a working link in it's SCMTrigger cause

Before the fix step 8 returned a broken link.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Fix link to polling log of upstream build caused by an SCM trigger after a Jenkins restart

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
