### PR TITLE
Fix delete button being missing and actions showing when they shouldn't be

### DIFF
--- a/core/src/main/java/jenkins/model/run/DeleteRunAction.java
+++ b/core/src/main/java/jenkins/model/run/DeleteRunAction.java
@@ -6,6 +6,7 @@ import hudson.model.Run;
 import java.util.Collection;
 import java.util.Set;
 import jenkins.model.TransientActionFactory;
+import jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag;
 import jenkins.model.menu.Group;
 import jenkins.model.menu.Semantic;
 import jenkins.model.menu.event.ConfirmationEvent;
@@ -21,6 +22,13 @@ public class DeleteRunAction extends TransientActionFactory<Run> {
 
     @Override
     public Collection<? extends Action> createFor(Run target) {
+        Boolean newBuildPageEnabled = new NewBuildPageUserExperimentalFlag().getFlagValue();
+
+        // This condition can be removed when the flag has been removed
+        if (!newBuildPageEnabled) {
+            return Set.of();
+        }
+
         if (!target.hasPermission(Run.DELETE) || target.isKeepLog()) {
             return Set.of();
         }

--- a/core/src/main/java/jenkins/model/run/KeepRunAction.java
+++ b/core/src/main/java/jenkins/model/run/KeepRunAction.java
@@ -7,6 +7,7 @@ import hudson.security.Permission;
 import java.util.Collection;
 import java.util.Set;
 import jenkins.model.TransientActionFactory;
+import jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag;
 import jenkins.model.menu.Group;
 import jenkins.model.menu.event.Event;
 import jenkins.model.menu.event.LinkEvent;
@@ -21,6 +22,13 @@ public class KeepRunAction extends TransientActionFactory<Run> {
 
     @Override
     public Collection<? extends Action> createFor(Run target) {
+        Boolean newBuildPageEnabled = new NewBuildPageUserExperimentalFlag().getFlagValue();
+
+        // This condition can be removed when the flag has been removed
+        if (!newBuildPageEnabled) {
+            return Set.of();
+        }
+
         if (!target.canToggleLogKeep()) {
             return Set.of();
         }

--- a/core/src/main/java/jenkins/model/run/StopRunAction.java
+++ b/core/src/main/java/jenkins/model/run/StopRunAction.java
@@ -22,8 +22,14 @@ public class StopRunAction extends TransientActionFactory<Run> {
 
     @Override
     public Collection<? extends Action> createFor(Run target) {
-        var flag = new NewBuildPageUserExperimentalFlag();
-        if (!target.isBuilding() || !flag.getFlagValue()) {
+        Boolean newBuildPageEnabled = new NewBuildPageUserExperimentalFlag().getFlagValue();
+
+        // This condition can be removed when the flag has been removed
+        if (!newBuildPageEnabled) {
+            return Set.of();
+        }
+
+        if (!target.isBuilding()) {
             return Set.of();
         }
 

--- a/core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
@@ -33,6 +33,7 @@ THE SOFTWARE.
       <j:set var="buildUrl" value="${h.decompose(request2)}" />
 
       <st:include page="tasks.jelly"/>
+      <st:include page="delete.jelly" />
       <st:include page="actions.jelly"/>
       <t:actions actions="${it.transientActions}"/>
       <j:if test="${it.previousBuild!=null}">


### PR DESCRIPTION
Relates to https://github.com/jenkinsci/bom/pull/6504#issuecomment-4127652429

With thanks to @MarkEWaite and @jglick 

`delete.jelly` had been accidentally removed in https://github.com/jenkinsci/jenkins/pull/11204 causing the above test to fail. This has been restored in this PR, and whilst doing this PR, I noticed that several actions are visible when they shouldn't be (they should be hidden behind a feature flag).

### Testing done

* Delete is now visible
* Actions are hidden in legacy UI
* Actions are visible in experimental UI

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

<img width="349" height="402" alt="Screenshot 2026-03-25 at 16 59 47" src="https://github.com/user-attachments/assets/76b44deb-3188-4369-9928-26ebe7db37c2" />

#### After

<img width="339" height="356" alt="image" src="https://github.com/user-attachments/assets/eddf01b9-b9d7-4713-bd78-2a56d1697f32" />

#### Experimental UI actions are visible in experimental UI as expected

<img width="218" height="232" alt="image" src="https://github.com/user-attachments/assets/d024da48-aa38-4e57-871f-a81cab0f0c49" />

### Proposed changelog entries

- Fix delete button being missing and actions showing when they shouldn't be (regression in 2.556).

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui, bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux @MarkEWaite @jglick 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
