### PR TITLE
fix: support Java record deserialization in XStream2

### DIFF
--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -47,7 +47,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.diagnosis.OldDataMonitor;
 import hudson.model.Saveable;
 import hudson.security.ACL;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -285,9 +288,79 @@ public class RobustReflectionConverter implements Converter {
 
     @Override
     public Object unmarshal(final HierarchicalStreamReader reader, final UnmarshallingContext context) {
+        String readResolveValue = reader.getAttribute(mapper.aliasForAttribute("resolves-to"));
+        Class<?> type = readResolveValue != null ? mapper.realClass(readResolveValue) : context.getRequiredType();
+        if (type.isRecord()) {
+            return unmarshalRecord(type, reader, context);
+        }
         Object result = instantiateNewInstance(reader, context);
         result = doUnmarshal(result, reader, context);
         return serializationMethodInvoker.callReadResolve(result);
+    }
+
+    private Object unmarshalRecord(Class<?> type, HierarchicalStreamReader reader, UnmarshallingContext context) {
+        RecordComponent[] components = type.getRecordComponents();
+        Map<String, Integer> nameToIndex = new HashMap<>();
+        Class<?>[] componentTypes = new Class<?>[components.length];
+        for (int i = 0; i < components.length; i++) {
+            nameToIndex.put(components[i].getName(), i);
+            componentTypes[i] = components[i].getType();
+        }
+
+        Object[] args = new Object[components.length];
+        for (int i = 0; i < components.length; i++) {
+            if (componentTypes[i].isPrimitive()) {
+                args[i] = defaultPrimitiveValue(componentTypes[i]);
+            }
+        }
+
+        while (reader.hasMoreChildren()) {
+            reader.moveDown();
+            try {
+                String nodeName = reader.getNodeName();
+                String fieldName = mapper.realMember(type, nodeName);
+                Integer index = nameToIndex.get(fieldName);
+                if (index != null) {
+                    String classAttribute = reader.getAttribute(mapper.aliasForAttribute("class"));
+                    Class<?> fieldType;
+                    if (classAttribute != null) {
+                        fieldType = mapper.realClass(classAttribute);
+                    } else {
+                        fieldType = mapper.defaultImplementationOf(componentTypes[index]);
+                    }
+                    Converter converter = mapper.getLocalConverter(type, fieldName);
+                    Object value = context.convertAnother(null, fieldType, converter);
+                    args[index] = value;
+                } else {
+                    LOGGER.fine("Ignoring unknown field " + fieldName + " for record " + type.getName());
+                }
+            } catch (CriticalXStreamException e) {
+                throw e;
+            } catch (XStreamException | LinkageError e) {
+                addErrorInContext(context, e);
+            }
+            reader.moveUp();
+        }
+
+        try {
+            Constructor<?> canonical = type.getDeclaredConstructor(componentTypes);
+            canonical.setAccessible(true);
+            return canonical.newInstance(args);
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new ConversionException("Cannot construct record " + type.getName(), e);
+        }
+    }
+
+    private static Object defaultPrimitiveValue(Class<?> type) {
+        if (type == boolean.class) return Boolean.FALSE;
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0.0f;
+        if (type == double.class) return 0.0d;
+        if (type == char.class) return '\0';
+        return null;
     }
 
     public Object doUnmarshal(final Object result, final HierarchicalStreamReader reader, final UnmarshallingContext context) {

--- a/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/core/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -462,4 +462,65 @@ class RobustReflectionConverterTest {
             }
         }
     }
+
+    record SimpleRecord(String name, int count) {}
+
+    private XStream2 xstreamWithRecordAliases() {
+        XStream2 xs = new XStream2();
+        xs.alias("simple-record", SimpleRecord.class);
+        xs.alias("nested-record", NestedRecord.class);
+        return xs;
+    }
+
+    @Test
+    @Issue("JENKINS-26077")
+    void recordRoundTrip() {
+        XStream2 xs = xstreamWithRecordAliases();
+        SimpleRecord original = new SimpleRecord("test", 42);
+        String xml = xs.toXML(original);
+        SimpleRecord restored = (SimpleRecord) xs.fromXML(xml);
+        assertEquals(original, restored);
+    }
+
+    @Test
+    @Issue("JENKINS-26077")
+    void recordFromXml() {
+        XStream2 xs = xstreamWithRecordAliases();
+        SimpleRecord result = (SimpleRecord) xs.fromXML(
+                "<simple-record><name>hello</name><count>7</count></simple-record>");
+        assertEquals("hello", result.name());
+        assertEquals(7, result.count());
+    }
+
+    @Test
+    @Issue("JENKINS-26077")
+    void recordIgnoresUnknownFields() {
+        XStream2 xs = xstreamWithRecordAliases();
+        SimpleRecord result = (SimpleRecord) xs.fromXML(
+                "<simple-record><name>hello</name><count>7</count><extra>ignored</extra></simple-record>");
+        assertEquals("hello", result.name());
+        assertEquals(7, result.count());
+    }
+
+    @Test
+    @Issue("JENKINS-26077")
+    void recordMissingFieldsUseDefaults() {
+        XStream2 xs = xstreamWithRecordAliases();
+        SimpleRecord result = (SimpleRecord) xs.fromXML(
+                "<simple-record><name>hello</name></simple-record>");
+        assertEquals("hello", result.name());
+        assertEquals(0, result.count());
+    }
+
+    record NestedRecord(String label, SimpleRecord inner) {}
+
+    @Test
+    @Issue("JENKINS-26077")
+    void nestedRecordRoundTrip() {
+        XStream2 xs = xstreamWithRecordAliases();
+        NestedRecord original = new NestedRecord("outer", new SimpleRecord("inner", 99));
+        String xml = xs.toXML(original);
+        NestedRecord restored = (NestedRecord) xs.fromXML(xml);
+        assertEquals(original, restored);
+    }
 }


### PR DESCRIPTION
# Fixes #26077

## Problem

`RobustReflectionConverter.doUnmarshal()` uses `SunUnsafeReflectionProvider.writeField()` to inject values directly into fields via `Unsafe.objectFieldOffset()` during XML deserialization. This fails for Java records because record fields are immutable:

```
java.lang.UnsupportedOperationException: can't get field offset on a record class:
    private final some.Type somePackage.SomeRecord.someComponent
    at sun.misc.Unsafe.objectFieldOffset(Unsafe.java:648)
    at SunUnsafeReflectionProvider.getFieldOffset(SunUnsafeReflectionProvider.java:105)
    at SunUnsafeReflectionProvider.writeField(SunUnsafeReflectionProvider.java:56)
    at RobustReflectionConverter.doUnmarshal(RobustReflectionConverter.java:368)
```

Marshalling (`toXML`) already works for records, only deserialization (`fromXML`) is broken.

## Fix

Added an alternate unmarshal path in `RobustReflectionConverter` for record classes:

1. **Detection:** In `unmarshal()`, check `type.isRecord()` before entering the existing flow
2. **New `unmarshalRecord()` method:** Reads XML child elements into an `Object[]` array mapped by name to record component indices, then invokes the canonical constructor via reflection
3. **Robust error handling:** Unknown XML elements are gracefully ignored (logged at FINE level) and missing elements use type defaults (`null` for reference types, `0`/`false` for primitives) - consistent with the existing `RobustReflectionConverter` philosophy of tolerating schema evolution

The existing unmarshal path for regular classes is completely untouched, the record path is gated by `isRecord()`.

## How the fix works

For a record like `record Point(int x, int y) {}` and XML `<Point><x>1</x><y>2</y></Point>`:

| Step | What happens |
|---|---|
| 1 | `unmarshal()` detects `Point.isRecord() == true` |
| 2 | `unmarshalRecord()` gets `RecordComponent[] = [x:int, y:int]` |
| 3 | Initializes `args = [0, 0]` (primitive defaults) |
| 4 | Reads `<x>` → converts `"1"` to `int 1` → `args[0] = 1` |
| 5 | Reads `<y>` → converts `"2"` to `int 2` → `args[1] = 2` |
| 6 | Calls `new Point(1, 2)` via canonical constructor |

## Relationship to #26573

This fix is a dependency of #26573 (Support records for `Describable`). As @jglick noted in that issue: *"Probably depends on #26077."* With this fix, the full lifecycle of a record-based `Describable` - form rendering, property binding, XML save, and XML load is complete.

## Testing done

Added 5 automated tests in `RobustReflectionConverterTest.java`:

| Test | What it verifies |
|---|---|
| `recordRoundTrip` | Marshal a record to XML and unmarshal back - values match via `equals()` |
| `recordFromXml` | Unmarshal a record from hand-written XML - `String` and `int` fields correct |
| `recordIgnoresUnknownFields` | Extra XML elements are silently ignored (robust behavior) |
| `recordMissingFieldsUseDefaults` | Missing `int` field defaults to `0` instead of crashing |
| `nestedRecordRoundTrip` | Record containing another record survives a full round-trip |

All 15 tests pass (10 existing + 5 new, 1 pre-existing `@Disabled` skip, 0 failures).

Spotless check passes. Full WAR build (`mvn -am -pl war,bom -Pquick-build clean install`) succeeds.

### Proposed changelog entries

- Support deserialization of Java records in `XStream2` by using the canonical constructor instead of unsafe field injection

### Proposed changelog category

/label rfe,developer

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jglick @timja 

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.