### PR TITLE
Make scrollbar color derive from secondary text color

### DIFF
--- a/src/main/scss/base/_core.scss
+++ b/src/main/scss/base/_core.scss
@@ -6,6 +6,7 @@ html {
   scroll-padding-top: calc(var(--header-height) + var(--section-padding));
 
   $scrollbar-color: oklch(from var(--text-color-secondary) l c h / 0.35);
+
   scrollbar-color: $scrollbar-color $scrollbar-color;
 }
 

--- a/src/main/scss/base/_core.scss
+++ b/src/main/scss/base/_core.scss
@@ -4,6 +4,9 @@ html {
   -webkit-tap-highlight-color: transparent;
   color: var(--text-color);
   scroll-padding-top: calc(var(--header-height) + var(--section-padding));
+
+  $scrollbar-color: oklch(from var(--text-color-secondary) l c h / 0.35);
+  scrollbar-color: $scrollbar-color $scrollbar-color;
 }
 
 body {


### PR DESCRIPTION
Really small one to have scrollbars in Jenkins derive their color from the secondary text color variable. This is a subtle one but makes our UI a touch more cohesive.

### Testing done

* Tested body + card scrollbars, both using color as expected

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

<img width="239" height="215" alt="image" src="https://github.com/user-attachments/assets/cb139c21-44d9-4f8c-bcbf-28f1b9da39a6" />

#### After

<img width="221" height="223" alt="image" src="https://github.com/user-attachments/assets/66532b44-33bc-4af8-9382-9ec8676dd88f" />

#### Before

<img width="217" height="236" alt="image" src="https://github.com/user-attachments/assets/a9e975da-07bb-4365-86df-6d5e2e7b78e9" />

#### After

<img width="329" height="488" alt="image" src="https://github.com/user-attachments/assets/2756ccdc-409b-4f63-971f-b9f83d6ef8ce" />

(It's really hard to take a good screenshot of a scrollbar that fades away - but you get the gist, its more cohesive on non light/dark themes)

### Proposed changelog entries

- Make scrollbar color derive from secondary text color

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui,rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
