### PR TITLE
Revert "Update ant to v1.10.16"

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -164,7 +164,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.10.16</version>
+        <version>1.10.15</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Revert "Update ant to v1.10.16"

Fix a Windows bug introduced by the update to Apache Ant 1.10.16.  The unreleased [Apache Ant 1.10.17 What's New](https://github.com/apache/ant/blob/4198028c333ea163ac67e58a0e63f31d0475a214/WHATSNEW#L7) describes [bug 69992](https://lists.apache.org/thread/j1403k114kb44y3kxnh6rqfgxpg2ls58) as:

> The JavaEnvUtils and FileUtils classes statically depend on each other since Ant 1.10.16 making it impossible to load JavaEnvUtils without loading FileUtils first causing NullPointerException for programmatic use on Windows. This affected Eclipse and may also affect other projects using Ant as a library.

The Eclipse project discusses it in detail in https://github.com/eclipse-platform/eclipse.platform/issues/2605#issuecomment-4178796981

Automated tests on ci.jenkins.io Windows agents have been failing since [3 Apr 2026](https://ci.jenkins.io/job/Core/job/jenkins/job/master/8349/testReport).  The failures report a stack trace:

```
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.tools.ant.util.DeweyDecimal.compareTo(org.apache.tools.ant.util.DeweyDecimal)" because "org.apache.tools.ant.util.JavaEnvUtils.parsedJavaVersion" is null
	at org.apache.tools.ant.util.JavaEnvUtils.isAtLeastJavaVersion(JavaEnvUtils.java:301)
	at org.apache.tools.ant.util.FileUtils.<clinit>(FileUtils.java:94)
```

The failure only happens on Windows because the Ant source code added additional logic for Windows junctions in commit:

* https://github.com/apache/ant/commit/45b84bb3c3384b771f446b26fbb6ebb0a97fd9c5#diff-fdf66b5ecb8a9eb6a9d4e8bb1bc95ce8fc8872c5664fa7e5d899b3dc31af2891R91

This reverts commit d8ce08e37d6b957af9a002df88b9a708fd9c9dd0 from pull request:

* https://github.com/jenkinsci/jenkins/pull/26566

This is another case where the subset of tests run on Windows missed a test failure.  It is even more surprising that the Windows test selection process did not identify that the failing tests should be run in all pull requests after the initial failure on the master branch.  Probably needs further discussion with the predictive test selection experts at CloudBees.  @daniel-beck you are not alone.

This is also a case where the acceptance test harness and the plugin BOM did not catch the issue, because they do not run on Windows.  This type of platform specific bug happens so infrequently that I don't think it is worth the expense to run those tests on Windows.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- Fixes #<issue-number> -->

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

* Confirmed that I can duplicate the problem on my Windows computers with the commands:
  `mvn -am -pl war,bom -Pquick-build clean install`
  `mvn -pl test -Dtest=hudson.slaves.JNLPLauncherRealTest test`
* Confirmed that reverting Apache Ant 1.10.16 fixes the issue

I was unable to duplicate the issue from a Windows controller using websocket connected agents from a Windows computer or from two different Linux computers.  Likewise I was unable to duplicate the issue from a Windows controller with a Linux agent that connected without using websocket.  I suspect there is a user visible bug in Jenkins 2.558 due to this issue, but I was unable to find it.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Fix Windows null pointer exception due to Apache Ant 1.10.16 (regression in 2.558).

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers I'd appreciate a review of this pull request so that the regression is fixed in the next weekly release.

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->


### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
