### PR TITLE
Simplified `getInitialDelay`

### DIFF
--- a/core/src/main/java/hudson/model/AperiodicWork.java
+++ b/core/src/main/java/hudson/model/AperiodicWork.java
@@ -80,11 +80,7 @@ public abstract class AperiodicWork extends SafeTimerTask implements ExtensionPo
      * By default it chooses the value randomly between 0 and {@link #getRecurrencePeriod()}
      */
     public long getInitialDelay() {
-        long l = RANDOM.nextLong();
-        // Math.abs(Long.MIN_VALUE)==Long.MIN_VALUE!
-        if (l == Long.MIN_VALUE)
-            l++;
-        return Math.abs(l) % getRecurrencePeriod();
+        return RANDOM.nextLong(getRecurrencePeriod());
     }
 
     @Override

--- a/core/src/main/java/hudson/model/PeriodicWork.java
+++ b/core/src/main/java/hudson/model/PeriodicWork.java
@@ -87,11 +87,7 @@ public abstract class PeriodicWork extends SafeTimerTask implements ExtensionPoi
      * By default it chooses the value randomly between 0 and {@link #getRecurrencePeriod()}
      */
     public long getInitialDelay() {
-        long l = RANDOM.nextLong();
-        // Math.abs(Long.MIN_VALUE)==Long.MIN_VALUE!
-        if (l == Long.MIN_VALUE)
-            l++;
-        return Math.abs(l) % getRecurrencePeriod();
+        return RANDOM.nextLong(getRecurrencePeriod());
     }
 
     /**


### PR DESCRIPTION
1269cca9099ef909178571d42d599f752467dc2f and 5a2a2b3427fd98caa58d30f14147ee2b6c4d2837 predated https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/RandomGenerator.html which is simpler and better.

### Testing done

None.

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
