### PR TITLE
Fix legacy context menu items not working

### DIFF
--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -374,7 +374,6 @@ public interface ModelObjectWithContextMenu extends ModelObject {
          * @since 1.504
          */
         @Exported
-        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
         public boolean post;
 
         /**
@@ -382,7 +381,6 @@ public interface ModelObjectWithContextMenu extends ModelObject {
          * @since 1.512
          */
         @Exported
-        @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "read by Stapler")
         public boolean requiresConfirmation;
 
         private Badge badge;

--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -21,7 +21,9 @@ import java.util.List;
 import jenkins.management.Badge;
 import jenkins.model.menu.Group;
 import jenkins.model.menu.Semantic;
+import jenkins.model.menu.event.ConfirmationEvent;
 import jenkins.model.menu.event.Event;
+import jenkins.model.menu.event.LinkEvent;
 import jenkins.model.menu.event.SplitButtonEvent;
 import jenkins.security.stapler.StaplerNotDispatchable;
 import org.apache.commons.jelly.JellyContext;
@@ -111,7 +113,9 @@ public interface ModelObjectWithContextMenu extends ModelObject {
         }
 
         public ContextMenu add(String url, String text) {
-            items.add(new MenuItem().withUrl(url).withIcon(null).withDisplayName(text));
+            MenuItem menuItem = new MenuItem().withUrl(url).withIcon(null).withDisplayName(text);
+            menuItem.event = LinkEvent.of(menuItem.url);
+            items.add(menuItem);
             return this;
         }
 
@@ -262,10 +266,12 @@ public interface ModelObjectWithContextMenu extends ModelObject {
             if (text != null && icon != null && url != null) {
                 MenuItem item = new MenuItem().withUrl(url).withIcon(icon).withDisplayName(text);
                 item.iconXml = iconXml;
-                item.post = post;
-                item.requiresConfirmation = requiresConfirmation;
                 item.badge = badge;
-                item.message = message;
+                if (requiresConfirmation) {
+                    item.event = ConfirmationEvent.of(message, null, item.url);
+                } else {
+                    item.event = LinkEvent.of(item.url, post ? LinkEvent.LinkEventType.POST : LinkEvent.LinkEventType.GET);
+                }
                 items.add(item);
             }
             return this;
@@ -292,8 +298,13 @@ public interface ModelObjectWithContextMenu extends ModelObject {
         public ContextMenu from(ModelObjectWithContextMenu self, StaplerRequest2 request, StaplerResponse2 response, String view) throws JellyException, IOException {
             // Only Runs support getAppBarActions currently
             if (self instanceof Run) {
-                this.addAll(((Actionable) self).getAppBarActions());
-                return this;
+                List<Action> actions = ((Actionable) self).getAppBarActions().stream()
+                        .filter(action ->
+                                action.getIconFileName() != null
+                        )
+                        .toList();
+
+                return new ModelObjectWithContextMenu.ContextMenu().addAll(actions);
             }
 
             WebApp webApp = WebApp.getCurrent();

--- a/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
+++ b/core/src/main/java/jenkins/model/ModelObjectWithContextMenu.java
@@ -393,8 +393,6 @@ public interface ModelObjectWithContextMenu extends ModelObject {
 
         private Semantic semantic;
 
-        private String message;
-
         /**
          * The type of menu item
          * @since 2.340
@@ -439,8 +437,9 @@ public interface ModelObjectWithContextMenu extends ModelObject {
         }
 
         @Exported
+        @Deprecated
         public String getMessage() {
-            return message;
+            return null;
         }
 
         public MenuItem() {

--- a/src/main/js/components/dropdowns/inpage-jumplist.js
+++ b/src/main/js/components/dropdowns/inpage-jumplist.js
@@ -16,7 +16,10 @@ function init() {
         ),
       ).map((section) => {
         section.id = toId(section.textContent);
-        return { displayName: section.textContent, url: "#" + section.id };
+        return {
+          displayName: section.textContent,
+          event: { url: "#" + section.id, type: "GET" },
+        };
       });
     });
   }

--- a/src/main/js/components/dropdowns/jumplists.js
+++ b/src/main/js/components/dropdowns/jumplists.js
@@ -127,10 +127,12 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
       return fetch(Path.combinePath(href, urlSuffix))
         .then((response) => response.json())
         .then((json) => {
-          const items = Utils.generateDropdownItems(
-            mapChildrenItemsToDropdownItems(json.items),
+          const items = Utils.mapChildrenItemsToDropdownItems(json.items);
+          return Utils.generateDropdownItems(
+            items,
+            false,
+            element.dataset.href,
           );
-          return items;
         });
     };
 
@@ -190,75 +192,6 @@ function createDropdownContent(element, hasModelLink, hasChildrenLink, href) {
         instance.loaded = true;
       });
   };
-}
-
-/*
- * Generates the contents for the dropdown
- */
-function mapChildrenItemsToDropdownItems(items) {
-  return items.map((item) => {
-    if (item.type === "HEADER") {
-      return {
-        type: "HEADER",
-        label: item.displayName,
-      };
-    }
-
-    if (item.type === "SEPARATOR") {
-      return {
-        type: "SEPARATOR",
-      };
-    }
-
-    return {
-      icon: item.icon,
-      iconXml: item.iconXml,
-      displayName: item.displayName,
-      url: item.url,
-      type: item.post || item.requiresConfirmation ? "button" : "link",
-      badge: item.badge,
-      onClick: () => {
-        if (item.post || item.requiresConfirmation) {
-          if (item.requiresConfirmation) {
-            dialog
-              .confirm(item.displayName, { message: item.message })
-              .then(() => {
-                const form = document.createElement("form");
-                form.setAttribute("method", item.post ? "POST" : "GET");
-                form.setAttribute("action", item.url);
-                if (item.post) {
-                  crumb.appendToForm(form);
-                }
-                document.body.appendChild(form);
-                form.submit();
-              });
-          } else {
-            fetch(item.url, {
-              method: "post",
-              headers: crumb.wrap({}),
-            }).then((rsp) => {
-              if (rsp.ok) {
-                notificationBar.show(
-                  item.displayName + ": Done.",
-                  notificationBar.SUCCESS,
-                );
-              } else {
-                notificationBar.show(
-                  item.displayName + ": Failed.",
-                  notificationBar.ERROR,
-                );
-              }
-            });
-          }
-        }
-      },
-      subMenu: item.subMenu
-        ? () => {
-            return mapChildrenItemsToDropdownItems(item.subMenu.items);
-          }
-        : null,
-    };
-  });
 }
 
 export default { init };

--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -142,13 +142,15 @@ function menuItem(dropdownItem, type = "jenkins-dropdown__item", context = "") {
 
   const label = xmlEscape(itemOptions.displayName);
 
-  let clazz =
-    type +
-    " " +
-    itemOptions.clazz +
-    (itemOptions.semantic
+  const clazz = [
+    type,
+    itemOptions.clazz,
+    itemOptions.semantic
       ? " jenkins-!-" + itemOptions.semantic.toLowerCase() + "-color"
-      : "");
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   // If submenu
   if (itemOptions.event && itemOptions.event.event) {
@@ -186,6 +188,17 @@ function menuItem(dropdownItem, type = "jenkins-dropdown__item", context = "") {
 
   const tag =
     itemOptions.event && itemOptions.event.type === "GET" ? "a" : "button";
+
+  // Do not prepend the context path for root-relative or absolute URLs
+  if (tag === "a") {
+    if (
+      itemOptions.event.url.startsWith("/") ||
+      itemOptions.event.url.startsWith("http")
+    ) {
+      context = "";
+    }
+  }
+
   const url = tag === "a" ? context + xmlEscape(itemOptions.event.url) : null;
 
   const item = createElementFromHtml(`
@@ -258,7 +271,7 @@ function tryConfirmationPost(element, opt, context) {
     dialog
       .confirm(opt.event.title, {
         message: opt.event.description,
-        type: opt.semantic.toLowerCase() ?? "default",
+        type: opt.semantic?.toLowerCase() ?? "default",
       })
       .then(
         () => {
@@ -282,13 +295,17 @@ function tryPost(element, opt, context) {
     return;
   }
 
+  // Do not prepend the context path for root-relative URLs
+  if (opt.event.url.startsWith("/")) {
+    context = "";
+  }
+
   element.addEventListener("click", () => {
-    const form = document.createElement("form");
-    form.setAttribute("method", "POST");
-    form.setAttribute("action", context + xmlEscape(opt.event.url));
-    crumb.appendToForm(form);
-    document.body.appendChild(form);
-    form.submit();
+    fetch(context + xmlEscape(opt.event.url), {
+      method: "post",
+      headers: crumb.wrap({}),
+    });
+    window.location.href = ".";
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jenkins/issues/26528

Legacy context menu items, e.g. those powered by `sidepanel.jelly`, lack `event`s, causing them to not respond. There was also a few other issues found when resolving this - they can be seen below:

### Testing done

* Legacy context menu items now work as expected
* 'Build Now' no longer downloads a file
* Manage Jenkins -> System breadcrumb now links to sections appropriately
* No more `undefined` in menu item class attribute 
* Non relative URLs now link appropriately
* Some actions were appearing when they shouldn't

### Proposed changelog entries

- Fix legacy context menu items not working

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui, bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
