### PR TITLE
Use Awaitility instead of sleep-based waits in QueueTest

### DIFF
--- a/test/src/test/java/hudson/model/QueueTest.java
+++ b/test/src/test/java/hudson/model/QueueTest.java
@@ -550,12 +550,7 @@ public class QueueTest {
         p.setAssignedLabel(label);
         p.scheduleBuild2(0);
 
-        // Wait 3 seconds if job is not already in the queue, reduce test flakes
-        if (!p.isInQueue()) {
-            Thread.sleep(3000);
-        }
-
-        assertTrue(p.isInQueue(), "Build not queued");
+        await().untilAsserted(() -> assertTrue(p.isInQueue(), "Build not queued"));
 
         JenkinsRule.WebClient webclient = r.createWebClient();
 
@@ -667,18 +662,15 @@ public class QueueTest {
         await().until(() -> buildFuture.getStartCondition().isCancelled());
     }
 
-    private void waitUntilWaitingListIsEmpty(Queue q) throws InterruptedException {
-        boolean waitingItemsPresent = true;
-        while (waitingItemsPresent) {
-            waitingItemsPresent = false;
+    private void waitUntilWaitingListIsEmpty(Queue q) {
+        await().until(() -> {
             for (Queue.Item i : q.getItems()) {
                 if (i instanceof WaitingItem) {
-                    waitingItemsPresent = true;
-                    break;
+                    return false;
                 }
             }
-            Thread.sleep(1000);
-        }
+            return true;
+        });
     }
 
     @Issue("JENKINS-68780")


### PR DESCRIPTION
Fixes #

### Testing done

Executed the targeted test class:

```bash
mvn -pl test -Dtest=QueueTest test
```

Result:

```text
Tests run: 39, Failures: 0, Errors: 0, Skipped: 1
BUILD SUCCESS
```

This PR replaces sleep-based waiting logic in `QueueTest` with Awaitility-based condition polling.

Specifically:

- Replaces the fixed `Thread.sleep(3000)` wait in the queue API lookup test with `await().untilAsserted(...)`.
- Replaces the manual polling loop in `waitUntilWaitingListIsEmpty` with an Awaitility condition.
- Removes the now-unnecessary `throws InterruptedException` declaration from the helper method.

The change keeps the existing test intent unchanged while making the waits more explicit, less timing-dependent, and easier to read.

### Screenshots (UI changes only)

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- N/A — test-only reliability and readability improvement.

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.