### PR TITLE
[JENKINS-68443] Fix IndexOutOfBoundsException in doUploadPluginImpl

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1924,14 +1924,29 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
             File tmpDir = Files.createTempDirectory("uploadDir").toFile();
             JakartaServletFileUpload<DiskFileItem, DiskFileItemFactory> upload = new JakartaServletDiskFileUpload(DiskFileItemFactory.builder().setFile(tmpDir).get());
             List<DiskFileItem> items = upload.parseRequest(req);
-            String string = items.get(1).getString();
+            // Locate parts by field name rather than by positional index.
+            // Relying on index was fragile: servlet filters (e.g. CSRF protection)
+            // may consume or reorder the multipart stream before this point, causing
+            // an IndexOutOfBoundsException when the expected part is absent.
+            // See: https://issues.jenkins.io/browse/JENKINS-68443
+            DiskFileItem pluginUrlItem = items.stream()
+                    .filter(item -> "pluginUrl".equals(item.getFieldName()))
+                    .findFirst()
+                    .orElse(null);
+            String string = pluginUrlItem != null ? pluginUrlItem.getString() : null;
             if (string != null && !string.isBlank()) {
                 // this is a URL deployment
                 fileName = string;
                 copier = new UrlPluginCopier(fileName);
             } else {
                 // this is a file upload
-                FileItem fileItem = items.getFirst();
+                FileItem fileItem = items.stream()
+                        .filter(item -> "name".equals(item.getFieldName()))
+                        .findFirst()
+                        .orElse(null);
+                if (fileItem == null) {
+                    return new HttpRedirect("advanced");
+                }
                 fileName = Util.getFileName(fileItem.getName());
                 copier = new FileUploadPluginCopier(fileItem);
             }


### PR DESCRIPTION
## Summary

Fixes #18039 / [JENKINS-68443](https://issues.jenkins.io/browse/JENKINS-68443)

## Problem

`doUploadPluginImpl` locates multipart parts by **positional index**:

```java
String string = items.get(1).getString();   // assumes pluginUrl is always at index 1
FileItem fileItem = items.getFirst();        // assumes uploaded file is always at index 0
```

When a servlet filter reads (or partially consumes) the multipart request body before `doUploadPluginImpl` runs — for example, when `CrumbFilter.extractCrumbFromRequest()` calls `request.getParameterNames()`, triggering the servlet container's multipart pre-parsing — `upload.parseRequest(req)` returns fewer parts than expected. The positional `get(1)` call throws `IndexOutOfBoundsException`, which surfaces as an HTTP 500 that is silently swallowed and redirected to `/advanced`, leaving the user with no error message and a cleared file input.

This bug was introduced in Jenkins 2.320 with the \"upload plugin via URL\" feature (PR #5862 / JENKINS-4814) and affects all subsequent releases including 2.541.x.

A related report ([jenkinsci/jenkins#18039](https://github.com/jenkinsci/jenkins/issues/18039)) was filed in 2022 and closed in December 2025 without a fix.

## Root Cause

The implicit assumption that multipart parts always arrive in a fixed order is not guaranteed by the Servlet spec, and is actively broken by any filter that reads from the multipart body before the manager does.

## Fix

Replace both positional lookups with stream-based **field-name** lookups, which are order-independent and robust to any part being absent:

```java
// Locate pluginUrl by name, not by index
DiskFileItem pluginUrlItem = items.stream()
        .filter(item -> "pluginUrl".equals(item.getFieldName()))
        .findFirst()
        .orElse(null);
String string = pluginUrlItem != null ? pluginUrlItem.getString() : null;

// Locate the file upload part by name, not by getFirst()
FileItem fileItem = items.stream()
        .filter(item -> "name".equals(item.getFieldName()))
        .findFirst()
        .orElse(null);
if (fileItem == null) {
    return new HttpRedirect("advanced");
}
```

## Testing

Existing tests (`uploadJpi`, `uploadHpi`, `deployJpiFromUrl` in `PluginManagerTest`) continue to validate the happy paths. The fix is a purely defensive lookup change; no test infrastructure changes are needed.

## Reproduction

Observed on Jenkins 2.541.2 (Jetty EE9 / Java 21) with the Jenkins SSO plugin in place (a `CrumbFilter` variant that calls `request.getParameterNames()` during CSRF validation). Stack trace excerpt:

```
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
  at java.base/java.util.Objects.checkIndex(Objects.java:372)
  at java.base/java.util.ArrayList.get(ArrayList.java:459)
  at hudson.PluginManager.doUploadPluginImpl(PluginManager.java:1927)
```