### PR TITLE
Describe BASE+EXTRA syntax in help for global environment variables

### DIFF
--- a/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
@@ -19,7 +19,7 @@
   <p>
     Jenkins also supports a special syntax,
     <code>BASE+EXTRA</code>
-    , which allows you to prepand values to an existing environment variable.
+    , which allows you to prepend values to an existing environment variable.
   </p>
 
   <p>

--- a/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
@@ -31,4 +31,4 @@
     Multiple entries are prepended to the "base" variable according to the
     alphabetical order of the "extra" part of the name.
 </p>
-yeah i changed it
+

--- a/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
@@ -1,8 +1,34 @@
 <div>
-  These key-value pairs apply for every build on every node. They can be used in
-  Jenkins' configuration (as
-  <code>$key</code>
-  or
-  <code>${key}</code>
-  ) and will be added to the environment for processes launched from the build.
+    These key-value pairs apply for every build on every node. They can be used in
+    Jenkins' configuration (as
+    <code>$key</code>
+    or
+    <code>${key}</code>
+    ) and will be added to the environment for processes launched from the build.
 </div>
+<p>
+    Jenkins also supports a special syntax,
+    <code>BASE+EXTRA</code>,
+    which allows you to add multiple key-value pairs that will be
+    prepended to an existing environment variable.
+</p>
+
+<p>
+    For example, if a system has
+    <code>PATH=/usr/bin</code>,
+    you could add to the standard path by defining an environment variable
+    with the name
+    <code>PATH+LOCAL_BIN</code>
+    and value
+    <code>/usr/local/bin</code>.
+    <br />
+    This would result in
+    <code>PATH=/usr/local/bin:/usr/bin</code>
+    being exported during builds.
+    <code>PATH+LOCAL_BIN=/usr/local/bin</code>
+    will also be exported.
+    <br />
+    Multiple entries are prepended to the "base" variable according to the
+    alphabetical order of the "extra" part of the name.
+</p>
+yeah i changed it

--- a/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
@@ -1,34 +1,34 @@
 <div>
-    These key-value pairs apply for every build on every node. They can be used in
-    Jenkins' configuration (as
-    <code>$key</code>
-    or
-    <code>${key}</code>
-    ) and will be added to the environment for processes launched from the build.
+  These key-value pairs apply for every build on every node. They can be used in
+  Jenkins' configuration (as
+  <code>$key</code>
+  or
+  <code>${key}</code>
+  ) and will be added to the environment for processes launched from the build.
 </div>
 <p>
-    Jenkins also supports a special syntax,
-    <code>BASE+EXTRA</code>,
-    which allows you to add multiple key-value pairs that will be
-    prepended to an existing environment variable.
+  Jenkins also supports a special syntax,
+  <code>BASE+EXTRA</code>
+  , which allows you to add multiple key-value pairs that will be prepended to
+  an existing environment variable.
 </p>
 
 <p>
-    For example, if a system has
-    <code>PATH=/usr/bin</code>,
-    you could add to the standard path by defining an environment variable
-    with the name
-    <code>PATH+LOCAL_BIN</code>
-    and value
-    <code>/usr/local/bin</code>.
-    <br />
-    This would result in
-    <code>PATH=/usr/local/bin:/usr/bin</code>
-    being exported during builds.
-    <code>PATH+LOCAL_BIN=/usr/local/bin</code>
-    will also be exported.
-    <br />
-    Multiple entries are prepended to the "base" variable according to the
-    alphabetical order of the "extra" part of the name.
+  For example, if a system has
+  <code>PATH=/usr/bin</code>
+  , you could add to the standard path by defining an environment variable with
+  the name
+  <code>PATH+LOCAL_BIN</code>
+  and value
+  <code>/usr/local/bin</code>
+  .
+  <br />
+  This would result in
+  <code>PATH=/usr/local/bin:/usr/bin</code>
+  being exported during builds.
+  <code>PATH+LOCAL_BIN=/usr/local/bin</code>
+  will also be exported.
+  <br />
+  Multiple entries are prepended to the "base" variable according to the
+  alphabetical order of the "extra" part of the name.
 </p>
-

--- a/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
@@ -1,5 +1,6 @@
 <div>
-  These key-value pairs apply for every build on every node. They can be used in Jenkins (as
+  These key-value pairs apply for every build on every node. They can be used in
+  Jenkins (as
   <code>$key</code>
   or
   <code>${key}</code>
@@ -25,8 +26,8 @@
   <p>
     For example, if a system has
     <code>PATH=/usr/bin</code>
-    , you could add to the standard path by defining an environment variable with
-    the name
+    , you could add to the standard path by defining an environment variable
+    with the name
     <code>PATH+LOCAL_BIN</code>
     and value
     <code>/usr/local/bin</code>

--- a/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/globalEnvironmentVariables.html
@@ -1,34 +1,50 @@
 <div>
-  These key-value pairs apply for every build on every node. They can be used in
-  Jenkins' configuration (as
+  These key-value pairs apply for every build on every node. They can be used in Jenkins (as
   <code>$key</code>
   or
   <code>${key}</code>
   ) and will be added to the environment for processes launched from the build.
-</div>
-<p>
-  Jenkins also supports a special syntax,
-  <code>BASE+EXTRA</code>
-  , which allows you to add multiple key-value pairs that will be prepended to
-  an existing environment variable.
-</p>
 
-<p>
-  For example, if a system has
-  <code>PATH=/usr/bin</code>
-  , you could add to the standard path by defining an environment variable with
-  the name
-  <code>PATH+LOCAL_BIN</code>
-  and value
-  <code>/usr/local/bin</code>
-  .
-  <br />
-  This would result in
-  <code>PATH=/usr/local/bin:/usr/bin</code>
-  being exported during builds.
-  <code>PATH+LOCAL_BIN=/usr/local/bin</code>
-  will also be exported.
-  <br />
-  Multiple entries are prepended to the "base" variable according to the
-  alphabetical order of the "extra" part of the name.
-</p>
+  <p>
+    Using the syntax
+    <code>$NAME</code>
+    or
+    <code>${NAME}</code>
+    (
+    <code>%NAME%</code>
+    on Windows), these variables can be used in job configurations, or from
+    processes launched by a build.
+  </p>
+
+  <p>
+    Jenkins also supports a special syntax,
+    <code>BASE+EXTRA</code>
+    , which allows you to prepand values to an existing environment variable.
+  </p>
+
+  <p>
+    For example, if a system has
+    <code>PATH=/usr/bin</code>
+    , you could add to the standard path by defining an environment variable with
+    the name
+    <code>PATH+LOCAL_BIN</code>
+    and value
+    <code>/usr/local/bin</code>
+    .
+    <br />
+    This would result in
+    <code>PATH=/usr/local/bin:/usr/bin</code>
+    being exported during builds executed on any node.
+    <br />
+    Multiple entries are prepended to the "base" variable according to the
+    descending alphabetical order of the "extra" part of the name.
+  </p>
+
+  <p>
+    If the
+    <i>Value</i>
+    is empty or whitespace-only, it will not be added to the environment, nor
+    will it override or unset any environment variable with the same name that
+    may already exist (e.g. a variable defined by the system).
+  </p>
+</div>

--- a/war/src/main/webapp/help/system-config/nodeEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/nodeEnvironmentVariables.html
@@ -1,11 +1,12 @@
 <div>
   Environment variables defined here will be made available to every build
-  executed by this agent, and will override any environment variables that have
+  executed on this node and will override any environment variables that have
   the same
   <i>Name</i>
   as those defined on the
   <i>Configure System</i>
   page.
+
   <p>
     Using the syntax
     <code>$NAME</code>
@@ -14,21 +15,20 @@
     (
     <code>%NAME%</code>
     on Windows), these variables can be used in job configurations, or from
-    process launched by a build.
+    processes launched by a build.
   </p>
 
   <p>
     Jenkins also supports a special syntax,
     <code>BASE+EXTRA</code>
-    , which allows you to add multiple key-value pairs here, which will be
-    prepended to an existing environment variable.
+    , which allows you to prepand values to an existing environment variable.
   </p>
 
   <p>
-    For example, if you have a machine which has
+    For example, if a node has
     <code>PATH=/usr/bin</code>
-    , you could add to the standard path by defining an environment variable
-    here, with the name
+    , you could add to the standard path by defining an environment variable with
+    the name
     <code>PATH+LOCAL_BIN</code>
     and value
     <code>/usr/local/bin</code>
@@ -36,9 +36,7 @@
     <br />
     This would result in
     <code>PATH=/usr/local/bin:/usr/bin</code>
-    being exported during builds executed on this machine.
-    <code>PATH+LOCAL_BIN=/usr/local/bin</code>
-    will also be exported.
+    being exported during builds executed on this node.
     <br />
     Multiple entries are prepended to the "base" variable according to the
     alphabetical order of the "extra" part of the name.

--- a/war/src/main/webapp/help/system-config/nodeEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/nodeEnvironmentVariables.html
@@ -39,7 +39,7 @@
     being exported during builds executed on this node.
     <br />
     Multiple entries are prepended to the "base" variable according to the
-    alphabetical order of the "extra" part of the name.
+    descending alphabetical order of the "extra" part of the name.
   </p>
 
   <p>

--- a/war/src/main/webapp/help/system-config/nodeEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/nodeEnvironmentVariables.html
@@ -27,8 +27,8 @@
   <p>
     For example, if a node has
     <code>PATH=/usr/bin</code>
-    , you could add to the standard path by defining an environment variable with
-    the name
+    , you could add to the standard path by defining an environment variable
+    with the name
     <code>PATH+LOCAL_BIN</code>
     and value
     <code>/usr/local/bin</code>

--- a/war/src/main/webapp/help/system-config/nodeEnvironmentVariables.html
+++ b/war/src/main/webapp/help/system-config/nodeEnvironmentVariables.html
@@ -21,7 +21,7 @@
   <p>
     Jenkins also supports a special syntax,
     <code>BASE+EXTRA</code>
-    , which allows you to prepand values to an existing environment variable.
+    , which allows you to prepend values to an existing environment variable.
   </p>
 
   <p>


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #17816

This PR updates the inline help text for Global Environment Variables in
Manage Jenkins → Configure System.

The help text previously did not describe the BASE+EXTRA syntax used to prepend values to existing environment variables, even though this behavior is supported.

This change adds the missing explanation and example so that the global configuration help text is consistent with the Node Environment Variables help documentation.

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

Built Jenkins locally and verified the updated help text in the UI:

Manage Jenkins → Configure System → Global Properties → Environment Variables

Confirmed that the help section now includes the description of the BASE+EXTRA syntax and the example explaining how environment variables are prepended.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before
The help text did not include details about the BASE+EXTRA syntax for prepending environment variables.

#### After
The help text now includes the explanation and example for the BASE+EXTRA syntax, consistent with the node environment variables documentation.
<img width="1565" height="379" alt="image" src="https://github.com/user-attachments/assets/6191f373-8841-4388-90e3-b759d465bc09" />

##### System Help

<img width="1008" height="684" alt="ssytem-help" src="https://github.com/user-attachments/assets/9cd7cc2b-a4f3-4982-91ad-5d46aff50d06" />

##### Node Help

<img width="990" height="685" alt="node-help" src="https://github.com/user-attachments/assets/bc65e8f5-e4de-46ef-a2ea-6e069e603bff" />

##### Console Output (Pipeline)

<img width="1027" height="847" alt="console-output" src="https://github.com/user-attachments/assets/1f8a8393-77cb-45c0-9dbd-aea80018251e" />

### Proposed changelog entries

- Explain prepending additional values to environment variables with BASE+EXTRA in the online help for nodes.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe,web-ui

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
