### PR TITLE
Revamp Clouds page

### DIFF
--- a/core/src/main/java/jenkins/agents/CloudSet.java
+++ b/core/src/main/java/jenkins/agents/CloudSet.java
@@ -37,6 +37,7 @@ import hudson.model.ManagementLink;
 import hudson.model.RootAction;
 import hudson.model.UpdateCenter;
 import hudson.slaves.Cloud;
+import hudson.util.FormApply;
 import hudson.util.FormValidation;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -274,7 +275,7 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
     }
 
     @POST
-    public void doReorder(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+    public void doReorder(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         var names = req.getParameterValues("name");
         if (names == null) {
@@ -284,7 +285,7 @@ public class CloudSet extends AbstractModelObject implements Describable<CloudSe
         var clouds = new ArrayList<>(Jenkins.get().clouds);
         clouds.sort(Comparator.comparingInt(c -> getIndexOf(namesList, c)));
         Jenkins.get().clouds.replaceBy(clouds);
-        rsp.sendRedirect2(".");
+        FormApply.success(req.getContextPath() + "/manage").generateResponse(req, rsp, null);
     }
 
     private static int getIndexOf(List<String> namesList, Cloud cloud) {

--- a/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
+++ b/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
@@ -31,8 +31,8 @@ THE SOFTWARE.
             <l:task contextMenu="false" href="${url}/" icon="symbol-computer" title="${%Status}"/>
             <l:task href="${url}/configure" icon="symbol-settings"
                     title="${app.hasPermission(app.ADMINISTER) ? '%Configure' : '%View Configuration'}"/>
-            <l:delete permission="${app.ADMINISTER}" title="${%Delete Cloud}" message="${%delete.cloud(it.displayName)}" urlPrefix="${url}"/>
             <t:actions />
+            <l:delete permission="${app.ADMINISTER}" title="${%Delete Cloud}" message="${%delete.cloud(it.displayName)}" urlPrefix="${url}"/>
         </l:tasks>
         <j:forEach var="action" items="${it.allActions}">
             <st:include it="${action}" page="box.jelly" optional="true"/>

--- a/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
+++ b/core/src/main/resources/hudson/slaves/Cloud/sidepanel.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
         <l:tasks>
             <j:set var="url" value="${h.getNearestAncestorUrl(request2,it)}"/>
             <l:task contextMenu="false" href="${url}/" icon="symbol-computer" title="${%Status}"/>
-            <l:task href="${url}/configure" icon="symbol-settings"
+            <l:task href="${url}/configure" icon="symbol-settings" contextMenu="false"
                     title="${app.hasPermission(app.ADMINISTER) ? '%Configure' : '%View Configuration'}"/>
             <t:actions />
             <l:delete permission="${app.ADMINISTER}" title="${%Delete Cloud}" message="${%delete.cloud(it.displayName)}" urlPrefix="${url}"/>

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -76,7 +76,7 @@ THE SOFTWARE.
                       ${cloud.name}
                     </a>
                   </div>
-                  <div class="app-cloud-item__actions">
+                  <div class="app-cloud-item__actions ignore-dirty-panel">
                     <a href="${it.getCloudUrl(request2,app,cloud)}configure"
                        class="jenkins-button jenkins-button--tertiary">
                       <l:icon src="symbol-settings" />

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -27,11 +27,9 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:t="/lib/hudson">
-  <j:new var="managementLink" className="jenkins.agents.CloudsLink" />
-
   <j:set var="header">
     <l:view>
-      <l:app-bar title="${managementLink.displayName}">
+      <l:app-bar title="${it.displayName}">
         <j:if test="${it.cloudAvailable and it.hasClouds()}">
           <l:isAdmin>
             <a class="jenkins-button jenkins-button--primary" href="new">
@@ -48,7 +46,7 @@ THE SOFTWARE.
             ${%description}
           </j:when>
           <j:otherwise>
-            ${managementLink.description}
+            ${it.description}
           </j:otherwise>
         </j:choose>
       </p>

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -54,14 +54,13 @@ THE SOFTWARE.
   </j:set>
 
   <l:settings-subpage header="${header}" noDefer="true">
-    <l:isAdmin>
-      <script src="${resURL}/jsbundles/pages/cloud-set.js" type="text/javascript" />
-      <link rel="stylesheet" href="${resURL}/jsbundles/pages/cloud-set.css" type="text/css" />
-    </l:isAdmin>
-
     <j:set var="readOnlyMode" value="${!app.hasPermission(app.ADMINISTER)}"/>
     <j:choose>
       <j:when test="${it.cloudAvailable and it.hasClouds()}">
+        <l:isAdmin>
+          <script src="${resURL}/jsbundles/pages/cloud-set.js" type="text/javascript" />
+          <link rel="stylesheet" href="${resURL}/jsbundles/pages/cloud-set.css" type="text/css" />
+        </l:isAdmin>
 
         <f:form method="post" name="config" action="reorder">
           <div class="with-drag-drop jenkins-!-margin-bottom-5">

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
     </l:view>
   </j:set>
 
-  <l:settings-subpage from="${managementLink}" header="${header}" noDefer="true">
+  <l:settings-subpage header="${header}" noDefer="true">
     <l:isAdmin>
       <script src="${resURL}/jsbundles/pages/cloud-set.js" type="text/javascript" />
       <link rel="stylesheet" href="${resURL}/jsbundles/pages/cloud-set.css" type="text/css" />

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -104,14 +104,14 @@ THE SOFTWARE.
           <j:when test="${it.cloudAvailable}">
             <l:notice title="${%noCloudAvailable}" icon="symbol-cloud">
               <a href="new">
-                <span>${%newCloud}</span>
+                ${%newCloud}
               </a>
             </l:notice>
           </j:when>
           <j:otherwise>
             <l:notice title="${%noCloudPlugin}" icon="symbol-cloud">
               <a href="${rootURL}/manage/pluginManager/available?filter=${it.cloudUpdateCenterCategoryLabel}">
-                <span>${%installCloudPlugin}</span>
+                ${%installCloudPlugin}
               </a>
             </l:notice>
           </j:otherwise>

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -27,9 +27,11 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:t="/lib/hudson">
+  <j:new var="managementLink" className="jenkins.agents.CloudsLink" />
+
   <j:set var="header">
     <l:view>
-      <l:app-bar title="${it.displayName}">
+      <l:app-bar title="${managementLink.displayName}">
         <j:if test="${it.cloudAvailable and it.hasClouds()}">
           <l:isAdmin>
             <a class="jenkins-button jenkins-button--primary" href="new">
@@ -46,7 +48,7 @@ THE SOFTWARE.
             ${%description}
           </j:when>
           <j:otherwise>
-            ${it.description}
+            ${managementLink.description}
           </j:otherwise>
         </j:choose>
       </p>

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -94,7 +94,7 @@ THE SOFTWARE.
           </div>
 
           <l:isAdmin>
-            <f:bottomButtonBar>
+            <f:bottomButtonBar hidden="true">
               <f:apply value="${%Save}" clazz="jenkins-button--primary" />
             </f:bottomButtonBar>
           </l:isAdmin>

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.jelly
@@ -26,8 +26,36 @@ THE SOFTWARE.
   Entrance to the configuration page
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-  <l:settings-subpage managementLink="${it.managementLink}" header="${null}" noDefer="true">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:t="/lib/hudson">
+  <j:new var="managementLink" className="jenkins.agents.CloudsLink" />
+
+  <j:set var="header">
+    <l:view>
+      <l:app-bar title="${managementLink.displayName}">
+        <j:if test="${it.cloudAvailable and it.hasClouds()}">
+          <l:isAdmin>
+            <a class="jenkins-button jenkins-button--primary" href="new">
+              <l:icon src="symbol-add"/>
+              ${%newCloud}
+            </a>
+          </l:isAdmin>
+        </j:if>
+        <t:help href="https://www.jenkins.io/redirect/distributed-builds" />
+      </l:app-bar>
+      <p class="jenkins-page-description">
+        <j:choose>
+          <j:when test="${it.cloudAvailable and it.hasClouds()}">
+            ${%description}
+          </j:when>
+          <j:otherwise>
+            ${managementLink.description}
+          </j:otherwise>
+        </j:choose>
+      </p>
+    </l:view>
+  </j:set>
+
+  <l:settings-subpage from="${managementLink}" header="${header}" noDefer="true">
     <l:isAdmin>
       <script src="${resURL}/jsbundles/pages/cloud-set.js" type="text/javascript" />
       <link rel="stylesheet" href="${resURL}/jsbundles/pages/cloud-set.css" type="text/css" />
@@ -36,111 +64,61 @@ THE SOFTWARE.
     <j:set var="readOnlyMode" value="${!app.hasPermission(app.ADMINISTER)}"/>
     <j:choose>
       <j:when test="${it.cloudAvailable and it.hasClouds()}">
-        <l:app-bar title="${%Clouds}">
-          <l:isAdmin>
-            <a class="jenkins-button jenkins-button--primary" href="new">
-              <l:icon src="symbol-add"/>
-              ${%newCloud}
-            </a>
-          </l:isAdmin>
-        </l:app-bar>
-        <p class="description">${%description}</p>
+
         <f:form method="post" name="config" action="reorder">
-          <table id="clouds" class="jenkins-table">
-            <thead>
-              <tr>
-                <th tooltip="${%Drag and drop cells to reorder}">${%Order}</th>
-                <th>${%Name}</th>
-                <th/>
-              </tr>
-            </thead>
-            <tbody class="with-drag-drop">
-              <j:forEach var="cloud" items="${it.clouds}">
-                <tr class="repeated-chunk" id="cloud_${cloud.name}">
-                  <td data="${cloud.icon}" class="jenkins-table__cell--tight jenkins-table__icon">
-                    <div class="jenkins-table__cell__button-wrapper dd-handle">
-                      <l:icon src="${cloud.iconClassName}" tooltip="${cloud.iconAltText}"/>
-                    </div>
-                  </td>
-                  <td>
+          <div class="with-drag-drop jenkins-!-margin-bottom-5">
+            <j:forEach var="cloud" items="${it.clouds}">
+              <div class="repeated-chunk" id="cloud_${cloud.name}">
+                <div class="app-cloud-item">
+                  <div class="dd-handle" />
+                  <l:icon src="${cloud.iconClassName}" tooltip="${cloud.iconAltText}" />
+                  <div>
                     <input type="hidden" name="name" value="${cloud.name}" />
-                    <a href="${it.getCloudUrl(request2,app,cloud)}" class="jenkins-table__link model-link inside">${cloud.name}</a>
-                  </td>
-                  <td class="jenkins-table__cell--tight">
-                    <div class="jenkins-table__cell__button-wrapper">
-                      <a href="${it.getCloudUrl(request2,app,cloud)}configure" class="jenkins-button">
-                        <l:icon src="symbol-settings"/>
-                      </a>
-                    </div>
-                  </td>
-                </tr>
-              </j:forEach>
-            </tbody>
-          </table>
+                    <a href="${it.getCloudUrl(request2,app,cloud)}">
+                      ${cloud.name}
+                    </a>
+                  </div>
+                  <div class="app-cloud-item__actions">
+                    <a href="${it.getCloudUrl(request2,app,cloud)}configure"
+                       class="jenkins-button jenkins-button--tertiary">
+                      <l:icon src="symbol-settings" />
+                    </a>
+                    <button type="button"
+                            data-href="${it.getCloudUrl(request2,app,cloud)}"
+                            class="jenkins-button jenkins-button--tertiary jenkins-jumplist-link">
+                      <l:icon src="symbol-menu" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </j:forEach>
+          </div>
+
           <l:isAdmin>
             <f:bottomButtonBar>
-              <f:submit id="saveButton" value="${%Save}" clazz="jenkins-hidden" />
+              <f:apply value="${%Save}" clazz="jenkins-button--primary" />
             </f:bottomButtonBar>
           </l:isAdmin>
         </f:form>
         <st:adjunct includes="lib.form.confirm" />
       </j:when>
       <j:otherwise>
-        <div class="empty-state-block">
-          <l:app-bar title="${%Clouds}"/>
-
-          <section class="empty-state-section">
-            <j:choose>
-              <j:when test="${it.cloudAvailable}">
-                <j:choose>
-                  <j:when test="${h.hasPermission(app.ADMINISTER)}">
-                    <p>${%noCloudAvailableCTA}</p>
-                  </j:when>
-                  <j:otherwise>
-                    <p>${%noCloudAvailable}</p>
-                  </j:otherwise>
-                </j:choose>
-              </j:when>
-              <j:otherwise>
-                <p>${%noCloudPlugin}</p>
-              </j:otherwise>
-            </j:choose>
-            <ul class="empty-state-section-list">
-              <l:isAdmin>
-                <j:if test="${it.cloudAvailable}">
-                  <li class="content-block">
-                    <a href="new"
-                       class="content-block__link">
-                      <span>${%newCloud}</span>
-                      <span class="trailing-icon">
-                        <l:icon src="symbol-add"/>
-                      </span>
-                    </a>
-                  </li>
-                </j:if>
-                <li class="content-block">
-                  <a href="${rootURL}/manage/pluginManager/available?filter=${it.cloudUpdateCenterCategoryLabel}"
-                     class="content-block__link">
-                    <span>${%installCloudPlugin}</span>
-                    <span class="trailing-icon">
-                      <l:icon src="symbol-plugins" />
-                    </span>
-                  </a>
-                </li>
-              </l:isAdmin>
-              <li class="content-block">
-                <a href="https://www.jenkins.io/redirect/distributed-builds"
-                   class="content-block__link"
-                   target="_blank" rel="noopener noreferrer">
-                  <span>${%learnMoreDistributedBuilds}</span>
-                  <span class="trailing-icon">
-                    <l:icon src="symbol-help-circle" />
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </section>
-        </div>
+        <j:choose>
+          <j:when test="${it.cloudAvailable}">
+            <l:notice title="${%noCloudAvailable}" icon="symbol-cloud">
+              <a href="new">
+                <span>${%newCloud}</span>
+              </a>
+            </l:notice>
+          </j:when>
+          <j:otherwise>
+            <l:notice title="${%noCloudPlugin}" icon="symbol-cloud">
+              <a href="${rootURL}/manage/pluginManager/available?filter=${it.cloudUpdateCenterCategoryLabel}">
+                <span>${%installCloudPlugin}</span>
+              </a>
+            </l:notice>
+          </j:otherwise>
+        </j:choose>
       </j:otherwise>
     </j:choose>
   </l:settings-subpage>

--- a/core/src/main/resources/jenkins/agents/CloudSet/index.properties
+++ b/core/src/main/resources/jenkins/agents/CloudSet/index.properties
@@ -1,7 +1,5 @@
-learnMoreDistributedBuilds=Learn more about distributed builds
-noCloudAvailableCTA=There are no clouds currently set up. Create one, or install a plugin for more cloud options.
-noCloudAvailable=There are no clouds currently set up.
-noCloudPlugin=There is no plugin installed that supports clouds.
+noCloudAvailable=There are no clouds currently set up
+noCloudPlugin=There are no plugins installed that support clouds
 newCloud=New cloud
-installCloudPlugin=Install a plugin
+installCloudPlugin=Find plugins
 description=During node provisioning, clouds are tried in the order they appear in this table.

--- a/core/src/main/resources/lib/form/apply.jelly
+++ b/core/src/main/resources/lib/form/apply.jelly
@@ -32,6 +32,9 @@ THE SOFTWARE.
     When this button is pressed, the FORM element fires the "jenkins:apply" event
     that allows interested parties to write back whatever states back into the INPUT
     elements.
+    <s:attribute name="clazz">
+      Additional CSS class(es) to add.
+    </s:attribute>
     <s:attribute name="value">
       The text of the apply button.
     </s:attribute>
@@ -39,7 +42,7 @@ THE SOFTWARE.
 
   <st:adjunct includes="lib.form.apply.apply"/>
   <input type="hidden" name="core:apply" value="" />
-  <button type="button" class="jenkins-button apply-button" name="Apply">
+  <button type="button" class="jenkins-button ${attrs.clazz} apply-button" name="Apply">
     ${attrs.value ?: '%Apply'}
   </button>
 </j:jelly>

--- a/core/src/main/resources/lib/form/bottomButtonBar.jelly
+++ b/core/src/main/resources/lib/form/bottomButtonBar.jelly
@@ -32,10 +32,13 @@ THE SOFTWARE.
     <st:attribute name="borderless">
       Hides the border of the bottom app bar unless its overlaying content.
     </st:attribute>
+    <st:attribute name="hidden">
+      Optionally hides the bottom button bar, can then be made visible with JavaScript. Defaults to false.
+    </st:attribute>
   </st:documentation>
 
-  <div class="jenkins-bottom-app-bar__shadow ${attrs.borderless ? 'jenkins-bottom-app-bar__shadow--borderless' : ''}"></div>
-  <div id="bottom-sticker">
+  <div class="jenkins-bottom-app-bar__shadow ${attrs.borderless ? 'jenkins-bottom-app-bar__shadow--borderless' : ''} ${attrs.hidden ? 'jenkins-hidden' : ''}"></div>
+  <div id="bottom-sticker" class="${attrs.hidden ? 'jenkins-hidden' : ''}">
     <div class="bottom-sticker-inner jenkins-buttons-row jenkins-buttons-row--equal-width">
       <d:invokeBody />
     </div>

--- a/src/main/js/pages/cloud-set/index.js
+++ b/src/main/js/pages/cloud-set/index.js
@@ -1,9 +1,30 @@
-import { registerSortableTableDragDrop } from "@/sortable-drag-drop";
+import { registerSortableDragDrop } from "@/sortable-drag-drop";
 
 document.addEventListener("DOMContentLoaded", function () {
-  document.querySelectorAll("tbody").forEach((table) =>
-    registerSortableTableDragDrop(table, function () {
-      document.getElementById("saveButton").classList.remove("jenkins-hidden");
-    }),
+  const bottomStickerShadow = document.querySelector(
+    ".jenkins-bottom-app-bar__shadow",
   );
+  const bottomSticker = document.querySelector("#bottom-sticker");
+
+  // Hide the bottom sticker initially
+  hideBottomSticker();
+
+  // Hide the bottom sticker when the Save button is clicked
+  document
+    .querySelector("[name='Apply']")
+    .addEventListener("click", hideBottomSticker);
+
+  // Show the bottom sticker when clouds have been reordered
+  const items = document.querySelector(".with-drag-drop");
+  registerSortableDragDrop(items, showBottomSticker);
+
+  function showBottomSticker() {
+    bottomStickerShadow.classList.remove("jenkins-hidden");
+    bottomSticker.classList.remove("jenkins-hidden");
+  }
+
+  function hideBottomSticker() {
+    bottomStickerShadow.classList.add("jenkins-hidden");
+    bottomSticker.classList.add("jenkins-hidden");
+  }
 });

--- a/src/main/js/pages/cloud-set/index.js
+++ b/src/main/js/pages/cloud-set/index.js
@@ -6,9 +6,6 @@ document.addEventListener("DOMContentLoaded", function () {
   );
   const bottomSticker = document.querySelector("#bottom-sticker");
 
-  // Hide the bottom sticker initially
-  hideBottomSticker();
-
   // Hide the bottom sticker when the Save button is clicked
   document
     .querySelector("[name='Apply']")

--- a/src/main/js/pages/cloud-set/index.scss
+++ b/src/main/js/pages/cloud-set/index.scss
@@ -1,3 +1,30 @@
-.dd-handle {
-  cursor: move;
+.app-cloud-item {
+  --tertiary-color: var(--text-color-secondary);
+
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  align-items: center;
+
+  & > svg {
+    width: 1.125rem;
+    height: 1.125rem;
+    margin-right: 0.75rem;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-right: 0.4375rem;
+
+    & > .jenkins-button {
+      padding: 0;
+      aspect-ratio: 1;
+      transition: color var(--standard-transition);
+      min-height: 2rem !important;
+    }
+
+    &:empty {
+      display: none;
+    }
+  }
 }

--- a/src/main/js/sortable-drag-drop.js
+++ b/src/main/js/sortable-drag-drop.js
@@ -12,7 +12,7 @@ import Sortable, { AutoScroll } from "sortablejs/modular/sortable.core.esm.js";
 
 Sortable.mount(new AutoScroll());
 
-function registerSortableDragDrop(e) {
+export function registerSortableDragDrop(e, onChangeFunction) {
   if (!e || !e.classList.contains("with-drag-drop")) {
     return false;
   }
@@ -61,17 +61,6 @@ function registerSortableDragDrop(e) {
         currentItem = null;
       }
     },
-  });
-}
-
-export function registerSortableTableDragDrop(e, onChangeFunction) {
-  if (!e || !e.classList.contains("with-drag-drop")) {
-    return false;
-  }
-
-  Sortable.create(e, {
-    handle: ".dd-handle",
-    items: "tr",
     onChange: function (event) {
       if (onChangeFunction) {
         onChangeFunction(event);

--- a/src/main/scss/form/_reorderable-list.scss
+++ b/src/main/scss/form/_reorderable-list.scss
@@ -36,6 +36,32 @@ div.repeated-chunk {
     border-bottom-right-radius: var(--form-input-border-radius);
   }
 
+  .dd-handle {
+    position: relative;
+    width: 44px;
+    height: 46px;
+    cursor: move;
+    opacity: 0.75;
+    color: var(--text-color-secondary);
+    transition: var(--standard-transition);
+    margin-right: -2px;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-color: currentColor;
+      mask-image: url("../images/svgs/mask-reorderable-list__handle.svg");
+      mask-position: center;
+      mask-repeat: no-repeat;
+    }
+
+    &:hover {
+      opacity: 1;
+      color: var(--text-color);
+    }
+  }
+
   &__header {
     position: relative;
     display: flex;
@@ -43,32 +69,6 @@ div.repeated-chunk {
     justify-content: flex-start;
     font-weight: var(--form-label-font-weight);
     min-height: 46px;
-
-    .dd-handle {
-      position: relative;
-      width: 44px;
-      height: 46px;
-      cursor: move;
-      opacity: 0.75;
-      color: var(--text-color-secondary);
-      transition: var(--standard-transition);
-      margin-right: -2px;
-
-      &::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background-color: currentColor;
-        mask-image: url("../images/svgs/mask-reorderable-list__handle.svg");
-        mask-position: center;
-        mask-repeat: no-repeat;
-      }
-
-      &:hover {
-        opacity: 1;
-        color: var(--text-color);
-      }
-    }
 
     &--no-handle {
       padding-left: $inset;


### PR DESCRIPTION
This PR revamps the Clouds page.

* Now using the [Notice component](https://weekly.ci.jenkins.io/design-library/empty-states/) for empty states
* Table has been replaced by the [repeatable list](https://weekly.ci.jenkins.io/design-library/repeatable-list/) component for consistency and predictability

### Testing done

* Possible to add clouds
* Help link works
* Install plugins link works
* Reordering clouds works
* No users of `registerSortableTableDragDrop` so I've removed it

### Screenshots (UI changes only)

#### Before (no plugins installed)
<img width="350" height="228" alt="Screenshot 2026-02-16 at 10 19 41" src="https://github.com/user-attachments/assets/1d5d82cc-d1eb-45d2-acbd-57dea089eff3" />

#### After (no plugins installed)
<img width="878" height="351" alt="image" src="https://github.com/user-attachments/assets/a2d8bd09-ca46-4a46-82c3-909c7be07a50" />

#### Before
<img width="622" height="290" alt="Screenshot 2026-02-16 at 10 17 19" src="https://github.com/user-attachments/assets/d457e2f1-46c1-4e00-a98a-cd0219046a0e" />

#### After
<img width="863" height="360" alt="Screenshot 2026-02-16 at 10 17 30" src="https://github.com/user-attachments/assets/0baa8cd2-77f0-42e4-95f8-372eb2eaa86e" />

#### Before
<img width="870" height="299" alt="Screenshot 2026-02-16 at 10 16 33" src="https://github.com/user-attachments/assets/21be0646-f334-4620-8156-9c8661d7dc03" />

#### After
<img width="880" height="220" alt="Screenshot 2026-02-16 at 10 16 14" src="https://github.com/user-attachments/assets/ede9d78e-6555-4b3b-b3e1-530498cfda22" />

### Proposed changelog entries

- Revamp Clouds page

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui,rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
