### PR TITLE
JENKINS-26500 Use AJAX dialog for Delete Build Action

### DIFF
--- a/core/src/main/resources/hudson/model/Run/delete.jelly
+++ b/core/src/main/resources/hudson/model/Run/delete.jelly
@@ -28,6 +28,6 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <j:if test="${!it.logUpdated and !it.keepLog}">
-    <l:task href="${buildUrl.baseUrl}/confirmDelete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%delete.build(it.displayName)}"/>
+    <l:task href="${buildUrl.baseUrl}/confirmDelete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" data-ajax-dialog="true" title="${%delete.build(it.displayName)}"/>
   </j:if>
 </j:jelly>

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -5,6 +5,7 @@ import SearchBar from "@/components/search-bar";
 import Tooltips from "@/components/tooltips";
 import StopButtonLink from "@/components/stop-button-link";
 import ConfirmationLink from "@/components/confirmation-link";
+import AjaxDialog from "@/components/ajax-dialog";
 import Dialogs from "@/components/dialogs";
 import Defer from "@/components/defer";
 
@@ -16,4 +17,5 @@ SearchBar.init();
 Tooltips.init();
 StopButtonLink.init();
 ConfirmationLink.init();
+AjaxDialog.init();
 Dialogs.init();

--- a/src/main/js/components/ajax-dialog/index.js
+++ b/src/main/js/components/ajax-dialog/index.js
@@ -1,0 +1,108 @@
+import behaviorShim from "@/util/behavior-shim";
+
+function registerAjaxDialogLink(element) {
+  element.addEventListener("click", function (e) {
+    e.preventDefault();
+    const href = element.getAttribute("href") || element.getAttribute("data-url");
+
+    // Suggestion 2: Show loading cursor immediately
+    document.body.style.cursor = "wait";
+
+    fetch(href, {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+      },
+    })
+      .then((response) => response.text())
+      .then((html) => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, "text/html");
+
+        const mainPanel = doc.querySelector("#main-panel") || doc.querySelector(".jenkins-app-bar")?.nextElementSibling || doc.body;
+
+        const content = document.createElement("div");
+
+        // Suggestion 3: Wrap warnings in a scope to preserve CSS rules
+        const warningsWrapper = document.createElement("div");
+        warningsWrapper.className = "jenkins-dialog-warnings";
+        const messages = mainPanel.querySelectorAll(".warning, .error");
+        messages.forEach(msg => warningsWrapper.appendChild(msg.cloneNode(true)));
+        if (warningsWrapper.childElementCount > 0) {
+          content.appendChild(warningsWrapper);
+        }
+
+        let titleText = element.getAttribute("data-title") || element.getAttribute("title") || "Confirm";
+
+        const form = mainPanel.querySelector("form");
+        if (form) {
+          const actionUrl = new URL(form.getAttribute("action"), new URL(href, window.location.origin)).href;
+          const clonedForm = form.cloneNode(true);
+          clonedForm.setAttribute("action", actionUrl);
+
+          if (typeof crumb !== "undefined") {
+            crumb.appendToForm(clonedForm);
+          }
+
+          const span = clonedForm.querySelector("span");
+          if (span) {
+            titleText = span.innerText;
+            span.remove();
+          }
+
+          // Suggestion 4: Add explicit Cancel button next to the Delete button
+          const submitBtn = clonedForm.querySelector("input[type='submit'], button[type='submit'], .jenkins-button");
+          if (submitBtn) {
+            const cancelBtn = document.createElement("button");
+            cancelBtn.innerText = "Cancel";
+            cancelBtn.type = "button";
+            cancelBtn.className = "jenkins-button";
+            cancelBtn.style.marginRight = "1rem";
+            cancelBtn.addEventListener("click", (e) => {
+              e.preventDefault();
+              const d = cancelBtn.closest("dialog");
+              if (d) {
+                d.dispatchEvent(new Event("cancel"));
+                if (typeof d.close === "function") d.close();
+              }
+            });
+            // Insert Cancel before Submit
+            submitBtn.parentNode.insertBefore(cancelBtn, submitBtn);
+          }
+
+          content.appendChild(clonedForm);
+        } else {
+          const fallbackMsg = document.createElement("p");
+          fallbackMsg.innerText = "Are you sure you want to proceed?";
+          content.appendChild(fallbackMsg);
+        }
+
+        window.dialog.modal(content, {
+          maxWidth: "550px",
+          title: titleText
+        });
+      })
+      .catch((err) => {
+        console.error("AJAX dialog fetch failed", err);
+        window.location.href = href;
+      })
+      .finally(() => {
+        // Clear loading cursor
+        document.body.style.cursor = "";
+      });
+
+    return false;
+  });
+}
+
+function init() {
+  behaviorShim.specify(
+    "A[data-ajax-dialog='true']",
+    "ajax-dialog",
+    0,
+    (element) => {
+      registerAjaxDialogLink(element);
+    }
+  );
+}
+
+export default { init };


### PR DESCRIPTION
This replaces the full-page redirect for deleting a build with a modern AJAX-driven popup dialog that cleanly preserves legacy plugin warnings by scraping the original confirmDelete HTML, and seamlessly hosts the title natively in the Jenkins dialog module.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #26500 

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->
### Context
The "Delete Build" action historically redirected the user to a completely separate `confirmDelete` HTML page. This PR modernizes the UI by introducing a custom `ajax-dialog` Javascript module. When "Delete Build" is clicked, this script transparently fetches the `confirmDelete` page in the background, specifically scrapes out the form and any custom HTML warnings (ensuring backward compatibility for plugins like `matrix-project-plugin` that inject custom warnings), and renders them seamlessly inside Jenkins's native modal pop-up dialog.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
-->
* **Manual UI Verification**: Spun up a local Jenkins instance, ran a pipeline build, and triggered the "Delete Build" action from the side panel to visually verify the dialog layout, the red destructive button, and the hoisted header title.
* **Plugin Compatibility Verification**: Temporarily injected mock HTML warning elements (mimicking the Matrix Project Plugin's custom warnings) directly into [confirmDelete.jelly](cci:7://file:///c:/Users/ankey/Downloads/jenkins/core/src/main/resources/hudson/model/Run/confirmDelete.jelly:0:0-0:0) and verified that the `ajax-dialog` script successfully scraped them from the background request and rendered them accurately within the modal dialog.

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before
*(Note: It previously navigated away to a clunky full-page redirect)*
<!-- PLEASE DRAG AND DROP YOUR "BEFORE" SCREENSHOT HERE -->
![WhatsApp Image 2026-03-20 at 11 26 54 PM](https://github.com/user-attachments/assets/ddb46681-f04f-46d8-b056-560e3c7c3fa9)
![WhatsApp Image 2026-03-20 at 11 26 57 PM](https://github.com/user-attachments/assets/a3fa8327-a7ec-4968-9eb2-ddf3f50edd72)


#### After
<!-- PLEASE DRAG AND DROP YOUR FINAL "AFTER" RED POPUP SCREENSHOT HERE -->
<img width="1428" height="867" alt="image" src="https://github.com/user-attachments/assets/76edca78-d79b-4d3f-98dc-5e193a054c1b" />


### Proposed changelog entries

- Replace the full-page redirect for deleting a build with a modern popup dialog.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe, web-ui

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
@novinxy (Reporter) - To verify the UI modernization.
@mawinter69 - To verify the scraping logic for plugin-injected warnings (e.g., Matrix projects).
@timja @MarkEWaite - For core maintenance review and merge approval.

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
