### PR TITLE
Redesigned new job page: CascadeChoiceParameter does not work

### DIFF
--- a/src/main/js/components/dialogs/index.js
+++ b/src/main/js/components/dialogs/index.js
@@ -151,11 +151,14 @@ Dialog.prototype.checkInput = function () {
 Dialog.prototype.appendButtons = function () {
   const buttons = createElementFromHtml(`<div
       class="jenkins-buttons-row jenkins-buttons-row--equal-width jenkins-dialog__buttons">
-      <button data-id="ok" type="${this.options.submitButton ? "submit" : "button"
-    }" class="jenkins-button jenkins-button--primary ${_typeClassMap[this.options.type]
-    }">${this.options.okText}</button>
-      <button data-id="cancel" class="jenkins-button">${this.options.cancelText
-    }</button>
+      <button data-id="ok" type="${
+        this.options.submitButton ? "submit" : "button"
+      }" class="jenkins-button jenkins-button--primary ${
+        _typeClassMap[this.options.type]
+      }">${this.options.okText}</button>
+      <button data-id="cancel" class="jenkins-button">${
+        this.options.cancelText
+      }</button>
     </div>`);
 
   if (this.dialogType === "form") {
@@ -281,7 +284,7 @@ function init() {
       dialog
         .show()
         .then()
-        .catch(() => { });
+        .catch(() => {});
     },
 
     alert: function (title, options) {
@@ -294,7 +297,7 @@ function init() {
       dialog
         .show()
         .then()
-        .catch(() => { });
+        .catch(() => {});
     },
 
     confirm: function (title, options) {

--- a/src/main/js/components/dialogs/index.js
+++ b/src/main/js/components/dialogs/index.js
@@ -2,6 +2,16 @@ import { createElementFromHtml } from "@/util/dom";
 import { CLOSE } from "@/util/symbols";
 import behaviorShim from "@/util/behavior-shim";
 import jenkins from "@/util/jenkins";
+function _reapplyBehaviors(container) {
+  behaviorShim.applySubtree(container, true);
+
+  // Dispatch on both document and window since plugins may listen on either.
+  // The Active Choices plugin uses window.addEventListener("DOMContentLoaded")
+  // and manually created events do not bubble, so we must dispatch on window explicitly.
+  var event = new Event("DOMContentLoaded");
+  document.dispatchEvent(event);
+  window.dispatchEvent(event);
+}
 
 let _defaults = {
   title: null,
@@ -54,7 +64,7 @@ Dialog.prototype.init = function () {
       );
       content.appendChild(this.options.content);
       this.dialog.appendChild(content);
-      behaviorShim.applySubtree(content, true);
+      _reapplyBehaviors(content);
     }
     if (this.options.hideCloseButton !== true) {
       const closeButton = createElementFromHtml(`
@@ -86,7 +96,7 @@ Dialog.prototype.init = function () {
       this.form = this.options.form;
       contents.appendChild(this.options.form);
       this.dialog.appendChild(contents);
-      behaviorShim.applySubtree(contents, true);
+      _reapplyBehaviors(contents);
     }
     if (this.dialogType !== "form") {
       const message = createElementFromHtml(
@@ -95,7 +105,7 @@ Dialog.prototype.init = function () {
       if (this.options.content != null && this.dialogType === "alert") {
         message.appendChild(this.options.content);
         this.dialog.appendChild(message);
-        behaviorShim.applySubtree(message, true);
+        _reapplyBehaviors(message);
       } else if (this.options.message != null && this.dialogType !== "prompt") {
         const message = createElementFromHtml(
           `<div class='jenkins-dialog__contents'/>`,

--- a/src/main/js/components/dialogs/index.js
+++ b/src/main/js/components/dialogs/index.js
@@ -54,6 +54,7 @@ Dialog.prototype.init = function () {
       );
       content.appendChild(this.options.content);
       this.dialog.appendChild(content);
+      behaviorShim.applySubtree(content, true);
     }
     if (this.options.hideCloseButton !== true) {
       const closeButton = createElementFromHtml(`
@@ -94,6 +95,7 @@ Dialog.prototype.init = function () {
       if (this.options.content != null && this.dialogType === "alert") {
         message.appendChild(this.options.content);
         this.dialog.appendChild(message);
+        behaviorShim.applySubtree(message, true);
       } else if (this.options.message != null && this.dialogType !== "prompt") {
         const message = createElementFromHtml(
           `<div class='jenkins-dialog__contents'/>`,
@@ -257,7 +259,6 @@ function renderOnDemandDialog(dialogId) {
       window.location.hash = hash;
     }
 
-    behaviorShim.applySubtree(content, false);
     dialog.modal(content, {
       maxWidth: "550px",
       title: title,

--- a/src/main/js/components/dialogs/index.js
+++ b/src/main/js/components/dialogs/index.js
@@ -2,16 +2,6 @@ import { createElementFromHtml } from "@/util/dom";
 import { CLOSE } from "@/util/symbols";
 import behaviorShim from "@/util/behavior-shim";
 import jenkins from "@/util/jenkins";
-function _reapplyBehaviors(container) {
-  behaviorShim.applySubtree(container, true);
-
-  // Dispatch on both document and window since plugins may listen on either.
-  // The Active Choices plugin uses window.addEventListener("DOMContentLoaded")
-  // and manually created events do not bubble, so we must dispatch on window explicitly.
-  var event = new Event("DOMContentLoaded");
-  document.dispatchEvent(event);
-  window.dispatchEvent(event);
-}
 
 let _defaults = {
   title: null,
@@ -64,7 +54,7 @@ Dialog.prototype.init = function () {
       );
       content.appendChild(this.options.content);
       this.dialog.appendChild(content);
-      _reapplyBehaviors(content);
+      behaviorShim.applySubtree(content, true);
     }
     if (this.options.hideCloseButton !== true) {
       const closeButton = createElementFromHtml(`
@@ -96,7 +86,7 @@ Dialog.prototype.init = function () {
       this.form = this.options.form;
       contents.appendChild(this.options.form);
       this.dialog.appendChild(contents);
-      _reapplyBehaviors(contents);
+      behaviorShim.applySubtree(contents, true);
     }
     if (this.dialogType !== "form") {
       const message = createElementFromHtml(
@@ -105,7 +95,7 @@ Dialog.prototype.init = function () {
       if (this.options.content != null && this.dialogType === "alert") {
         message.appendChild(this.options.content);
         this.dialog.appendChild(message);
-        _reapplyBehaviors(message);
+        behaviorShim.applySubtree(message, true);
       } else if (this.options.message != null && this.dialogType !== "prompt") {
         const message = createElementFromHtml(
           `<div class='jenkins-dialog__contents'/>`,
@@ -161,14 +151,11 @@ Dialog.prototype.checkInput = function () {
 Dialog.prototype.appendButtons = function () {
   const buttons = createElementFromHtml(`<div
       class="jenkins-buttons-row jenkins-buttons-row--equal-width jenkins-dialog__buttons">
-      <button data-id="ok" type="${
-        this.options.submitButton ? "submit" : "button"
-      }" class="jenkins-button jenkins-button--primary ${
-        _typeClassMap[this.options.type]
-      }">${this.options.okText}</button>
-      <button data-id="cancel" class="jenkins-button">${
-        this.options.cancelText
-      }</button>
+      <button data-id="ok" type="${this.options.submitButton ? "submit" : "button"
+    }" class="jenkins-button jenkins-button--primary ${_typeClassMap[this.options.type]
+    }">${this.options.okText}</button>
+      <button data-id="cancel" class="jenkins-button">${this.options.cancelText
+    }</button>
     </div>`);
 
   if (this.dialogType === "form") {
@@ -294,7 +281,7 @@ function init() {
       dialog
         .show()
         .then()
-        .catch(() => {});
+        .catch(() => { });
     },
 
     alert: function (title, options) {
@@ -307,7 +294,7 @@ function init() {
       dialog
         .show()
         .then()
-        .catch(() => {});
+        .catch(() => { });
     },
 
     confirm: function (title, options) {


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #26371

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done
Enabled the experimental feature, new job page and built a job with the provided groovy code and reviewed the build with parameter UI. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before
<img width="533" height="403" alt="Screenshot From 2026-03-05 23-37-58" src="https://github.com/user-attachments/assets/4104fc2d-73cb-45bc-811d-7322cd88b6fe" />


#### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d6c2d236-a864-4b5f-a346-40870b744261" />


### Proposed changelog entries
- Added _reapplyBehaviors() function that dispatches DOMContentLoaded on both document and window after dialog content is appended to the DOM. This allows plugins like Active Choices, which register DOMContentLoaded listeners during script loading, to initialize correctly when dialog content is loaded dynamically via rednerOnDemand

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
