### PR TITLE
`AccessDeniedException3` was unserializable

### DIFF
--- a/core/src/main/java/hudson/security/AccessDeniedException3.java
+++ b/core/src/main/java/hudson/security/AccessDeniedException3.java
@@ -28,7 +28,7 @@ public class AccessDeniedException3 extends AccessDeniedException {
     /**
      * This object represents the permission that the user needed.
      */
-    public final Permission permission;
+    public final transient Permission permission;
 
     public AccessDeniedException3(Authentication authentication, Permission permission) {
         this(null, authentication, permission);


### PR DESCRIPTION
While looking into a `RealJenkinsRule` test flake in CloudBees CI code, I saw that sometimes an assertion

```java
@Override
public void run(final JenkinsRule r) throws Throwable {
    assertThatThrownBy(() -> …).isInstanceOf(AccessDeniedException3.class);
}
```

failed but not in the expected way:

```
java.io.WriteAbortedException: writing aborted; java.io.NotSerializableException: hudson.security.Permission
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1627)
	at …
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:445)
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture$Init.readSer(RealJenkinsFixture.java:1722)
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture.runRemotely(RealJenkinsFixture.java:1358)
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture.runRemotely(RealJenkinsFixture.java:1320)
	at org.jvnet.hudson.test.RealJenkinsRule.runRemotely(RealJenkinsRule.java:655)
	at …
Caused by: java.io.NotSerializableException: hudson.security.Permission
	at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1085)
	at …
	at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:325)
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture$Init.writeSer(RealJenkinsFixture.java:1697)
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture$Endpoint.doStep(RealJenkinsFixture.java:1845)
	at …
```

Perhaps using `hudson.remoting.ProxyException` would fix this, though it is not clear to me what exactly is being serialized.

At any rate, `Throwable`s generally are expected to be `Serializable`, and `Permission` is not, so this cannot be a persisted field. The `detailMessage` should preserve the identity of the permission; the `permission` field is used by the call chain while producing the HTTP response but that should not go through Java serialization.

### Testing done

With this change, the test fails like I would have expected:

```
org.jvnet.hudson.test.fixtures.RealJenkinsFixture$StepException: 
Remote step in … threw an exception: java.lang.AssertionError: 
Expecting code to raise a throwable.
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture.runRemotely(RealJenkinsFixture.java:1368)
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture.runRemotely(RealJenkinsFixture.java:1320)
	at org.jvnet.hudson.test.RealJenkinsRule.runRemotely(RealJenkinsRule.java:655)
	at …
Caused by: java.lang.AssertionError: 
Expecting code to raise a throwable.
	at …
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture$StepsToStep2.run(RealJenkinsFixture.java:1937)
	at org.jvnet.hudson.test.fixtures.RealJenkinsFixture$Endpoint.lambda$doStep$0(RealJenkinsFixture.java:1833)
	at …
Caused by: java.lang.AssertionError: 
Expecting code to raise a throwable.
	... 8 more
```

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
