### PR TITLE
Limit RSS changelog feed by default and add tests

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -110,6 +110,7 @@ import jenkins.scm.RunWithSCM;
 import jenkins.security.HexStringConfidentialKey;
 import jenkins.security.stapler.StaplerNotDispatchable;
 import jenkins.triggers.SCMTriggerItem;
+import jenkins.util.SystemProperties;
 import jenkins.widgets.HasWidgets;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
@@ -1137,10 +1138,42 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * RSS feed for changes in this project.
+     * The feed is limited by default to reduce response size and server load (see
+     * {@code hudson.model.Job.rssChangelogMaxEntries} system property, default 20).
+     * Clients that want a full-length feed can request it explicitly via the {@code max}
+     * query parameter: e.g. {@code ?max=50} for 50 entries, or {@code ?max=all} for the
+     * full feed up to the cap (see {@code hudson.model.Job.rssChangelogMaxEntriesCap}, default 1000).
      *
      * @since 2.60
      */
     public void doRssChangelog(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
+        int defaultMaxEntries = 20;
+        Integer defaultProp = SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20);
+        if (defaultProp != null && defaultProp > 0) {
+            defaultMaxEntries = defaultProp;
+        }
+
+        int maxEntriesCap = 1000;
+        Integer capProp = SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntriesCap", 1000);
+        if (capProp != null && capProp > 0) {
+            maxEntriesCap = capProp;
+        }
+
+        String maxParam = req.getParameter("max");
+        int maxEntries = defaultMaxEntries;
+        if (maxParam != null && !maxParam.isEmpty()) {
+            if (maxParam.equalsIgnoreCase("all")) {
+                maxEntries = maxEntriesCap;
+            } else {
+                try {
+                    int requested = Integer.parseInt(maxParam);
+                    maxEntries = Math.max(1, Math.min(requested, maxEntriesCap));
+                } catch (NumberFormatException e) {
+                    maxEntries = defaultMaxEntries;
+                }
+            }
+        }
+
         class FeedItem {
             ChangeLogSet.Entry e;
             int idx;
@@ -1165,12 +1198,16 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             scmDisplayName = " " + String.join(", ", scmNames);
         }
 
+        buildChangelogLoop:
         for (RunT r = getLastBuild(); r != null; r = r.getPreviousBuild()) {
             int idx = 0;
             if (r instanceof RunWithSCM) {
                 for (ChangeLogSet<? extends ChangeLogSet.Entry> c : ((RunWithSCM<?, ?>) r).getChangeSets()) {
                     for (ChangeLogSet.Entry e : c) {
                         entries.add(new FeedItem(e, idx++));
+                        if (entries.size() >= maxEntries) {
+                            break buildChangelogLoop;
+                        }
                     }
                 }
             }

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -140,8 +140,7 @@ class ComputerTest {
     void offlineCauseRemainsAfterTemporaryCauseRemoved() throws Exception {
         var agent = j.createSlave();
         var computer = agent.toComputer();
-        await().atMost(Duration.ofSeconds(30)).until(
-                () -> computer.getOfflineCause() != null && !computer.isConnecting());
+        computer.connect(false).get();
         var initialOfflineCause = new OfflineCause.UserCause(User.getOrCreateByIdOrFullName("username"), "Initial cause");
         computer.setOfflineCause(initialOfflineCause);
         assertThat(computer.getOfflineCause(), equalTo(initialOfflineCause));

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -140,6 +140,8 @@ class ComputerTest {
     void offlineCauseRemainsAfterTemporaryCauseRemoved() throws Exception {
         var agent = j.createSlave();
         var computer = agent.toComputer();
+        await().atMost(Duration.ofSeconds(30)).until(
+                () -> computer.getOfflineCause() != null && !computer.isConnecting());
         var initialOfflineCause = new OfflineCause.UserCause(User.getOrCreateByIdOrFullName("username"), "Initial cause");
         computer.setOfflineCause(initialOfflineCause);
         assertThat(computer.getOfflineCause(), equalTo(initialOfflineCause));

--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,9 +46,11 @@ import java.util.Date;
 import java.util.List;
 import jenkins.model.Jenkins;
 import org.htmlunit.xml.XmlPage;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.FakeChangeLogSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
@@ -70,9 +73,18 @@ class RSSTest {
 
     private JenkinsRule j;
 
+    private static final String RSS_CHANGELOG_MAX_ENTRIES_PROP = Job.class.getName() + ".rssChangelogMaxEntries";
+    private static final String RSS_CHANGELOG_MAX_ENTRIES_CAP_PROP = Job.class.getName() + ".rssChangelogMaxEntriesCap";
+
     @BeforeEach
     void setUp(JenkinsRule rule) {
         j = rule;
+    }
+
+    @AfterEach
+    void clearRssChangelogSystemProperties() {
+        System.clearProperty(RSS_CHANGELOG_MAX_ENTRIES_PROP);
+        System.clearProperty(RSS_CHANGELOG_MAX_ENTRIES_CAP_PROP);
     }
 
     @Test
@@ -346,6 +358,87 @@ class RSSTest {
         checkAtomBasicNodes(documentElement, "Jenkins:log (WARNING entries)", expectedNodes);
     }
 
+    @Test
+    void rssChangelog_defaultLimit() throws Exception {
+        createJobWithChangelogEntries("rssChangelogTest", 25);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        XmlPage atomPage = getRssChangelogPage(wc, "rssChangelogTest", "", true);
+        XmlPage rssPage = getRssChangelogPage(wc, "rssChangelogTest", "", false);
+        assertThat(countChangelogEntries(atomPage, true), lessThanOrEqualTo(20));
+        assertThat(countChangelogEntries(rssPage, false), lessThanOrEqualTo(20));
+    }
+
+    @Test
+    void rssChangelog_maxParam() throws Exception {
+        createJobWithChangelogEntries("rssChangelogTest", 25);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        XmlPage page5 = getRssChangelogPage(wc, "rssChangelogTest", "max=5", true);
+        XmlPage page50 = getRssChangelogPage(wc, "rssChangelogTest", "max=50", true);
+        assertThat(countChangelogEntries(page5, true), lessThanOrEqualTo(5));
+        assertEquals(25, countChangelogEntries(page50, true));
+    }
+
+    @Test
+    void rssChangelog_maxAll() throws Exception {
+        createJobWithChangelogEntries("rssChangelogTest", 25);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        XmlPage page = getRssChangelogPage(wc, "rssChangelogTest", "max=all", true);
+        assertEquals(25, countChangelogEntries(page, true));
+    }
+
+    @Test
+    void rssChangelog_systemPropertyDefault() throws Exception {
+        try {
+            System.setProperty(RSS_CHANGELOG_MAX_ENTRIES_PROP, "5");
+            createJobWithChangelogEntries("rssChangelogTest", 10);
+            JenkinsRule.WebClient wc = j.createWebClient();
+            XmlPage page = getRssChangelogPage(wc, "rssChangelogTest", "", true);
+            assertThat(countChangelogEntries(page, true), lessThanOrEqualTo(5));
+        } finally {
+            System.clearProperty(RSS_CHANGELOG_MAX_ENTRIES_PROP);
+        }
+    }
+
+    @Test
+    void rssChangelog_systemPropertyCap() throws Exception {
+        try {
+            System.setProperty(RSS_CHANGELOG_MAX_ENTRIES_CAP_PROP, "10");
+            createJobWithChangelogEntries("rssChangelogTest", 25);
+            JenkinsRule.WebClient wc = j.createWebClient();
+            XmlPage page = getRssChangelogPage(wc, "rssChangelogTest", "max=all", true);
+            assertEquals(10, countChangelogEntries(page, true));
+        } finally {
+            System.clearProperty(RSS_CHANGELOG_MAX_ENTRIES_CAP_PROP);
+        }
+    }
+
+    @Test
+    void rssChangelog_invalidMaxFallsBackToDefault() throws Exception {
+        createJobWithChangelogEntries("rssChangelogTest", 25);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        XmlPage page = getRssChangelogPage(wc, "rssChangelogTest", "max=foo", true);
+        assertThat(countChangelogEntries(page, true), lessThanOrEqualTo(20));
+    }
+
+    @Test
+    void rssChangelog_noChangelog() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject("noChangelogJob");
+        j.buildAndAssertSuccess(p);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        XmlPage page = getRssChangelogPage(wc, "noChangelogJob", "", true);
+        assertEquals(0, countChangelogEntries(page, true));
+    }
+
+    @Test
+    void rssChangelog_fewEntries() throws Exception {
+        createJobWithChangelogEntries("rssChangelogTest", 3);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        XmlPage defaultPage = getRssChangelogPage(wc, "rssChangelogTest", "", true);
+        XmlPage maxPage = getRssChangelogPage(wc, "rssChangelogTest", "max=10", true);
+        assertEquals(3, countChangelogEntries(defaultPage, true));
+        assertEquals(3, countChangelogEntries(maxPage, true));
+    }
+
     private JenkinsRule.WebClient loginAsUser(String userId) throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to(userId));
@@ -468,6 +561,35 @@ class RSSTest {
     private XmlPage getRssLatestPage(JenkinsRule.WebClient webClient, String pathPrefix) throws Exception {
         String prefix = computeAdjustedPathPrefix(pathPrefix);
         return (XmlPage) webClient.goTo(prefix + "rssLatest?flavor=rss20", "text/xml");
+    }
+
+    private XmlPage getRssChangelogPage(JenkinsRule.WebClient webClient, String jobName, String queryString, boolean atom) throws Exception {
+        String path = "job/" + jobName + "/rssChangelog";
+        if (atom) {
+            if (!queryString.isEmpty()) {
+                path += "?" + queryString;
+            }
+            return (XmlPage) webClient.goTo(path, "application/atom+xml");
+        } else {
+            String fullQuery = queryString.isEmpty() ? "flavor=rss20" : queryString + "&flavor=rss20";
+            return (XmlPage) webClient.goTo(path + "?" + fullQuery, "text/xml");
+        }
+    }
+
+    private int countChangelogEntries(XmlPage page, boolean atom) {
+        String tag = atom ? "entry" : "item";
+        return page.getXmlDocument().getElementsByTagName(tag).getLength();
+    }
+
+    private FreeStyleProject createJobWithChangelogEntries(String jobName, int entryCount) throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject(jobName);
+        FakeChangeLogSCM scm = new FakeChangeLogSCM();
+        p.setScm(scm);
+        for (int i = 0; i < entryCount; i++) {
+            scm.addChange().withAuthor("u" + i);
+            j.buildAndAssertSuccess(p);
+        }
+        return p;
     }
 
     private FreeStyleProject runSuccessfulBuild() throws Exception {


### PR DESCRIPTION
- Limit job RSS/Atom changelog feed (rssChangelog) to reduce size and load. Default max entries: 20 (configurable via hudson.model.Job.rssChangelogMaxEntries). Cap for full feed: 1000 (hudson.model.Job.rssChangelogMaxEntriesCap).
- Support request parameter 'max': ?max=N for a custom limit, ?max=all for full feed up to the cap. Invalid values fall back to the default.
- Stop iterating builds once the limit is reached so older builds are not loaded (preserves lazy loading).
- Add tests in RSSTest: default limit, max param, max=all, system property default and cap, invalid max fallback, no changelog, few entries.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

Fixes #14784

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

- Added 8 tests in `RSSTest`: `rssChangelog_defaultLimit`, `rssChangelog_maxParam`, `rssChangelog_maxAll`, `rssChangelog_systemPropertyDefault`, `rssChangelog_systemPropertyCap`, `rssChangelog_invalidMaxFallsBackToDefault`, `rssChangelog_noChangelog`, `rssChangelog_fewEntries`. Tests use `FakeChangeLogSCM` to create jobs with changelog entries and assert entry counts for default URL, `?max=N`, `?max=all`, and system properties.
- Manually verified: job with many builds and changelogs; `job/<name>/rssChangelog` returns ≤ 20 entries by default; `?max=5` and `?max=all` behave as documented.

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Limit RSS/Atom changelog feed (`rssChangelog`) by default to 20 entries; add `max` query parameter and system properties for tuning and full feed

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@MarkEWaite @timja @mawinter69 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.