### PR TITLE
Add streamLoadedBuilds method to avoid full map copy in getEstimatedDurationCandidates

### DIFF
--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -43,7 +43,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -51,7 +50,6 @@ import java.util.function.IntPredicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import jenkins.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -251,28 +249,16 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
      * Returns a read-only view of records that has already been loaded.
      */
     public SortedMap<Integer, R> getLoadedBuilds() {
-        TreeMap<Integer, BuildReference<R>> res = new TreeMap<>(Comparator.reverseOrder());
-        for (var entry : this.core.entrySet()) {
-            BuildReference<R> buildRef = entry.getValue();
-            if (buildRef.isSet() && !buildRef.isUnloadable()) {
-                res.put(entry.getKey(), buildRef);
+        return new BuildReferenceMapAdapter<>(core, new BuildReferenceMapAdapterResolver() {
+            // Only return builds still in memory, skip GC'd builds instead of loading from disk
+            @Override
+            public R resolveBuildRef(BuildReference<R> buildRef) {
+                if (buildRef == null) {
+                    return null;
+                }
+                return buildRef.get();
             }
-        }
-        return new BuildReferenceMapAdapter<>(res, buildResolver);
-    }
-
-    /**
-     * Returns a lazy stream of build objects, sorted by newest first, skipping GC builds
-     * Unlike {@link #getLoadedBuilds()}, this doesn't require copying the entire map
-     *
-     * @since TODO
-     */
-    public Stream<R> loadedBuilds() {
-        return core.entrySet().stream()
-                .map(Map.Entry::getValue)
-                .filter(ref -> ref.isSet() && !ref.isUnloadable())
-                .map(BuildReference::get)
-                .filter(Objects::nonNull);
+        });
     }
 
     /**

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -249,8 +249,24 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
      * Returns a read-only view of records that has already been loaded.
      */
     public SortedMap<Integer, R> getLoadedBuilds() {
+        return getLoadedBuilds(Integer.MAX_VALUE);
+    }
+
+    /**
+     * Returns a read-only view of records that has already been loaded,
+     * capping at most {@code maxBuilds} entries.
+     * {@code core} is sorted by build number decreasing, so this always returns
+     * up to {@code maxBuilds} most recent builds
+     * @param maxBuilds the maximum number of builds to load into the map
+     * @since TODO
+     */
+    public SortedMap<Integer, R> getLoadedBuilds(int maxBuilds) {
         TreeMap<Integer, BuildReference<R>> res = new TreeMap<>(Comparator.reverseOrder());
         for (var entry : this.core.entrySet()) {
+            if (res.size() >= maxBuilds) {
+                break;
+            }
+
             BuildReference<R> buildRef = entry.getValue();
             if (buildRef.isSet() && !buildRef.isUnloadable()) {
                 res.put(entry.getKey(), buildRef);

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -43,6 +43,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -50,6 +51,7 @@ import java.util.function.IntPredicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import jenkins.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -249,30 +251,28 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
      * Returns a read-only view of records that has already been loaded.
      */
     public SortedMap<Integer, R> getLoadedBuilds() {
-        return getLoadedBuilds(Integer.MAX_VALUE);
-    }
-
-    /**
-     * Returns a read-only view of records that has already been loaded,
-     * capping at most {@code maxBuilds} entries.
-     * {@code core} is sorted by build number decreasing, so this always returns
-     * up to {@code maxBuilds} most recent builds
-     * @param maxBuilds the maximum number of builds to load into the map
-     * @since TODO
-     */
-    public SortedMap<Integer, R> getLoadedBuilds(int maxBuilds) {
         TreeMap<Integer, BuildReference<R>> res = new TreeMap<>(Comparator.reverseOrder());
         for (var entry : this.core.entrySet()) {
-            if (res.size() >= maxBuilds) {
-                break;
-            }
-
             BuildReference<R> buildRef = entry.getValue();
             if (buildRef.isSet() && !buildRef.isUnloadable()) {
                 res.put(entry.getKey(), buildRef);
             }
         }
         return new BuildReferenceMapAdapter<>(res, buildResolver);
+    }
+
+    /**
+     * Returns a lazy stream of build objects, sorted by newest first, skipping GC builds
+     * Unlike {@link #getLoadedBuilds()}, this doesn't require copying the entire map
+     *
+     * @since TODO
+     */
+    public Stream<R> loadedBuilds() {
+        return core.entrySet().stream()
+                .map(Map.Entry::getValue)
+                .filter(ref -> ref.isSet() && !ref.isUnloadable())
+                .map(BuildReference::get)
+                .filter(Objects::nonNull);
     }
 
     /**

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -43,6 +43,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -50,6 +51,7 @@ import java.util.function.IntPredicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import jenkins.util.MemoryReductionUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
@@ -249,16 +251,20 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
      * Returns a read-only view of records that has already been loaded.
      */
     public SortedMap<Integer, R> getLoadedBuilds() {
-        return new BuildReferenceMapAdapter<>(core, new BuildReferenceMapAdapterResolver() {
-            // Only return builds still in memory, skip GC'd builds instead of loading from disk
-            @Override
-            public R resolveBuildRef(BuildReference<R> buildRef) {
-                if (buildRef == null) {
-                    return null;
-                }
-                return buildRef.get();
-            }
-        });
+        TreeMap<Integer, R> res = new TreeMap<>(Comparator.reverseOrder());
+        streamLoadedBuilds().forEach(r -> res.put(getNumberOf(r), r));
+        return res;
+    }
+
+    /**
+     * Returns a lazy stream of build objects, sorted by newest first, skipping GC builds
+     * Unlike {@link #getLoadedBuilds()}, this doesn't require copying the entire map
+     * @since TODO
+     */
+    public Stream<R> streamLoadedBuilds() {
+        return core.values().stream()
+                .map(BuildReference::get)
+                .filter(Objects::nonNull);
     }
 
     /**

--- a/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
@@ -116,7 +116,7 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
         if (!ref.isSet()) {
             resolver.resolveBuildRef(ref);
         }
-        return ref.isSet() && !ref.isUnloadable();
+        return !ref.isUnloadable();
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
@@ -116,7 +116,7 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
         if (!ref.isSet()) {
             resolver.resolveBuildRef(ref);
         }
-        return !ref.isUnloadable();
+        return ref.isSet() && !ref.isUnloadable();
     }
 
     @Override

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -273,10 +273,9 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
      * @since 2.407
      */
     public List<RunT> getEstimatedDurationCandidates() {
-        var loadedBuilds = builds.getLoadedBuilds().values(); // reverse chronological order
         List<RunT> candidates = new ArrayList<>(3);
         for (Result threshold : List.of(Result.UNSTABLE, Result.FAILURE)) {
-            for (RunT build : loadedBuilds) {
+            for (RunT build : (Iterable<RunT>) builds.streamLoadedBuilds()::iterator) {
                 if (candidates.contains(build)) {
                     continue;
                 }

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -273,7 +273,9 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
      * @since 2.407
      */
     public List<RunT> getEstimatedDurationCandidates() {
-        var loadedBuilds = builds.getLoadedBuilds().values(); // reverse chronological order
+        // somewhat arbitrary but load the most recent 100 builds to try and find 3 completed builds
+        // this avoids recreating the entire TreeMap for large build histories
+        var loadedBuilds = builds.getLoadedBuilds(100).values(); // reverse chronological order
         List<RunT> candidates = new ArrayList<>(3);
         for (Result threshold : List.of(Result.UNSTABLE, Result.FAILURE)) {
             for (RunT build : loadedBuilds) {

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -273,10 +273,10 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
      * @since 2.407
      */
     public List<RunT> getEstimatedDurationCandidates() {
+        var loadedBuilds = builds.getLoadedBuilds().values(); // reverse chronological order
         List<RunT> candidates = new ArrayList<>(3);
         for (Result threshold : List.of(Result.UNSTABLE, Result.FAILURE)) {
-            // loadedBuilds() returns a lazy stream over core (sorted newest first)
-            for (RunT build : (Iterable<RunT>) builds.loadedBuilds()::iterator) {
+            for (RunT build : loadedBuilds) {
                 if (candidates.contains(build)) {
                     continue;
                 }

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -273,12 +273,10 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
      * @since 2.407
      */
     public List<RunT> getEstimatedDurationCandidates() {
-        // somewhat arbitrary but load the most recent 100 builds to try and find 3 completed builds
-        // this avoids recreating the entire TreeMap for large build histories
-        var loadedBuilds = builds.getLoadedBuilds(100).values(); // reverse chronological order
         List<RunT> candidates = new ArrayList<>(3);
         for (Result threshold : List.of(Result.UNSTABLE, Result.FAILURE)) {
-            for (RunT build : loadedBuilds) {
+            // loadedBuilds() returns a lazy stream over core (sorted newest first)
+            for (RunT build : (Iterable<RunT>) builds.loadedBuilds()::iterator) {
                 if (candidates.contains(build)) {
                     continue;
                 }

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -335,11 +336,18 @@ class AbstractLazyLoadRunMapTest {
     void entrySetIterator() {
         Iterator<Map.Entry<Integer, Build>> itr = a.entrySet().iterator();
 
+        // iterator, when created fresh, shouldn't force loading everything
+        // this involves binary searching, so it can load several.
+        assertTrue(a.getLoadedBuilds().size() < 3);
+
         // check if the first entry is legit
         assertTrue(itr.hasNext());
         Map.Entry<Integer, Build> e = itr.next();
         assertEquals((Integer) 5, e.getKey());
         e.getValue().asserts(5);
+
+        // now that the first entry is returned, we expect there to be two loaded
+        assertTrue(a.getLoadedBuilds().size() < 3);
 
         // check if the second entry is legit
         assertTrue(itr.hasNext());
@@ -365,6 +373,7 @@ class AbstractLazyLoadRunMapTest {
     void entrySetEmpty() {
         // entrySet().isEmpty() shouldn't cause full data load
         assertFalse(a.entrySet().isEmpty());
+        assertTrue(a.getLoadedBuilds().size() < 3);
     }
 
     @Issue("JENKINS-18065")
@@ -401,6 +410,19 @@ class AbstractLazyLoadRunMapTest {
         assertThat(c.toArray(), arrayWithSize(3));
         assertThat(c.toArray(Object[]::new), arrayWithSize(3));
         // TODO check behavior of subMap
+    }
+
+    @Test
+    void streamLoadedBuilds() {
+        a.getByNumber(1);
+        a.getByNumber(3);
+        a.getByNumber(5);
+
+        var fromStream = a.streamLoadedBuilds().map(b -> b.n).toList();
+        assertEquals(List.of(5, 3, 1), fromStream);
+
+        var firstTwo = a.streamLoadedBuilds().limit(2).map(b -> b.n).toList();
+        assertEquals(List.of(5, 3), firstTwo);
     }
 
     @Issue("JENKINS-22767")

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -423,7 +423,7 @@ class AbstractLazyLoadRunMapTest {
         assertEquals(List.of(5, 3, 1), fromStream);
 
         // should lazily load first two builds
-        var firstTwo = a.loadedBuilds().limit(2).map(b -> ((Build) b).n).toList();
+        var firstTwo = a.loadedBuilds().limit(2).map(b -> b.n).toList();
         assertEquals(List.of(5, 3), firstTwo);
     }
 

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -412,14 +413,18 @@ class AbstractLazyLoadRunMapTest {
     }
 
     @Test
-    void getLoadedBuildsCapped() {
+    void loadedBuildsStream() {
         a.getByNumber(1);
         a.getByNumber(3);
         a.getByNumber(5);
-        assertEquals("[5, 3, 1]", a.getLoadedBuilds().keySet().toString());
 
-        // should load only 2 most recent builds
-        assertEquals("[5, 3]", a.getLoadedBuilds(2).keySet().toString());
+        // loadedBuilds() should return the same builds as getLoadedBuilds() in the same order
+        var fromStream = a.loadedBuilds().map(b -> ((Build) b).n).toList();
+        assertEquals(List.of(5, 3, 1), fromStream);
+
+        // should lazily load first two builds
+        var firstTwo = a.loadedBuilds().limit(2).map(b -> ((Build) b).n).toList();
+        assertEquals(List.of(5, 3), firstTwo);
     }
 
     @Issue("JENKINS-22767")

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -411,6 +411,17 @@ class AbstractLazyLoadRunMapTest {
         // TODO check behavior of subMap
     }
 
+    @Test
+    void getLoadedBuildsCapped() {
+        a.getByNumber(1);
+        a.getByNumber(3);
+        a.getByNumber(5);
+        assertEquals("[5, 3, 1]", a.getLoadedBuilds().keySet().toString());
+
+        // should load only 2 most recent builds
+        assertEquals("[5, 3]", a.getLoadedBuilds(2).keySet().toString());
+    }
+
     @Issue("JENKINS-22767")
     @Test
     void slowRetrieve() throws Exception {

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -40,7 +40,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -336,18 +335,11 @@ class AbstractLazyLoadRunMapTest {
     void entrySetIterator() {
         Iterator<Map.Entry<Integer, Build>> itr = a.entrySet().iterator();
 
-        // iterator, when created fresh, shouldn't force loading everything
-        // this involves binary searching, so it can load several.
-        assertTrue(a.getLoadedBuilds().size() < 3);
-
         // check if the first entry is legit
         assertTrue(itr.hasNext());
         Map.Entry<Integer, Build> e = itr.next();
         assertEquals((Integer) 5, e.getKey());
         e.getValue().asserts(5);
-
-        // now that the first entry is returned, we expect there to be two loaded
-        assertTrue(a.getLoadedBuilds().size() < 3);
 
         // check if the second entry is legit
         assertTrue(itr.hasNext());
@@ -373,7 +365,6 @@ class AbstractLazyLoadRunMapTest {
     void entrySetEmpty() {
         // entrySet().isEmpty() shouldn't cause full data load
         assertFalse(a.entrySet().isEmpty());
-        assertTrue(a.getLoadedBuilds().size() < 3);
     }
 
     @Issue("JENKINS-18065")
@@ -410,21 +401,6 @@ class AbstractLazyLoadRunMapTest {
         assertThat(c.toArray(), arrayWithSize(3));
         assertThat(c.toArray(Object[]::new), arrayWithSize(3));
         // TODO check behavior of subMap
-    }
-
-    @Test
-    void loadedBuildsStream() {
-        a.getByNumber(1);
-        a.getByNumber(3);
-        a.getByNumber(5);
-
-        // loadedBuilds() should return the same builds as getLoadedBuilds() in the same order
-        var fromStream = a.loadedBuilds().map(b -> b.n).toList();
-        assertEquals(List.of(5, 3, 1), fromStream);
-
-        // should lazily load first two builds
-        var firstTwo = a.loadedBuilds().limit(2).map(b -> b.n).toList();
-        assertEquals(List.of(5, 3), firstTwo);
     }
 
     @Issue("JENKINS-22767")

--- a/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
+++ b/core/src/test/java/jenkins/model/lazy/AbstractLazyLoadRunMapTest.java
@@ -419,7 +419,7 @@ class AbstractLazyLoadRunMapTest {
         a.getByNumber(5);
 
         // loadedBuilds() should return the same builds as getLoadedBuilds() in the same order
-        var fromStream = a.loadedBuilds().map(b -> ((Build) b).n).toList();
+        var fromStream = a.loadedBuilds().map(b -> b.n).toList();
         assertEquals(List.of(5, 3, 1), fromStream);
 
         // should lazily load first two builds


### PR DESCRIPTION
Fixes [#26596](https://github.com/jenkinsci/jenkins/issues/26596)

See issue for more context. `getLoadedBuilds()` is called by `getEstimatedDurationCandidates()` on every queue maintenance lock. `getLoadedBuilds()` copies the entire `core` map into a new tree map for every call, even though it only needs the 3 most recent completed builds, which is expensive for jobs with large build histories.

This PR adds `streamLoadedBuilds` to lazily stream over builds in memory instead of copying into a new map every queue maintenance cycle in `getEstimatedDurationCandidates`. Also simplifies `getLoadedBuilds` to call `streamLoadedBuilds`, which still does create a new map but is needed for plugin compatibility

### Testing done

It's a small change but I sanity checked it by running Jenkins locally before my change, added logging around the `loadedBuilds` and `getEstimatedDurationCandidates`, confirmed that new jobs lazily load 3 builds after examining 4 (since the 4th build is the current one in progress)

### Screenshots (UI changes only)


#### Before

#### After

### Proposed changelog entries
- Improve queue maintenance performance for jobs with large build histories

### Proposed changelog category

/label bug,rfe

### Proposed upgrade guidelines

N/A


### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
