### PR TITLE
Use dialog for Delete Build

### DIFF
--- a/core/src/main/resources/hudson/model/Run/delete.jelly
+++ b/core/src/main/resources/hudson/model/Run/delete.jelly
@@ -28,6 +28,13 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <j:if test="${!it.logUpdated and !it.keepLog}">
-    <l:task href="${buildUrl.baseUrl}/confirmDelete" icon="icon-edit-delete icon-md" permission="${it.DELETE}" title="${%delete.build(it.displayName)}"/>
+    <l:task href="${buildUrl.baseUrl}/doDelete"
+            icon="icon-edit-delete icon-md"
+            permission="${it.DELETE}"
+            title="${%Delete\ this\ build}"
+            requiresConfirmation="true"
+            confirmationMessage="${%delete.build(it.displayName)}?"
+            post="true"
+            destructive="true"/>
   </j:if>
 </j:jelly>


### PR DESCRIPTION
**Build Description Dialog (#26488)**
**Issue:** Clicking "Edit Description" currently replaces the text with an inline form on the page, which is inconsistent with the modern Jenkins UI.

**What i fixed:** Changed the "Edit Description" flow to open in a clean, modal dialog box.

**How i fixed it:** Modified the editable-description.js and editDescriptionButton.jelly files to use the Jenkins Dialog API (window.dialog.form). This fetches the edit form via AJAX and displays it in a modal over the current page.