### PR TITLE
Support Java records for Describable implementations

### DIFF
--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -540,7 +540,7 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
 
         if (clazz.isRecord()) {
             for (RecordComponent component : clazz.getRecordComponents()) {
-                r.put(component.getName(), new PropertyType(component.getAccessor()));
+                r.putIfAbsent(component.getName(), new PropertyType(component.getAccessor()));
             }
         }
 

--- a/core/src/main/java/hudson/model/Descriptor.java
+++ b/core/src/main/java/hudson/model/Descriptor.java
@@ -56,6 +56,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -537,6 +538,12 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
             if (m.getName().startsWith("get"))
                 r.put(Introspector.decapitalize(m.getName().substring(3)), new PropertyType(m));
 
+        if (clazz.isRecord()) {
+            for (RecordComponent component : clazz.getRecordComponents()) {
+                r.put(component.getName(), new PropertyType(component.getAccessor()));
+            }
+        }
+
         return r;
     }
 
@@ -925,10 +932,13 @@ public abstract class Descriptor<T extends Describable<T>> implements Loadable, 
 
     private String getViewPage(Class<?> clazz, Collection<String> pageNames, String defaultValue) {
         while (clazz != Object.class && clazz != null) {
-            for (String pageName : pageNames) {
-                String name = clazz.getName().replace('.', '/').replace('$', '/') + "/" + pageName;
-                if (clazz.getClassLoader().getResource(name) != null)
-                    return '/' + name;
+            ClassLoader cl = clazz.getClassLoader();
+            if (cl != null) {
+                for (String pageName : pageNames) {
+                    String name = clazz.getName().replace('.', '/').replace('$', '/') + "/" + pageName;
+                    if (cl.getResource(name) != null)
+                        return '/' + name;
+                }
             }
             clazz = clazz.getSuperclass();
         }

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -26,7 +26,9 @@ package hudson.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -245,6 +247,32 @@ public class DescriptorTest {
         }
 
         @TestExtension("nestedDescribableSharingClass") public static class DescriptorImpl extends Descriptor<Builder> {}
+    }
+
+    @Issue("JENKINS-26573")
+    @Test
+    void recordDescribablePropertyTypes() {
+        Descriptor<?> descriptor = Jenkins.get().getDescriptorOrDie(SampleRecord.class);
+        PropertyType nameType = descriptor.getPropertyType("name");
+        assertNotNull(nameType, "record component 'name' should be discovered as a property");
+        assertEquals(String.class, nameType.clazz);
+        PropertyType countType = descriptor.getPropertyType("count");
+        assertNotNull(countType, "record component 'count' should be discovered as a property");
+        assertEquals(int.class, countType.clazz);
+    }
+
+    @Issue("JENKINS-26573")
+    @Test
+    void recordDescribableGetViewPageDoesNotThrow() {
+        Descriptor<?> descriptor = Jenkins.get().getDescriptorOrDie(SampleRecord.class);
+        assertDoesNotThrow(descriptor::getConfigPage);
+    }
+
+    public record SampleRecord(String name, int count) implements Describable<SampleRecord> {
+        @DataBoundConstructor
+        public SampleRecord {}
+
+        @TestExtension public static class DescriptorImpl extends Descriptor<SampleRecord> {}
     }
 
     @Test

--- a/test/src/test/java/hudson/model/DescriptorTest.java
+++ b/test/src/test/java/hudson/model/DescriptorTest.java
@@ -249,7 +249,7 @@ public class DescriptorTest {
         @TestExtension("nestedDescribableSharingClass") public static class DescriptorImpl extends Descriptor<Builder> {}
     }
 
-    @Issue("JENKINS-26573")
+    @Issue("#26573")
     @Test
     void recordDescribablePropertyTypes() {
         Descriptor<?> descriptor = Jenkins.get().getDescriptorOrDie(SampleRecord.class);
@@ -261,7 +261,7 @@ public class DescriptorTest {
         assertEquals(int.class, countType.clazz);
     }
 
-    @Issue("JENKINS-26573")
+    @Issue("#26573")
     @Test
     void recordDescribableGetViewPageDoesNotThrow() {
         Descriptor<?> descriptor = Jenkins.get().getDescriptorOrDie(SampleRecord.class);


### PR DESCRIPTION
# Fixes #26573

## Summary

This PR addresses two problems that prevent Java `record` types from being used as `Describable` implementations, as described by @jglick in #26573.

**Problem 1 - `NullPointerException` in `getViewPage()`:**

When opening a form page for a record-based `Describable`, `Descriptor.getViewPage()` traverses the class hierarchy looking for view templates. For a record, the superclass is `java.lang.Record`, which is loaded by the bootstrap class loader. `Class.getClassLoader()` returns `null` for bootstrap classes, causing a `NullPointerException` at `Descriptor.java` line 930.

**Fix:** Check for a `null` class loader before calling `getResource()`. Classes loaded by the bootstrap class loader will never contain Jenkins view templates, so skipping them is correct.

**Problem 2 - Record properties not discovered by Stapler:**

`Descriptor.buildPropertyTypes()` only discovers properties via JavaBeans-style `getXxx()` methods. Java records use accessor methods without the `get` prefix (e.g., `name()` instead of `getName()`), so Stapler could not find any properties to bind form fields to.

**Fix:** When the class is a record, also iterate over `Class.getRecordComponents()` and register each component's accessor method as a `PropertyType`.

## Note on related issue #26077

As @jglick noted, full end-to-end record support for `Describable` probably also depends on #26077 (XStream2 record deserialization support). This PR does not address XML serialization/deserialization of records that is tracked separately. This PR focuses on the `Descriptor`-level fixes that are within the scope of #26573: preventing the crash and enabling property discovery.

## Testing done

Added two new automated tests in `DescriptorTest.java` using a `SampleRecord(String name, int count)` that implements `Describable`:

- **`recordDescribablePropertyTypes`** - Verifies that record component accessors (`name()`, `count()`) are discovered as `PropertyType`s with the correct types (`String.class`, `int.class`). Without the `buildPropertyTypes()` fix, these return `null`.
- **`recordDescribableGetViewPageDoesNotThrow`** - Verifies that calling `descriptor.getConfigPage()` on a record-based `Describable` does not throw a `NullPointerException`. Without the `getViewPage()` fix, this crashes.

All existing `DescriptorTest` tests continue to pass (7 total: 6 passed, 1 pre-existing `@Disabled`).

Spotless check passes.

## Proposed changelog category

/label rfe,developer

## Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

## Desired reviewers

@jglick @timja 

Before the changes are marked as `ready-for-merge`:

## Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.