### PR TITLE
Fix NPE in details-bar.jelly when detail.link is null

### DIFF
--- a/core/src/main/resources/lib/layout/details-bar.jelly
+++ b/core/src/main/resources/lib/layout/details-bar.jelly
@@ -41,7 +41,9 @@ THE SOFTWARE.
           <j:if test="${detail.iconClassName != null}">
             <x:element name="${detail.link != null ? 'a' : 'div'}">
               <x:attribute name="class">jenkins-details__item</x:attribute>
-              <x:attribute name="href">${detail.link}</x:attribute>
+              <j:if test="${detail.link != null}">
+                  <x:attribute name="href">${detail.link}</x:attribute>
+              </j:if>
               <div class="jenkins-details__item__icon">
                 <l:icon src="${detail.iconClassName}" />
               </div>


### PR DESCRIPTION
## Problem
Fixes NullPointerException in `details-bar.jelly` when `detail.link` 
is null. Reported in #26436.

## Root Cause
The `href` attribute was unconditionally evaluated even when 
`detail.link` is null, despite `Detail.getLink()` being `@Nullable`.

## Fix
Wrapped the `href` attribute in a `<j:if>` null check so it only 
renders when `detail.link` is non-null.
```xml
<j:if test="${detail.link != null}">
    <x:attribute name="href">${detail.link}</x:attribute>
</j:if>
```

Fixes #26436