### PR TITLE
Truncated log displayed in middle of line, showing Base64-encoded ConsoleNote garbage

### DIFF
--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -35,6 +35,7 @@ import hudson.remoting.ObjectInputStreamEx;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -243,9 +244,13 @@ public class AnnotatedLargeText<T> extends LargeText {
     public long writeHtmlTo(long start, Writer w) throws IOException {
         StaplerRequest2 req = Stapler.getCurrentRequest2();
         StaplerResponse2 rsp = Stapler.getCurrentResponse2();
+
+        long adjustedStart = start > 0 ? Math.max(0, start - 4) : start;
+        Writer safeWriter = start > 0 ? new SkipUntilNewlineWriter(w) : w;
+
         ConsoleAnnotationOutputStream<T> caw = new ConsoleAnnotationOutputStream<>(
-                w, createAnnotator(req), context, charset);
-        long r = super.writeLogTo(start, caw);
+                safeWriter, createAnnotator(req), context, charset);
+        long r = super.writeLogTo(adjustedStart, caw);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         Cipher sym = PASSING_ANNOTATOR.encrypt();
@@ -266,4 +271,57 @@ public class AnnotatedLargeText<T> extends LargeText {
      * Used for sending the state of ConsoleAnnotator to the client, because we are deserializing this object later.
      */
     private static final CryptoConfidentialKey PASSING_ANNOTATOR = new CryptoConfidentialKey(AnnotatedLargeText.class, "consoleAnnotator");
+
+    private static class SkipUntilNewlineWriter extends FilterWriter {
+
+        private boolean foundNewline = false;
+        private final StringBuilder buffer = new StringBuilder();
+
+        SkipUntilNewlineWriter(Writer out) {
+            super(out);
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            if (foundNewline) {
+                out.write(cbuf, off, len);
+                return;
+            }
+            for (int i = off; i < off + len; i++) {
+                if (cbuf[i] == '\n') {
+                    foundNewline = true;
+                    // write everything AFTER the \n
+                    out.write(cbuf, i + 1, (off + len) - (i + 1));
+                    return;
+                }
+            }
+            // no \n found yet
+            buffer.append(cbuf, off, len);
+        }
+
+        @Override
+        public void write(String str, int off, int len) throws IOException {
+            write(str.toCharArray(), off, len);
+        }
+
+        @Override
+        public void write(int c) throws IOException {
+            if (foundNewline) { out.write(c); return; }
+            if (c == '\n') {
+                foundNewline = true;
+            } else {
+                buffer.append((char) c);
+            }
+        }
+
+        @Override
+        public void flush() throws IOException {
+            // if stream ended with no \n, dump buffer
+            if (!foundNewline && !buffer.isEmpty()) {
+                out.write(buffer.toString());
+                buffer.setLength(0);
+            }
+            out.flush();
+        }
+    }
 }

--- a/test/src/test/java/hudson/console/AnnotatedLargeTextTest.java
+++ b/test/src/test/java/hudson/console/AnnotatedLargeTextTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.MarkupText;
@@ -164,6 +165,33 @@ class AnnotatedLargeTextTest {
         text.writeHtmlTo(0, w);
         assertThat(w.toString(), matchesRegex("Some text[.]\nGo back to .*your home[.]\nMore text[.]\n"));
         assertThat(logging.getMessages(), hasItem(matchesRegex("Failed to resurrect annotation from .+")));
+    }
+
+    @Issue("JENKINS-44972")
+    @Test
+    void truncatedLogMidLineSkipsGarbage() throws Exception {
+        ByteBuffer buf = new ByteBuffer();
+        PrintStream ps = new PrintStream(buf, true, StandardCharsets.UTF_8);
+
+        ps.print("First line " + TestNote.encodeTo("/root", "click here") + ".\n");
+        ps.print("Second line clean.\n");
+        ps.print("Third line clean.\n");
+
+        AnnotatedLargeText<Void> text = new AnnotatedLargeText<>(buf, StandardCharsets.UTF_8, true, null);
+
+        StringWriter w = new StringWriter();
+        text.writeHtmlTo(0, w);
+        assertThat(w.toString(), containsString("First line"));
+
+        StringWriter w2 = new StringWriter();
+        text.writeHtmlTo(5, w2);
+
+        assertThat(w2.toString(), not(matchesRegex(".*[A-Za-z0-9+/]{20,}.*")));
+
+        assertThat(w2.toString(), containsString("Second line clean."));
+
+        ByteBuffer singleLine = new ByteBuffer();
+        singleLine.write("no newline at all".getBytes(StandardCharsets.UTF_8));
     }
 
     /** Simplified version of {@link HyperlinkNote}. */


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace #22143 with the issue number.
-->

Fixes #22143 

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->
This PR resolves the issue of truncated log getting displayed showing base64-encoded garbage.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
Added truncatedLogMidLineSkipsGarbage test in AnnotatedLargeTextTest that verifies: 
1. start=0 is unaffected
2. starting mid-line skips garbage and starts output cleanly from the next newline. 
Bug was confirmed reproducible before the fix and absent after.

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
