### PR TITLE
Guard api/xml and api/json against OutOfMemoryError

### DIFF
--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -81,6 +81,7 @@ Api.MultipleMatch=XPath "{0}" matched {1} nodes. \
     Create XPath that only matches one, or use the "wrapper" query parameter to wrap them all under a root element.
 Api.NoXPathMatch=XPath {0} didn’t match
 Api.WrapperParamInvalid=The wrapper parameter can only contain alphanumeric characters or dash/dot/underscore. The first character has to be a letter or underscore.
+Api.LowMemory=Insufficient heap memory to process this API request. The server may run out of memory when serializing large responses. To avoid this, use the tree parameter to limit the data returned, e.g. tree=jobs[name],builds[number]. See the API documentation for details.
 
 BallColor.Aborted=Aborted
 BallColor.Disabled=Disabled


### PR DESCRIPTION
**Summary**
Introduce a heap memory guard for api/xml and api/json endpoints to reduce the risk of OutOfMemoryError when serving large API responses (JENKINS-75747).

Large API responses may require building substantial in-memory object graphs during serialization. Under low heap conditions, this can result in JVM instability affecting the entire controller. This change adds a configurable safety threshold to reject such requests before memory exhaustion occurs.

**Changes**
_Api.java_
Check available heap before serving XML, JSON, and Python API endpoints.
If free memory is below the configured threshold:
Respond with HTTP 503 (Service Unavailable).
Include a message suggesting use of the tree parameter to reduce payload size.
_Messages.properties_
Add Api_LowMemory message for the 503 response.
_ApiTest.java_
Add lowHeapRejectsApiRequest test to verify request rejection when available heap is below threshold.

**Configuration**

New system property:
hudson.model.Api.minFreeMemoryBytes
Defines the minimum free heap (in bytes) required before allowing API response processing.
Default: 50MB
Set to 0 to disable the guard.

This keeps default behavior unchanged under normal operating conditions while allowing administrators to tune or disable the protection if needed.

**Rationale**
Prevents controller-wide instability caused by large API serializations under low memory.
Keeps change minimally invasive.
Avoids architectural changes (e.g., streaming refactor) while providing immediate safety.
Fully configurable for different deployment sizes.

**Testing**
mvn test -Dtest=ApiTest#lowHeapRejectsApiRequest
With default configuration:
Normal API requests continue to succeed.
Guard only activates when heap falls below configured threshold.