### PR TITLE
Use Awaitility instead of sleep-based waits in QueueTest

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -550,12 +550,7 @@ public class QueueTest {
         p.setAssignedLabel(label);
         p.scheduleBuild2(0);
 
-        // Wait 3 seconds if job is not already in the queue, reduce test flakes
-        if (!p.isInQueue()) {
-            Thread.sleep(3000);
-        }
-
-        assertTrue(p.isInQueue(), "Build not queued");
+        await().untilAsserted(() -> assertTrue(p.isInQueue(), "Build not queued"));
 
         JenkinsRule.WebClient webclient = r.createWebClient();
 
@@ -667,18 +662,15 @@ public class QueueTest {
         await().until(() -> buildFuture.getStartCondition().isCancelled());
     }
 
-    private void waitUntilWaitingListIsEmpty(Queue q) throws InterruptedException {
-        boolean waitingItemsPresent = true;
-        while (waitingItemsPresent) {
-            waitingItemsPresent = false;
+    private void waitUntilWaitingListIsEmpty(Queue q) {
+        await().until(() -> {
             for (Queue.Item i : q.getItems()) {
                 if (i instanceof WaitingItem) {
-                    waitingItemsPresent = true;
-                    break;
+                    return false;
                 }
             }
-            Thread.sleep(1000);
-        }
+            return true;
+        });
     }
 
     @Issue("JENKINS-68780")


### PR DESCRIPTION
## Summary

This PR replaces sleep-based waiting logic in `QueueTest` with Awaitility-based condition polling.

The change keeps the existing test intent unchanged while making the waits more explicit, less timing-dependent and easier to read.

## Changes

### 1. Replace fixed sleep in queue API lookup test

The test previously waited with a fixed delay:

```java
if (!p.isInQueue()) {
    Thread.sleep(3000);
}
assertTrue(p.isInQueue(), "Build not queued");
```

This has been replaced with:

```java
await().untilAsserted(() -> assertTrue(p.isInQueue(), "Build not queued"));
```

This waits only until the expected queue condition is satisfied, instead of relying on a hard-coded delay.

### 2. Replace manual polling loop in `waitUntilWaitingListIsEmpty`

The helper method previously used:

- a manual `while` loop,
- a boolean tracking flag,
- and `Thread.sleep(1000)` polling.

It now uses Awaitility to wait until there are no remaining `WaitingItem` entries in the queue.

### 3. Remove unnecessary checked exception declaration

Since the helper method no longer calls `Thread.sleep`, the `throws InterruptedException` declaration has been removed.

## Motivation

The previous implementation relied on fixed sleeps and manual polling. These patterns can:

- slow tests down unnecessarily,
- still be flaky when asynchronous conditions take longer than the hard-coded delay,
- and make the intended wait condition less clear.

Using Awaitility expresses the asynchronous expectation directly and is consistent with other queue-related waits already present in `QueueTest`.

## Testing

Executed the targeted test class:

```bash
mvn -pl test -Dtest=QueueTest test
```

Result:

```text
Tests run: 39, Failures: 0, Errors: 0, Skipped: 1
BUILD SUCCESS
```

## Changelog

No changelog entry is needed. This is a test-only reliability and readability improvement.