### PR TITLE
Fix new view links to use request context path

### DIFF
--- a/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
+++ b/core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="controls">
-    <a href="${rootURL}/newView" class="jenkins-button jenkins-button--primary">${%Create a view now}</a>
+    <a href="${request2.contextPath}/newView" class="jenkins-button jenkins-button--primary">${%Create a view now}</a>
   </j:set>
   <l:adminMonitor controls="${controls}">
     ${%blurb}

--- a/core/src/main/resources/hudson/views/DefaultMyViewsTabBar/myViewTabs.jelly
+++ b/core/src/main/resources/hudson/views/DefaultMyViewsTabBar/myViewTabs.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
       <l:tab name="${v.displayName}" active="${v==currentView}" href="${rootURL}/${v.url}" />
     </j:forEach>
     <j:if test="${currentView.hasPermission(currentView.CREATE)}">
-      <l:tabNewItem href="${rootURL}/${currentView.owner.url}newView" title="${%New View}" />
+      <l:tabNewItem href="${request2.contextPath}/${currentView.owner.url}newView" title="${%New View}" />
     </j:if>
   </l:tabBar>
 </j:jelly>

--- a/core/src/main/resources/hudson/views/DefaultViewsTabBar/viewTabs.jelly
+++ b/core/src/main/resources/hudson/views/DefaultViewsTabBar/viewTabs.jelly
@@ -41,7 +41,7 @@ THE SOFTWARE.
         </j:forEach>
 
         <j:if test="${currentView.hasPermission(currentView.CREATE)}">
-          <a href="${rootURL}/${currentView.owner.url}newView" tooltip="${%New View}" class="jenkins-button jenkins-button--tertiary">
+          <a href="${request2.contextPath}/${currentView.owner.url}newView" tooltip="${%New View}" class="jenkins-button jenkins-button--tertiary">
             <l:icon src="symbol-add" />
           </a>
         </j:if>
@@ -53,7 +53,7 @@ THE SOFTWARE.
           <l:tab name="${v.displayName}" active="${v==currentView}" href="${rootURL}/${v.url}" />
         </j:forEach>
         <j:if test="${currentView.hasPermission(currentView.CREATE)}">
-          <l:tabNewItem href="${rootURL}/${currentView.owner.url}newView" title="${%New View}" />
+          <l:tabNewItem href="${request2.contextPath}/${currentView.owner.url}newView" title="${%New View}" />
         </j:if>
       </l:tabBar>
     </j:otherwise>

--- a/test/src/test/java/jenkins/model/JenkinsLocationConfigurationTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsLocationConfigurationTest.java
@@ -189,6 +189,27 @@ class JenkinsLocationConfigurationTest {
         });
     }
 
+    @Test
+    @Issue("JENKINS-51291")
+    void newViewLinkUsesCurrentContextPathInsteadOfConfiguredRootUrl() throws Throwable {
+        session.then(j -> {
+            JenkinsRule.WebClient wc = j.createWebClient();
+            j.createFreeStyleProject();
+
+            settingRootURL(j, "https://jenkins-server.example.com/jenkins/");
+
+            HtmlPage page = wc.goTo("");
+
+            HtmlAnchor newViewLink = page.getDocumentElement().getElementsByTagName("a").stream()
+                    .filter(HtmlAnchor.class::isInstance).map(HtmlAnchor.class::cast)
+                    .filter(a -> a.getHrefAttribute().endsWith("newView"))
+                    .findFirst().orElseThrow(AssertionError::new);
+
+            String href = newViewLink.getHrefAttribute();
+            assertThat(href, not(containsString("jenkins-server.example.com")));
+        });
+    }
+
     private void settingRootURL(JenkinsRule j, String desiredRootUrl) throws Exception {
         HtmlPage configurePage = j.createWebClient().goTo("configure");
         HtmlForm configForm = configurePage.getFormByName("config");


### PR DESCRIPTION
Fixes #22743

### Testing done

- Added an automated regression test: `newViewLinkUsesCurrentContextPathInsteadOfConfiguredRootUrl` in `JenkinsLocationConfigurationTest`.
- Test coverage verifies that `newView` links do not embed the configured absolute Root URL host.
- I could not run the Maven test suite locally in this environment because neither `mvn` nor `mvnw` is available here. CI should execute the added test.

### Screenshots (UI changes only)

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- Use request context path for "New View" links instead of configured Root URL.

### Proposed changelog category

/label bug,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers
