### PR TITLE
Stabilize Enabled-column sorting states in plugin manager

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/_table.js
+++ b/core/src/main/resources/hudson/PluginManager/_table.js
@@ -191,6 +191,22 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
       pluginTR.classList.remove("has-disabled-dependency");
     }
 
+    function updateEnabledStateSortValue(pluginTR) {
+      var pluginMetadata = pluginTR.jenkinsPluginMetadata;
+      var enableTD = pluginMetadata.enableTD;
+      var sortValue = "2";
+
+      if (pluginMetadata.enableInput.checked) {
+        sortValue =
+          pluginTR.classList.contains("has-dependents") &&
+          !pluginTR.classList.contains("all-dependents-disabled")
+            ? "1"
+            : "0";
+      }
+
+      enableTD.setAttribute("data", sortValue);
+    }
+
     function setEnableWidgetStates() {
       for (var i = 0; i < pluginTRs.length; i++) {
         var pluginMetadata = pluginTRs[i].jenkinsPluginMetadata;
@@ -201,6 +217,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
         }
         markAllDependentsDisabled(pluginTRs[i]);
         markHasDisabledDependencies(pluginTRs[i]);
+        updateEnabledStateSortValue(pluginTRs[i]);
       }
     }
 
@@ -367,6 +384,7 @@ Behaviour.specify("#filter-box", "_table", 0, function (e) {
         enableInput: enableInput,
         dependenciesDiv: dependenciesDiv,
         dependentsDiv: dependentsDiv,
+        enableTD: enableTD,
       };
 
       if (dependenciesDiv) {

--- a/test/src/test/java/hudson/PluginManagerInstalledGUITest.java
+++ b/test/src/test/java/hudson/PluginManagerInstalledGUITest.java
@@ -83,12 +83,14 @@ class PluginManagerInstalledGUITest {
             // because no other plugins depend on it.
             mandatoryDependerPlugin.assertEnabled();
             mandatoryDependerPlugin.assertEnabledStateChangeable();
+            mandatoryDependerPlugin.assertEnabledSortValue("0");
             mandatoryDependerPlugin.assertUninstallable();
 
             // This plugin should be enabled, but it should not be possible to disable or uninstall it
             // because another plugin depends on it.
             dependeePlugin.assertEnabled();
             dependeePlugin.assertEnabledStateNotChangeable();
+            dependeePlugin.assertEnabledSortValue("1");
             dependeePlugin.assertNotUninstallable();
 
             // Disable one plugin
@@ -98,6 +100,7 @@ class PluginManagerInstalledGUITest {
             // and it should still be uninstallable.
             mandatoryDependerPlugin.assertNotEnabled(); // this is different to earlier
             mandatoryDependerPlugin.assertEnabledStateChangeable();
+            mandatoryDependerPlugin.assertEnabledSortValue("2");
             mandatoryDependerPlugin.assertUninstallable();
 
             // The dependee plugin should still be enabled, but it should now be possible to disable it because
@@ -105,6 +108,7 @@ class PluginManagerInstalledGUITest {
             // Note that the depender plugin does not block its disablement.
             dependeePlugin.assertEnabled();
             dependeePlugin.assertEnabledStateChangeable(); // this is different to earlier
+            dependeePlugin.assertEnabledSortValue("0");
             dependeePlugin.assertNotUninstallable();
             dependerPlugin.assertEnabled();
 
@@ -115,16 +119,19 @@ class PluginManagerInstalledGUITest {
             // of the plugins it depends on is not enabled.
             mandatoryDependerPlugin.assertNotEnabled();
             mandatoryDependerPlugin.assertEnabledStateNotChangeable();  // this is different to earlier
+            mandatoryDependerPlugin.assertEnabledSortValue("2");
             mandatoryDependerPlugin.assertUninstallable();
             dependerPlugin.assertEnabled();
 
             // You can disable a detached plugin if there is no explicit dependency on it.
             matrixAuthPlugin.assertEnabled();
             matrixAuthPlugin.assertEnabledStateChangeable();
+            matrixAuthPlugin.assertEnabledSortValue("0");
             matrixAuthPlugin.assertUninstallable();
             matrixAuthPlugin.clickEnabledWidget();
             matrixAuthPlugin.assertNotEnabled();
             matrixAuthPlugin.assertEnabledStateChangeable();
+            matrixAuthPlugin.assertEnabledSortValue("2");
             matrixAuthPlugin.assertUninstallable();
         });
     }
@@ -186,6 +193,10 @@ class PluginManagerInstalledGUITest {
             return (HtmlInput) input;
         }
 
+        private String getEnableSortValue() {
+            return pluginRow.getCells().get(hasHealth ? 2 : 1).getAttribute("data");
+        }
+
         public void assertEnabled() {
             HtmlInput enableWidget = getEnableWidget();
             assertTrue(enableWidget.isChecked(), "Plugin '" + getId() + "' is expected to be enabled.");
@@ -199,6 +210,13 @@ class PluginManagerInstalledGUITest {
         public void clickEnabledWidget() throws IOException {
             HtmlInput enableWidget = getEnableWidget();
             HtmlElementUtil.click(enableWidget);
+        }
+
+        public void assertEnabledSortValue(String expectedSortValue) {
+            String actualSortValue = getEnableSortValue();
+            assertTrue(
+                    expectedSortValue.equals(actualSortValue),
+                    "Plugin '" + getId() + "' has unexpected enabled sort value. Expected: " + expectedSortValue + ", actual: " + actualSortValue);
         }
 
         public void assertEnabledStateChangeable() {


### PR DESCRIPTION
Fixes #20694 

### Summary

Introduce a deterministic three-state numeric sort value for the **Installed plugins → Enabled** column.  
The sorting now consistently distinguishes between:

- Enabled (changeable)
- Enabled (blocked due to dependencies)
- Disabled

Additionally, GUI test assertions have been added to validate correct sort-value transitions when plugin states change due to dependency enable/disable actions.

---

### Testing done

- Manually verified sorting behavior in the Installed Plugins table:
  - Confirmed correct ordering across all three states.
  - Triggered dependency-based enable/disable flows and verified that sort values update accordingly.
- Added GUI test assertions to:
  - Validate correct numeric sort values for each state.
  - Ensure transitions occur correctly when plugin dependencies affect enablement.
- Confirmed no regression in existing plugin manager UI behavior.



### Proposed changelog entries

- Ensure deterministic sorting in Installed plugins Enabled column using three-state numeric values  
- Add GUI test coverage for dependency-driven enable/disable sort transitions  

---

### Proposed changelog category

/label rfe,web-ui

---

### Proposed upgrade guidelines

N/A

---

### Submitter checklist

- [ ] The issue, if it exists, is well-described.  
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.  
- [ ] There is automated testing or an explanation as to why this change has no tests.  
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.  
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.  
- [ ] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.  
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.  
- [ ] For new APIs and extension points, there is a link to at least one consumer.  

---

### Desired reviewers

@mention  

---

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.  
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.  
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.  
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.  
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.  
- [ ] If it would make sense to backport the change to LTS, ensure it is labeled as `lts-candidate`.