### PR TITLE
[JENKINS-36718] Specify charset in DM_DEFAULT_ENCODING paths

### DIFF
--- a/core/src/main/java/hudson/console/ConsoleNote.java
+++ b/core/src/main/java/hudson/console/ConsoleNote.java
@@ -193,9 +193,8 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
      * Technically, this method only works if the {@link Writer} to {@link OutputStream}
      * encoding is ASCII compatible.
      */
-    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "TODO needs triage")
     public void encodeTo(Writer out) throws IOException {
-        out.write(encodeToBytes().toString());
+        out.write(encodeToBytes().toString(StandardCharsets.UTF_8));
     }
 
     private ByteArrayOutputStream encodeToBytes() throws IOException {
@@ -224,9 +223,8 @@ public abstract class ConsoleNote<T> implements Serializable, Describable<Consol
     /**
      * Works like {@link #encodeTo(Writer)} but obtain the result as a string.
      */
-    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "TODO needs triage")
     public String encode() throws IOException {
-        return encodeToBytes().toString();
+        return encodeToBytes().toString(StandardCharsets.UTF_8);
     }
 
     /**

--- a/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
+++ b/core/src/main/java/hudson/lifecycle/WindowsServiceLifecycle.java
@@ -27,7 +27,6 @@ package hudson.lifecycle;
 import static hudson.util.jna.Kernel32.MOVEFILE_DELAY_UNTIL_REBOOT;
 import static hudson.util.jna.Kernel32.MOVEFILE_REPLACE_EXISTING;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import hudson.Launcher.LocalLauncher;
 import hudson.Util;
@@ -119,7 +118,6 @@ public class WindowsServiceLifecycle extends Lifecycle {
     }
 
     @Override
-    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "TODO needs triage")
     public void restart() throws IOException, InterruptedException {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         try {
@@ -146,7 +144,7 @@ public class WindowsServiceLifecycle extends Lifecycle {
         int r = new LocalLauncher(task).launch().cmds(executable, "restart!")
                 .stdout(task).pwd(home).join();
         if (r != 0)
-            throw new IOException(baos.toString());
+            throw new IOException(baos.toString(task.getCharset()));
     }
 
     private static File getBaseDir() {

--- a/core/src/main/java/hudson/util/TextFile.java
+++ b/core/src/main/java/hudson/util/TextFile.java
@@ -25,11 +25,9 @@
 package hudson.util;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
@@ -112,11 +110,10 @@ public class TextFile {
     /**
      * Reads the first N characters or until we hit EOF.
      */
-    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "TODO needs triage")
     public @NonNull String head(int numChars) throws IOException {
         char[] buf = new char[numChars];
         int read = 0;
-        try (Reader r = new FileReader(file)) {
+        try (Reader r = Files.newBufferedReader(Util.fileToPath(file), StandardCharsets.UTF_8)) {
             while (read < numChars) {
                 int d = r.read(buf, read, buf.length - read);
                 if (d < 0)


### PR DESCRIPTION
Fixes #17339

### Testing done

- Replaced default-encoding usage with explicit charset handling in these core paths:
  - `TextFile.head(int)` now reads with UTF-8.
  - `WindowsServiceLifecycle.restart()` now decodes launcher output with `task.getCharset()`.
  - `ConsoleNote.encodeTo(Writer)` and `ConsoleNote.encode()` now decode bytes as UTF-8.
- Removed now-unneeded `@SuppressFBWarnings("DM_DEFAULT_ENCODING")` suppressions in the touched methods.
- Local Maven execution is not available in this environment (`mvn` and `mvnw` are unavailable), so local test execution was not possible here. CI will provide full validation.

### Screenshots (UI changes only)

#### Before

N/A (no UI change)

#### After

N/A (no UI change)

### Proposed changelog entries

- Specify explicit character sets in core text encoding paths to avoid default-encoding behavior.

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. (No new public API in this PR.)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. (No new deprecations in this PR.)
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). (No UI/JavaScript changes in this PR.)
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. (No dependency updates in this PR.)
- [x] For new APIs and extension points, there is a link to at least one consumer. (No new APIs or extension points in this PR.)

### Desired reviewers

@jenkinsci/core-pr-reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
