### PR TITLE
Fix description editor initially empty

### DIFF
--- a/src/main/js/components/dialogs/index.js
+++ b/src/main/js/components/dialogs/index.js
@@ -84,7 +84,7 @@ Dialog.prototype.init = function () {
     if (this.options.form != null && this.dialogType === "form") {
       this.form = this.options.form;
       content.appendChild(this.options.form);
-      behaviorShim.applySubtree(content, true);
+      setTimeout(() => behaviorShim.applySubtree(content, true));
     }
     if (this.dialogType !== "form") {
       if (this.options.content != null && this.dialogType === "alert") {


### PR DESCRIPTION
Fixes #26665


This is a regression introduced by previous changes most likely #26535, which moved description editing into a modal dialog. CodeMirror cannot compute its layout while its container is hidden (`display: none` on a `<dialog>` before `showModal()`), so the editor rendered empty until the window was resized and CodeMirror's resize handler kicked in. 

### Initial fix
Calling `refresh()` on each CodeMirror instance inside the dialog right after `showModal()` forces it to recalculate immediately. 

### Updated fix 
Use `setTimeout` to delay behavior setup until after the dialog is shown, so CodeMirror can initialize with the correct dimensions. This avoids coupling the generic `Dialog` component to CodeMirror.
Thanks @timja for the suggestion.

  ### Testing done

  Manually reproduced and verified the fix in a local development instance 
  1. Created a freestyle job.
  2. Set its description with the Safe HTML formatter and saved.
  3. Refreshed the page and clicked "Edit description".

  Before the change: the editor opened empty; content only appeared after resizing the window.
  After the change: the editor opens with the existing description rendered correctly.

  ### Screenshots
  #### Before
<img width="765" height="377" alt="image" src="https://github.com/user-attachments/assets/24e41ff3-0d2a-4adc-add2-5caaac3e0865" />

  #### After
  
<img width="766" height="388" alt="image" src="https://github.com/user-attachments/assets/158703c4-54ff-4720-b553-3537e3e8917d" />


  ### Proposed changelog entries

  - Fix description editor rendering empty when reopened inside a modal dialog.

  ### Proposed changelog category
  
  /label regression-fix,web-ui

  ### Proposed upgrade guidelines

  N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.
  ### Desired reviewers

  @zbynek, @timja

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.