### PR TITLE
[JENKINS-76289] Add icon size control to new dashboard page

### DIFF
--- a/core/src/main/resources/lib/hudson/projectView.jelly
+++ b/core/src/main/resources/lib/hudson/projectView.jelly
@@ -88,9 +88,11 @@ THE SOFTWARE.
         </div>
 
         <l:userExperimentalFlag var="newDashboardPage" flagClassName="jenkins.model.experimentalflags.NewDashboardPageUserExperimentalFlag" />
-        <j:if test="${!newDashboardPage}">
-          <t:iconSize><t:rssBar/></t:iconSize>
-        </j:if>
+        <t:iconSize>
+          <j:if test="${!newDashboardPage}">
+            <t:rssBar/>
+          </j:if>
+        </t:iconSize>
       </div>
 
       <div class="jenkins-jobs-list jenkins-mobile-show">

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -71,6 +71,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import jenkins.model.Jenkins;
 import jenkins.model.ProjectNamingStrategy;
+import jenkins.model.experimentalflags.UserExperimentalFlagsProperty;
 import jenkins.security.NotReallyRoleSensitiveCallable;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.FormEncodingType;
@@ -135,6 +136,27 @@ class ViewTest {
         assertEquals("Some description", view.getDescription());
         assertTrue(view.isFilterExecutors());
         assertTrue(view.isFilterQueue());
+    }
+
+    @Issue("JENKINS-76289")
+    @Test
+    void newDashboardShowsIconSizeControl() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+
+        User user = User.getOrCreateByIdOrFullName("new-dashboard-user");
+        Map<String, String> flags = new HashMap<>();
+        flags.put("new-dashboard-page.flag", "true");
+        user.addProperty(new UserExperimentalFlagsProperty(flags));
+
+        j.createFreeStyleProject("p");
+
+        WebClient webClient = j.createWebClient().withBasicCredentials(user.getId());
+        HtmlPage page = webClient.goTo("view/all/");
+
+        assertNotNull(page.getFirstByXPath("//div[contains(@class,'app-build-bar')]"));
+        assertNotNull(page.getFirstByXPath("//div[contains(@class,'jenkins-icon-size')]"));
+        assertNotNull(page.getFirstByXPath("//a[contains(@href,'iconSize?16x16')]"));
+        assertNotNull(page.getFirstByXPath("//a[contains(@href,'iconSize?24x24')]"));
     }
 
     @Issue("JENKINS-7100")


### PR DESCRIPTION
Fixes #16844

### Testing done
- Added regression test `newDashboardShowsIconSizeControl` in `ViewTest`.
- The test enables `new-dashboard-page.flag` for a user and verifies the new dashboard still renders icon-size controls.
- Executed locally:
  - `mvn -am -pl war,bom -Pquick-build -DskipTests clean install`
  - `mvn -pl test -Dtest=hudson.model.ViewTest#newDashboardShowsIconSizeControl test`
- Result: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`.

### Screenshots (UI changes only)
Before
N/A

After
N/A

### Proposed changelog entries
Add icon size controls to the new dashboard page.

### Proposed changelog category
/label bug

### Proposed upgrade guidelines
N/A

### Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples). Fill in the Proposed upgrade guidelines section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. (No new public API in this PR.)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. (No new deprecations in this PR.)
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see documentation). (No new JS/UI behavior pattern; only Jelly composition change.)
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. (No dependency updates in this PR.)
- [x] For new APIs and extension points, there is a link to at least one consumer. (No new API/extension point in this PR.)

### Desired reviewers
@jenkinsci/core-pr-reviewers

Before the changes are marked as ready-for-merge:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or Proposed changelog entries are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a Proposed upgrade guidelines section in the pull request title (see example).
- [ ] If it would make sense to backport the change to LTS, be a Bug or Improvement, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
