### PR TITLE
Fix ParserConfigurator to not reference Jenkins class on agents

### DIFF
--- a/core/src/main/java/hudson/util/io/ParserConfigurator.java
+++ b/core/src/main/java/hudson/util/io/ParserConfigurator.java
@@ -31,8 +31,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import jenkins.model.Jenkins;
 import jenkins.security.SlaveToMasterCallable;
 import org.dom4j.io.SAXReader;
 
@@ -75,14 +73,14 @@ public abstract class ParserConfigurator implements ExtensionPoint, Serializable
     }
 
     public static void applyConfiguration(SAXReader reader, Object context) throws IOException, InterruptedException {
-        Collection<ParserConfigurator> all = Collections.emptyList();
+        Collection<ParserConfigurator> all;
 
-        if (Jenkins.getInstanceOrNull() == null) {
-            Channel ch = Channel.current();
-            if (ch != null)
-                all = ch.call(new GetParserConfigurators());
-        } else
+        Channel ch = Channel.current();
+        if (ch != null) {
+            all = ch.call(new GetParserConfigurators());
+        } else {
             all = all();
+        }
         for (ParserConfigurator pc : all)
             pc.configure(reader, context);
     }


### PR DESCRIPTION
## What is the problem?

When `ParserConfigurator.applyConfiguration()` is called on a Jenkins agent (for example, during JUnit XML parsing), it calls `Jenkins.getInstanceOrNull()`. This triggers the static initializer of the `Jenkins` class, which is a heavy operation and can cause a `java.lang.ExceptionInInitializerError` with a classloading timeout on the agent.

Stack trace from the bug report:
```
<clinit>: Failed to load Jenkins.class
java.lang.ExceptionInInitializerError
    at jenkins.model.Jenkins.<clinit>(Jenkins.java:4805)
    at hudson.util.io.ParserConfigurator.applyConfiguration(ParserConfigurator.java:78)
    at hudson.tasks.junit.SuiteResult.parse(SuiteResult.java:124)
    ...
```

## What is the fix?

Instead of checking `Jenkins.getInstanceOrNull() == null` to detect whether we are on an agent, we now check `Channel.current()` directly.

- If `Channel.current()` is not null, we are on an agent — fetch configurators from the master via the channel.
- If `Channel.current()` is null, we are on the master — use the local extension list directly.

This removes the direct reference to `jenkins.model.Jenkins` from this method entirely, avoiding the classloading issue.

## Changes

- Removed `import jenkins.model.Jenkins` (no longer needed)
- Removed `import java.util.Collections` (no longer needed)
- Simplified `applyConfiguration()` to check the channel first

Fixes #22197 (JENKINS-45689)