### PR TITLE
Make getLoadedBuilds not to copy all coreMap builds

### DIFF
--- a/core/src/main/java/hudson/model/RunMap.java
+++ b/core/src/main/java/hudson/model/RunMap.java
@@ -25,8 +25,6 @@
 package hudson.model;
 
 import static java.util.logging.Level.FINEST;
-import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.ASC;
-import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.DESC;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -40,7 +38,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.SortedMap;
 import java.util.function.IntPredicate;
@@ -120,32 +117,7 @@ public final class RunMap<R extends Run<?, R>> extends AbstractLazyLoadRunMap<R>
      */
     @Override
     public Iterator<R> iterator() {
-        return new Iterator<>() {
-            R last = null;
-            R next = newestBuild();
-
-            @Override
-            public boolean hasNext() {
-                return next != null;
-            }
-
-            @Override
-            public R next() {
-                last = next;
-                if (last != null)
-                    next = last.getPreviousBuild();
-                else
-                    throw new NoSuchElementException();
-                return last;
-            }
-
-            @Override
-            public void remove() {
-                if (last == null)
-                    throw new UnsupportedOperationException();
-                removeValue(last);
-            }
-        };
+        return values().iterator();
     }
 
     @Override
@@ -165,14 +137,14 @@ public final class RunMap<R extends Run<?, R>> extends AbstractLazyLoadRunMap<R>
      * This is the newest build (with the biggest build number)
      */
     public R newestValue() {
-        return search(Integer.MAX_VALUE, DESC);
+        return newestBuild();
     }
 
     /**
      * This is the oldest build (with the smallest build number)
      */
     public R oldestValue() {
-        return search(Integer.MIN_VALUE, ASC);
+        return oldestBuild();
     }
 
     /**

--- a/core/src/main/java/hudson/util/CopyOnWriteMap.java
+++ b/core/src/main/java/hudson/util/CopyOnWriteMap.java
@@ -172,16 +172,16 @@ public abstract class CopyOnWriteMap<K, V> implements Map<K, V> {
     }
 
     @Override public int hashCode() {
-        return copy().hashCode();
+        return core.hashCode();
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     @Override public boolean equals(Object obj) {
-        return copy().equals(obj);
+        return core.equals(obj);
     }
 
     @Override public String toString() {
-        return copy().toString();
+        return core.toString();
     }
 
     /**
@@ -198,6 +198,11 @@ public abstract class CopyOnWriteMap<K, V> implements Map<K, V> {
         @Override
         protected Map<K, V> copy() {
             return new LinkedHashMap<>(core);
+        }
+
+        @Override
+        public synchronized void replaceBy(Map<? extends K, ? extends V> data) {
+            update(new LinkedHashMap<>(data));
         }
 
         public static class ConverterImpl extends MapConverter {
@@ -226,14 +231,14 @@ public abstract class CopyOnWriteMap<K, V> implements Map<K, V> {
      * {@link CopyOnWriteMap} backed by {@link TreeMap}.
      */
     public static final class Tree<K, V> extends CopyOnWriteMap<K, V> implements NavigableMap<K, V> {
-        private final Comparator<K> comparator;
+        private final Comparator<? super K> comparator;
 
         public Tree(Map<K, V> core, Comparator<K> comparator) {
             this(comparator);
             putAll(core);
         }
 
-        public Tree(Comparator<K> comparator) {
+        public Tree(Comparator<? super K> comparator) {
             super(new TreeMap<>(comparator));
             this.comparator = comparator;
         }
@@ -252,6 +257,13 @@ public abstract class CopyOnWriteMap<K, V> implements Map<K, V> {
         @Override
         public synchronized void clear() {
             update(new TreeMap<>(comparator));
+        }
+
+        @Override
+        public synchronized void replaceBy(Map<? extends K, ? extends V> data) {
+            TreeMap<K, V> m = new TreeMap<>(comparator);
+            m.putAll(data);
+            update(m);
         }
 
         @Override

--- a/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
+++ b/core/src/main/java/jenkins/model/lazy/AbstractLazyLoadRunMap.java
@@ -24,10 +24,6 @@
 
 package jenkins.model.lazy;
 
-import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.ASC;
-import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.DESC;
-import static jenkins.model.lazy.AbstractLazyLoadRunMap.Direction.EXACT;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.Job;
 import hudson.model.Run;
@@ -40,6 +36,7 @@ import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
@@ -92,10 +89,14 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @since 1.485
  */
 public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> implements SortedMap<Integer, R> {
-    private final CopyOnWriteMap.Tree<Integer, BuildReference<R>> core = new CopyOnWriteMap.Tree<>(
-            Collections.reverseOrder());
-    private final BuildReferenceMapAdapter.Resolver<R> buildResolver = new BuildReferenceMapAdapterResolver();
-    private final BuildReferenceMapAdapter<R> adapter = new BuildReferenceMapAdapter<>(core, buildResolver) {
+    private final BuildTypeDescriptor buildTypeDescriptor = new BuildTypeDescriptor();
+    private final BuildReferenceMapAdapter.BuildReferenceResolver<R> loadedOnlyBuildRefResolver =
+            new LoadedOnlyBuildReferenceResolver<>();
+    private final BuildReferenceMapAdapter.BuildReferenceResolver<R> defaultBuildRefResolver =
+            new DefaultBuildReferenceResolver();
+    private final CopyOnWriteMap.Tree<Integer, BuildReference<R>> core = new CopyOnWriteMap.Tree<>(comparator());
+    private final BuildReferenceMapAdapter<R> adapter = new BuildReferenceMapAdapter<>(core, defaultBuildRefResolver,
+            buildTypeDescriptor) {
         @Override
         protected boolean removeValue(R value) {
             return AbstractLazyLoadRunMap.this.removeValue(value);
@@ -139,7 +140,8 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
     }
 
     /**
-     * @return true if {@link AbstractLazyLoadRunMap#AbstractLazyLoadRunMap} was called with a non-null param, or {@link RunMap#load(Job, RunMap.Constructor)} was called
+     * @return true if {@link AbstractLazyLoadRunMap#AbstractLazyLoadRunMap} was called with a non-null param,
+     * or {@link RunMap#load(Job, RunMap.Constructor)} was called
      */
     @Restricted(NoExternalUse.class)
     public final boolean baseDirInitialized() {
@@ -175,7 +177,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
             // the job may have just been created
             kids = MemoryReductionUtil.EMPTY_STRING_ARRAY;
         }
-        TreeMap<Integer, BuildReference<R>> newBuildRefsMap = new TreeMap<>();
+        TreeMap<Integer, BuildReference<R>> newBuildRefsMap = new TreeMap<>(core.comparator());
         var allower = createLoadAllower();
         for (String s : kids) {
             if (!BUILD_NUMBER.matcher(s).matches()) {
@@ -229,7 +231,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
 
     @Override
     public Comparator<? super Integer> comparator() {
-        return core.comparator();
+        return Collections.reverseOrder();
     }
 
     @Override
@@ -249,17 +251,17 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
 
     /**
      * Returns a read-only view of records that has already been loaded.
+     * <p>
+     * <b>Note:</b> Consider using {@link #streamLoadedBuilds()} instead of this method,
+     * as (like {@code size()}) method of the returned map is implemented
+     * inefficiently and may cause performance issues.
      */
     public SortedMap<Integer, R> getLoadedBuilds() {
-        TreeMap<Integer, R> res = new TreeMap<>(Comparator.reverseOrder());
-        streamLoadedBuilds().forEach(r -> res.put(getNumberOf(r), r));
-        return res;
+        return new ConsistentSizeBuildReferenceMapAdapter<>(core, loadedOnlyBuildRefResolver, buildTypeDescriptor);
     }
 
     /**
      * Returns a lazy stream of build objects, sorted by newest first, skipping GC builds
-     * Unlike {@link #getLoadedBuilds()}, this doesn't require copying the entire map
-     * @since TODO
      */
     public Stream<R> streamLoadedBuilds() {
         return core.values().stream()
@@ -299,11 +301,13 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
     }
 
     public R newestBuild() {
-        return search(Integer.MAX_VALUE, DESC);
+        Map.Entry<Integer, R> entry = adapter.firstEntry();
+        return entry == null ? null : entry.getValue();
     }
 
     public R oldestBuild() {
-        return search(Integer.MIN_VALUE, ASC);
+        Map.Entry<Integer, R> entry = adapter.lastEntry();
+        return entry == null ? null : entry.getValue();
     }
 
     @Override
@@ -339,15 +343,11 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
      *      If DESC, finds the closest #M that satisfies M ≤ N.
      */
     public @CheckForNull R search(final int n, final Direction d) {
-        if (d == EXACT) {
+        if (d == Direction.EXACT) {
             return this.adapter.get(n);
         }
-        // prepare sub map, where we need to find first resolvable entry
-        NavigableMap<Integer, BuildReference<R>> subCore = (d == ASC)
-                ? core.headMap(n, true).descendingMap()
-                : core.tailMap(n, true);
-        // wrap with BuildReferenceMapAdapter to skip unresolvable entries
-        return new BuildReferenceMapAdapter<>(subCore, buildResolver).values().stream().findFirst().orElse(null);
+        Map.Entry<Integer, R> entry = (d == Direction.ASC ? adapter.reversed() : adapter).tailMap(n).firstEntry();
+        return entry == null ? null : entry.getValue();
     }
 
     public R getById(String id) {
@@ -430,7 +430,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
 
     @Override
     public synchronized void putAll(Map<? extends Integer, ? extends R> newData) {
-        TreeMap<Integer, BuildReference<R>> newWrapperData = new TreeMap<>();
+        TreeMap<Integer, BuildReference<R>> newWrapperData = new TreeMap<>(core.comparator());
         for (Map.Entry<? extends Integer, ? extends R> entry : newData.entrySet()) {
             newWrapperData.put(entry.getKey(), createReference(entry.getValue()));
         }
@@ -508,7 +508,7 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
      * Replaces all the current loaded Rs with the given ones.
      */
     public synchronized void reset(Map<Integer, R> builds) {
-        TreeMap<Integer, BuildReference<R>> copy = new TreeMap<>();
+        TreeMap<Integer, BuildReference<R>> copy = new TreeMap<>(core.comparator());
         for (R r : builds.values()) {
             copy.put(getNumberOf(r), createReference(r));
         }
@@ -530,12 +530,38 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
         ASC, DESC, EXACT
     }
 
-    private class BuildReferenceMapAdapterResolver implements BuildReferenceMapAdapter.Resolver<R> {
+    /**
+     * Default implementation of {@link BuildReferenceMapAdapter.BuildReferenceResolver} that handles
+     * reference resolution for {@link AbstractLazyLoadRunMap}.
+     */
+    private final class DefaultBuildReferenceResolver implements BuildReferenceMapAdapter.BuildReferenceResolver<R> {
+        /**
+         * Returns the build already loaded into memory if it exists;
+         * otherwise, loads it from the disk.
+         *
+         * @param buildRef the build reference to resolve
+         * @return the resolved build instance, or {@code null} if it cannot be found
+         */
         @Override
         public R resolveBuildRef(BuildReference<R> buildRef) {
             return AbstractLazyLoadRunMap.this.resolveBuildRef(buildRef);
         }
 
+        /**
+         * Checks if the reference can be resolved. If the reference was already resolved,
+         * returns the cached status. Otherwise, attempts to resolve it and returns the result.
+         *
+         * @param buildRef the reference to check
+         * @return {@code true} if the reference points to a valid build
+         */
+        @Override
+        public boolean isBuildRefResolvable(BuildReference<R> buildRef) {
+            return buildRef != null &&
+                    (buildRef.isSet() ? !buildRef.isUnloadable() : this.resolveBuildRef(buildRef) != null);
+        }
+    }
+
+    private final class BuildTypeDescriptor implements BuildReferenceMapAdapter.BuildTypeDescriptor<R> {
         @Override
         public Integer getNumberOf(R build) {
             return AbstractLazyLoadRunMap.this.getNumberOf(build);
@@ -544,6 +570,57 @@ public abstract class AbstractLazyLoadRunMap<R> extends AbstractMap<Integer, R> 
         @Override
         public Class<R> getBuildClass() {
             return AbstractLazyLoadRunMap.this.getBuildClass();
+        }
+    }
+
+    /**
+     * An implementation of {@link BuildReferenceMapAdapter.BuildReferenceResolver} that does not
+     * perform disk loading and only uses values already loaded into memory.
+     */
+    private static final class LoadedOnlyBuildReferenceResolver<R>
+            implements BuildReferenceMapAdapter.BuildReferenceResolver<R> {
+        @Override
+        public R resolveBuildRef(BuildReference<R> buildRef) {
+            return buildRef == null ? null : buildRef.get();
+        }
+
+        @Override
+        public boolean isBuildRefResolvable(BuildReference<R> buildRef) {
+            return resolveBuildRef(buildRef) != null;
+        }
+    }
+
+    /**
+     * An implementation of {@link BuildReferenceMapAdapter} that provides a precise
+     * {@link #size()} implementation by iterating over all entries.
+     * <p>
+     * Unlike {@link BuildReferenceMapAdapter}, this version ensures that only valid,
+     * resolvable entries are counted.
+     */
+    private static class ConsistentSizeBuildReferenceMapAdapter<R> extends BuildReferenceMapAdapter<R> {
+        ConsistentSizeBuildReferenceMapAdapter(NavigableMap<Integer, BuildReference<R>> core,
+                                               BuildReferenceResolver<R> resolver,
+                                               BuildTypeDescriptor<R> typeDescriptor) {
+            super(core, resolver, typeDescriptor);
+        }
+
+        @Override
+        protected ConsistentSizeBuildReferenceMapAdapter<R> createInstance(
+                NavigableMap<Integer, BuildReference<R>> core) {
+            return new ConsistentSizeBuildReferenceMapAdapter<>(core, resolver, typeDescriptor);
+        }
+
+        /**
+         * Avoid using this method as it performs a full collection scan and can be very slow for large maps.
+         * Suitable for tests only.
+         */
+        @Override
+        public int size() {
+            int count = 0;
+            for (Iterator<?> iter = super.entrySet().iterator(); iter.hasNext(); iter.next()) {
+                count++;
+            }
+            return count;
         }
     }
 

--- a/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
+++ b/core/src/main/java/jenkins/model/lazy/BuildReferenceMapAdapter.java
@@ -22,7 +22,7 @@ import java.util.function.IntConsumer;
  * Take {@code SortedMap<Integer,BuildReference<R>>} and make it look like {@code SortedMap<Integer,R>}.
  *
  * <p>
- * When {@link BuildReference} lost the build object, we'll use {@link Resolver} to obtain one.
+ * When {@link BuildReference} lost the build object, we'll use {@link BuildReferenceResolver} to obtain one.
  * </p>
  *
  * <p>
@@ -43,17 +43,21 @@ import java.util.function.IntConsumer;
  *
  * @author Kohsuke Kawaguchi
  */
-class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements SortedMap<Integer, R> {
-    private final NavigableMap<Integer, BuildReference<R>> core;
-    private final Resolver<R> resolver;
+class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R>
+        implements SortedMap<Integer, R> {
+    protected final NavigableMap<Integer, BuildReference<R>> core;
+    protected final BuildReferenceResolver<R> resolver;
+    protected final BuildTypeDescriptor<R>  typeDescriptor;
 
     private final Set<Integer> keySet = new KeySetAdapter();
     private final Collection<R> values = new ValuesAdapter();
     private final Set<Map.Entry<Integer, R>> entrySet = new EntrySetAdapter();
 
-    BuildReferenceMapAdapter(NavigableMap<Integer, BuildReference<R>> core, Resolver<R> resolver) {
+    BuildReferenceMapAdapter(NavigableMap<Integer, BuildReference<R>> core, BuildReferenceResolver<R> resolver,
+                             BuildTypeDescriptor<R> typeDescriptor) {
         this.core = core;
         this.resolver = resolver;
+        this.typeDescriptor = typeDescriptor;
     }
 
     @Override
@@ -63,17 +67,22 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
 
     @Override
     public SortedMap<Integer, R> subMap(Integer fromKey, Integer toKey) {
-        return new BuildReferenceMapAdapter<>(core.subMap(fromKey, true, toKey, false), resolver);
+        return createInstance(core.subMap(fromKey, true, toKey, false));
     }
 
     @Override
     public SortedMap<Integer, R> headMap(Integer toKey) {
-        return new BuildReferenceMapAdapter<>(core.headMap(toKey, false), resolver);
+        return createInstance(core.headMap(toKey, false));
     }
 
     @Override
     public SortedMap<Integer, R> tailMap(Integer fromKey) {
-        return new BuildReferenceMapAdapter<>(core.tailMap(fromKey, true), resolver);
+        return createInstance(core.tailMap(fromKey, true));
+    }
+
+    @Override
+    public SortedMap<Integer, R> reversed() {
+        return createInstance(core.descendingMap());
     }
 
     @Override
@@ -83,7 +92,7 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
 
     @Override
     public Integer lastKey() {
-        return new BuildReferenceMapAdapter<>(core.descendingMap(), resolver).firstKey();
+        return reversed().firstKey();
     }
 
     @Override
@@ -102,30 +111,27 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
     }
 
     @Override
+    public int size() {
+        return core.size();
+    }
+
+    @Override
     public boolean isEmpty() {
-        return entrySet().isEmpty();
+        return entrySet().stream().findFirst().isEmpty();
     }
 
     @Override
     public boolean containsKey(Object key) {
-        BuildReference<R> ref = key instanceof Integer ? core.get(key) : null;
-        if (ref == null) {
-            return false;
-        }
-        // if found, check if value is loadable
-        if (!ref.isSet()) {
-            resolver.resolveBuildRef(ref);
-        }
-        return !ref.isUnloadable();
+        return resolver.isBuildRefResolvable(key instanceof Integer ? core.get(key) : null);
     }
 
     @Override
     public boolean containsValue(Object value) {
-        if (!resolver.getBuildClass().isInstance(value)) {
+        if (!typeDescriptor.getBuildClass().isInstance(value)) {
             return false;
         }
-        R val = resolver.getBuildClass().cast(value);
-        return val.equals(get(resolver.getNumberOf(val)));
+        R val = typeDescriptor.getBuildClass().cast(value);
+        return val.equals(get(typeDescriptor.getNumberOf(val)));
     }
 
     @Override
@@ -140,6 +146,10 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
             return null;
         }
         return removeValue(val) ? val : null;
+    }
+
+    protected BuildReferenceMapAdapter<R> createInstance(NavigableMap<Integer, BuildReference<R>> coreMap) {
+        return new BuildReferenceMapAdapter<>(coreMap, resolver, typeDescriptor);
     }
 
     protected boolean removeValue(R value) {
@@ -172,16 +182,7 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
             return Iterators.removeNull(Iterators.map(
                     BuildReferenceMapAdapter.this.core.entrySet().iterator(), coreEntry -> {
                         BuildReference<R> ref = coreEntry.getValue();
-                        if (!ref.isSet()) {
-                            R r = resolver.resolveBuildRef(ref);
-                            if (r == null) {
-                                return null;
-                            }
-                        }
-                        if (ref.isUnloadable()) {
-                            return null;
-                        }
-                        return ref.number;
+                        return resolver.isBuildRefResolvable(ref) ? ref.number : null;
                     }));
         }
 
@@ -227,8 +228,8 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
 
         @Override
         public boolean remove(Object o) {
-            return resolver.getBuildClass().isInstance(o) &&
-                    BuildReferenceMapAdapter.this.removeValue(resolver.getBuildClass().cast(o));
+            return typeDescriptor.getBuildClass().isInstance(o) &&
+                    BuildReferenceMapAdapter.this.removeValue(typeDescriptor.getBuildClass().cast(o));
         }
 
         @Override
@@ -250,12 +251,12 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
     private class EntrySetAdapter extends AbstractSet<Map.Entry<Integer, R>> {
         @Override
         public int size() {
-            return BuildReferenceMapAdapter.this.core.size();
+            return BuildReferenceMapAdapter.this.size();
         }
 
         @Override
         public boolean isEmpty() {
-            return this.stream().findFirst().isEmpty();
+            return BuildReferenceMapAdapter.this.isEmpty();
         }
 
         @Override
@@ -269,8 +270,8 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
         @Override
         public boolean remove(Object o) {
             if (o instanceof Map.Entry<?, ?> e) {
-                return resolver.getBuildClass().isInstance(e.getValue()) &&
-                        BuildReferenceMapAdapter.this.removeValue(resolver.getBuildClass().cast(e.getValue()));
+                return typeDescriptor.getBuildClass().isInstance(e.getValue()) &&
+                        BuildReferenceMapAdapter.this.removeValue(typeDescriptor.getBuildClass().cast(e.getValue()));
             }
             return false;
         }
@@ -314,12 +315,12 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
 
     /**
      * An interface for resolving build references into actual build instances
-     * and extracting basic metadata from them.
      **/
-    public interface Resolver<R> {
-
+    interface BuildReferenceResolver<R> {
         /**
          * Resolves the given build reference into an actual build instance.
+         * This method is used by {@link BuildReferenceMapAdapter} for operations
+         * that return map values or entries.
          *
          * @param buildRef the reference to a build to resolve, can be {@code null}
          * @return the resolved build instance, or {@code null} if the reference is {@code null}
@@ -327,6 +328,27 @@ class BuildReferenceMapAdapter<R> extends AbstractMap<Integer, R> implements Sor
          */
         R resolveBuildRef(BuildReference<R> buildRef);
 
+        /**
+         * Checks whether the given build reference can be resolved to a non-null build instance.
+         * This method is used by {@link BuildReferenceMapAdapter} to determine whether a key
+         * effectively exists in the map.
+         *
+         * <p>This method may be weakly consistent with {@link #resolveBuildRef(BuildReference)}.
+         * However, the following guarantee must hold:
+         * if this method returns {@code false}, then {@link #resolveBuildRef(BuildReference)}
+         * must return {@code null} for the same reference.</p>
+         *
+         * @param buildRef the reference to a build, may be {@code null}
+         * @return {@code true} if the reference can be resolved to a non-null build instance,
+         *         {@code false} otherwise
+         */
+        boolean isBuildRefResolvable(BuildReference<R> buildRef);
+    }
+
+    /**
+     * An interface for extracting basic metadata from the build instance.
+     **/
+    interface BuildTypeDescriptor<R> {
         /**
          * Returns the build number associated with the given build instance.
          *

--- a/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
+++ b/core/src/main/java/jenkins/model/lazy/LazyBuildMixIn.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.logging.Level;
@@ -130,11 +131,11 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
             TreeMap<Integer, RunT> stillBuildingBuilds = new TreeMap<>();
             for (RunT r : currentBuilds.getLoadedBuilds().values()) {
                 if (r.isBuilding()) {
-                    // Do not use RunMap.put(Run):
                     stillBuildingBuilds.put(r.getNumber(), r);
                     LOGGER.log(Level.FINE, "keeping reloaded {0}", r);
                 }
             }
+            // Do not use RunMap.put(Run) here, as it may trigger resolution of the replacing BuildReference.
             _builds.putAll(stillBuildingBuilds);
         }
         this.builds = _builds;
@@ -273,23 +274,27 @@ public abstract class LazyBuildMixIn<JobT extends Job<JobT, RunT> & Queue.Task &
      * @since 2.407
      */
     public List<RunT> getEstimatedDurationCandidates() {
-        List<RunT> candidates = new ArrayList<>(3);
-        for (Result threshold : List.of(Result.UNSTABLE, Result.FAILURE)) {
-            for (RunT build : (Iterable<RunT>) builds.streamLoadedBuilds()::iterator) {
-                if (candidates.contains(build)) {
-                    continue;
-                }
-                if (!build.isBuilding()) {
-                    Result result = build.getResult();
-                    if (result != null && result.isBetterOrEqualTo(threshold)) {
+        final int desiredCandidatesSize = 3;
+        List<RunT> candidates = new ArrayList<>(desiredCandidatesSize);
+        List<RunT> failureCandidates = new ArrayList<>(desiredCandidatesSize);
+        Iterator<RunT> it = builds.streamLoadedBuilds().iterator();
+        while (it.hasNext() && candidates.size() < desiredCandidatesSize) {
+            RunT build = it.next();
+            if (!build.isBuilding()) {
+                Result result = build.getResult();
+                if (result != null) {
+                    if (result.isBetterOrEqualTo(Result.UNSTABLE)) {
                         candidates.add(build);
-                        if (candidates.size() == 3) {
-                            LOGGER.fine(() -> "Candidates: " + candidates);
-                            return candidates;
-                        }
+                    } else if (result.isBetterOrEqualTo(Result.FAILURE)
+                            && failureCandidates.size() < desiredCandidatesSize) {
+                        failureCandidates.add(build);
                     }
                 }
             }
+        }
+        it = failureCandidates.iterator();
+        while (candidates.size() < desiredCandidatesSize && it.hasNext()) {
+            candidates.add(it.next());
         }
         LOGGER.fine(() -> "Candidates: " + candidates);
         return candidates;


### PR DESCRIPTION
Related to [https://github.com/jenkinsci/jenkins/issues/26596](https://github.com/jenkinsci/jenkins/issues/26596)

This change refactors `getLoadedBuilds()` to return a `BuildReferenceMapAdapter` backed by the existing `core` map with a `LoadedOnlyBuildReferenceResolver` that only returns builds already loaded into memory, without triggering disk loads. This avoids the unnecessary copy and allocation.

As part of this refactoring:
- Extracted `BuildReferenceResolver` interface from the inner `Resolver` interface in `BuildReferenceMapAdapter`, separating build reference resolution logic from build metadata (`BuildTypeDescriptor`)
- Introduced `LoadedOnlyBuildReferenceResolver` — resolves only in-memory references, used by `getLoadedBuilds()`
- Introduced `DefaultBuildReferenceResolver` — resolves references with disk loading fallback, used by all other operations

### Testing done
Manual testing done on local environment, Jenkins PR automated testing done

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Avoid unnecessary copy of all loaded builds in `AbstractLazyLoadRunMap.getLoadedBuilds()`.

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jglick @timja @bennettzhu1


Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
