### PR TITLE
Encode log recorder name when redirecting

### DIFF
--- a/core/src/main/java/hudson/logging/LogRecorderManager.java
+++ b/core/src/main/java/hudson/logging/LogRecorderManager.java
@@ -173,7 +173,7 @@ public class LogRecorderManager extends AbstractModelObject implements ModelObje
         recorders.add(new LogRecorder(name));
 
         // redirect to the config screen
-        return new HttpRedirect(name + "/configure");
+        return new HttpRedirect(Util.rawEncode(name) + "/configure");
     }
 
     @Restricted(NoExternalUse.class)

--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -40,6 +40,7 @@ import hudson.model.Computer;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 import hudson.remoting.VirtualChannel;
+import hudson.Util;
 import hudson.util.FormValidation;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -128,6 +129,19 @@ class LogRecorderManagerTest {
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", Level.WARNING.getName()));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", Level.SEVERE.getName()));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", Level.OFF.getName()));
+    }
+
+    @Test
+    void createLogRecorderWithNonAsciiName() throws Exception {
+        String name = "Journal d’accès";
+
+        HtmlPage page = j.createWebClient().goTo("log/new");
+        HtmlForm form = page.getFormByName("configSubmit");
+        form.getInputByName("name").setValueAttribute(name);
+        j.submit(form);
+
+        assertNotNull(j.jenkins.getLog().getLogRecorder(name));
+        j.createWebClient().goTo("log/" + Util.rawEncode(name) + "/configure");
     }
 
     @Issue({"JENKINS-18274", "JENKINS-63458"})

--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -35,12 +35,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.Computer;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 import hudson.remoting.VirtualChannel;
-import hudson.Util;
 import hudson.util.FormValidation;
 import java.io.IOException;
 import java.net.HttpURLConnection;


### PR DESCRIPTION
Fixes #26318

### Testing done

- Added a regression test `createLogRecorderWithNonAsciiName` in `LogRecorderManagerTest`.
- The test creates a log recorder named `Journal d’accès` and verifies that the configure URL resolves with an encoded path segment.
- CI builds are running for full validation.

### Screenshots (UI changes only)

#### Before

N/A (no UI layout change)

#### After

N/A (no UI layout change)

### Proposed changelog entries

- Redirect to the correct URL when creating log recorders with non-ASCII names.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. (No new public API in this PR.)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. (No new deprecations in this PR.)
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). (No JS/UI behavior change in this PR.)
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. (No dependency updates in this PR.)
- [x] For new APIs and extension points, there is a link to at least one consumer. (No new API/extension point in this PR.)

### Desired reviewers

@jenkinsci/core-pr-reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
