### PR TITLE
Update Jenkins CLI subpages to use experimental Manage Jenkins UI

### DIFF
--- a/core/src/main/java/hudson/cli/BuildCommand.java
+++ b/core/src/main/java/hudson/cli/BuildCommand.java
@@ -221,21 +221,7 @@ public class BuildCommand extends CLICommand {
 
     @Override
     protected void printUsageSummary(PrintStream stderr) {
-        stderr.println(
-                """
-                Starts a build, and optionally waits for a completion.
-                Aside from general scripting use, this command can be
-                used to invoke another job from within a build of one job.
-                With the -s option, this command changes the exit code based on
-                the outcome of the build (exit code 0 indicates a success)
-                and interrupting the command will interrupt the job.
-                With the -f option, this command changes the exit code based on
-                the outcome of the build (exit code 0 indicates a success)
-                however, unlike -s, interrupting the command will not interrupt
-                the job (exit code 125 indicates the command was interrupted).
-                With the -c option, a build will only run if there has been
-                an SCM change."""
-        );
+        stderr.println(Messages.BuildCommand_PrintUsageSummary());
     }
 
     public static class CLICause extends UserIdCause {

--- a/core/src/main/resources/hudson/cli/CLIAction/command.jelly
+++ b/core/src/main/resources/hudson/cli/CLIAction/command.jelly
@@ -24,19 +24,21 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:layout title="${command.name}" permission="${app.READ}" type="one-column">
-    <l:breadcrumb title="${command.name}" />
-    <l:main-panel>
-      <h1>
-        Command ${command.name}
-      </h1>
+  <l:settings-subpage title="Command ${command.name}" permission="${app.READ}" includeBreadcrumb="true" noDefer="true">
+    <div class="jenkins-page-description">
+      <j:out value="${h.escape(command.longDescription)}"/>
+    </div>
+
+    <f:section title="${%Command}">
       <j:set var="commandArgs" value="${command.name}${command.singleLineSummary}"/>
-      <st:include page="example.jelly"/>
-      <pre class="jenkins-!-margin-top-3">
-        <j:out value="${h.escape(command.longDescription)}"/>
-        <j:set var="usage" value="${command.usage}"/>
-        <j:if test="${!empty usage}"><br/>${command.usage}</j:if>
-      </pre>
-    </l:main-panel>
-  </l:layout>
+      <st:include page="example.jelly" />
+
+      <j:set var="usage" value="${command.usage}"/>
+      <j:if test="${!empty usage}">
+        <pre class="jenkins-!-margin-top-3">
+          ${command.usage}
+        </pre>
+      </j:if>
+    </f:section>
+  </l:settings-subpage>
 </j:jelly>

--- a/core/src/main/resources/hudson/cli/CLIAction/index.properties
+++ b/core/src/main/resources/hudson/cli/CLIAction/index.properties
@@ -1,4 +1,4 @@
 description=You can access various features in Jenkins through a command-line tool. This can be convenient for scripting\
   \ of routine tasks, bulk updates, troubleshooting, and more.
 instruction1=Download the Jenkins CLI:
-instruction2=Run it as follows
+instruction2=Run it as follows:

--- a/core/src/main/resources/hudson/cli/Messages.properties
+++ b/core/src/main/resources/hudson/cli/Messages.properties
@@ -68,6 +68,13 @@ SessionIdCommand.ShortDescription=Outputs the session ID, which changes every ti
 UpdateViewCommand.ShortDescription=\
  Updates the view definition XML from stdin. The opposite of the get-view command.
 
+BuildCommand.PrintUsageSummary=Starts a build, and optionally waits for a completion. \
+  Aside from general scripting use, this command can be used to invoke another job from within a build of one job. \
+  With the -s option, this command changes the exit code based on the outcome of the build (exit code 0 indicates a \
+  success) and interrupting the command will interrupt the job. With the -f option, this command changes the exit \
+  code based on the outcome of the build (exit code 0 indicates a success) however, unlike -s, interrupting the \
+  command will not interrupt the job (exit code 125 indicates the command was interrupted). With the -c option, a \
+  build will only run if there has been an SCM change.
 BuildCommand.CLICause.ShortDescription=Started from command line by {0}
 BuildCommand.CLICause.CannotBuildDisabled=\
 Cannot build {0} because it is disabled.

--- a/core/src/main/resources/lib/layout/settings-subpage.jelly
+++ b/core/src/main/resources/lib/layout/settings-subpage.jelly
@@ -44,6 +44,16 @@ THE SOFTWARE.
     <st:attribute name="header">
       Optional header for the page, falls back to a default header if not set.
     </st:attribute>
+    <st:attribute name="title">
+      <![CDATA[
+      Optional title for the page, falls back to <code>managementLink.displayName</code> if not set.
+      ]]>
+    </st:attribute>
+    <st:attribute name="description">
+      <![CDATA[
+      Optional description for the page, falls back to <code>managementLink.description</code> if not set.
+      ]]>
+    </st:attribute>
     <st:attribute name="includeBreadcrumb">
       <![CDATA[
       Optional breadcrumb, will add a breadcrumb for the current <code>it</code>
@@ -60,8 +70,10 @@ THE SOFTWARE.
   <l:userExperimentalFlag var="newManageJenkins" flagClassName="jenkins.model.experimentalflags.NewManageJenkinsUserExperimentalFlag" />
 
   <j:set var="managementLink" value="${attrs.managementLink ?: it}" />
+  <j:set var="pageTitle" value="${attrs.title ?: managementLink.displayName}" />
+  <j:set var="description" value="${attrs.description ?: managementLink.description}" />
 
-  <l:layout title="${managementLink.displayName} - ${manageJenkinsAction.displayName}"
+  <l:layout title="${pageTitle} - ${manageJenkinsAction.displayName}"
             permission="${attrs.permission}"
             permissions="${attrs.permissions}"
             type="${newManageJenkins ? 'two-column' : 'one-column'}">
@@ -70,10 +82,10 @@ THE SOFTWARE.
       <!-- Hacky - this will be improved in subsequent PRs -->
       <j:choose>
         <j:when test="${managementLink.class.name eq 'jenkins.management.ConfigureLink'}">
-          <f:breadcrumb-config-outline title="${managementLink.displayName}" />
+          <f:breadcrumb-config-outline title="${pageTitle}" />
         </j:when>
         <j:otherwise>
-          <l:breadcrumb title="${managementLink.displayName}" />
+          <l:breadcrumb title="${pageTitle}" />
         </j:otherwise>
       </j:choose>
     </j:if>
@@ -109,10 +121,12 @@ THE SOFTWARE.
           <div class="app-settings-container">
             <div class="app-settings-container__inner">
               <j:if test="${!attrs.containsKey('header')}">
-                <l:app-bar title="${managementLink.displayName}" />
-                <div class="jenkins-page-description">
-                  ${managementLink.description}
-                </div>
+                <l:app-bar title="${pageTitle}" />
+                <j:if test="${!empty(description)}">
+                  <div class="jenkins-page-description">
+                    ${description}
+                  </div>
+                </j:if>
               </j:if>
 
               <j:out value="${attrs.header}" />
@@ -146,10 +160,12 @@ THE SOFTWARE.
       <j:otherwise>
         <l:main-panel>
           <j:if test="${!attrs.containsKey('header')}">
-            <l:app-bar title="${managementLink.displayName}" />
-            <div class="jenkins-page-description">
-              ${managementLink.description}
-            </div>
+            <l:app-bar title="${pageTitle}" />
+            <j:if test="${!empty(description)}">
+              <div class="jenkins-page-description">
+                ${description}
+              </div>
+            </j:if>
           </j:if>
 
           <j:out value="${attrs.header}" />


### PR DESCRIPTION
This PR updates the Jenkins CLI's subpages to use the experimental Manage Jenkins UI. It also adds support for custom title and descriptions, making it easier for pages without `ManagementLink` backing them to use the new layout.

I've localised the Build command and removed its new lines as it looked rather odd in this new layout.

### Testing done

* Commands show as expected in old and new UI

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before
<img width="1728" height="336" alt="Screenshot 2026-02-16 at 11 05 42" src="https://github.com/user-attachments/assets/a1ac6a81-8264-4c76-883d-e76fcc23739a" />

#### After
<img width="902" height="348" alt="Screenshot 2026-02-16 at 11 05 07" src="https://github.com/user-attachments/assets/5fccc6c5-41e8-481e-a586-f9c226374d8a" />

#### Before (with flag on)
<img width="1728" height="336" alt="Screenshot 2026-02-16 at 11 05 42" src="https://github.com/user-attachments/assets/a1ac6a81-8264-4c76-883d-e76fcc23739a" />

#### After (with flag on)
<img width="1728" height="438" alt="image" src="https://github.com/user-attachments/assets/f8ca6623-9531-483f-a51a-5137774beb03" />

### Proposed changelog entries

- Update Jenkins CLI's subpages to use experimental Manage Jenkins UI

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui,rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
