### PR TITLE
Use standard size node icon even with long node names (again)

### DIFF
--- a/src/main/scss/base/_typography.scss
+++ b/src/main/scss/base/_typography.scss
@@ -119,6 +119,7 @@ a {
   svg {
     width: 16px;
     height: 16px;
+    flex: 0 0 auto;
     color: var(--text-color) !important;
   }
 }


### PR DESCRIPTION
I previous did an MR https://github.com/jenkinsci/jenkins/pull/8089 which fixed icon sizes in links with icons, most noticeable in the node links

<img width="290" height="285" alt="image" src="https://github.com/user-attachments/assets/a15dbee9-54d5-4f08-89a4-bef93ceb68eb" />

It turns out that approximately a week later that change was lost when this MR moved styles to a different file https://github.com/jenkinsci/jenkins/pull/8375

So here's the commit again nearly 3 years later when I noticed again

Sorry for the lazy MR filling but the previous MR details still stand regarding logic and testing

### Testing done

Confirmed bug is visible on ci.jenkins.io and is fixed by the proposed change.

### Proposed changelog entries

- Use standard size node icon even with long node names.

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The Jira issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)).
  - Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] New or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

### Maintainer checklist

Before the changes are marked as `ready-for-merge`:

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, a Jira issue must exist, be a _Bug_ or _Improvement_, and be labeled as `lts-candidate` to be considered (see [query](https://issues.jenkins.io/issues/?filter=12146)).