### PR TITLE
Fix NullPointerException in LazyBuildMixIn on jenkins reload

### DIFF
--- a/core/src/main/java/hudson/tasks/LogRotator.java
+++ b/core/src/main/java/hudson/tasks/LogRotator.java
@@ -163,9 +163,12 @@ public class LogRotator extends BuildDiscarder {
         Run lsb = removeLastBuild ? null : job.getLastSuccessfulBuild();
         Run lstb = removeLastBuild ? null : job.getLastStableBuild();
 
+        Map<Integer, ? extends Run<?, ?>> runMap = job.getBuildsAsMap();
         if (numToKeep != -1) {
-            job.getBuildsAsMap().entrySet().stream().skip(numToKeep).map(Map.Entry::getValue)
-                    .filter(r -> !shouldKeepRun(r, lsb, lstb)).forEach(r -> {
+            // Iterate through keySet() instead of entrySet() or values() to avoid triggering lazy loading
+            // for the first `numToKeep` builds
+            runMap.keySet().stream().skip(numToKeep).map(runMap::get)
+                    .filter(r -> r != null && !shouldKeepRun(r, lsb, lstb)).forEach(r -> {
                 LOGGER.log(FINE, "{0} is to be removed", r);
                 try { r.delete(); }
                 catch (IOException ex) { exceptionMap.computeIfAbsent(r, key -> new HashSet<>()).add(ex); }
@@ -190,8 +193,10 @@ public class LogRotator extends BuildDiscarder {
         }
 
         if (artifactNumToKeep != null && artifactNumToKeep != -1) {
-            job.getBuildsAsMap().entrySet().stream().skip(artifactNumToKeep).map(Map.Entry::getValue)
-                    .filter(r -> !shouldKeepRun(r, lsb, lstb)).forEach(r -> {
+            // Iterate through keySet() instead of entrySet() or values() to avoid triggering lazy loading
+            // for the first `artifactNumToKeep` builds
+            runMap.keySet().stream().skip(artifactNumToKeep).map(runMap::get)
+                    .filter(r -> r != null && !shouldKeepRun(r, lsb, lstb)).forEach(r -> {
                 LOGGER.log(FINE, "{0} is to be purged of artifacts", r);
                 try { r.deleteArtifacts(); }
                 catch (IOException ex) { exceptionMap.computeIfAbsent(r, key -> new HashSet<>()).add(ex); }

--- a/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
@@ -169,12 +169,20 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
 
         @Override
         public Iterator<Integer> iterator() {
-            return new AdaptedIterator<>(BuildReferenceMapAdapter.this.entrySet().iterator()) {
-                @Override
-                protected Integer adapt(Map.Entry<Integer, R> e) {
-                    return e.getKey();
-                }
-            };
+            return Iterators.removeNull(Iterators.map(
+                    BuildReferenceMapAdapter.this.core.entrySet().iterator(), coreEntry -> {
+                        BuildReference<R> ref = coreEntry.getValue();
+                        if (!ref.isSet()) {
+                            R r = resolver.resolveBuildRef(ref);
+                            if (r == null) {
+                                return null;
+                            }
+                        }
+                        if (ref.isUnloadable()) {
+                            return null;
+                        }
+                        return ref.number;
+                    }));
         }
 
         @Override
@@ -273,19 +281,9 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
                 private Map.Entry<Integer, R> current;
                 private final Iterator<Map.Entry<Integer, R>> it = Iterators.removeNull(Iterators.map(
                         BuildReferenceMapAdapter.this.core.entrySet().iterator(), coreEntry -> {
-                            BuildReference<R> ref = coreEntry.getValue();
-                            if (!ref.isSet()) {
-                                R r = resolver.resolveBuildRef(ref);
-                                // load not loaded or unloadable build
-                                if (r == null) {
-                                    return null;
-                                }
-                                return new EntryAdapter(coreEntry, r);
-                            }
-                            if (ref.isUnloadable()) {
-                                return null;
-                            }
-                            return new EntryAdapter(coreEntry);
+                            R r = resolver.resolveBuildRef(coreEntry.getValue());
+                            // if null - load not allowed or build is unloadable
+                            return r == null ? null : new AbstractMap.SimpleImmutableEntry<>(coreEntry.getKey(), r);
                         }));
 
                 @Override
@@ -311,59 +309,6 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
         @Override
         public Spliterator<Map.Entry<Integer, R>> spliterator() {
             return Spliterators.spliteratorUnknownSize(iterator(), Spliterator.DISTINCT | Spliterator.ORDERED);
-        }
-    }
-
-    private class EntryAdapter implements Entry<Integer, R> {
-        private final Map.Entry<Integer, BuildReference<R>> coreEntry;
-        private volatile R resolvedValue;
-
-        EntryAdapter(Map.Entry<Integer, BuildReference<R>> coreEntry) {
-            this(coreEntry, null);
-        }
-
-        EntryAdapter(Map.Entry<Integer, BuildReference<R>> coreEntry, R resolvedValue) {
-            this.coreEntry = coreEntry;
-            this.resolvedValue = resolvedValue;
-        }
-
-        private Map.Entry<Integer, R> getResolvedEntry() {
-            return new AbstractMap.SimpleEntry<>(getKey(), getValue());
-        }
-
-        @Override
-        public Integer getKey() {
-            return coreEntry.getKey();
-        }
-
-        @Override
-        public R getValue() {
-            R value = resolvedValue;
-            if (value != null) {
-                return value;
-            }
-            return resolvedValue = resolver.resolveBuildRef(coreEntry.getValue());
-        }
-
-        @Override
-        public R setValue(R value) {
-            // BuildReferenceAdapter is read only
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public String toString() {
-            return getResolvedEntry().toString();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return (o instanceof Map.Entry<?, ?>) && getResolvedEntry().equals(o);
-        }
-
-        @Override
-        public int hashCode() {
-            return getResolvedEntry().hashCode();
         }
     }
 


### PR DESCRIPTION
Fixes #26397

This PR removes the lazy loading behavior of RunMap’s entry.getValue(). The value will now be resolved inside iterator.next() instead of in entry.getValue() itself.

The weak semantics will be preserved for keySet() iteration, allowing iteration without resolving values on each step. Values can still be resolved explicitly by calling RunMap.get(someKey).

### Testing done
Only jenkins integration tests. It is hard to reproduce the issue

### Screenshots (UI changes only)


#### Before

#### After

### Proposed changelog entries

- Partially revert optimisation in `RunMap` that causes issues when reloading 

### Proposed changelog category

/label regression-fix

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jglick 

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
