### PR TITLE
[JENKINS-46257] Improve Run Parameters folders support for auto-completion

### DIFF
--- a/core/src/main/java/hudson/model/RunParameterDefinition.java
+++ b/core/src/main/java/hudson/model/RunParameterDefinition.java
@@ -35,6 +35,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
@@ -154,8 +155,9 @@ public class RunParameterDefinition extends SimpleParameterDefinition {
             return req.bindJSON(RunParameterDefinition.class, formData);
         }
 
-        public AutoCompletionCandidates doAutoCompleteProjectName(@QueryParameter String value) {
-            return AutoCompletionCandidates.ofJobNames(Job.class, value, null, Jenkins.get());
+        public AutoCompletionCandidates doAutoCompleteProjectName(
+                @QueryParameter String value, @AncestorInPath Item self, @AncestorInPath ItemGroup container) {
+            return AutoCompletionCandidates.ofJobNames(Job.class, value, self, container);
         }
 
     }


### PR DESCRIPTION
Fixes #22250

### Testing done

- Added regression test `autoCompleteProjectNameInFoldersUsesLocalContext` in `RunParameterDefinitionTest`.
- The test covers autocomplete for a Run Parameter project name when jobs are in folders and verifies sibling resolution via local context.
- I could not execute Maven tests locally in this environment because `mvn` is not installed (`CommandNotFoundException`); CI is expected to run full validation.

### Screenshots (UI changes only)

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- Use local folder context when auto-completing Run Parameter project names.

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. (No new public API in this PR.)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. (No new deprecations in this PR.)
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). (No JS/UI behavior change in this PR.)
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. (No dependency updates in this PR.)
- [x] For new APIs and extension points, there is a link to at least one consumer. (No new API/extension point in this PR.)

### Desired reviewers

@jenkinsci/core-pr-reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
