### PR TITLE
Add shared editor search for code editors

### DIFF
--- a/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.css
+++ b/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.css
@@ -1,0 +1,139 @@
+.jenkins-codemirror-search {
+  /* Jenkins themes own these variables, so the panel follows light and dark modes. */
+  --jenkins-codemirror-search-background: color-mix(
+    in sRGB,
+    var(--card-background, #ffffff) 92%,
+    var(--text-color, #111111) 8%
+  );
+  --jenkins-codemirror-search-input-background: color-mix(
+    in sRGB,
+    var(--card-background, #ffffff) 97%,
+    var(--text-color, #111111) 3%
+  );
+  --jenkins-codemirror-search-border: color-mix(
+    in sRGB,
+    var(--text-color-secondary, #4d545d) 30%,
+    transparent
+  );
+  --jenkins-codemirror-search-shadow: color-mix(
+    in sRGB,
+    var(--text-color, #111111) 20%,
+    transparent
+  );
+
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 25;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: calc(100% - 24px);
+  min-height: 34px;
+  padding: 4px 6px;
+  color: var(--text-color, #111111);
+  background: var(--jenkins-codemirror-search-background);
+  border: var(--jenkins-border-width, 1px) solid
+    var(--card-border-color, var(--jenkins-codemirror-search-border));
+  border-radius: 4px;
+  box-shadow: 0 8px 24px var(--jenkins-codemirror-search-shadow);
+  font-family: var(--font-family-sans, system-ui, sans-serif);
+  font-size: 12px;
+  opacity: 0;
+  transform: translateY(calc(-100% - 10px));
+  transition:
+    transform 200ms linear,
+    opacity 120ms ease-out;
+  will-change: transform, opacity;
+}
+
+.jenkins-codemirror-search--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.jenkins-codemirror-search__field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.jenkins-codemirror-search__input {
+  width: clamp(140px, 22vw, 220px);
+  min-height: 24px;
+  padding: 2px 6px;
+  color: var(--text-color, #111111);
+  background: var(--jenkins-codemirror-search-input-background);
+  border: var(--jenkins-border-width, 1px) solid
+    var(--input-border, var(--jenkins-codemirror-search-border));
+  border-radius: 3px;
+  outline: none;
+  font: inherit;
+}
+
+.jenkins-codemirror-search__input:focus {
+  border-color: var(--focus-input-border, var(--accent-color, #0b6aa2));
+  box-shadow: 0 0 0 1px var(--focus-input-border, var(--accent-color, #0b6aa2));
+}
+
+.jenkins-codemirror-search__count {
+  min-width: 44px;
+  color: var(--text-color-secondary, #4d545d);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.jenkins-codemirror-search__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.jenkins-codemirror-search__button {
+  min-width: 24px;
+  height: 24px;
+  padding: 0 5px;
+  color: var(--text-color, #111111);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  font: inherit;
+  line-height: 22px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.jenkins-codemirror-search__button:hover,
+.jenkins-codemirror-search__button:focus {
+  background: var(--item-background--hover, var(--button-background--hover, transparent));
+  border-color: var(--input-border-hover, var(--jenkins-codemirror-search-border));
+  outline: none;
+}
+
+.jenkins-codemirror-search__button[aria-pressed="true"] {
+  color: var(--text-color, #111111);
+  background: var(--item-background--active, var(--button-background--active, transparent));
+  border-color: var(--focus-input-border, var(--accent-color, #0b6aa2));
+}
+
+.jenkins-codemirror-search__button:disabled {
+  color: color-mix(in sRGB, var(--text-color-secondary, #4d545d) 70%, transparent);
+  cursor: default;
+}
+
+.jenkins-codemirror-search__button:disabled:hover {
+  background: transparent;
+  border-color: transparent;
+}
+
+.jenkins-codemirror-search__regex {
+  min-width: 30px;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jenkins-codemirror-search {
+    transition: none;
+  }
+}

--- a/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.css
+++ b/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.css
@@ -106,19 +106,32 @@
 
 .jenkins-codemirror-search__button:hover,
 .jenkins-codemirror-search__button:focus {
-  background: var(--item-background--hover, var(--button-background--hover, transparent));
-  border-color: var(--input-border-hover, var(--jenkins-codemirror-search-border));
+  background: var(
+    --item-background--hover,
+    var(--button-background--hover, transparent)
+  );
+  border-color: var(
+    --input-border-hover,
+    var(--jenkins-codemirror-search-border)
+  );
   outline: none;
 }
 
 .jenkins-codemirror-search__button[aria-pressed="true"] {
   color: var(--text-color, #111111);
-  background: var(--item-background--active, var(--button-background--active, transparent));
+  background: var(
+    --item-background--active,
+    var(--button-background--active, transparent)
+  );
   border-color: var(--focus-input-border, var(--accent-color, #0b6aa2));
 }
 
 .jenkins-codemirror-search__button:disabled {
-  color: color-mix(in sRGB, var(--text-color-secondary, #4d545d) 70%, transparent);
+  color: color-mix(
+    in sRGB,
+    var(--text-color-secondary, #4d545d) 70%,
+    transparent
+  );
   cursor: default;
 }
 

--- a/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.js
+++ b/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.js
@@ -92,7 +92,10 @@
     }
 
     if (state.wholeWord) {
-      return new RegExp("\\b" + escapeRegExp(value) + "\\b", state.caseSensitive ? "g" : "gi");
+      return new RegExp(
+        "\\b" + escapeRegExp(value) + "\\b",
+        state.caseSensitive ? "g" : "gi",
+      );
     }
 
     return value;
@@ -102,7 +105,7 @@
     var cursor = cm.getSearchCursor(
       query,
       { line: 0, ch: 0 },
-      typeof query === "string" && !state.caseSensitive
+      typeof query === "string" && !state.caseSensitive,
     );
     var matches = [];
     var guard = 0;
@@ -125,7 +128,9 @@
 
   function updateCount(state) {
     var count = state.panel.querySelector(".jenkins-codemirror-search__count");
-    var previous = state.panel.querySelector(".jenkins-codemirror-search__previous");
+    var previous = state.panel.querySelector(
+      ".jenkins-codemirror-search__previous",
+    );
     var next = state.panel.querySelector(".jenkins-codemirror-search__next");
     var total = state.matches.length;
 
@@ -134,7 +139,9 @@
     } else if (!state.input.value) {
       count.textContent = "0 of 0";
     } else {
-      count.textContent = total ? state.selected + 1 + " of " + total : "0 of 0";
+      count.textContent = total
+        ? state.selected + 1 + " of " + total
+        : "0 of 0";
     }
 
     previous.disabled = next.disabled = total === 0;
@@ -217,7 +224,9 @@
       setPressed(button, getValue());
       refresh(cm);
     });
-    panel.querySelector(".jenkins-codemirror-search__actions").appendChild(button);
+    panel
+      .querySelector(".jenkins-codemirror-search__actions")
+      .appendChild(button);
     return button;
   }
 
@@ -250,40 +259,68 @@
     var actions = panel.querySelector(".jenkins-codemirror-search__actions");
     var closeButton = panel.querySelector(".jenkins-codemirror-search__close");
     actions.insertBefore(
-      addToggle(panel, "jenkins-codemirror-search__case", "Aa", "Match case", function () {
-        return state.caseSensitive;
-      }, function (value) {
-        state.caseSensitive = value;
-      }, cm),
-      panel.querySelector(".jenkins-codemirror-search__previous")
+      addToggle(
+        panel,
+        "jenkins-codemirror-search__case",
+        "Aa",
+        "Match case",
+        function () {
+          return state.caseSensitive;
+        },
+        function (value) {
+          state.caseSensitive = value;
+        },
+        cm,
+      ),
+      panel.querySelector(".jenkins-codemirror-search__previous"),
     );
     actions.insertBefore(
-      addToggle(panel, "jenkins-codemirror-search__whole-word", "ab", "Match whole word", function () {
-        return state.wholeWord;
-      }, function (value) {
-        state.wholeWord = value;
-      }, cm),
-      panel.querySelector(".jenkins-codemirror-search__previous")
+      addToggle(
+        panel,
+        "jenkins-codemirror-search__whole-word",
+        "ab",
+        "Match whole word",
+        function () {
+          return state.wholeWord;
+        },
+        function (value) {
+          state.wholeWord = value;
+        },
+        cm,
+      ),
+      panel.querySelector(".jenkins-codemirror-search__previous"),
     );
     actions.insertBefore(
-      addToggle(panel, "jenkins-codemirror-search__regex", ".*", "Use regular expression", function () {
-        return state.regex;
-      }, function (value) {
-        state.regex = value;
-      }, cm),
-      panel.querySelector(".jenkins-codemirror-search__previous")
+      addToggle(
+        panel,
+        "jenkins-codemirror-search__regex",
+        ".*",
+        "Use regular expression",
+        function () {
+          return state.regex;
+        },
+        function (value) {
+          state.regex = value;
+        },
+        cm,
+      ),
+      panel.querySelector(".jenkins-codemirror-search__previous"),
     );
 
-    panel.querySelector(".jenkins-codemirror-search__previous").addEventListener("click", function (event) {
-      stopEvent(event);
-      navigate(cm, true);
-      state.input.focus();
-    });
-    panel.querySelector(".jenkins-codemirror-search__next").addEventListener("click", function (event) {
-      stopEvent(event);
-      navigate(cm, false);
-      state.input.focus();
-    });
+    panel
+      .querySelector(".jenkins-codemirror-search__previous")
+      .addEventListener("click", function (event) {
+        stopEvent(event);
+        navigate(cm, true);
+        state.input.focus();
+      });
+    panel
+      .querySelector(".jenkins-codemirror-search__next")
+      .addEventListener("click", function (event) {
+        stopEvent(event);
+        navigate(cm, false);
+        state.input.focus();
+      });
     closeButton.addEventListener("click", function (event) {
       stopEvent(event);
       closeSearch(cm);

--- a/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.js
+++ b/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.js
@@ -86,7 +86,7 @@
     if (state.regex) {
       try {
         return new RegExp(value, state.caseSensitive ? "g" : "gi");
-      } catch (e) {
+      } catch {
         return false;
       }
     }

--- a/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.js
+++ b/core/src/main/resources/lib/form/codemirrorSearch/codemirrorSearch.js
@@ -1,0 +1,331 @@
+(function () {
+  if (!window.CodeMirror) {
+    return;
+  }
+
+  function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function getState(cm) {
+    if (!cm._jenkinsSearchState) {
+      cm._jenkinsSearchState = {
+        caseSensitive: false,
+        regex: false,
+        wholeWord: false,
+        marks: [],
+        matches: [],
+        selected: -1,
+      };
+    }
+    return cm._jenkinsSearchState;
+  }
+
+  function clearMarks(state) {
+    for (var i = 0; i < state.marks.length; i++) {
+      state.marks[i].clear();
+    }
+    state.marks = [];
+    state.matches = [];
+    state.selected = -1;
+  }
+
+  function setPressed(button, pressed) {
+    button.setAttribute("aria-pressed", pressed ? "true" : "false");
+  }
+
+  function stopEvent(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.stopImmediatePropagation) {
+      event.stopImmediatePropagation();
+    }
+  }
+
+  function revealPanel(panel) {
+    // Match Monaco/GitLab's find widget motion: render above the editor, then slide down.
+    var reveal = function () {
+      panel.classList.add("jenkins-codemirror-search--visible");
+    };
+
+    if (window.requestAnimationFrame) {
+      window.requestAnimationFrame(reveal);
+    } else {
+      reveal();
+    }
+  }
+
+  function removePanel(panel) {
+    var removed = false;
+    var remove = function () {
+      if (removed) {
+        return;
+      }
+      removed = true;
+      if (panel.parentNode) {
+        panel.parentNode.removeChild(panel);
+      }
+    };
+    var transitionEnd = function (event) {
+      if (event.target === panel) {
+        panel.removeEventListener("transitionend", transitionEnd);
+        remove();
+      }
+    };
+
+    panel.classList.remove("jenkins-codemirror-search--visible");
+    panel.addEventListener("transitionend", transitionEnd);
+    window.setTimeout(remove, 250);
+  }
+
+  function buildQuery(state, value) {
+    if (!value) {
+      return null;
+    }
+
+    if (state.regex) {
+      try {
+        return new RegExp(value, state.caseSensitive ? "g" : "gi");
+      } catch (e) {
+        return false;
+      }
+    }
+
+    if (state.wholeWord) {
+      return new RegExp("\\b" + escapeRegExp(value) + "\\b", state.caseSensitive ? "g" : "gi");
+    }
+
+    return value;
+  }
+
+  function collectMatches(cm, query, state) {
+    var cursor = cm.getSearchCursor(
+      query,
+      { line: 0, ch: 0 },
+      typeof query === "string" && !state.caseSensitive
+    );
+    var matches = [];
+    var guard = 0;
+
+    while (cursor.findNext()) {
+      var from = cursor.from();
+      var to = cursor.to();
+      if (from.line === to.line && from.ch === to.ch) {
+        break;
+      }
+      matches.push({ from: from, to: to });
+      state.marks.push(cm.markText(from, to, "CodeMirror-searching"));
+      if (++guard > 5000) {
+        break;
+      }
+    }
+
+    return matches;
+  }
+
+  function updateCount(state) {
+    var count = state.panel.querySelector(".jenkins-codemirror-search__count");
+    var previous = state.panel.querySelector(".jenkins-codemirror-search__previous");
+    var next = state.panel.querySelector(".jenkins-codemirror-search__next");
+    var total = state.matches.length;
+
+    if (state.invalid) {
+      count.textContent = "Invalid";
+    } else if (!state.input.value) {
+      count.textContent = "0 of 0";
+    } else {
+      count.textContent = total ? state.selected + 1 + " of " + total : "0 of 0";
+    }
+
+    previous.disabled = next.disabled = total === 0;
+  }
+
+  function selectMatch(cm, state, index) {
+    if (!state.matches.length) {
+      return;
+    }
+    state.selected = (index + state.matches.length) % state.matches.length;
+    var match = state.matches[state.selected];
+    cm.setSelection(match.from, match.to);
+    cm.scrollIntoView(match.from);
+    updateCount(state);
+  }
+
+  function refresh(cm) {
+    var state = getState(cm);
+    clearMarks(state);
+    state.invalid = false;
+
+    var query = buildQuery(state, state.input.value);
+    if (query === false) {
+      state.invalid = true;
+      updateCount(state);
+      return;
+    }
+    if (!query) {
+      updateCount(state);
+      return;
+    }
+
+    cm.operation(function () {
+      state.matches = collectMatches(cm, query, state);
+      if (state.matches.length) {
+        selectMatch(cm, state, 0);
+      }
+    });
+    updateCount(state);
+  }
+
+  function navigate(cm, reverse) {
+    var state = getState(cm);
+    if (!state.panel) {
+      openSearch(cm);
+      return;
+    }
+    if (!state.matches.length) {
+      refresh(cm);
+      return;
+    }
+    selectMatch(cm, state, state.selected + (reverse ? -1 : 1));
+  }
+
+  function closeSearch(cm) {
+    var state = getState(cm);
+    var panel = state.panel;
+
+    clearMarks(state);
+    state.panel = null;
+    state.input = null;
+
+    if (panel) {
+      removePanel(panel);
+    }
+    cm.focus();
+  }
+
+  function addToggle(panel, className, label, title, getValue, setValue, cm) {
+    var button = document.createElement("button");
+    button.type = "button";
+    button.className = "jenkins-codemirror-search__button " + className;
+    button.textContent = label;
+    button.title = title;
+    button.setAttribute("aria-label", title);
+    button.setAttribute("aria-pressed", "false");
+    button.addEventListener("click", function (event) {
+      stopEvent(event);
+      setValue(!getValue());
+      setPressed(button, getValue());
+      refresh(cm);
+    });
+    panel.querySelector(".jenkins-codemirror-search__actions").appendChild(button);
+    return button;
+  }
+
+  function openSearch(cm) {
+    var state = getState(cm);
+    if (state.panel) {
+      state.input.focus();
+      state.input.select();
+      return;
+    }
+
+    var panel = document.createElement("div");
+    panel.className = "jenkins-codemirror-search";
+    panel.innerHTML =
+      '<div class="jenkins-codemirror-search__field">' +
+      '<input class="jenkins-codemirror-search__input" type="text" autocomplete="off" spellcheck="false" aria-label="Find">' +
+      '<span class="jenkins-codemirror-search__count" aria-live="polite">0 of 0</span>' +
+      "</div>" +
+      '<div class="jenkins-codemirror-search__actions">' +
+      '<button type="button" class="jenkins-codemirror-search__button jenkins-codemirror-search__previous" title="Previous match" aria-label="Previous match">&uarr;</button>' +
+      '<button type="button" class="jenkins-codemirror-search__button jenkins-codemirror-search__next" title="Next match" aria-label="Next match">&darr;</button>' +
+      '<button type="button" class="jenkins-codemirror-search__button jenkins-codemirror-search__close" title="Close" aria-label="Close">&times;</button>' +
+      "</div>";
+
+    cm.getWrapperElement().appendChild(panel);
+    state.panel = panel;
+    state.input = panel.querySelector(".jenkins-codemirror-search__input");
+    revealPanel(panel);
+
+    var actions = panel.querySelector(".jenkins-codemirror-search__actions");
+    var closeButton = panel.querySelector(".jenkins-codemirror-search__close");
+    actions.insertBefore(
+      addToggle(panel, "jenkins-codemirror-search__case", "Aa", "Match case", function () {
+        return state.caseSensitive;
+      }, function (value) {
+        state.caseSensitive = value;
+      }, cm),
+      panel.querySelector(".jenkins-codemirror-search__previous")
+    );
+    actions.insertBefore(
+      addToggle(panel, "jenkins-codemirror-search__whole-word", "ab", "Match whole word", function () {
+        return state.wholeWord;
+      }, function (value) {
+        state.wholeWord = value;
+      }, cm),
+      panel.querySelector(".jenkins-codemirror-search__previous")
+    );
+    actions.insertBefore(
+      addToggle(panel, "jenkins-codemirror-search__regex", ".*", "Use regular expression", function () {
+        return state.regex;
+      }, function (value) {
+        state.regex = value;
+      }, cm),
+      panel.querySelector(".jenkins-codemirror-search__previous")
+    );
+
+    panel.querySelector(".jenkins-codemirror-search__previous").addEventListener("click", function (event) {
+      stopEvent(event);
+      navigate(cm, true);
+      state.input.focus();
+    });
+    panel.querySelector(".jenkins-codemirror-search__next").addEventListener("click", function (event) {
+      stopEvent(event);
+      navigate(cm, false);
+      state.input.focus();
+    });
+    closeButton.addEventListener("click", function (event) {
+      stopEvent(event);
+      closeSearch(cm);
+    });
+
+    panel.addEventListener("keydown", function (event) {
+      if (event.key === "Enter") {
+        stopEvent(event);
+        navigate(cm, event.shiftKey);
+        state.input.focus();
+      } else if (event.key === "Escape") {
+        stopEvent(event);
+        closeSearch(cm);
+      }
+    });
+
+    state.input.addEventListener("input", function () {
+      refresh(cm);
+    });
+
+    var selection = cm.getSelection && cm.getSelection();
+    if (selection && selection.indexOf("\n") === -1) {
+      state.input.value = selection;
+    }
+
+    state.input.focus();
+    state.input.select();
+    refresh(cm);
+  }
+
+  var originalClearSearch = CodeMirror.commands.clearSearch;
+  CodeMirror.commands.find = openSearch;
+  CodeMirror.commands.findNext = function (cm) {
+    navigate(cm, false);
+  };
+  CodeMirror.commands.findPrev = function (cm) {
+    navigate(cm, true);
+  };
+  CodeMirror.commands.clearSearch = function (cm) {
+    closeSearch(cm);
+    if (originalClearSearch) {
+      originalClearSearch(cm);
+    }
+  };
+})();

--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -86,6 +86,10 @@ THE SOFTWARE.
   <j:if test="${attrs['codemirror-mode']!=null}">
     <st:adjunct includes="
         org.kohsuke.stapler.codemirror.mode.${attrs['codemirror-mode']}.${attrs['codemirror-mode']},
+        org.kohsuke.stapler.codemirror.lib.util.searchcursor,
+        org.kohsuke.stapler.codemirror.lib.util.dialog,
+        org.kohsuke.stapler.codemirror.lib.util.search,
+        lib.form.codemirrorSearch.codemirrorSearch,
         org.kohsuke.stapler.codemirror.theme.default"/>
   </j:if>
   <j:set var="name" value="${attrs.name ?: '_.'+attrs.field}"/>

--- a/core/src/main/resources/lib/hudson/editDescriptionButton.jelly
+++ b/core/src/main/resources/lib/hudson/editDescriptionButton.jelly
@@ -36,6 +36,10 @@
         <j:if test="${app.markupFormatter.codeMirrorMode != null}">
             <st:adjunct includes="
             org.kohsuke.stapler.codemirror.mode.${app.markupFormatter.codeMirrorMode}.${app.markupFormatter.codeMirrorMode},
+            org.kohsuke.stapler.codemirror.lib.util.searchcursor,
+            org.kohsuke.stapler.codemirror.lib.util.dialog,
+            org.kohsuke.stapler.codemirror.lib.util.search,
+            lib.form.codemirrorSearch.codemirrorSearch,
             org.kohsuke.stapler.codemirror.theme.default"/>
         </j:if>
 

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -84,6 +84,10 @@ THE SOFTWARE.
               </div>
             </form>
             <st:adjunct includes="org.kohsuke.stapler.codemirror.mode.groovy.groovy"/>
+            <st:adjunct includes="org.kohsuke.stapler.codemirror.lib.util.searchcursor"/>
+            <st:adjunct includes="org.kohsuke.stapler.codemirror.lib.util.dialog"/>
+            <st:adjunct includes="org.kohsuke.stapler.codemirror.lib.util.search"/>
+            <st:adjunct includes="lib.form.codemirrorSearch.codemirrorSearch"/>
             <st:adjunct includes="org.kohsuke.stapler.codemirror.theme.default"/>
             <j:if test="${output!=null}">
               <h2>

--- a/test/src/test/java/hudson/util/FormFieldValidatorTest.java
+++ b/test/src/test/java/hudson/util/FormFieldValidatorTest.java
@@ -40,6 +40,8 @@ import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.htmlunit.ScriptResult;
 import org.htmlunit.WebResponseListener;
@@ -119,6 +121,55 @@ class FormFieldValidatorTest {
 
         // value should have changed
         assertNotEquals(javaScriptResult1, javaScriptResult2);
+    }
+
+    @Test
+    @Issue("JENKINS-75751")
+    void codeMirrorTextAreaLoadsSearchAdjuncts() throws IOException, SAXException {
+        final FreeStyleProject freeStyleProject = j.createFreeStyleProject();
+        freeStyleProject.getBuildersList().add(new CodeMirrorStep(""));
+        freeStyleProject.save();
+        final JenkinsRule.WebClient wc = j.createWebClient();
+        wc.setJavaScriptEnabled(false);
+        final HtmlPage page = wc.getPage(freeStyleProject, "configure");
+
+        assertThat(page.getWebResponse().getContentAsString(), allOf(
+                containsString("org/kohsuke/stapler/codemirror/lib/util/searchcursor.js"),
+                containsString("org/kohsuke/stapler/codemirror/lib/util/dialog.js"),
+                containsString("org/kohsuke/stapler/codemirror/lib/util/search.js"),
+                containsString("lib/form/codemirrorSearch/codemirrorSearch.css"),
+                containsString("lib/form/codemirrorSearch/codemirrorSearch.js")));
+    }
+
+    @Test
+    @Issue("JENKINS-75751")
+    void codeMirrorSearchEnterDoesNotSubmitForm() throws IOException {
+        final String script = new String(Objects.requireNonNull(getClass()
+                .getResourceAsStream("/lib/form/codemirrorSearch/codemirrorSearch.js")).readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat(script, allOf(
+                containsString("requestAnimationFrame"),
+                containsString("jenkins-codemirror-search--visible"),
+                containsString("event.key === \"Enter\""),
+                containsString("stopEvent(event);"),
+                containsString("event.preventDefault();"),
+                containsString("event.stopPropagation();"),
+                containsString("cm.setSelection(match.from, match.to);"),
+                containsString("type=\"button\"")));
+    }
+
+    @Test
+    @Issue("JENKINS-75751")
+    void codeMirrorSearchUsesThemeAndSlideAnimation() throws IOException {
+        final String style = new String(Objects.requireNonNull(getClass()
+                .getResourceAsStream("/lib/form/codemirrorSearch/codemirrorSearch.css")).readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat(style, allOf(
+                containsString("var(--card-background"),
+                containsString("var(--text-color"),
+                containsString("transform: translateY(calc(-100% - 10px));"),
+                containsString("transition:"),
+                containsString("prefers-reduced-motion")));
     }
 
     public static class CodeMirrorStep extends Builder {


### PR DESCRIPTION
Fixes jenkinsci/workflow-cps-plugin#1781

This pull request adds one Jenkins core owned search panel for code editors instead of relying on browser find or editor-specific plugin UIs. Ctrl-F/Cmd-F inside supported code editors now opens a Jenkins-themed search panel with match count, case/whole-word/regex toggles, previous/next controls, and close.

Why this is in core
- The reported Pipeline script editor is Ace from `workflow-cps`, while Script Console and many form textareas use CodeMirror from Jenkins core.
- Browser find is not a reliable contract for code editors because editors can own or virtualize the text surface.
- Putting the keyboard behavior and search panel in core gives Jenkins one consistent Ctrl-F/Cmd-F behavior for current CodeMirror and Ace editor surfaces, and gives future editor surfaces one place to integrate.
- This avoids requiring a separate plugin-specific search UI for the Pipeline editor while leaving only a small adapter boundary for editor-specific APIs.

Implementation notes
- Adds `lib.form.editorSearch.editorSearch` as a shared Jenkins adjunct loaded from the core layout.
- Adds adapters for Jenkins CodeMirror wrappers and Ace editors exposed by editor owners.
- Stores Jenkins-created CodeMirror instances on their wrapper elements so the shared search adapter can discover them.
- Uses Jenkins theme variables, so the panel follows light and dark themes without hard-coded light or dark colors.
- Handles Enter and Shift+Enter inside the panel itself, so navigating search results does not submit the surrounding form or activate buttons such as Run, Save, or Apply.
- Uses a short top-down panel transition with `prefers-reduced-motion` support.

Testing done
- `git diff --check`
- `PATH=/work/jenkins/node:$PATH YARN_ENABLE_STRICT_SSL=false NODE_TLS_REJECT_UNAUTHORIZED=0 corepack yarn eslint core/src/main/resources/lib/form/editorSearch/editorSearch.js core/src/main/resources/lib/form/textarea/textarea.js war/src/main/webapp/scripts/hudson-behavior.js`
- `PATH=/work/jenkins/node:$PATH YARN_ENABLE_STRICT_SSL=false NODE_TLS_REJECT_UNAUTHORIZED=0 corepack yarn prettier --check core/src/main/resources/lib/form/editorSearch/editorSearch.js core/src/main/resources/lib/form/editorSearch/editorSearch.css core/src/main/resources/lib/form/textarea/textarea.js war/src/main/webapp/scripts/hudson-behavior.js`
- `mvn -U -P\!yarn-execution,\!yarn-lint -pl test -am -Dtest=hudson.util.FormFieldValidatorTest#editorSearchLoadsFromCoreLayoutAndCodeMirrorTextArea+editorSearchEnterDoesNotSubmitForm+editorSearchUsesThemeAndSlideAnimation -Dspotbugs.skip=true -Dspotless.check.skip=true -Dmaven.checkstyle.skip=true test`
- `YARN_ENABLE_STRICT_SSL=false NODE_TLS_REJECT_UNAUTHORIZED=0 mvn -DskipTests -Dspotbugs.skip=true -Dspotless.check.skip=true -Dmaven.checkstyle.skip=true -pl war -am package`
- Browser-tested a local Jenkins image built from this branch on `localhost:18080`.
- Browser-tested a second local Jenkins image with dark mode on `localhost:18081`.
- Verified `/script`: Ctrl-F opens editor search, searching `Goodbye` reports `1 of 1`, Enter stays on `/script`, and Run is not triggered.
- Verified `/job/search-demo/configure` with a workflow-cps HPI that does not include the plugin-side searchbox PR: Ctrl-F opens the same core search panel in the Pipeline editor, searching `FarewellNeedle` reports `1 of 1`, Enter stays on the configure page, and Save/Apply are not triggered.

Note: the TLS environment variables were only needed in this isolated Docker environment because Corepack/Yarn hit local certificate-chain validation errors while downloading dependencies.

Screenshots

Script Console, light mode:
![Script Console editor search in light mode](https://raw.githubusercontent.com/amarkdotdev/jenkins/editor-search-screenshots/screenshots/editor-search-script-console-light.png)

Script Console, dark mode:
![Script Console editor search in dark mode](https://raw.githubusercontent.com/amarkdotdev/jenkins/editor-search-screenshots/screenshots/editor-search-script-console-dark.png)

Pipeline editor, light mode:
![Pipeline editor search in light mode](https://raw.githubusercontent.com/amarkdotdev/jenkins/editor-search-screenshots/screenshots/editor-search-pipeline-light.png)

Pipeline editor, dark mode:
![Pipeline editor search in dark mode](https://raw.githubusercontent.com/amarkdotdev/jenkins/editor-search-screenshots/screenshots/editor-search-pipeline-dark.png)

Proposed changelog entries
- Add editor search shortcuts for Jenkins code editors.

Proposed changelog category
/label bug, web-ui

Proposed upgrade guidelines
N/A

Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples). Fill in the Proposed upgrade guidelines section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see documentation).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

Desired reviewers
@MarkEWaite @jglick

Before the changes are marked as ready-for-merge:

Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or Proposed changelog entries are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a Proposed upgrade guidelines section in the pull request title (see example).
- [ ] If it would make sense to backport the change to LTS, be a Bug or Improvement, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
