### PR TITLE
Fix chevron box misalignment on Build History view

### DIFF
--- a/src/main/scss/components/_table.scss
+++ b/src/main/scss/components/_table.scss
@@ -165,7 +165,8 @@
 
   &__link {
     .jenkins-menu-dropdown-chevron {
-      top: 0;
+      top: 50%;
+      transform: translateY(-50%);
     }
   }
 


### PR DESCRIPTION
Fixes #26491

### Testing done
Verified the vertical alignment of the dropdown chevron in the Build History table across different row heights.

### Screenshots (UI changes only)
(You can drag and drop your "After" screenshot here)

### Proposed changelog entries
- Fix vertical misalignment of the dropdown chevron in the Build History table.
### Proposed changelog category
/label bug

### Proposed upgrade guidelines
N/A