### PR TITLE
fix: ensure description editor is populated when opened - Issue #26665

### DIFF
--- a/core/src/main/resources/lib/hudson/editable-description.js
+++ b/core/src/main/resources/lib/hudson/editable-description.js
@@ -8,12 +8,32 @@
     if (actualDescription == null) {
       actualDescription = "";
     }
-    textarea.value = actualDescription;
     form.addEventListener("keydown", function (e) {
       if (e.key === "Enter") {
         e.stopPropagation();
       }
     });
+
+    // Initialize behaviors (CodeMirror, etc.) before showing dialog
+    Behaviour.applySubtree(form, true);
+    
+    // Set the textarea value after behaviors are applied
+    // For CodeMirror, use a macrotask to ensure proper initialization
+    const setTextareaValue = () => {
+      if (textarea.codemirrorObject) {
+        textarea.codemirrorObject.setValue(actualDescription);
+      } else {
+        textarea.value = actualDescription;
+      }
+    };
+    
+    // Use setTimeout to ensure CodeMirror has fully initialized
+    if (textarea.codemirrorObject) {
+      setTimeout(setTextareaValue, 0);
+    } else {
+      // For plain textarea, set immediately
+      setTextareaValue();
+    }
 
     dialog
       .form(form, {


### PR DESCRIPTION
Fixes Issue #26665: Description editor appears initially empty when opening the dialog.

When opening the description editor dialog, the description text would appear empty until the dialog was resized.

Root cause: textarea value was being set before Behaviour.applySubtree() initialized CodeMirror and other form behaviors.

Solution:
1. Call Behaviour.applySubtree() immediately after cloning the form
2. Set textarea value AFTER behaviors are applied (using setTimeout for CodeMirror)
3. If CodeMirror is active, use setValue() method
4. For plain textarea, use standard value property

Result: Description text is now visible immediately when dialog opens.