### PR TITLE
Enable native CodeMirror search

### DIFF
--- a/core/src/main/resources/lib/form/textarea.jelly
+++ b/core/src/main/resources/lib/form/textarea.jelly
@@ -86,7 +86,10 @@ THE SOFTWARE.
   <j:if test="${attrs['codemirror-mode']!=null}">
     <st:adjunct includes="
         org.kohsuke.stapler.codemirror.mode.${attrs['codemirror-mode']}.${attrs['codemirror-mode']},
-        org.kohsuke.stapler.codemirror.theme.default"/>
+        org.kohsuke.stapler.codemirror.theme.default,
+        org.kohsuke.stapler.codemirror.lib.util.searchcursor,
+        org.kohsuke.stapler.codemirror.lib.util.dialog,
+        org.kohsuke.stapler.codemirror.lib.util.search"/>
   </j:if>
   <j:set var="name" value="${attrs.name ?: '_.'+attrs.field}"/>
   <f:possibleReadOnlyField>

--- a/core/src/main/resources/lib/form/textarea/textarea.js
+++ b/core/src/main/resources/lib/form/textarea/textarea.js
@@ -33,6 +33,9 @@ Behaviour.specify("TEXTAREA.codemirror", "textarea", 0, function (e) {
   }
   var codemirror = CodeMirror.fromTextArea(e, config);
   e.codemirrorObject = codemirror;
+  if (typeof window.installCodeMirrorSearchNavigation === "function") {
+    window.installCodeMirrorSearchNavigation(codemirror);
+  }
   if (typeof codemirror.getScrollerElement !== "function") {
     // Maybe older versions of CodeMirror do not provide getScrollerElement method.
     codemirror.getScrollerElement = function () {

--- a/core/src/main/resources/lib/hudson/editDescriptionButton.jelly
+++ b/core/src/main/resources/lib/hudson/editDescriptionButton.jelly
@@ -36,7 +36,10 @@
         <j:if test="${app.markupFormatter.codeMirrorMode != null}">
             <st:adjunct includes="
             org.kohsuke.stapler.codemirror.mode.${app.markupFormatter.codeMirrorMode}.${app.markupFormatter.codeMirrorMode},
-            org.kohsuke.stapler.codemirror.theme.default"/>
+            org.kohsuke.stapler.codemirror.theme.default,
+            org.kohsuke.stapler.codemirror.lib.util.searchcursor,
+            org.kohsuke.stapler.codemirror.lib.util.dialog,
+            org.kohsuke.stapler.codemirror.lib.util.search"/>
         </j:if>
 
         <j:set var="submissionUrl" value="${args.submissionUrl}" defaultValue="submitDescription"/>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -83,8 +83,12 @@ THE SOFTWARE.
                 <f:submit  value="${%Run}"/>
               </div>
             </form>
-            <st:adjunct includes="org.kohsuke.stapler.codemirror.mode.groovy.groovy"/>
-            <st:adjunct includes="org.kohsuke.stapler.codemirror.theme.default"/>
+            <st:adjunct includes="
+                org.kohsuke.stapler.codemirror.mode.groovy.groovy,
+                org.kohsuke.stapler.codemirror.theme.default,
+                org.kohsuke.stapler.codemirror.lib.util.searchcursor,
+                org.kohsuke.stapler.codemirror.lib.util.dialog,
+                org.kohsuke.stapler.codemirror.lib.util.search"/>
             <j:if test="${output!=null}">
               <h2>
                 ${%Result}

--- a/src/main/scss/form/_codemirror.scss
+++ b/src/main/scss/form/_codemirror.scss
@@ -168,6 +168,45 @@
   .CodeMirror-nonmatchingbracket {
     color: var(--red) !important;
   }
+
+  .CodeMirror-dialog {
+    inset: 0 0 auto;
+    padding: 0.5rem;
+    background: var(--card-background);
+    border-bottom: var(--jenkins-border-width) solid var(--input-border);
+    color: var(--text-color);
+    box-shadow: 0 0.5rem 1rem
+      color-mix(in sRGB, var(--text-color) 10%, transparent);
+  }
+
+  .CodeMirror-dialog input {
+    width: min(24rem, 100%);
+    margin: 0 0.5rem;
+    padding: 0.25rem 0.5rem;
+    background: var(--input-color);
+    border: var(--jenkins-border-width) solid var(--input-border);
+    border-radius: var(--form-input-border-radius);
+    color: var(--text-color);
+    font-family: var(--font-family-mono);
+
+    &:focus {
+      outline: none;
+      border-color: var(--focus-input-border);
+      box-shadow: var(--form-input-glow--focus);
+    }
+  }
+
+  &.jenkins-codemirror-search-open .CodeMirror-scroll {
+    padding-top: var(--jenkins-codemirror-search-offset, 0);
+  }
+
+  .CodeMirror-searching {
+    background-color: color-mix(
+      in sRGB,
+      var(--warning-color) 35%,
+      transparent
+    ) !important;
+  }
 }
 
 .jenkins-codemirror-resizer {

--- a/test/src/test/java/hudson/util/FormFieldValidatorTest.java
+++ b/test/src/test/java/hudson/util/FormFieldValidatorTest.java
@@ -121,6 +121,28 @@ class FormFieldValidatorTest {
         assertNotEquals(javaScriptResult1, javaScriptResult2);
     }
 
+    @Test
+    @Issue("JENKINS-75751")
+    void codeMirrorTextAreaLoadsNativeSearchAddons() throws Exception {
+        final FreeStyleProject freeStyleProject = j.createFreeStyleProject();
+        freeStyleProject.getBuildersList().add(new CodeMirrorStep(""));
+        freeStyleProject.save();
+        final HtmlPage page = j.createWebClient().getPage(freeStyleProject, "configure");
+
+        assertThat(page.getWebResponse().getContentAsString(), allOf(
+                containsString("searchcursor.js"),
+                containsString("dialog.js"),
+                containsString("dialog.css"),
+                containsString("search.js")));
+        assertTrue((Boolean) page.executeJavaScript("""
+                typeof CodeMirror.commands.find === 'function' &&
+                typeof CodeMirror.commands.findNext === 'function' &&
+                typeof CodeMirror.commands.findPrev === 'function' &&
+                typeof document.querySelector('.CodeMirror').CodeMirror.getSearchCursor === 'function' &&
+                typeof document.querySelector('.CodeMirror').CodeMirror.openDialog === 'function'
+                """).getJavaScriptResult());
+    }
+
     public static class CodeMirrorStep extends Builder {
         private String command;
 

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -29,6 +29,7 @@ import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -414,6 +415,25 @@ public class JenkinsTest {
         //TODO: remove once RUN_SCRIPTS is finally retired
         wc.withBasicApiToken(User.getById("charlie", true));
         wc.assertFails("script", HttpURLConnection.HTTP_FORBIDDEN);
+    }
+
+    @Test
+    @Issue("JENKINS-75751")
+    void scriptConsoleLoadsNativeCodeMirrorSearchAddons() throws Exception {
+        HtmlPage page = j.createWebClient().goTo("script");
+
+        assertThat(page.getWebResponse().getContentAsString(), allOf(
+                containsString("searchcursor.js"),
+                containsString("dialog.js"),
+                containsString("dialog.css"),
+                containsString("search.js")));
+        assertTrue((Boolean) page.executeJavaScript("""
+                typeof CodeMirror.commands.find === 'function' &&
+                typeof CodeMirror.commands.findNext === 'function' &&
+                typeof CodeMirror.commands.findPrev === 'function' &&
+                typeof document.querySelector('.CodeMirror').CodeMirror.getSearchCursor === 'function' &&
+                typeof document.querySelector('.CodeMirror').CodeMirror.openDialog === 'function'
+                """).getJavaScriptResult());
     }
 
     @Test

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -1169,10 +1169,7 @@ function helpButtonOnClick() {
   return false;
 }
 
-function isCommandKey(event) {
-  return event.key === "Meta";
-}
-function isReturnKeyDown() {
+function isReturnKeyDown(event) {
   return event.type == "keydown" && event.key === "Enter";
 }
 function getParentForm(element) {
@@ -1185,6 +1182,178 @@ function getParentForm(element) {
 
   return getParentForm(element.parentNode);
 }
+
+function getCodeMirrorSearchState(editor) {
+  if (!editor._searchState) {
+    editor._searchState = {
+      posFrom: null,
+      posTo: null,
+      query: null,
+      marked: [],
+    };
+  }
+  return editor._searchState;
+}
+
+function parseCodeMirrorSearchQuery(query) {
+  var regex = query.match(/^\/(.*)\/([a-z]*)$/);
+  if (!regex) {
+    return query;
+  }
+  try {
+    return new RegExp(regex[1], regex[2].indexOf("i") == -1 ? "" : "i");
+  } catch {
+    return query;
+  }
+}
+
+function clearCodeMirrorSearch(editor) {
+  var state = getCodeMirrorSearchState(editor);
+  for (var i = 0; i < state.marked.length; i++) {
+    state.marked[i].clear();
+  }
+  state.marked.length = 0;
+  state.query = null;
+  state.posFrom = null;
+  state.posTo = null;
+}
+
+function markCodeMirrorSearchMatches(editor, state) {
+  if (editor.lineCount() >= 2000) {
+    return;
+  }
+  var caseInsensitive =
+    typeof state.query == "string" && state.query == state.query.toLowerCase();
+  var cursor = editor.getSearchCursor(state.query, null, caseInsensitive);
+  while (cursor.findNext()) {
+    if (cursor.from().line === cursor.to().line) {
+      state.marked.push(
+        editor.markText(cursor.from(), cursor.to(), "CodeMirror-searching"),
+      );
+    }
+  }
+}
+
+function getCodeMirrorSearchDialogHeight(editor) {
+  var dialog = editor
+    .getWrapperElement()
+    .querySelector(".CodeMirror-dialog-top");
+  return dialog ? dialog.getBoundingClientRect().height : 0;
+}
+
+function syncCodeMirrorSearchDialogOffset(editor) {
+  var wrapper = editor.getWrapperElement();
+  var searchDialogHeight = getCodeMirrorSearchDialogHeight(editor);
+  if (searchDialogHeight > 0) {
+    wrapper.classList.add("jenkins-codemirror-search-open");
+    wrapper.style.setProperty(
+      "--jenkins-codemirror-search-offset",
+      searchDialogHeight + "px",
+    );
+  } else {
+    wrapper.classList.remove("jenkins-codemirror-search-open");
+    wrapper.style.removeProperty("--jenkins-codemirror-search-offset");
+  }
+}
+
+function restoreCodeMirrorSearchInputFocus(input) {
+  if (input && document.body.contains(input)) {
+    input.focus();
+  }
+}
+
+function updateCodeMirrorSearch(editor, query) {
+  var state = getCodeMirrorSearchState(editor);
+  if (!query) {
+    clearCodeMirrorSearch(editor);
+    return;
+  }
+
+  var parsedQuery = parseCodeMirrorSearchQuery(query);
+  if (state.query !== null && String(state.query) === String(parsedQuery)) {
+    return;
+  }
+
+  var anchor = state.jenkinsSearchAnchor || editor.getCursor();
+  clearCodeMirrorSearch(editor);
+  state = getCodeMirrorSearchState(editor);
+  state.query = parsedQuery;
+  state.jenkinsSearchAnchor = anchor;
+  state.posFrom = anchor;
+  state.posTo = anchor;
+  markCodeMirrorSearchMatches(editor, state);
+}
+
+function installCodeMirrorSearchNavigation(editor) {
+  var wrapper = editor.getWrapperElement();
+  if (wrapper.jenkinsSearchNavigationInstalled) {
+    return;
+  }
+  wrapper.jenkinsSearchNavigationInstalled = true;
+  wrapper.CodeMirror = editor;
+
+  if (typeof MutationObserver === "function") {
+    new MutationObserver(function () {
+      syncCodeMirrorSearchDialogOffset(editor);
+    }).observe(wrapper, { childList: true });
+  }
+
+  // The bundled CodeMirror dialog closes on Enter. Keep Jenkins search open so
+  // Enter moves through matches instead of returning focus to the editor.
+  wrapper.addEventListener(
+    "keydown",
+    function (event) {
+      if (!isReturnKeyDown(event)) {
+        return;
+      }
+
+      var dialog = event.target.closest
+        ? event.target.closest(".CodeMirror-dialog")
+        : null;
+      if (
+        !dialog ||
+        event.target.tagName !== "INPUT" ||
+        dialog.textContent.indexOf("Search:") === -1
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.stopImmediatePropagation) {
+        event.stopImmediatePropagation();
+      }
+      var input = event.target;
+      updateCodeMirrorSearch(editor, input.value);
+      CodeMirror.commands[event.shiftKey ? "findPrev" : "findNext"](editor);
+      restoreCodeMirrorSearchInputFocus(input);
+    },
+    true,
+  );
+
+  wrapper.addEventListener("input", function (event) {
+    var dialog = event.target.closest
+      ? event.target.closest(".CodeMirror-dialog")
+      : null;
+    if (
+      !dialog ||
+      event.target.tagName !== "INPUT" ||
+      dialog.textContent.indexOf("Search:") === -1
+    ) {
+      return;
+    }
+
+    var state = getCodeMirrorSearchState(editor);
+    if (!state.query) {
+      state.jenkinsSearchAnchor = editor.getCursor();
+    }
+    var input = event.target;
+    updateCodeMirrorSearch(editor, input.value);
+    CodeMirror.commands.findNext(editor);
+    restoreCodeMirrorSearchInputFocus(input);
+  });
+}
+window.installCodeMirrorSearchNavigation = installCodeMirrorSearchNavigation;
 
 // figure out the corresponding end marker
 function findEnd(e) {
@@ -1371,11 +1540,9 @@ function rowvgStartEachRow(recursive, f) {
   // Script Console : settings and shortcut key
   Behaviour.specify("TEXTAREA.script", "textarea-script", ++p, function (e) {
     (function () {
-      var cmdKeyDown = false;
       var mode = e.getAttribute("script-mode") || "text/x-groovy";
 
-      // eslint-disable-next-line no-unused-vars
-      var w = CodeMirror.fromTextArea(e, {
+      var editor = CodeMirror.fromTextArea(e, {
         mode: mode,
         lineNumbers: true,
         matchBrackets: true,
@@ -1388,26 +1555,40 @@ function rowvgStartEachRow(recursive, f) {
 
           // Mac (Command + Enter)
           if (navigator.userAgent.indexOf("Mac") > -1) {
-            if (event.type == "keydown" && isCommandKey(event)) {
-              cmdKeyDown = true;
-            }
-            if (event.type == "keyup" && isCommandKey(event)) {
-              cmdKeyDown = false;
-            }
-            if (cmdKeyDown && isReturnKeyDown()) {
+            if (event.metaKey && isReturnKeyDown(event)) {
               saveAndSubmit();
               return true;
             }
 
             // Windows, Linux (Ctrl + Enter)
           } else {
-            if (event.ctrlKey && isReturnKeyDown()) {
+            if (event.ctrlKey && isReturnKeyDown(event)) {
               saveAndSubmit();
               return true;
             }
           }
         },
-      }).getWrapperElement();
+      });
+      installCodeMirrorSearchNavigation(editor);
+      var wrapper = editor.getWrapperElement();
+      var form = getParentForm(e);
+      var hasCodeMirrorFocus = false;
+
+      wrapper.addEventListener("focusin", function () {
+        hasCodeMirrorFocus = true;
+      });
+      wrapper.addEventListener("focusout", function (event) {
+        if (!wrapper.contains(event.relatedTarget)) {
+          hasCodeMirrorFocus = false;
+        }
+      });
+
+      form.addEventListener("submit", function (event) {
+        var activeElement = document.activeElement;
+        if (hasCodeMirrorFocus || wrapper.contains(activeElement)) {
+          event.preventDefault();
+        }
+      });
     })();
   });
 


### PR DESCRIPTION
Fixes #16755

Load the existing bundled CodeMirror search addons for Jenkins core CodeMirror editors, including Script Console and `f:textarea codemirror-mode="..."` fields. This lets Ctrl-F/Cmd-F use CodeMirror search over editor content instead of relying on browser find over the rendered editor DOM.

This PR is intentionally scoped to Jenkins core CodeMirror surfaces. Pipeline Replay uses Ace from the Pipeline plugin area, so changing its search UI is out of scope for this core change.

Testing done

- `git diff --check`
- `./node/node ./node/corepack yarn lint:js`
- `./node/node ./node/corepack yarn lint:css`
- `./node/node ./node/corepack yarn prod`
- `mvn -P\!yarn-execution,\!yarn-lint -am -pl war -DskipTests install`
- `mvn -U -P\!yarn-execution,\!yarn-lint -pl test -Dtest=hudson.util.FormFieldValidatorTest#codeMirrorTextAreaLoadsNativeSearchAddons,jenkins.model.JenkinsTest#scriptConsoleLoadsNativeCodeMirrorSearchAddons test`
- Manual browser verification against a Jenkins WAR built from this branch:
  - Cmd-F opens CodeMirror editor search in Script Console.
  - Typing updates matches without leaving the search input.
  - Enter moves to the next match.
  - Shift-Enter moves to the previous match.
  - Enter in the search input does not run the script.
  - The first line remains visible while the search dialog is open.
  - Light and dark themes both render correctly.

Screenshots (UI changes only)

No new persistent UI is added. This change styles CodeMirror's existing search dialog with Jenkins theme variables. Light and dark mode screenshots were verified locally.

Proposed changelog entries

Enable native CodeMirror search shortcuts in Jenkins code editors.

Proposed changelog category

/label bug, web-ui

Proposed upgrade guidelines

N/A

Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples). Fill in the Proposed upgrade guidelines section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see documentation).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

Desired reviewers

N/A
