### PR TITLE
fix: restore cancel button on build log page

### DIFF
--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -33,9 +33,11 @@ THE SOFTWARE.
     <j:arg value="${it}"/>
   </j:new>
 
+  <l:userExperimentalFlag var="newBuildPage" flagClassName="jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag" />
+
   <l:run-subpage>
     <l:app-bar title="${%Console}">
-      <j:if test="${it.object.building}">
+      <j:if test="${!newBuildPage and it.object.building}">
         <div class="build-caption-progress-container">
           ${%Progress}:
           <t:buildProgressBar build="${it.object}" animate="true"/>

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -28,13 +28,24 @@ THE SOFTWARE.
   Displays the console output
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
   <j:new className="jenkins.run.ConsoleTab" var="it">
     <j:arg value="${it}"/>
   </j:new>
 
   <l:run-subpage>
     <l:app-bar title="${%Console}">
+      <j:if test="${it.object.building}">
+        <div class="build-caption-progress-container">
+          ${%Progress}:
+          <t:buildProgressBar build="${it.object}" animate="true"/>
+          <j:if test="${it.object.parent.hasAbortPermission()}">
+            <l:stopButton href="${rootURL}/${it.object.url}stop"
+                          confirm="${%confirm(it.object.fullDisplayName)}"
+                          alt="${%cancel}"/>
+          </j:if>
+        </div>
+      </j:if>
       <a class="jenkins-button" href="consoleText" download="${it.object.displayName}.txt">
         <l:icon src="symbol-download" />
         ${%Download}

--- a/core/src/main/resources/hudson/model/Run/console.properties
+++ b/core/src/main/resources/hudson/model/Run/console.properties
@@ -21,3 +21,6 @@
 # THE SOFTWARE.
 
 skipSome=Skipping {0,number,integer} KB.. <a href="{1}">Full Log</a>
+Progress=Progress
+confirm=Are you sure you want to abort {0}?
+cancel=Cancel


### PR DESCRIPTION
# Fixes #26635

## Problem

As reported by @daniel-beck, it is no longer possible to cancel a running build directly from its Console Output page. The typical workflow — see something going wrong in the log, cancel the build, then stay on the log to verify the cancellation took effect — is broken. Users have to navigate away from the log to find a cancel button, which costs several seconds and loses the live log view.

## Root cause

`core/src/main/resources/hudson/model/Run/console.jelly` wraps its content in `<l:run-subpage>` with an inline `<l:app-bar title="${%Console}">` that only contains the Download, Copy, and View as plain text buttons. There is no progress indicator or stop button, so while a build is running, the Console Output page has no way to abort it.

For comparison, the legacy build index page at `core/src/main/resources/hudson/model/Run/index.jelly` uses `<t:buildCaption>`, which renders a `Progress: [bar] [stop-button]` block while `it.building` is true. That same UX used to be present on the Console Output page in earlier Jenkins versions (verified against 2.528.1, where the red stop button is visible at the top-right of the Console Output page while a build runs).

## Fix

Added the same `Progress + Cancel` block to `console.jelly`'s `<l:app-bar>`, gated by `it.object.building` and `it.object.parent.hasAbortPermission()`, mirroring the existing `buildCaption.jelly` pattern. The block renders as a sibling of the existing Download / Copy / View as plain text buttons, so when a build finishes it disappears and the remaining buttons stay in place.

Also added the three new i18n keys (`Progress`, `confirm`, `cancel`) to `console.properties`.

## Why reuse the existing components

`<t:buildProgressBar>` and `<l:stopButton>` are already the canonical Jenkins components for this UX and are still used by `buildCaption.jelly` on the build index page. Reusing them keeps the Console Output page visually consistent with the rest of the build UI and inherits existing styling, tooltips, and confirmation dialog behavior.

### Testing done

Manually tested in a local dev instance (`mvn -pl war jetty:run` on a clean master build, then applied the fix):

1. Built `mvn -am -pl war,bom -Pquick-build clean install` — **BUILD SUCCESS**
2. `mvn spotless:check -pl core` — **PASSED**
3. Created a Freestyle project running a long-running batch command (`ping -n 120 127.0.0.1 > nul`) and clicked **Build Now**
4. Navigated to the build's **Console Output** page while the build was running — the `Progress: [bar] [red X]` block now appears at the top-right of the page
5. Clicked the red X — a confirmation dialog appears ("Are you sure you want to abort…"), and confirming stops the build, with the Console Output page immediately updating to reflect the cancelled state
6. Verified the Progress/Cancel block is **not** shown for finished builds (only renders when `it.building` is true)
7. Verified the block is **not** shown to users without `ABORT` permission (gated by `hasAbortPermission()`, matching `buildCaption.jelly`)
8. Stashed the change, reloaded the Console Output page for a running build, and confirmed the Cancel button was absent (reproducing the bug). Restored the change and reloaded, and confirmed the Cancel button reappeared.

No automated test added because this is a pure Jelly/resource change with no Java logic to unit-test; the existing `<l:stopButton>` and `<t:buildProgressBar>` components are already covered by their own usages and any regression in the stop endpoint itself would be caught by existing build-cancellation tests.

### Screenshots (UI changes only)

#### Before

<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/b02cf339-8855-49f4-a0cb-f5d5b9defc4b" />


#### After

<img width="1919" height="968" alt="image" src="https://github.com/user-attachments/assets/ff6e7fd1-03a9-4365-9ba1-892f1eda08cf" />

### Proposed changelog entries

- Restore the Cancel button on the Console Output page of running builds so users can abort a build without leaving the log view.

### Proposed changelog category

/label regression-fix,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@daniel-beck @janfaracik

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
