### PR TITLE
Fix Search Bar Navigation

### DIFF
--- a/src/main/js/components/search-bar/index.js
+++ b/src/main/js/components/search-bar/index.js
@@ -35,8 +35,7 @@ function init() {
           results.forEach((item, index) => {
             container.appendChild(
               createElementFromHtml(
-                `<a class="jenkins-dropdown__item ${index === 0 ? SELECTED_CLASS : ""}" href="${
-                  item.url
+                `<a class="jenkins-dropdown__item ${index === 0 ? SELECTED_CLASS : ""}" href="${item.url
                 }"><div class="jenkins-dropdown__item__icon">${item.icon}</div>${xmlEscape(item.label)}</a>`,
               ),
             );
@@ -103,6 +102,11 @@ function init() {
             searchResults.offsetHeight + "px";
           showResultsContainer();
         }
+      });
+      searchBar.addEventListener("click", () => {
+        searchBar.focus();
+        const len = searchBar.value.length;
+        searchBar.setSelectionRange(len, len);
       });
 
       document.addEventListener("click", (event) => {

--- a/src/main/scss/form/_search-bar.scss
+++ b/src/main/scss/form/_search-bar.scss
@@ -13,6 +13,14 @@
     padding: 0 0.25rem 0 calc(var(--search-bar-height) * 0.9);
     height: var(--search-bar-height);
 
+
+
+    &::placeholder {
+      user-select: none;
+      pointer-events: none;
+    }
+
+
     // Safari adds unwanted padding - let's remove it
     &::-webkit-search-decoration {
       -webkit-appearance: none;
@@ -44,6 +52,7 @@
     }
 
     &:not(:disabled) {
+
       &:active,
       &:focus {
         &::-webkit-search-cancel-button {


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <26389> with the issue number.
-->

Fixes #<issue-number>

<!-- Comment:
Fixed the search bar navigation issue where the entire text was getting selected when clicking on the search field. Now, when the user clicks on the search bar, the text is not auto-selected and the user can directly start typing their query. This improves the search experience and makes navigation smoother.

-->

### Testing done

<!-- Comment:
### How this change was tested

The change was tested locally by running the Jenkins project in development mode.

Steps performed:

1. Built the project using Maven.
2. Started Jenkins locally using the development server.
3. Opened the Jenkins UI in the browser at `http://localhost:8080`.
4. Navigated to the page containing the search bar in the navigation section.
5. Clicked on the search bar before the change and observed that the entire text was automatically selected.
6. After applying the fix, clicked on the search bar again and verified that the text is no longer auto-selected and the user can directly type their query.

Result:
The updated behavior allows users to click the search bar and start typing immediately without the entire text being selected.

Automated tests were not added because this change affects frontend UI behavior and the current test coverage does not include automated tests for this specific interaction.

-->



@cris 

