### PR TITLE
Retire SHOW_LEGACY_TOKEN_TO_ADMINS system property in ApiTokenProperty

### DIFF
--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -60,7 +60,6 @@ import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import jenkins.security.apitoken.ApiTokenStats;
 import jenkins.security.apitoken.ApiTokenStore;
 import jenkins.security.apitoken.TokenUuidAndPlainValue;
-import jenkins.util.SystemProperties;
 import net.jcip.annotations.Immutable;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -86,29 +85,6 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  */
 public class ApiTokenProperty extends UserProperty {
     private static final Logger LOGGER = Logger.getLogger(ApiTokenProperty.class.getName());
-
-    /**
-     * If enabled, the users with {@link Jenkins#ADMINISTER} permissions can view legacy tokens for
-     * other users.<p>
-     * Disabled by default due to the security reasons.<p>
-     * If enabled, it restores the original Jenkins behavior (SECURITY-200).
-     *
-     * @since 1.638
-     */
-    private static /* not final */ boolean SHOW_LEGACY_TOKEN_TO_ADMINS =
-            SystemProperties.getBoolean(ApiTokenProperty.class.getName() + ".showTokenToAdmins");
-
-    /**
-     * If enabled, the users with {@link Jenkins#ADMINISTER} permissions can generate new tokens for
-     * other users. Normally a user can only generate tokens for himself.<p>
-     * Take care that only the creator of a token will have the plain value as it's only stored as an hash in the system.<p>
-     * Disabled by default due to the security reasons.
-     * It's the version of {@link #SHOW_LEGACY_TOKEN_TO_ADMINS} for the new API Token system (SECURITY-200).
-     *
-     * @since 2.129
-     */
-    private static /* not final */ boolean ADMIN_CAN_GENERATE_NEW_TOKENS =
-            SystemProperties.getBoolean(ApiTokenProperty.class.getName() + ".adminCanGenerateNewTokens");
 
     private volatile Secret apiToken;
     private ApiTokenStore tokenStore;
@@ -152,7 +128,7 @@ public class ApiTokenProperty extends UserProperty {
     /**
      * Gets the API token.
      * The method performs security checks since 1.638. Only the current user and SYSTEM may see it.
-     * Users with {@link Jenkins#ADMINISTER} may be allowed to do it using {@link #SHOW_LEGACY_TOKEN_TO_ADMINS}.
+     * Users with {@link Jenkins#ADMINISTER} permissions may also be allowed to see it.
      *
      * @return API Token. Never null, but may be {@link Messages#ApiTokenProperty_ChangeToken_TokenIsHidden()}
      *         if the user has no appropriate permissions.
@@ -213,7 +189,7 @@ public class ApiTokenProperty extends UserProperty {
      */
     private boolean hasPermissionToSeeToken() {
         // Administrators can do whatever they want
-        return canCurrentUserControlObject(SHOW_LEGACY_TOKEN_TO_ADMINS, user);
+        return canCurrentUserControlObject(true, user);
     }
 
     private static boolean canCurrentUserControlObject(boolean trustAdmins, User propertyOwner) {
@@ -563,7 +539,7 @@ public class ApiTokenProperty extends UserProperty {
         // for Jelly view
         @Restricted(NoExternalUse.class)
         public boolean hasCurrentUserRightToGenerateNewToken(User propertyOwner) {
-            return canCurrentUserControlObject(ADMIN_CAN_GENERATE_NEW_TOKENS, propertyOwner);
+            return canCurrentUserControlObject(true, propertyOwner);
         }
 
         /**

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -189,14 +189,10 @@ public class ApiTokenProperty extends UserProperty {
      */
     private boolean hasPermissionToSeeToken() {
         // Administrators can do whatever they want
-        return canCurrentUserControlObject(true, user);
+        return canCurrentUserControlObject(user);
     }
 
-    private static boolean canCurrentUserControlObject(boolean trustAdmins, User propertyOwner) {
-        if (trustAdmins && Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-            return true;
-        }
-
+    private static boolean canCurrentUserControlObject(User propertyOwner) {
         User current = User.current();
         if (current == null) { // Anonymous
             return false;
@@ -539,7 +535,7 @@ public class ApiTokenProperty extends UserProperty {
         // for Jelly view
         @Restricted(NoExternalUse.class)
         public boolean hasCurrentUserRightToGenerateNewToken(User propertyOwner) {
-            return canCurrentUserControlObject(true, propertyOwner);
+            return canCurrentUserControlObject(propertyOwner);
         }
 
         /**

--- a/core/src/main/java/jenkins/security/ApiTokenProperty.java
+++ b/core/src/main/java/jenkins/security/ApiTokenProperty.java
@@ -193,6 +193,10 @@ public class ApiTokenProperty extends UserProperty {
     }
 
     private static boolean canCurrentUserControlObject(User propertyOwner) {
+        if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+            return true;
+        }
+
         User current = User.current();
         if (current == null) { // Anonymous
             return false;


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #26377
Removes the deprecated `SHOW_LEGACY_TOKEN_TO_ADMINS` system property from `ApiTokenProperty`.
Since the permission changes introduced after JEP-223, administrators inherently have full control and can perform actions such as running Groovy scripts. Therefore limiting what administrators can do through this property no longer makes sense.
This change removes:
- the `SHOW_LEGACY_TOKEN_TO_ADMINS` system property
- the related `SystemProperties` usage
- the associated documentation block

### Testing done

This change is a code cleanup that removes an unused system property and related configuration logic.
Testing performed:
- Built Jenkins locally using: mvn -DskipTests clean install
- Verified that the project compiles successfully after the removal.
- Reviewed the permission logic to ensure behavior remains unchanged: administrators continue to have access as before.

### Screenshots (UI changes only)
N/A
<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Remove deprecated `SHOW_LEGACY_TOKEN_TO_ADMINS` system property from `ApiTokenProperty`

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category
/label internal

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
