### PR TITLE
Fix live console log streaming dropping partial lines

### DIFF
--- a/core/src/main/java/hudson/console/ConsoleAnnotationOutputStream.java
+++ b/core/src/main/java/hudson/console/ConsoleAnnotationOutputStream.java
@@ -150,6 +150,7 @@ public class ConsoleAnnotationOutputStream<T> extends LineTransformationOutputSt
 
     @Override
     public void flush() throws IOException {
+        forceEol();
         out.flush();
     }
 

--- a/core/src/test/java/hudson/console/ConsoleAnnotationOutputStreamTest.java
+++ b/core/src/test/java/hudson/console/ConsoleAnnotationOutputStreamTest.java
@@ -1,0 +1,33 @@
+package hudson.console;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class ConsoleAnnotationOutputStreamTest {
+
+    /**
+     * Verifies that flush() drains any partial line buffered in
+     * LineTransformationOutputStream even when the line has no trailing newline.
+     *
+     * Regression test for https://github.com/jenkinsci/jenkins/issues/26739
+     * Programs that output lines with a leading newline (e.g. PHP scripts using
+     * {@code echo "\nChecked: [$domain]."}) caused live console log streaming to
+     * silently drop buffered partial lines because flush() did not call forceEol().
+     */
+    @Test
+    public void flushShouldDrainPartialLineBuffer() throws Exception {
+        StringWriter writer = new StringWriter();
+        ConsoleAnnotationOutputStream<Void> stream =
+                new ConsoleAnnotationOutputStream<>(writer, null, null, StandardCharsets.UTF_8);
+
+        byte[] data = "Checked: [m012345xxxx].".getBytes(StandardCharsets.UTF_8);
+        stream.write(data);
+
+        stream.flush();
+
+        assertEquals("Checked: [m012345xxxx].", writer.toString());
+    }
+}


### PR DESCRIPTION
Fixes #26739

`ConsoleAnnotationOutputStream.flush()` only flushed the downstream writer
but did not drain its internal line buffer inherited from
`LineTransformationOutputStream`. That buffer only releases content when a
newline is encountered via `eol()`.

When a program outputs text without a trailing newline in a given polling
interval (e.g. PHP scripts using `echo "\nChecked: [$domain]."`) the
content is buffered but never written to the response. Meanwhile
`CountingOutputStream` already counted those bytes and reported them in
the `end` metadata field, permanently advancing the client `fetchedBytes`
offset and causing those lines to be silently skipped in live streaming.

The fix calls `forceEol()` in `flush()` to drain any partial line from
the buffer before flushing downstream.

### Testing done

- Added unit test `ConsoleAnnotationOutputStreamTest` verifying that
  `flush()` drains partial lines that have no trailing newline.
- Reproduced manually with a freestyle job running a PHP script that
  outputs lines with a leading `\n`. Confirmed that after the fix, lines
  appear live in the console without requiring a page refresh (F5).

### Screenshots (UI changes only)

N/A

### Proposed changelog entries

- Fix live console log streaming silently dropping partial lines when output lacks a trailing newline (regression in 2.534).

### Proposed changelog category

/label regression-fix

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers