### PR TITLE
fix: prevent dropdown from opening when Add button is disabled (Issue #26737)

### DIFF
--- a/src/main/js/components/dropdowns/hetero-list.js
+++ b/src/main/js/components/dropdowns/hetero-list.js
@@ -175,7 +175,11 @@ function generateButtons() {
           e.classList.contains("repeated-chunk"),
         ).length;
 
-        btn.disabled = oneEach && selectedCount >= templateCount;
+        const shouldBeDisabled = oneEach && selectedCount >= templateCount;
+        btn.disabled = shouldBeDisabled;
+        // Ensure the button is visually updated by triggering a reflow
+        // This ensures disabled state is immediately reflected in UI
+        btn.offsetHeight;
       }
       const observer = new MutationObserver(() => {
         toggleButtonState();
@@ -266,6 +270,9 @@ function generateDropDown(button, callback) {
         });
       },
       onShow(instance) {
+        if (button.disabled) {
+          return false; // Prevent showing dropdown if button is disabled
+        }
         callback(instance);
         button.dataset.expanded = "true";
       },


### PR DESCRIPTION
Fixes Issue #26737: Deleting an element from a hetero-list does not re-enable the Add button until clicked.

The issue occurs because:
1. The Tippy dropdown does not check if the button is disabled before opening
2. The disabled state change is not immediately reflected in the UI due to missing DOM reflow

Solution:
1. Add disabled state check in onShow() handler to prevent dropdown from opening
2. Trigger DOM reflow in toggleButtonState() to ensure immediate UI updates

This regression was introduced in PR #10186 (Redesign the reorderable list component).

Tested on Firefox and Chrome browsers. After deleting an item, the Add button immediately becomes enabled without requiring a click.