### PR TITLE
Refine experimental Run overflow menu

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -170,6 +170,7 @@ import jenkins.model.SimplePageDecorator;
 import jenkins.model.details.Detail;
 import jenkins.model.details.DetailFactory;
 import jenkins.model.details.DetailGroup;
+import jenkins.model.menu.Group;
 import jenkins.telemetry.impl.PasswordMasking;
 import jenkins.util.SystemProperties;
 import net.sf.json.JSONObject;
@@ -181,6 +182,7 @@ import org.apache.commons.jexl.parser.ASTSizeFunction;
 import org.apache.commons.jexl.util.Introspector;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
+import org.jenkins.ui.icon.IconSpec;
 import org.jvnet.tiger_types.Types;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -2669,7 +2671,10 @@ public class Functions {
         ModelObjectWithContextMenu.ContextMenu contextMenu = new ModelObjectWithContextMenu.ContextMenu();
         contextMenu.addAll(actions
                 .stream()
-                .filter(action -> action.getIconFileName() != null)
+                .filter(action ->
+                        action.getIconFileName() != null
+                                || (action instanceof IconSpec iconSpec && iconSpec.getIconClassName() != null)
+                ).filter(action -> action.getGroup().getOrder() < Group.FIRST_IN_MENU.getOrder())
                 .toList());
         JSONObject jsonObject = JSONObject.fromObject(contextMenu);
         jsonObject.put("url", Util.ensureEndsWith(baseUrl, "/"));

--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -292,8 +292,17 @@ public interface ModelObjectWithContextMenu extends ModelObject {
         public ContextMenu from(ModelObjectWithContextMenu self, StaplerRequest2 request, StaplerResponse2 response, String view) throws JellyException, IOException {
             // Only Runs support getAppBarActions currently
             if (self instanceof Run) {
-                this.addAll(((Actionable) self).getAppBarActions());
-                return this;
+                boolean menuOnly = Boolean.parseBoolean(request.getParameter("menu-only"));
+
+                List<Action> actions = ((Actionable) self).getAppBarActions().stream()
+                        .filter(action ->
+                                action.getIconFileName() != null
+                                        || (action instanceof IconSpec iconSpec && iconSpec.getIconClassName() != null)
+                        )
+                        .filter(action -> !menuOnly || action.getGroup().getOrder() >= Group.FIRST_IN_MENU.getOrder())
+                        .toList();
+
+                return new ModelObjectWithContextMenu.ContextMenu().addAll(actions);
             }
 
             WebApp webApp = WebApp.getCurrent();

--- a/core/src/main/resources/lib/layout/actions.jelly
+++ b/core/src/main/resources/lib/layout/actions.jelly
@@ -25,17 +25,22 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:documentation>
-    Generates a strip of controls based on the given actions parameter.
+    Generates a strip of actions based on the given Actionable.
 
-    <st:attribute name="actions">
-      The actions to show.
+    <st:attribute name="it" use="required" type="hudson.model.Actionable">
+      The object to display actions for.
     </st:attribute>
   </st:documentation>
 
+  <j:set var="url" value="${h.getNearestAncestorUrl(request2, it)}/" />
+  <j:set var="actions" value="${attrs.it.appBarActions}" />
+
   <j:if test="${actions != null}">
-    <button id="auto-overflow"
-            class="jenkins-button"
+    <button data-type="auto-overflow"
+            class="jenkins-button jenkins-jumplist-link"
             tooltip="${%More actions}"
+            data-href="${url}"
+            data-jumplist-type="menu"
             data-testid="app-bar-overflow-button"
             type="button">
       <div class="jenkins-overflow-button__ellipsis">
@@ -44,9 +49,9 @@ THE SOFTWARE.
         <span />
       </div>
     </button>
-    <j:set var="url" value="${h.getNearestAncestorUrl(request2,it.object)}"/>
+
     <template>
-      ${h.convertActionsToJson(url, actions)}
+      ${h.convertActionsToJson(url, attrs.it.appBarActions)}
     </template>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/run-subpage.jelly
+++ b/core/src/main/resources/lib/layout/run-subpage.jelly
@@ -68,7 +68,7 @@ THE SOFTWARE.
             </div>
 
             <div class="app-build-bar__controls">
-              <l:app-bar-controls actions="${it.object.appBarActions}" />
+              <l:actions it="${it.object}" />
             </div>
           </div>
 

--- a/src/main/js/components/app-bar/index.js
+++ b/src/main/js/components/app-bar/index.js
@@ -2,38 +2,34 @@ import behaviorShim from "@/util/behavior-shim";
 import Utils from "@/components/dropdowns/utils";
 import Templates from "@/components/dropdowns/templates";
 
+/**
+ * Generates inline actions and an overflow menu if necessary.
+ */
 function init() {
-  behaviorShim.specify("#auto-overflow", "-dropdowns-", 1000, (element) => {
-    const template = JSON.parse(element.nextSibling.content.textContent);
-    const appBarItems = Utils.mapChildrenItemsToDropdownItems(
-      template.items.filter((e) => e.group.order <= 2),
-    );
-    const overflowItems = Utils.mapChildrenItemsToDropdownItems(
-      template.items.filter((e) => e.group.order > 2),
-    );
-
-    // Append top-level items to the app bar
-    appBarItems.forEach((item, index) => {
-      // Only the first button in an app bar should have an icon
-      if (index > 0) {
-        item.icon = null;
-        item.iconXml = null;
-      }
-      element.parentNode.insertBefore(
-        Templates.menuItem(item, "jenkins-button", template.url),
-        element,
+  behaviorShim.specify(
+    "[data-type='auto-overflow']",
+    "-dropdowns-",
+    1000,
+    (element) => {
+      const template = JSON.parse(element.nextSibling.content.textContent);
+      const topLevelActions = Utils.mapChildrenItemsToDropdownItems(
+        template.items.filter((e) => e.group.order <= 2),
       );
-    });
 
-    // Add any additional items as an overflow menu
-    if (overflowItems.length > 0) {
-      Utils.generateDropdown(element, (instance) => {
-        instance.setContent(
-          Utils.generateDropdownItems(overflowItems, false, template.url),
+      // Append top-level items next to the overflow menu
+      topLevelActions.forEach((item, index) => {
+        // Only the first button in an app bar should have an icon
+        if (index > 0) {
+          item.icon = null;
+          item.iconXml = null;
+        }
+        element.parentNode.insertBefore(
+          Templates.menuItem(item, "jenkins-button", template.url),
+          element,
         );
       });
-    }
-  });
+    },
+  );
 }
 
 export default { init };

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -95,7 +95,13 @@ function generateDropdowns() {
           return;
         }
 
-        fetch(Path.combinePath(href, jumplistType))
+        // If requested, only return menu actions rather than top-level app bar actions
+        let query = "";
+        if (element.dataset.jumplistType === "menu") {
+          query = "?menu-only=true";
+        }
+
+        fetch(Path.combinePath(href, jumplistType) + query)
           .then((response) => response.json())
           .then((json) =>
             instance.setContent(


### PR DESCRIPTION
This PR refines the recent App Bar API for the Run page. 

#### What's changed?

* Improved performance (ever so slightly)
  * Instead of loading in overflow menu items immediately, they're now deferred until a user clicks on the button.
* Some actions weren't showing, such as Embeddable Build Status
  * This was due to a null `iconFileName`, we now check against `IconSpec` if implemented
* Renamed `app-bar-controls.jelly` to `actions.jelly`
  * The thinking behind this is that these actions might appear outside of app bars, e.g. inside of tables or cards, and renaming it now future proofs us

### Testing done

* Menu shows
* Check network tab to confirm it's a separate, deferred call

### Screenshots (UI changes only)

#### Before

<img width="218" height="237" alt="Screenshot 2026-03-25 at 14 58 30" src="https://github.com/user-attachments/assets/0fb50ce2-a258-4de8-881d-b9a4d7b87ee7" />

#### After

<img width="245" height="265" alt="Screenshot 2026-03-25 at 14 57 01" src="https://github.com/user-attachments/assets/78cbce92-a2d4-4b52-adfd-8a9931dbf3db" />

### Proposed changelog entries

- Refine experimental Run overflow menu

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui,rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
