### PR TITLE
Test Spring 7 pull requests

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -63,7 +63,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>6.2.16</version>
+        <version>7.0.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -71,7 +71,7 @@ THE SOFTWARE.
         <!-- https://docs.spring.io/spring-security/reference/6.3/getting-spring-security.html#getting-maven-no-boot -->
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-bom</artifactId>
-        <version>6.5.8</version>
+        <version>7.0.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -456,7 +456,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         }
 
         try {
-            PASSWORD_HASH_ENCODER.encode(si.password1);
+            PASSWORD_HASH_ENCODER.encode2(si.password1);
         }  catch (RuntimeException ex) {
             si.errors.put("password1", ex.getMessage());
         }
@@ -853,7 +853,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
                 // The password is being changed
                 try {
-                    PASSWORD_HASH_ENCODER.encode(pwd);
+                    PASSWORD_HASH_ENCODER.encode2(pwd);
                 } catch (RuntimeException ex) {
                     throw new FormException(ex.getMessage(), "user.password");
                 }
@@ -934,9 +934,9 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
         private static final Pattern BCRYPT_PATTERN = Pattern.compile("^\\$2a\\$([0-9]{2})\\$.{53}$");
 
         @Override
-        public String encode(CharSequence rawPassword) {
+        public String encode2(CharSequence rawPassword) {
             try {
-                return super.encode(rawPassword);
+                return encode(rawPassword);
             } catch (IllegalArgumentException ex) {
                 if (ex.getMessage().equals("password cannot be more than 72 bytes")) {
                     if (rawPassword.toString().matches("\\A\\p{ASCII}+\\z")) {

--- a/core/src/main/java/hudson/security/PasswordHashEncoder.java
+++ b/core/src/main/java/hudson/security/PasswordHashEncoder.java
@@ -27,4 +27,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 interface PasswordHashEncoder extends PasswordEncoder {
      boolean isHashValid(String hash);
+
+     default String encode2(CharSequence rawPassword) {
+         return encode(rawPassword);
+     }
 }

--- a/core/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/core/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -160,7 +160,7 @@ class HudsonPrivateSecurityRealmTest {
     @Issue("JENKINS-75533")
     @Test
     void ensureExpectedMessageAscii() {
-        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode(
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode2(
                 "1234567890123456789012345678901234567890123456789012345678901234567890123"));
         assertThat(ex.getMessage(), is(Messages.HudsonPrivateSecurityRealm_CreateAccount_BCrypt_PasswordTooLong_ASCII()));
     }
@@ -168,9 +168,16 @@ class HudsonPrivateSecurityRealmTest {
     @Issue("JENKINS-75533")
     @Test
     void ensureExpectedMessageEmoji() {
-        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode(
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode2(
                 "\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20" +
                         "\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20\uD83E\uDD20")); // 🤠
         assertThat(ex.getMessage(), is(Messages.HudsonPrivateSecurityRealm_CreateAccount_BCrypt_PasswordTooLong()));
+    }
+
+    @Test
+    void ensureExpectedMessageFromEncode() {
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> HudsonPrivateSecurityRealm.PASSWORD_HASH_ENCODER.encode(
+                "1234567890123456789012345678901234567890123456789012345678901234567890123"));
+        assertThat(ex.getMessage(), is("password cannot be more than 72 bytes"));
     }
 }

--- a/test/src/test/java/hudson/security/TokenBasedRememberMeServices2Test.java
+++ b/test/src/test/java/hudson/security/TokenBasedRememberMeServices2Test.java
@@ -33,6 +33,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -126,7 +127,8 @@ class TokenBasedRememberMeServices2Test {
         wc.executeOnServer(() -> {
             Authentication a = Jenkins.getAuthentication2();
             assertEquals("bob", a.getName());
-            assertEquals(Arrays.asList("authenticated", "myteam"), a.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList()));
+            assertEquals(Arrays.asList("authenticated", "myteam"),
+                         a.getAuthorities().stream().map(GrantedAuthority::getAuthority).filter(authority -> !authority.equals(FactorGrantedAuthority.PASSWORD_AUTHORITY)).collect(Collectors.toList()));
             return null;
         });
     }

--- a/test/src/test/java/jenkins/security/LastGrantedAuthoritiesPropertyTest.java
+++ b/test/src/test/java/jenkins/security/LastGrantedAuthoritiesPropertyTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -80,7 +81,7 @@ class LastGrantedAuthoritiesPropertyTest {
     }
 
     private void _assertAuthorities(Collection<? extends GrantedAuthority> grantedAuthorities, String expected) {
-        List<String> authorities = grantedAuthorities.stream().map(GrantedAuthority::getAuthority).sorted().collect(Collectors.toList());
+        List<String> authorities = grantedAuthorities.stream().map(GrantedAuthority::getAuthority).filter(authority -> !authority.equals(FactorGrantedAuthority.PASSWORD_AUTHORITY)).sorted().collect(Collectors.toList());
 
         assertEquals(expected, String.join(":", authorities));
     }


### PR DESCRIPTION
# Test Spring v7 updates

Testing changes for pull requests:

* https://github.com/jenkinsci/jenkins/pull/11304
* https://github.com/jenkinsci/jenkins/pull/11292

Includes my attempt to adapt to the `encode()` method becoming final when we extended it to provide a better error message.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

* Ran automated tests and confirmed that two tests fail in my environment, though one of the two tests does not fail when running in the debugger
* Performed minor interactive testing with the simplest security realm and found no issues

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
