### PR TITLE
Revert 'Fix false Build Scheduled notification'

### DIFF
--- a/core/src/main/resources/hudson/views/BuildButtonColumn/icon.js
+++ b/core/src/main/resources/hudson/views/BuildButtonColumn/icon.js
@@ -14,7 +14,7 @@ Behaviour.specify(
         method: "post",
         headers: crumb.wrap({}),
       }).then((rsp) => {
-        if (rsp.status === 201) {
+        if (rsp.ok) {
           notificationBar.show(message, notificationBar.SUCCESS);
         } else {
           notificationBar.show(failure, notificationBar.ERROR);

--- a/core/src/main/resources/lib/hudson/project/configurable/configurable.js
+++ b/core/src/main/resources/lib/hudson/project/configurable/configurable.js
@@ -10,7 +10,7 @@
         method: "post",
         headers: crumb.wrap({}),
       }).then((rsp) => {
-        if (rsp.status === 201) {
+        if (rsp.ok) {
           notificationBar.show(success, notificationBar.SUCCESS);
         } else {
           notificationBar.show(failure, notificationBar.ERROR);


### PR DESCRIPTION
## Revert 'Fix false Build Scheduled notification'


* https://github.com/jenkinsci/jenkins/issues/26516

This reverts commit a7d32255b687ef6765e5632e3d820e8e53c70356.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #26516

Multibranch scan no longer starts from "run" button of the parent of multibranch folder.  It starts as expected with Jenkins 2.546 and earlier.  It starts as expected from the "Scan Multibranch Pipeline Now" button inside the folder.

I've [asked](https://github.com/jenkinsci/jenkins/pull/26117#issuecomment-4119436478) @LakshyaBagani if she has time to investigate a fix, since it would be much better to fix it than to revert the fix.

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

This pull request is intentionally draft so that we do not merge it until @LakshyaBagani has responded.

### Testing done

Confirmed the bug is visible in my [weekly LTS configuration](https://github.com/MarkEWaite/docker-lfs/blob/6b852eccd4160765206cb67458e511282ad4d1ef/plugins.txt#L57) and in a separate verification test of Jenkins 2.555 (the next LTS baseline).

Confirmed that the issue is fixed when I revert pull request:

* https://github.com/jenkinsci/jenkins/pull/26117

No automated test has been created.  It seems reasonable that a RealJenkinsRule test could be created based on the contents of the zip file that is included in the bug report.

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

<img width="1232" height="835" alt="Screenshot -before" src="https://github.com/user-attachments/assets/f7f16802-f863-4338-a753-9e6f529845e1" />


#### After

<img width="1240" height="738" alt="Screenshot -after" src="https://github.com/user-attachments/assets/5be8c98c-2ea4-444f-8bff-69f028284814" />

### Proposed changelog entries

- Fix multibranch Pipeline scan from parent folder (regression).

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mawinter69

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
