### PR TITLE
Render floatingBox.jelly for computer actions on Computer page

### DIFF
--- a/core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/core/src/main/resources/hudson/model/Computer/index.jelly
@@ -55,7 +55,15 @@ THE SOFTWARE.
         </j:choose>
         <t:help href="https://www.jenkins.io/doc/book/using/using-agents/" />
       </l:app-bar>
+      </l:app-bar>
 
+      <!-- FloatingBox rendering for computer actions -->
+      <div style="float:right">
+        <j:forEach var="a" items="${it.allActions}">
+          <j:set var="action" value="${a}" />
+          <st:include page="floatingBox.jelly" from="${a}" optional="true" />
+        </j:forEach>
+      </div>
       <st:include page="index-top.jelly" it="${it}" />
 
       <j:if test="${it.offlineCause!=null and it.offline and !it.connecting}">


### PR DESCRIPTION
Fixes #23461

### Testing done

Manually tested using a plugin that provides a computer action with floatingBox.jelly. Verified that after this change, the floating box correctly appears on the Computer (agent/node) page, whereas previously it did not render.

### Screenshots (UI changes only)

#### Before

_No floating box displayed for computer actions on the Computer page._

#### After

_Floating box is now visible for computer actions on the Computer page._

### Proposed changelog entries

- Render floatingBox.jelly for computer actions on the Computer page to improve UI consistency and allow plugin actions to display floating boxes for nodes/agents.

### Proposed changelog category

/label rfe, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).

### Desired reviewers

@jenkinsci/core-pr-reviewers