### PR TITLE
Fix/upload implied dependencies

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2008,12 +2008,15 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             }
 
             // Now create a dummy plugin that we can dynamically load (the InstallationJob will force a restart if one is needed):
-            JSONObject cfg = new JSONObject().
-                    element("name", baseName).
-                    element("version", "0"). // unused but mandatory
-                    element("url", t.toURI().toString()).
-                    element("dependencies", dependencies).
-                    element("requiredCore", requiredCore != null ? requiredCore : "");
+            JSONObject cfg = new JSONObject()
+                    .element("name", baseName)
+                    .element("version", "0") // unused but mandatory
+                    .element("url", t.toURI().toString())
+                    .element("dependencies", dependencies);
+            String normalizedRequiredCore = Util.fixEmptyAndTrim(requiredCore);
+            if (normalizedRequiredCore != null) {
+                cfg.element("requiredCore", normalizedRequiredCore);
+            }
             new UpdateSite(UpdateCenter.ID_UPLOAD, null).new Plugin(UpdateCenter.ID_UPLOAD, cfg).deploy(true);
             return new HttpRedirect("updates/");
         } catch (FileUploadException e) {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1962,11 +1962,16 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
             pluginUploaded = true;
 
+            String requiredCore = null;
             JSONArray dependencies = new JSONArray();
             try {
                 Manifest m;
                 try (JarFile jarFile = new JarFile(t)) {
                     m = jarFile.getManifest();
+                }
+                requiredCore = m.getMainAttributes().getValue("Jenkins-Version");
+                if (requiredCore == null) {
+                    requiredCore = m.getMainAttributes().getValue("Hudson-Version");
                 }
                 String deps = m.getMainAttributes().getValue("Plugin-Dependencies");
 
@@ -1982,6 +1987,22 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                                 .element("optional", p.contains("resolution:=optional")));
                     }
                 }
+                // JENKINS-33308 - include implied dependencies for older plugins that may need them (e.g. matrix-auth)
+                for (Dependency dep : DetachedPluginsUtil.getImpliedDependencies(baseName, requiredCore)) {
+                    boolean already = false;
+                    for (Object o : dependencies) {
+                        if (dep.shortName.equals(((JSONObject) o).getString("name"))) {
+                            already = true;
+                            break;
+                        }
+                    }
+                    if (!already) {
+                        dependencies.add(new JSONObject()
+                                .element("name", dep.shortName)
+                                .element("version", dep.version)
+                                .element("optional", false));
+                    }
+                }
             } catch (IOException e) {
                 LOGGER.log(WARNING, "Unable to setup dependency list for plugin upload", e);
             }
@@ -1991,7 +2012,8 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                     element("name", baseName).
                     element("version", "0"). // unused but mandatory
                     element("url", t.toURI().toString()).
-                    element("dependencies", dependencies);
+                    element("dependencies", dependencies).
+                    element("requiredCore", requiredCore != null ? requiredCore : "");
             new UpdateSite(UpdateCenter.ID_UPLOAD, null).new Plugin(UpdateCenter.ID_UPLOAD, cfg).deploy(true);
             return new HttpRedirect("updates/");
         } catch (FileUploadException e) {

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1987,7 +1987,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
                                 .element("optional", p.contains("resolution:=optional")));
                     }
                 }
-                // JENKINS-33308 - include implied dependencies for older plugins that may need them (e.g. matrix-auth)
+
                 for (Dependency dep : DetachedPluginsUtil.getImpliedDependencies(baseName, requiredCore)) {
                     boolean already = false;
                     for (Object o : dependencies) {

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -46,6 +46,7 @@ import hudson.model.DownloadService;
 import hudson.model.Hudson;
 import hudson.model.RootAction;
 import hudson.model.UpdateCenter;
+import hudson.model.UpdateCenter.InstallationJob;
 import hudson.model.UpdateCenter.UpdateCenterJob;
 import hudson.model.UpdateSite;
 import hudson.model.User;
@@ -56,6 +57,7 @@ import hudson.util.PersistedList;
 import jakarta.servlet.ServletException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.CookieHandler;
@@ -84,6 +86,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 import jenkins.ClassLoaderReflectionToolkit;
 import jenkins.RestartRequiredException;
 import jenkins.model.Jenkins;
@@ -640,6 +645,60 @@ class PluginManagerTest {
             assertNotNull(r.jenkins.getPluginManager().getPlugin("mandatory-depender"));
             assertNotNull(r.jenkins.getPluginManager().getPlugin("dependee"));
         });
+    }
+
+    /**
+     * JENKINS-33308: Uploaded plugins with old Jenkins-Version get implied dependencies (e.g. matrix-auth)
+     * so that they install correctly when code was detached from core.
+     */
+    @Test
+    @Issue("JENKINS-33308")
+    void uploadPluginAddsImpliedDependencies() throws Throwable {
+        session.then(r -> {
+            File dir = newFolder(tmp, "junit");
+            File plugin = new File(dir, "ownership.jpi");
+            createMinimalPluginJar(plugin, "ownership", "1.500", null);
+
+            HtmlPage page = r.createWebClient().goTo("pluginManager/advanced");
+            HtmlForm f = page.getFormByName("uploadPlugin");
+            f.getInputByName("name").setValue(plugin.getAbsolutePath());
+            r.submit(f);
+
+            assertThat(r.jenkins.getUpdateCenter().getJobs(), not(empty()));
+
+            InstallationJob job = r.jenkins.getUpdateCenter().getJobs().stream()
+                    .filter(InstallationJob.class::isInstance)
+                    .map(InstallationJob.class::cast)
+                    .filter(j -> "ownership".equals(j.plugin.name))
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(job, "Upload should create an InstallationJob for the uploaded plugin");
+            assertTrue(
+                    job.plugin.dependencies.containsKey("matrix-auth"),
+                    "Implied dependency matrix-auth should be in plugin metadata (built for Jenkins 1.500 <= 1.535)"
+            );
+        });
+    }
+
+    /**
+     * Creates a minimal valid JAR with the given manifest entries (no Plugin-Dependencies).
+     */
+    private static void createMinimalPluginJar(File jarFile, String shortName, String jenkinsVersion, String pluginDependencies) throws IOException {
+        Manifest manifest = new Manifest();
+        Attributes attrs = manifest.getMainAttributes();
+        attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attrs.putValue("Short-Name", shortName);
+        attrs.putValue("Plugin-Version", "0.5");
+        attrs.putValue("Jenkins-Version", jenkinsVersion);
+        if (pluginDependencies != null) {
+            attrs.putValue("Plugin-Dependencies", pluginDependencies);
+        }
+        try (FileOutputStream fos = new FileOutputStream(jarFile);
+             JarOutputStream jos = new JarOutputStream(fos, manifest)) {
+            jos.putNextEntry(new java.util.zip.ZipEntry("dummy"));
+            jos.write(0);
+            jos.closeEntry();
+        }
     }
 
     @Issue("JENKINS-44898")

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -647,12 +647,8 @@ class PluginManagerTest {
         });
     }
 
-    /**
-     * JENKINS-33308: Uploaded plugins with old Jenkins-Version get implied dependencies (e.g. matrix-auth)
-     * so that they install correctly when code was detached from core.
-     */
+
     @Test
-    @Issue("JENKINS-33308")
     void uploadPluginAddsImpliedDependencies() throws Throwable {
         session.then(r -> {
             File dir = newFolder(tmp, "junit");

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -677,7 +677,8 @@ class PluginManagerTest {
     }
 
     /**
-     * Creates a minimal valid JAR with the given manifest entries (no Plugin-Dependencies).
+     * Creates a minimal valid JAR with the given manifest entries.
+     * Adds a {@code Plugin-Dependencies} manifest entry if {@code pluginDependencies} is non-null.
      */
     private static void createMinimalPluginJar(File jarFile, String shortName, String jenkinsVersion, String pluginDependencies) throws IOException {
         Manifest manifest = new Manifest();

--- a/test/src/test/java/jenkins/plugins/DetachedPluginsUtilTest.java
+++ b/test/src/test/java/jenkins/plugins/DetachedPluginsUtilTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, the Jenkins project.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Tests for {@link DetachedPluginsUtil}, especially implied dependencies used when uploading plugins.
+ */
+class DetachedPluginsUtilTest {
+
+    /**
+     * JENKINS-33308: Plugins built for Jenkins &lt;= 1.535 get matrix-auth as an implied dependency
+     * (it was detached from core at 1.535). Upload path must add these so manual uploads install correctly.
+     */
+    @Test
+    @Issue("JENKINS-33308")
+    void getImpliedDependenciesIncludesMatrixAuthForOldCore() {
+        String pluginName = "ownership";
+        String jenkinsVersion = "1.500"; // older than matrix-auth split (1.535)
+        var deps = DetachedPluginsUtil.getImpliedDependencies(pluginName, jenkinsVersion);
+        var shortNames = deps.stream().map(d -> d.shortName).toList();
+        assertThat(
+                "Plugin built for 1.500 should get matrix-auth as implied dependency",
+                shortNames,
+                hasItem("matrix-auth")
+        );
+    }
+
+    /**
+     * Same with null Jenkins version (old manifests): implied deps should still be returned.
+     */
+    @Test
+    @Issue("JENKINS-33308")
+    void getImpliedDependenciesWithNullJenkinsVersion() {
+        var deps = DetachedPluginsUtil.getImpliedDependencies("some-plugin", null);
+        assertTrue(
+                deps.stream().anyMatch(d -> "matrix-auth".equals(d.shortName)),
+                "Null Jenkins version should still imply matrix-auth for plugins needing it"
+        );
+    }
+}


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #17450

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

Manual plugin uploads only used `Plugin-Dependencies` from the manifest and did not add implied dependencies for detached plugins (e.g. matrix-auth for plugins built for Jenkins ≤ 1.535). That caused install failures for plugins like Ownership 0.5. This change makes `PluginManager.doUploadPluginImpl` call `DetachedPluginsUtil.getImpliedDependencies` and merge implied deps into the dependency list, and pass `requiredCore` in the plugin metadata, matching the update-center path.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

- Added `PluginManagerTest.uploadPluginAddsImpliedDependencies()`: builds a minimal plugin JAR with old `Jenkins-Version` (1.500) and no matrix-auth in manifest, uploads it via the form, and asserts the created `InstallationJob`’s plugin metadata includes `matrix-auth` in `dependencies`.
- Added `DetachedPluginsUtilTest`: `getImpliedDependenciesIncludesMatrixAuthForOldCore()` and `getImpliedDependenciesWithNullJenkinsVersion()` assert that `DetachedPluginsUtil.getImpliedDependencies` returns matrix-auth for plugins built for Jenkins ≤ 1.535 (and for null core version).
- Ran `DetachedPluginsUtilTest` (passes). `PluginManagerTest` upload test runs in the same session as other PluginManager tests.

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

N/A – no UI change.

#### After

N/A – no UI change.

### Proposed changelog entries

- Resolve implied dependencies when uploading plugins manually so plugins that depend on detached plugins (e.g. matrix-auth) install correctly

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@MarkEWaite @timja @mawinter69 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.