### PR TITLE
Keep Duplicate Jenkins checker enabled after global config save

### DIFF
--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
@@ -39,7 +39,7 @@ f.section(title: _("Administrative monitors"), description: _("blurb")) {
                         f.checkbox(name: "administrativeMonitor",
                                 title: am.displayName,
                                 checked: am.enabled,
-                                json: am.id)
+                                json: am.@id)
                         if (am.isSecurity()) {
                             span(style: 'margin-left: 0.5rem', class: 'jenkins-badge', _("Security"))
                         }

--- a/test/src/test/java/jenkins/management/AdministrativeMonitorsConfigurationTest.java
+++ b/test/src/test/java/jenkins/management/AdministrativeMonitorsConfigurationTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Jenkins project contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.management;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import hudson.ExtensionList;
+import hudson.util.DoubleLaunchChecker;
+import org.htmlunit.html.HtmlForm;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class AdministrativeMonitorsConfigurationTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    @Issue("#26285")
+    @Test
+    void globalConfigurationRoundTripKeepsDoubleLaunchCheckerEnabled() throws Exception {
+        DoubleLaunchChecker monitor = ExtensionList.lookupSingleton(DoubleLaunchChecker.class);
+        assertThat(monitor.id, is(DoubleLaunchChecker.class.getName()));
+        assertThat(monitor.getId(), not(monitor.id));
+        assertThat(monitor.isEnabled(), is(true));
+
+        HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
+        j.submit(form);
+
+        assertThat(monitor.isEnabled(), is(true));
+    }
+}


### PR DESCRIPTION
Fixes #26285

The administrative monitor configuration page was serializing `am.id` from Groovy. For `DoubleLaunchChecker`, Groovy resolves that property through `getId()`, which returns the current process ID instead of the stable `AdministrativeMonitor.id` field. Saving the global configuration then disables the monitor because the submitted value does not match the persisted monitor ID.

This uses direct field access for the serialized monitor ID and adds a regression test for the global configuration round-trip.

### Testing done

```
JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH /tmp/apache-maven-3.9.6/bin/mvn -pl test -Dtest=jenkins.management.AdministrativeMonitorsConfigurationTest test
```

Also installed the required local `jenkins-core` and `jenkins-war` snapshots first with the documented quick-build profile because this environment only had Maven 3.8.7 on `PATH`:

```
JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH /tmp/apache-maven-3.9.6/bin/mvn '-Pquick-build,!yarn-execution,!yarn-lint,!yarn-ci-lint' -pl war,bom -am -rf :jenkins-core -DskipTests -Dspotbugs.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true install
```

### Screenshots (UI changes only)

N/A

#### Before

#### After

### Proposed changelog entries

- Keep the Duplicate Jenkins checker enabled when saving the global configuration (regression in 2.549).

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
