### PR TITLE
Implement URL validation and security checks in ClientHttpRedirect

### DIFF
--- a/core/src/main/java/jenkins/util/ClientHttpRedirect.java
+++ b/core/src/main/java/jenkins/util/ClientHttpRedirect.java
@@ -24,9 +24,11 @@
 
 package jenkins.util;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
+import java.util.Locale;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
@@ -36,13 +38,33 @@ import org.kohsuke.stapler.StaplerResponse2;
  * Unlike {@link org.kohsuke.stapler.HttpRedirect}, this implements a client-side redirect (using meta tag and/or JavaScript).
  * This allows the redirect to work even when Content Security Policy is enforced in Chrome
  * (which applies {@code form-action} to redirects after form submission).
+ * <p>
+ * For security reasons, only HTTP/HTTPS URLs and relative paths are allowed.
+ * Attempts to redirect to other schemes (e.g., {@code javascript:}, {@code data:}, {@code file:})
+ * will result in a security warning page instead of performing the redirect.
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/form-action">MDN documentation on form-action</a>
  * @see <a href="https://github.com/w3c/webappsec-csp/issues/8">Content Security Policy issue discussing this behavior</a>
  * @since 2.550
  */
 public record ClientHttpRedirect(String redirectUrl) implements HttpResponse {
+
+    private static boolean isSafeToRedirectTo(@NonNull String url) {
+        if (Util.isSafeToRedirectTo(url)) {
+            return true;
+        }
+
+        String urlLower = url.toLowerCase(Locale.ENGLISH);
+        return urlLower.startsWith("http://") || urlLower.startsWith("https://");
+    }
+
     @Override
     public void generateResponse(StaplerRequest2 req, StaplerResponse2 rsp, Object o) throws IOException, ServletException {
+        if (!isSafeToRedirectTo(redirectUrl)) {
+            throw hudson.util.HttpResponses.error(403,
+                "Unsafe redirect blocked: Jenkins only allows redirects to HTTP/HTTPS URLs or relative paths. "
+                    + "Blocked URL: " + Util.escape(redirectUrl));
+        }
+
         rsp.setContentType("text/html;charset=UTF-8");
         Util.printRedirect(req.getContextPath(), redirectUrl, redirectUrl, rsp.getWriter());
     }

--- a/test/src/test/java/jenkins/util/ClientHttpRedirectTest.java
+++ b/test/src/test/java/jenkins/util/ClientHttpRedirectTest.java
@@ -1,0 +1,172 @@
+package jenkins.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
+import org.mockito.Mockito;
+
+/**
+ * Tests for {@link ClientHttpRedirect} URL validation.
+ */
+class ClientHttpRedirectTest {
+
+    /**
+     * Test that HTTP URLs pass validation and generate response.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "http://www.example.com/page",
+        "https://www.jenkins.io/doc/",
+        "HTTP://EXAMPLE.COM",
+        "HTTPS://JENKINS.IO"
+    })
+    void testAllowedUrlSchemes(String url) throws Exception {
+        ClientHttpRedirect redirect = new ClientHttpRedirect(url);
+        StaplerRequest2 req = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 rsp = Mockito.mock(StaplerResponse2.class);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(baos);
+
+        Mockito.when(rsp.getWriter()).thenReturn(writer);
+        Mockito.when(req.getContextPath()).thenReturn("");
+
+        redirect.generateResponse(req, rsp, null);
+
+        writer.flush();
+        String output = baos.toString();
+        assert output.length() > 0;
+    }
+
+    /**
+     * Test that relative URLs are allowed.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "manage/configure",
+        "/jenkins/manage",
+        "/../config",
+        "foo/bar"
+    })
+    void testRelativeUrlsAllowed(String url) throws Exception {
+        ClientHttpRedirect redirect = new ClientHttpRedirect(url);
+        StaplerRequest2 req = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 rsp = Mockito.mock(StaplerResponse2.class);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(baos);
+
+        Mockito.when(rsp.getWriter()).thenReturn(writer);
+        Mockito.when(req.getContextPath()).thenReturn("");
+
+        redirect.generateResponse(req, rsp, null);
+
+        writer.flush();
+        String output = baos.toString();
+        assert output.length() > 0;
+    }
+
+    /**
+     * Test that javascript: URLs are blocked.
+     */
+    @Test
+    void testJavaScriptUrlBlocked() {
+        ClientHttpRedirect redirect = new ClientHttpRedirect("javascript:alert('XSS')");
+        StaplerRequest2 req = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 rsp = Mockito.mock(StaplerResponse2.class);
+
+        try {
+            redirect.generateResponse(req, rsp, null);
+            throw new AssertionError("Should have thrown an exception");
+        } catch (Exception e) {
+            assert e.getMessage().contains("Unsafe redirect blocked");
+        }
+    }
+
+    /**
+     * Test that data: URLs are blocked.
+     */
+    @Test
+    void testDataUrlBlocked() {
+        ClientHttpRedirect redirect = new ClientHttpRedirect("data:text/html,<script>alert('XSS')</script>");
+        StaplerRequest2 req = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 rsp = Mockito.mock(StaplerResponse2.class);
+
+        try {
+            redirect.generateResponse(req, rsp, null);
+            throw new AssertionError("Should have thrown an exception");
+        } catch (Exception e) {
+            assert e.getMessage().contains("Unsafe redirect blocked");
+        }
+    }
+
+    /**
+     * Test that file: URLs are blocked.
+     */
+    @Test
+    void testFileUrlBlocked() {
+        ClientHttpRedirect redirect = new ClientHttpRedirect("file:///etc/passwd");
+        StaplerRequest2 req = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 rsp = Mockito.mock(StaplerResponse2.class);
+
+        try {
+            redirect.generateResponse(req, rsp, null);
+            throw new AssertionError("Should have thrown an exception");
+        } catch (Exception e) {
+            assert e.getMessage().contains("Unsafe redirect blocked");
+        }
+    }
+
+    /**
+     * Test that custom scheme URLs are blocked.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "custom-scheme://malicious",
+        "ftp://server/file",
+        "telnet://host:23"
+    })
+    void testCustomSchemesBlocked(String url) {
+        ClientHttpRedirect redirect = new ClientHttpRedirect(url);
+        StaplerRequest2 req = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 rsp = Mockito.mock(StaplerResponse2.class);
+
+        try {
+            redirect.generateResponse(req, rsp, null);
+            throw new AssertionError("Should have thrown an exception");
+        } catch (Exception e) {
+            assert e.getMessage().contains("Unsafe redirect blocked");
+        }
+    }
+
+    /**
+     * Test that mixed case HTTP/HTTPS URLs are allowed.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "HtTp://www.example.com",
+        "HtTpS://www.jenkins.io",
+        "hTTp://test.com"
+    })
+    void testMixedCaseHttpAllowed(String url) throws Exception {
+        ClientHttpRedirect redirect = new ClientHttpRedirect(url);
+        StaplerRequest2 req = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 rsp = Mockito.mock(StaplerResponse2.class);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(baos);
+
+        Mockito.when(rsp.getWriter()).thenReturn(writer);
+        Mockito.when(req.getContextPath()).thenReturn("");
+
+        redirect.generateResponse(req, rsp, null);
+
+        writer.flush();
+        String output = baos.toString();
+        assert output.length() > 0;
+    }
+}


### PR DESCRIPTION
Fixes #26387 >

### Testing done

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

/label skip-changelog

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
