### PR TITLE
Use dialog for changing Build Description

### DIFF
--- a/core/src/main/resources/lib/hudson/editDescriptionButton.jelly
+++ b/core/src/main/resources/lib/hudson/editDescriptionButton.jelly
@@ -38,6 +38,7 @@
              href="editDescription"
              data-description="${actualDescription}"
              data-url="${submissionUrl}"
+             data-title="${label}"
              tooltip="${attrs.compact ? label : null}">
             <l:icon src="symbol-description" />
             <j:if test="${!attrs.compact}">

--- a/core/src/main/resources/lib/hudson/editable-description.js
+++ b/core/src/main/resources/lib/hudson/editable-description.js
@@ -14,25 +14,4 @@
       });
     }
   });
-
-  Behaviour.specify(
-    ".description-cancel-button",
-    "description-cancel-button",
-    0,
-    function (b) {
-      b.onclick = function () {
-        const descriptionLink = document.getElementById("description-link");
-        const descriptionContent = document.getElementById(
-          "description-content",
-        );
-        const descriptionEditForm = document.getElementById(
-          "description-edit-form",
-        );
-        descriptionEditForm.innerHTML = "";
-        descriptionEditForm.classList.add("jenkins-hidden");
-        descriptionContent.classList.remove("jenkins-hidden");
-        descriptionLink.classList.remove("jenkins-hidden");
-      };
-    },
-  );
 })();

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1991,7 +1991,7 @@ function replaceDescription(initialDescription, submissionUrl) {
         );
         const okText = submitBtn
           ? (submitBtn.value || submitBtn.textContent).trim()
-          : "Save";
+          : undefined;
         const buttonsRow = form.querySelector(".jenkins-buttons-row");
         if (buttonsRow) {
           buttonsRow.remove();

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1969,6 +1969,7 @@ function replaceDescription(initialDescription, submissionUrl) {
     })
     .then(function (responseText) {
       if (!responseText) {
+        restoreLink();
         return;
       }
       const tempContainer = document.createElement("div");

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1932,13 +1932,16 @@ function xor(a, b) {
   return !a != !b;
 }
 
-// used by editableDescription.jelly to replace the description field with a form
+// used by editableDescription.jelly to open a dialog for editing the description
 // eslint-disable-next-line no-unused-vars
 function replaceDescription(initialDescription, submissionUrl) {
-  const descriptionContent = document.getElementById("description-content");
-  const descriptionEditForm = document.getElementById("description-edit-form");
-  descriptionEditForm.innerHTML = "<div class='jenkins-spinner'></div>";
-  descriptionContent.classList.add("jenkins-hidden");
+  function restoreLink() {
+    var link = document.getElementById("description-link");
+    if (link) {
+      link.classList.remove("jenkins-hidden");
+    }
+  }
+
   let parameters = {};
   if (initialDescription !== null && initialDescription !== "") {
     parameters["description"] = initialDescription;
@@ -1952,18 +1955,53 @@ function replaceDescription(initialDescription, submissionUrl) {
       "Content-Type": "application/x-www-form-urlencoded",
     }),
     body: objectToUrlFormEncoded(parameters),
-  }).then((rsp) => {
-    rsp.text().then((responseText) => {
-      descriptionEditForm.innerHTML = responseText;
-      descriptionEditForm.classList.remove("jenkins-hidden");
+  })
+    .then((rsp) => rsp.text())
+    .then((responseText) => {
+      const tempContainer = document.createElement("div");
+      tempContainer.innerHTML = responseText;
       evalInnerHtmlScripts(responseText, function () {
-        Behaviour.applySubtree(descriptionEditForm);
-        descriptionEditForm.getElementsByTagName("TEXTAREA")[0].focus();
+        const form = tempContainer.querySelector("form");
+        if (!form) {
+          restoreLink();
+          return;
+        }
+
+        // Extract Save button text (preserves i18n) before removing original buttons
+        const submitBtn = form.querySelector(
+          ".jenkins-buttons-row [type='submit']",
+        );
+        const okText = submitBtn
+          ? (submitBtn.value || submitBtn.textContent).trim()
+          : "Save";
+        const buttonsRow = form.querySelector(".jenkins-buttons-row");
+        if (buttonsRow) {
+          buttonsRow.remove();
+        }
+
+        // Prevent the dialog from intercepting Enter in form fields.
+        // This covers both the plain textarea and CodeMirror editor widgets,
+        // since CodeMirror replaces the textarea with its own DOM elements.
+        form.addEventListener("keydown", function (e) {
+          if (e.key === "Enter") {
+            e.stopPropagation();
+          }
+        });
+
+        const descriptionLink = document.getElementById("description-link");
+        const title = descriptionLink
+          ? descriptionLink.getAttribute("data-title") || "Description"
+          : "Description";
+
+        dialog
+          .form(form, {
+            title: title,
+            okText: okText,
+          })
+          .catch(restoreLink);
       });
-      layoutUpdateCallback.call();
-      return false;
-    });
-  });
+    })
+    .catch(restoreLink);
 }
 
 /**

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1956,14 +1956,31 @@ function replaceDescription(initialDescription, submissionUrl) {
     }),
     body: objectToUrlFormEncoded(parameters),
   })
-    .then((rsp) => rsp.text())
-    .then((responseText) => {
+    .then(function (rsp) {
+      if (!rsp.ok) {
+        restoreLink();
+        var link = document.getElementById("description-link");
+        window.location.href = link
+          ? link.getAttribute("href")
+          : "editDescription";
+        return;
+      }
+      return rsp.text();
+    })
+    .then(function (responseText) {
+      if (!responseText) {
+        return;
+      }
       const tempContainer = document.createElement("div");
       tempContainer.innerHTML = responseText;
       evalInnerHtmlScripts(responseText, function () {
         const form = tempContainer.querySelector("form");
         if (!form) {
           restoreLink();
+          var link = document.getElementById("description-link");
+          window.location.href = link
+            ? link.getAttribute("href")
+            : "editDescription";
           return;
         }
 
@@ -1999,6 +2016,16 @@ function replaceDescription(initialDescription, submissionUrl) {
             okText: okText,
           })
           .catch(restoreLink);
+
+        // Focus the description input after dialog and CodeMirror are initialized
+        setTimeout(function () {
+          var textarea = form.querySelector("textarea[name='description']");
+          if (textarea && textarea.codemirrorObject) {
+            textarea.codemirrorObject.focus();
+          } else if (textarea) {
+            textarea.focus();
+          }
+        }, 0);
       });
     })
     .catch(restoreLink);


### PR DESCRIPTION
Fixes #26488

Replace the inline description editing form with a modal dialog using Jenkins' existing `dialog.form()` component. This makes the description editing experience consistent with the new Jenkins UI direction, as discussed in [sig-ux#7](https://github.com/jenkinsci/sig-ux/issues/7).

### Testing done

No automated test exists for this specific UI interaction. Manual testing scenarios:
1. Click "Edit description" on a build page → dialog opens with current description in textarea
2. Edit text with Enter key for newlines → newlines inserted correctly (both plain textarea and CodeMirror modes)
3. Click Save → description updated, page refreshes
4. Click Cancel or press Escape → dialog closes, edit button reappears
5. Double-click the edit button rapidly → only one dialog opens (button hidden during fetch)
6. Repeat above for job and view description entry points

**Known limitation:** If adjunct scripts loaded by `evalInnerHtmlScripts` fail or hang, the edit button stays hidden until page refresh. This is a pre-existing gap in `loadScript` (no `onerror` handler). The old inline implementation degraded more gracefully by having the raw form already in the DOM. A follow-up issue for adding `onerror` to `loadScript` would address this systemically.

### Screenshots (UI changes only)

_I do not have a running Jenkins instance to capture screenshots. Reviewers are encouraged to verify the dialog appearance locally._

#### Before

Inline form replaces description content on the page.

#### After

Modal dialog opens above the page content using `dialog.form()`.

### Proposed changelog entries

- Use dialog for changing description on build, job, and view pages

### Proposed changelog category

/label rfe,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja