### PR TITLE
Generate & Publish SBOM

### DIFF
--- a/.github/workflows/publish-sbom.yml
+++ b/.github/workflows/publish-sbom.yml
@@ -15,7 +15,7 @@ jobs:
       is-rc: ${{ steps.set-version.outputs.is-rc }}
     steps:
       - name: Setup Maven
-        uses: s4u/setup-maven-action@v1.20.0
+        uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
           java-version: 21
           java-distribution: temurin

--- a/.github/workflows/publish-sbom.yml
+++ b/.github/workflows/publish-sbom.yml
@@ -1,0 +1,55 @@
+name: Publish SBOM
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  determine-version:
+    if: ${{ github.repository_owner == 'jenkinsci' }}
+    runs-on: ubuntu-latest
+    outputs:
+      is-rc: ${{ steps.set-version.outputs.is-rc }}
+    steps:
+      - name: Setup Maven
+        uses: s4u/setup-maven-action@v1.20.0
+        with:
+          java-version: 21
+          java-distribution: temurin
+      - name: Set version
+        id: set-version
+        run: |
+          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          is_rc=false
+          if [[ ${version} == *"-SNAPSHOT" ]]; then
+            is_rc=true
+          fi
+          echo "is-rc=${is_rc}" >> $GITHUB_OUTPUT
+
+  sbom:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: determine-version
+    if: ${{ needs.determine-version.outputs.is-rc == 'false' }}
+    steps:
+      - name: Setup Maven
+        uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
+        with:
+          java-version: 21
+          java-distribution: temurin
+      - name: Generate SBOM
+        run: |
+          mvn org.cyclonedx:cyclonedx-maven-plugin:makeBom -pl core
+          mvn org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom -pl war
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            core/target/jenkins-core-*-cyclonedx.json
+            war/target/jenkins-war-*-cyclonedx.json

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -669,6 +669,19 @@ THE SOFTWARE.
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-sbom</id>
+            <goals>
+              <goal>makeBom</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,14 @@ THE SOFTWARE.
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.8.14</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>2.9.1</version>
+          <configuration>
+            <outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -760,6 +760,19 @@ THE SOFTWARE.
           </webApp>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-sbom</id>
+            <goals>
+              <goal>makeAggregateBom</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
The change proposed adds an SBOM generation for `core` and `war`.

While GH offers something similar build-in, it covers dependencies only, it can infer statically from the repository, not what we actually compile and ship. 

A Software Bill of Materials (SBOM) is a machine-readable inventory of all components, dependencies, and their metadata that make up a software artifact, something like a cookbook ;) 
This cookbook contains different sets of data, like licenses, allowing consumers to verify license compatibility with their given requirements or even for us to see, if we pull something in, what could potentially be undesired.
Aside that, regulatory frameworks, such as EU 14028 or the EU CRA are increasingly mandating SBOMs as part of supply chain transparency.

I've scoped this to `core` and `war` only, given this focuses on what we ship. Happy to add this to the other modules too, if there's a demand for that, but the proposed setup would satisfy my work requirements.

The GH action publishes them as release assets alongside our distributables on the corresponding tag, based on the naming pattern `jenkins-<module>-<version>-cyclonedx.json`.

### Testing done

The outcome can be previewed on https://gist.github.com/NotMyFault/91209abd11b5cf1d33d2e729217f29e4, generated via
mvn org.cyclonedx:cyclonedx-maven-plugin:makeBom -pl core
mvn org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom -pl war

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Start generating and publishing SBOMs for `core` and `war` modules.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
