### PR TITLE
Reduce default agent ping interval to 30s to avoid idle timeouts

### DIFF
--- a/core/src/main/java/hudson/slaves/ChannelPinger.java
+++ b/core/src/main/java/hudson/slaves/ChannelPinger.java
@@ -57,7 +57,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Extension
 public class ChannelPinger extends ComputerListener {
     static final int PING_TIMEOUT_SECONDS_DEFAULT = 4 * 60;
-    static final int PING_INTERVAL_SECONDS_DEFAULT = 5 * 60;
+    static final int PING_INTERVAL_SECONDS_DEFAULT = 30;
 
     private static final Logger LOGGER = Logger.getLogger(ChannelPinger.class.getName());
     private static final String TIMEOUT_SECONDS_PROPERTY = ChannelPinger.class.getName() + ".pingTimeoutSeconds";


### PR DESCRIPTION
## Summary

This PR reduces the default TCP agent ping interval from 5 minutes to 30 seconds in .

Modern Jenkins installations frequently run behind load balancers and reverse proxies (such as AWS NLB + nginx-ingress) that use relatively short idle timeouts (around 60 seconds). With the existing 5-minute default, there can be long idle periods with no traffic, during which intermediaries terminate the TCP connection. The next scheduled  then sees a  and the server continues to believe the agent is already connected for several minutes, leading to repeated  logs and temporarily unavailable agents.

Aligning the default TCP ping interval with the websocket ping behavior (30s) keeps traffic flowing frequently enough to avoid these idle timeouts by default, without requiring manual system property tuning.

This change is motivated by and intended to address [#26338](https://github.com/jenkinsci/jenkins/issues/26338) and is consistent with the proposal in [#26353](https://github.com/jenkinsci/jenkins/issues/26353).

## Details

- Change  in  from  to .
- Existing system properties  and the deprecated  continue to override the default when explicitly set.

## Testing

-  already verifies that  uses the default constants when no system properties are set and that the system properties override behavior is preserved. Since these tests assert via the constants, they continue to validate the wiring with the new default value.

## Credits

Authored by @abhay1999 for improving robustness of Jenkins agent connections in modern cloud / proxy environments.

Made with [Cursor](https://cursor.com)