### PR TITLE
Fix newView link to use context-relative URL instead of rootURL

### DIFF
--- a/core/src/main/resources/hudson/views/DefaultMyViewsTabBar/myViewTabs.jelly
+++ b/core/src/main/resources/hudson/views/DefaultMyViewsTabBar/myViewTabs.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
       <l:tab name="${v.displayName}" active="${v==currentView}" href="${rootURL}/${v.url}" />
     </j:forEach>
     <j:if test="${currentView.hasPermission(currentView.CREATE)}">
-      <l:tabNewItem href="${rootURL}/${currentView.owner.url}newView" title="${%New View}" />
+      <l:tabNewItem href="${request.contextPath}/${currentView.owner.url}newView" title="${%New View}" />
     </j:if>
   </l:tabBar>
 </j:jelly>

--- a/core/src/main/resources/hudson/views/DefaultMyViewsTabBar/myViewTabs.jelly
+++ b/core/src/main/resources/hudson/views/DefaultMyViewsTabBar/myViewTabs.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <!-- view tab bar -->
   <l:tabBar>
     <j:forEach var="v" items="${it.sort(views)}">
-      <l:tab name="${v.displayName}" active="${v==currentView}" href="${rootURL}/${v.url}" />
+      <l:tab name="${v.displayName}" active="${v==currentView}" href="${request.contextPath}/${v.url}" />
     </j:forEach>
     <j:if test="${currentView.hasPermission(currentView.CREATE)}">
       <l:tabNewItem href="${request.contextPath}/${currentView.owner.url}newView" title="${%New View}" />

--- a/core/src/main/resources/hudson/views/DefaultViewsTabBar/viewTabs.jelly
+++ b/core/src/main/resources/hudson/views/DefaultViewsTabBar/viewTabs.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
     <j:when test="${newDashboardPage}">
       <div class="app-build-tabs">
         <j:forEach var="tab" items="${it.sort(views)}">
-          <a href="${rootURL}/${tab.url}"
+          <a href="${request.contextPath}/${tab.url}"
              class="jenkins-button ${tab == currentView ? '' : 'jenkins-button--tertiary'}">
             <j:if test="${tab.iconFileName != null}">
               <l:icon src="${tab.iconFileName}" />
@@ -50,7 +50,7 @@ THE SOFTWARE.
     <j:otherwise>
       <l:tabBar>
         <j:forEach var="v" items="${it.sort(views)}">
-          <l:tab name="${v.displayName}" active="${v==currentView}" href="${rootURL}/${v.url}" />
+          <l:tab name="${v.displayName}" active="${v==currentView}" href="${request.contextPath}/${v.url}" />
         </j:forEach>
         <j:if test="${currentView.hasPermission(currentView.CREATE)}">
           <l:tabNewItem href="${request.contextPath}/${currentView.owner.url}newView" title="${%New View}" />

--- a/core/src/main/resources/hudson/views/DefaultViewsTabBar/viewTabs.jelly
+++ b/core/src/main/resources/hudson/views/DefaultViewsTabBar/viewTabs.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
         </j:forEach>
 
         <j:if test="${currentView.hasPermission(currentView.CREATE)}">
-          <a href="${rootURL}/${currentView.owner.url}newView" tooltip="${%New View}" class="jenkins-button jenkins-button--tertiary">
+          <a href="${request.contextPath}/${currentView.owner.url}newView" tooltip="${%New View}" class="jenkins-button jenkins-button--tertiary">
             <l:icon src="symbol-add" />
           </a>
         </j:if>
@@ -53,7 +53,7 @@ THE SOFTWARE.
           <l:tab name="${v.displayName}" active="${v==currentView}" href="${rootURL}/${v.url}" />
         </j:forEach>
         <j:if test="${currentView.hasPermission(currentView.CREATE)}">
-          <l:tabNewItem href="${rootURL}/${currentView.owner.url}newView" title="${%New View}" />
+          <l:tabNewItem href="${request.contextPath}/${currentView.owner.url}newView" title="${%New View}" />
         </j:if>
       </l:tabBar>
     </j:otherwise>


### PR DESCRIPTION
Fixes #22743

**What was done**

The "New View" link in the view tab bar used `${rootURL}` which produces an absolute URL. When Jenkins is behind a reverse proxy (e.g. nginx) with Root URL set to the internal server for agent connectivity, clicking "New View" redirected users to the internal URL instead of staying on the proxy URL.

**Fix:** Use `${request.contextPath}/${currentView.owner.url}newView` instead of `${rootURL}/${currentView.owner.url}newView`. This produces a path-absolute URL (e.g. `/jenkins/newView` or `/jenkins/job/foo/newView`) that the browser resolves against the current origin (the proxy URL), while still correctly targeting the owning ViewGroup's newView for root, folders, and My Views.

This also addresses SECURITY-1471 by removing rootURL from the link, preventing javascript: injection via Root URL configuration.

**Testing done**

- Changed files: `DefaultViewsTabBar/viewTabs.jelly`, `DefaultMyViewsTabBar/myViewTabs.jelly`
- Existing test `JenkinsLocationConfigurationTest#cannotInjectJavaScriptUsingRootUrl_inNewViewLink` validates that the newView link does not use rootURL for XSS; this change strengthens that by not using rootURL at all
- Manual verification: Links now use path-relative format that resolves to current host

**Proposed changelog entries**

- Make the "New View" link use a context-relative URL so it works correctly when Jenkins is behind a reverse proxy with Root URL configured for internal agent connectivity

**Proposed changelog category**

/label bug

**Submitter checklist**

- [x] The issue is well-described
- [x] Changelog entry is in imperative mood
- [x] Existing SECURITY-1471 test covers the change
- [x] No new public APIs
- [x] No CSP impact (Jelly template change only)