### PR TITLE
Fix agent connected message showing when temporarily offline

### DIFF
--- a/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -103,10 +103,10 @@ ${copy_java_cmd_secret2_windows}
           </p>
       </j:if>
     </j:when>
-    <j:otherwise>
+    <j:when test="${!it.offline}">
       <p>
         ${%slaveAgent.connected}
       </p>
-    </j:otherwise>
+    </j:when>
   </j:choose>
 </j:jelly>


### PR DESCRIPTION
Fixes #26661

When an agent is marked temporarily offline, the UI incorrectly shows 
"Agent is connected." alongside the "Disconnected by admin" banner, 
which is contradictory and confusing to users.

The issue is in `JNLPLauncher/main.jelly` where `<j:otherwise>` was 
used as a catch-all, causing the connected message to appear even when 
the node was temporarily offline but the channel was still alive.

Fixed by replacing `<j:otherwise>` with `<j:when test="${!it.offline}">` 
so the message only appears when the agent is genuinely online.

### Testing done

Reproduced manually on Jenkins 2.555.1 on Windows:
1. Created a permanent agent and connected it via WebSocket
2. Clicked "Mark this node temporarily offline"
3. Before fix: page showed both "Disconnected by admin" AND "Agent is connected." simultaneously
4. After fix: only "Disconnected by admin" banner shows — no contradiction

### Screenshots (UI changes only)

#### Before
<img width="1899" height="585" alt="before" src="https://github.com/user-attachments/assets/ae8b52e8-1de3-4b8c-9daf-87c9528e2048" />

#### After
<img width="1904" height="683" alt="Screenshot 2026-04-18 233743" src="https://github.com/user-attachments/assets/ac66101a-7576-428d-a401-66ac9d58dbc5" />

### Proposed changelog entries
- Do not show "Agent is connected" message when node is marked temporarily offline

### Proposed changelog category
/label bug, web-ui

### Proposed upgrade guidelines
N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
@jenkinsci/core-pr-reviewers
Fixes #26661

When an agent is marked temporarily offline, the UI incorrectly shows 
"Agent is connected." alongside the "Disconnected by admin" banner, 
which is contradictory and confusing to users.

The issue is in `JNLPLauncher/main.jelly` where `<j:otherwise>` was 
used as a catch-all, causing the connected message to appear even when 
the node was temporarily offline but the channel was still alive.

Fixed by replacing `<j:otherwise>` with `<j:when test="${!it.offline}">` 
so the message only appears when the agent is genuinely online.

### Testing done

Reproduced manually on Jenkins 2.555.1 on Windows:
1. Created a permanent agent and connected it via WebSocket
2. Clicked "Mark this node temporarily offline"
3. Before fix: page showed both "Disconnected by admin" AND "Agent is connected." simultaneously
4. After fix: only "Disconnected by admin" banner shows — no contradiction

### Screenshots (UI changes only)

#### Before
<img width="1899" height="585" alt="before" src="https://github.com/user-attachments/assets/ae8b52e8-1de3-4b8c-9daf-87c9528e2048" />

#### After
<img width="1904" height="683" alt="Screenshot 2026-04-18 233743" src="https://github.com/user-attachments/assets/ac66101a-7576-428d-a401-66ac9d58dbc5" />

### Proposed changelog entries
- Do not show "Agent is connected" message when node is marked temporarily offline

### Proposed changelog category
/label bug, web-ui

### Proposed upgrade guidelines
N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
@jenkinsci/core-pr-reviewers