### PR TITLE
Fix NullPointerException in details-bar.jelly when Detail link is null

### DIFF
--- a/core/src/main/resources/lib/layout/details-bar.jelly
+++ b/core/src/main/resources/lib/layout/details-bar.jelly
@@ -41,7 +41,9 @@ THE SOFTWARE.
           <j:if test="${detail.iconClassName != null}">
             <x:element name="${detail.link != null ? 'a' : 'div'}">
               <x:attribute name="class">jenkins-details__item</x:attribute>
-              <x:attribute name="href">${detail.link}</x:attribute>
+              <j:if test="${detail.link != null}">
+                <x:attribute name="href">${detail.link}</x:attribute>
+              </j:if>
               <div class="jenkins-details__item__icon">
                 <l:icon src="${detail.iconClassName}" />
               </div>


### PR DESCRIPTION
Fixes #26436

### Testing done

**Explanation as to why this change has no tests:**
This PR introduces a standard defensive `<j:if>` null check inside the [details-bar.jelly](cci:7://file:///c:/Users/sahil/Desktop/jenkins/jenkins/core/src/main/resources/lib/layout/details-bar.jelly:0:0-0:0) UI template to prevent a `NullPointerException` when `detail.link` evaluates to null. Because this is a layout-only templating rendering fix, and Jenkins core currently lacks a focused HTMLUnit test harness for the `details-bar` component, no automated tests were added. I have manually syntax-checked the Jelly block to ensure structural correctness and valid XML.

### Screenshots (UI changes only)

N/A - This is a bug fix preventing an NPE crash error page. The UI will gracefully default to rendering a non-clickable `<div>` instead of an `<a>` tag (as originally intended by the layout author) when a detail link does not exist.

### Proposed changelog entries

- Prevent a `NullPointerException` when rendering objects without links in the `details-bar` UI component.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood. Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
