### PR TITLE
fix: enable tooltips on span badges by allowing pointer events - Issue #23866

### DIFF
--- a/src/main/scss/components/_badges.scss
+++ b/src/main/scss/components/_badges.scss
@@ -1,7 +1,8 @@
 @use "../abstracts/mixins";
 
 a.jenkins-badge,
-button.jenkins-badge {
+button.jenkins-badge,
+span.jenkins-badge {
   pointer-events: auto;
 }
 


### PR DESCRIPTION
Fixes Issue #23866: Badge tooltips not working anymore

## Problem
Badge tooltips are not displayed when hovering over badges in:
- Plugin Manager (update available badges)
- Manage Jenkins page (with new UI)
- Other areas using jenkins-badge elements

## Root Cause  
The CSS for .jenkins-badge class has pointer-events: none, which prevents hover events from being detected by Tippy.js.

While a.jenkins-badge and button.jenkins-badge elements were exempted with pointer-events: auto, span.jenkins-badge elements were not included in this exception.

This means:
1. Badge HTML is rendered with tooltip attribute set
2. Tippy.js attaches its listener
3. But when user hovers, browser can't detect mouse events due to pointer-events: none
4. Tippy's onShow handler is never triggered, so tooltip never displays

## Solution
Add span.jenkins-badge to the CSS exemption list that allows pointer events.

This is a minimal, focused fix that:
- Enables hover detection on span badges
- Allows Tippy.js to properly show tooltips
- Does not affect other badge styling or behavior

## Testing
- Hover over plugin update badges in Plugin Manager
- Verify tooltips now appear on hover
- Verify badge appearance and styling remains unchanged
- Verify tooltips also work on a.jenkins-badge and button.jenkins-badge elements