### PR TITLE
Add configurable password complexity policy to HudsonPrivateSecurityRealm

### DIFF
--- a/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -26,6 +26,7 @@ package hudson.security;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
@@ -84,6 +85,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.CompatibleFilter;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.ForwardToView;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -135,6 +137,12 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
      */
     private final boolean enableCaptcha;
 
+    private int minimumPasswordLength;
+    private boolean requireUppercase;
+    private boolean requireLowercase;
+    private boolean requireDigit;
+    private boolean requireSpecialCharacter;
+
     @Deprecated
     public HudsonPrivateSecurityRealm(boolean allowsSignup) {
         this(allowsSignup, false, (CaptchaSupport) null);
@@ -173,6 +181,61 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
      */
     public boolean isEnableCaptcha() {
         return enableCaptcha;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public int getMinimumPasswordLength() {
+        return minimumPasswordLength;
+    }
+
+    @DataBoundSetter
+    @Restricted(NoExternalUse.class)
+    public void setMinimumPasswordLength(int minimumPasswordLength) {
+        this.minimumPasswordLength = Math.max(0, minimumPasswordLength);
+    }
+
+    @Restricted(NoExternalUse.class)
+    public boolean isRequireUppercase() {
+        return requireUppercase;
+    }
+
+    @DataBoundSetter
+    @Restricted(NoExternalUse.class)
+    public void setRequireUppercase(boolean requireUppercase) {
+        this.requireUppercase = requireUppercase;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public boolean isRequireLowercase() {
+        return requireLowercase;
+    }
+
+    @DataBoundSetter
+    @Restricted(NoExternalUse.class)
+    public void setRequireLowercase(boolean requireLowercase) {
+        this.requireLowercase = requireLowercase;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public boolean isRequireDigit() {
+        return requireDigit;
+    }
+
+    @DataBoundSetter
+    @Restricted(NoExternalUse.class)
+    public void setRequireDigit(boolean requireDigit) {
+        this.requireDigit = requireDigit;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public boolean isRequireSpecialCharacter() {
+        return requireSpecialCharacter;
+    }
+
+    @DataBoundSetter
+    @Restricted(NoExternalUse.class)
+    public void setRequireSpecialCharacter(boolean requireSpecialCharacter) {
+        this.requireSpecialCharacter = requireSpecialCharacter;
     }
 
     /**
@@ -461,6 +524,11 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
             si.errors.put("password1", ex.getMessage());
         }
 
+        List<String> complexityErrors = validatePasswordComplexity(si.password1);
+        if (!complexityErrors.isEmpty()) {
+            si.errors.put("password1", String.join(" ", complexityErrors));
+        }
+
         if (si.fullname == null || si.fullname.isEmpty()) {
             si.fullname = si.username;
         }
@@ -512,6 +580,30 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
 
     private boolean containsOnlyAcceptableCharacters(@NonNull String value) {
         return value.matches(Objects.requireNonNullElse(ID_REGEX, DEFAULT_ID_REGEX));
+    }
+
+    @Restricted(NoExternalUse.class)
+    List<String> validatePasswordComplexity(@CheckForNull String password) {
+        List<String> errors = new ArrayList<>();
+        if (password == null || password.isEmpty()) {
+            return errors;
+        }
+        if (minimumPasswordLength > 0 && password.length() < minimumPasswordLength) {
+            errors.add(Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordTooShort(minimumPasswordLength));
+        }
+        if (requireUppercase && !password.matches(".*[A-Z].*")) {
+            errors.add(Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordRequiresUppercase());
+        }
+        if (requireLowercase && !password.matches(".*[a-z].*")) {
+            errors.add(Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordRequiresLowercase());
+        }
+        if (requireDigit && !password.matches(".*[0-9].*")) {
+            errors.add(Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordRequiresDigit());
+        }
+        if (requireSpecialCharacter && !password.matches(".*[^a-zA-Z0-9].*")) {
+            errors.add(Messages.HudsonPrivateSecurityRealm_CreateAccount_PasswordRequiresSpecialCharacter());
+        }
+        return errors;
     }
 
     @Restricted(NoExternalUse.class) // _entryForm.jelly and signup.jelly
@@ -856,6 +948,14 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
                     PASSWORD_HASH_ENCODER.encode2(pwd);
                 } catch (RuntimeException ex) {
                     throw new FormException(ex.getMessage(), "user.password");
+                }
+
+                SecurityRealm realm = Jenkins.get().getSecurityRealm();
+                if (realm instanceof HudsonPrivateSecurityRealm hpsr) {
+                    List<String> complexityErrors = hpsr.validatePasswordComplexity(pwd);
+                    if (!complexityErrors.isEmpty()) {
+                        throw new FormException(String.join(" ", complexityErrors), "user.password");
+                    }
                 }
 
                 User user = Util.getNearestAncestorOfTypeOrThrow(req, User.class);

--- a/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/config.jelly
+++ b/core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/config.jelly
@@ -27,6 +27,23 @@ THE SOFTWARE.
   <f:entry field="allowsSignup">
     <f:checkbox default="false" title="${%Allow users to sign up}" />
   </f:entry>
+  <f:advanced title="${%Password Policy}">
+    <f:entry title="${%Minimum password length}" field="minimumPasswordLength">
+      <f:number default="0" min="0" step="1"/>
+    </f:entry>
+    <f:entry field="requireUppercase">
+      <f:checkbox default="false" title="${%Require at least one uppercase letter (A-Z)}" />
+    </f:entry>
+    <f:entry field="requireLowercase">
+      <f:checkbox default="false" title="${%Require at least one lowercase letter (a-z)}" />
+    </f:entry>
+    <f:entry field="requireDigit">
+      <f:checkbox default="false" title="${%Require at least one digit (0-9)}" />
+    </f:entry>
+    <f:entry field="requireSpecialCharacter">
+      <f:checkbox default="false" title="${%Require at least one special character}" />
+    </f:entry>
+  </f:advanced>
   <j:if test="${size(h.captchaSupportDescriptors) gt 0}">
     <f:entry>
       <f:checkbox name="privateRealm.enableCaptcha" checked="${h.defaultToTrue(instance.isEnableCaptcha())}"

--- a/core/src/main/resources/hudson/security/Messages.properties
+++ b/core/src/main/resources/hudson/security/Messages.properties
@@ -45,6 +45,11 @@ HudsonPrivateSecurityRealm.CreateAccount.UserNameInvalidCharacters=User name mus
 HudsonPrivateSecurityRealm.CreateAccount.UserNameInvalidCharactersCustom=User name must match the following expression: {0}
 HudsonPrivateSecurityRealm.CreateAccount.InvalidEmailAddress=Invalid e-mail address
 HudsonPrivateSecurityRealm.CreateAccount.UserNameAlreadyTaken=User name is already taken
+HudsonPrivateSecurityRealm.CreateAccount.PasswordTooShort=Password must be at least {0} characters long.
+HudsonPrivateSecurityRealm.CreateAccount.PasswordRequiresUppercase=Password must contain at least one uppercase letter (A-Z).
+HudsonPrivateSecurityRealm.CreateAccount.PasswordRequiresLowercase=Password must contain at least one lowercase letter (a-z).
+HudsonPrivateSecurityRealm.CreateAccount.PasswordRequiresDigit=Password must contain at least one digit (0-9).
+HudsonPrivateSecurityRealm.CreateAccount.PasswordRequiresSpecialCharacter=Password must contain at least one special character.
 
 FullControlOnceLoggedInAuthorizationStrategy.DisplayName=Logged-in users can do anything
 

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -798,4 +798,112 @@ class HudsonPrivateSecurityRealmTest {
         XmlPage page = (XmlPage) wc.goTo("whoAmI/api/xml", "application/xml");
         assertThat(page, hasXPath("//name", not(is(notExpectedUsername))));
     }
+
+    @Test
+    void passwordComplexityDefaultAllowsAnyPassword() {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        assertTrue(securityRealm.validatePasswordComplexity("a").isEmpty());
+        assertTrue(securityRealm.validatePasswordComplexity("123").isEmpty());
+    }
+
+    @Test
+    void passwordComplexityMinimumLength() {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        securityRealm.setMinimumPasswordLength(8);
+        assertFalse(securityRealm.validatePasswordComplexity("short").isEmpty());
+        assertTrue(securityRealm.validatePasswordComplexity("longenough").isEmpty());
+    }
+
+    @Test
+    void passwordComplexityRequireUppercase() {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        securityRealm.setRequireUppercase(true);
+        assertFalse(securityRealm.validatePasswordComplexity("alllowercase").isEmpty());
+        assertTrue(securityRealm.validatePasswordComplexity("hasUppercase").isEmpty());
+    }
+
+    @Test
+    void passwordComplexityRequireLowercase() {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        securityRealm.setRequireLowercase(true);
+        assertFalse(securityRealm.validatePasswordComplexity("ALLUPPERCASE").isEmpty());
+        assertTrue(securityRealm.validatePasswordComplexity("HASLOWERcase").isEmpty());
+    }
+
+    @Test
+    void passwordComplexityRequireDigit() {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        securityRealm.setRequireDigit(true);
+        assertFalse(securityRealm.validatePasswordComplexity("nodigits").isEmpty());
+        assertTrue(securityRealm.validatePasswordComplexity("has1digit").isEmpty());
+    }
+
+    @Test
+    void passwordComplexityRequireSpecialCharacter() {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        securityRealm.setRequireSpecialCharacter(true);
+        assertFalse(securityRealm.validatePasswordComplexity("NoSpecial123").isEmpty());
+        assertTrue(securityRealm.validatePasswordComplexity("Has@Special1").isEmpty());
+    }
+
+    @Test
+    void passwordComplexityMultipleRules() {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        securityRealm.setMinimumPasswordLength(8);
+        securityRealm.setRequireUppercase(true);
+        securityRealm.setRequireLowercase(true);
+        securityRealm.setRequireDigit(true);
+        securityRealm.setRequireSpecialCharacter(true);
+
+        List<String> errors = securityRealm.validatePasswordComplexity("bad");
+        assertEquals(4, errors.size());
+
+        assertTrue(securityRealm.validatePasswordComplexity("GoodPass1!").isEmpty());
+    }
+
+    @Test
+    void passwordComplexityNullOrEmptyReturnsNoErrors() {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(false, false, null);
+        securityRealm.setMinimumPasswordLength(8);
+        securityRealm.setRequireUppercase(true);
+        assertTrue(securityRealm.validatePasswordComplexity(null).isEmpty());
+        assertTrue(securityRealm.validatePasswordComplexity("").isEmpty());
+    }
+
+    @Test
+    void signupRejectsWeakPasswordWhenPolicyConfigured() throws Exception {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(true, false, null);
+        securityRealm.setMinimumPasswordLength(8);
+        securityRealm.setRequireUppercase(true);
+        securityRealm.setRequireDigit(true);
+        j.jenkins.setSecurityRealm(securityRealm);
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        SignupPage signup = new SignupPage(wc.goTo("signup"));
+        signup.enterUsername("testuser");
+        signup.enterPassword("weak");
+        signup.enterFullName("Test User");
+        signup.enterEmail("test@example.com");
+        signup = new SignupPage(signup.submit(j));
+        signup.assertErrorContains("Password must be at least 8 characters long");
+        assertNull(User.get("testuser", false, Collections.emptyMap()));
+    }
+
+    @Test
+    void signupAcceptsStrongPasswordWhenPolicyConfigured() throws Exception {
+        HudsonPrivateSecurityRealm securityRealm = new HudsonPrivateSecurityRealm(true, false, null);
+        securityRealm.setMinimumPasswordLength(8);
+        securityRealm.setRequireUppercase(true);
+        securityRealm.setRequireDigit(true);
+        j.jenkins.setSecurityRealm(securityRealm);
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        SignupPage signup = new SignupPage(wc.goTo("signup"));
+        signup.enterUsername("testuser2");
+        signup.enterPassword("StrongPass1");
+        signup.enterFullName("Test User");
+        signup.enterEmail("test@example.com");
+        HtmlPage success = signup.submit(j);
+        assertThat(success.getElementById("main-panel").getTextContent(), containsString("Success"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add configurable password complexity rules (minimum length, require uppercase/lowercase/digit/special character) to `HudsonPrivateSecurityRealm`
- Password policy is configured via the Jenkins security settings UI (Manage Jenkins → Security) under a "Password Policy" advanced section
- Validation applies to both user self-registration (signup) and admin password changes
- All settings default to off (0 / false), preserving full backward compatibility

## Motivation

Jenkins' built-in user database currently has no password complexity enforcement beyond non-empty and encoder limits (72 char max for BCrypt, 14 char min for FIPS). This does not meet typical enterprise security policies. This PR adds optional, admin-configurable complexity rules so organizations can enforce password standards without relying on external plugins.

## Test plan

- [x] Password rejected when shorter than configured minimum length
- [x] Password rejected when missing required character types
- [x] Password accepted when all configured requirements are met
- [x] Default configuration (all off) allows any non-empty password — backward compatible
- [x] Password change flow also enforces complexity rules
