### PR TITLE
Fix QuotedStringTokenizer.unquote decoding \uXXXX escapes incorrectly

### DIFF
--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -472,10 +472,10 @@ public class QuotedStringTokenizer
                         break;
                     case 'u':
                         b.append((char) (
-                                (convertHexDigit((byte) s.charAt(i++)) << 24) +
-                                (convertHexDigit((byte) s.charAt(i++)) << 16) +
-                                (convertHexDigit((byte) s.charAt(i++)) << 8) +
-                                convertHexDigit((byte) s.charAt(i++))
+                                (convertHexDigit((byte) s.charAt(++i)) << 12) +
+                                (convertHexDigit((byte) s.charAt(++i)) << 8) +
+                                (convertHexDigit((byte) s.charAt(++i)) << 4) +
+                                convertHexDigit((byte) s.charAt(++i))
                                 )
                         );
                         break;

--- a/cli/src/test/java/hudson/util/QuotedStringTokenizerTest.java
+++ b/cli/src/test/java/hudson/util/QuotedStringTokenizerTest.java
@@ -25,6 +25,7 @@
 package hudson.util;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,6 +86,16 @@ class QuotedStringTokenizerTest {
         assertFalse(tokenizer.hasMoreTokens());
         tokenizer = new QuotedStringTokenizer("one");
         assertTrue(tokenizer.hasMoreTokens());
+    }
+
+    @Test
+    void testUnquoteUnicodeEscape() {
+        // \u0041 is 'A' — previously decoded to U+0004 due to wrong shifts and off-by-one
+        assertEquals("A", QuotedStringTokenizer.unquote("\"\\u0041\""));
+        // \u00E9 is 'é'
+        assertEquals("\u00E9", QuotedStringTokenizer.unquote("\"\\u00E9\""));
+        // multiple unicode escapes in one string
+        assertEquals("AB", QuotedStringTokenizer.unquote("\"\\u0041\\u0042\""));
     }
 
     private void check(String src, String... expected) {


### PR DESCRIPTION
## Problem

`QuotedStringTokenizer.unquote()` decodes `\uXXXX` Unicode escapes incorrectly.

Example:
```java
QuotedStringTokenizer.unquote("\"\\u0041\"")  // expected: "A", actual: U+0004
```

The `case 'u'` branch has three bugs:

1. It reads starting from `i` (the `u` character itself) using `i++`, instead of reading the four hex digits that follow `u`.
2. It uses bit shifts `24/16/8/0` instead of the correct `12/8/4/0` for a 4-hex-digit Unicode value.
3. Using post-increment `i++` causes the loop's own `i++` to skip the last hex digit.

This affects label expression parsing since `Jenkins.java` calls `QuotedStringTokenizer.unquote()` when evaluating label expressions with quoted Unicode names (e.g. `"windows\u002664bit"`).

## Fix

Use pre-increment `++i` to read the four digits *after* `u`, and correct the bit shifts to `12/8/4/0`.

## Testing

Added `testUnquoteUnicodeEscape()` to `QuotedStringTokenizerTest` covering:
- `\u0041` → `A`
- `\u00E9` → `é`
- multiple escapes in one string

Fixes #26466