### PR TITLE
Fix NPE in details-bar.jelly when detail.link is null

### DIFF
--- a/core/src/main/resources/lib/layout/details-bar.jelly
+++ b/core/src/main/resources/lib/layout/details-bar.jelly
@@ -41,7 +41,9 @@ THE SOFTWARE.
           <j:if test="${detail.iconClassName != null}">
             <x:element name="${detail.link != null ? 'a' : 'div'}">
               <x:attribute name="class">jenkins-details__item</x:attribute>
-              <x:attribute name="href">${detail.link}</x:attribute>
+              <j:if test="${detail.link != null}">
+                  <x:attribute name="href">${detail.link}</x:attribute>
+              </j:if>
               <div class="jenkins-details__item__icon">
                 <l:icon src="${detail.iconClassName}" />
               </div>


### PR DESCRIPTION
Fixes #26436

### Testing done

Manually reviewed the Jelly template logic. The `Detail.getLink()` method
is annotated `@Nullable` with a default return value of `null`. When
`detail.link` is null, the `href` attribute was still unconditionally
evaluated inside `<x:element>`, causing a NullPointerException.
The fix wraps the attribute in a `<j:if>` null check, so `href` is only
rendered when `detail.link` is non-null.
No automated test exists for Jelly rendering logic of this kind.

### Screenshots (UI changes only)

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- Fix NullPointerException in details-bar.jelly when detail.link is null

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.