### PR TITLE
Improve `Queue.maintain` performance by introducing cache for `Util.isOverridden`

### DIFF
--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -24,6 +24,7 @@
 
 package hudson;
 
+import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -47,6 +48,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.InetAddress;
@@ -97,11 +99,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.SimpleTimeZone;
 import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -1500,6 +1504,34 @@ public class Util {
         }
     }
 
+    // Keyed by (base, derived, methodName, paramTypes). Derived is held weakly so that plugin
+    // classloaders remain GC-eligible after unload. Results are stable for the lifetime of a
+    // classloader, so no invalidation is needed.
+    private static final ConcurrentHashMap<IsOverriddenCacheKey, Boolean> IS_OVERRIDDEN_CACHE =
+            new ConcurrentHashMap<>();
+
+    private record IsOverriddenCacheKey(
+            Class<?> base,
+            WeakReference<Class<?>> derivedRef,
+            String methodName,
+            List<Class<?>> types) {
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof IsOverriddenCacheKey other)) return false;
+            return base == other.base
+                    && derivedRef.get() == other.derivedRef.get()
+                    && methodName.equals(other.methodName)
+                    && types.equals(other.types);
+        }
+
+        @Override
+        public int hashCode() {
+            // Identity hash matches the identity comparison in equals.
+            return Objects.hash(base, System.identityHashCode(derivedRef.get()), methodName, types);
+        }
+    }
+
     /**
      * Checks whether the method defined on the base type with the given arguments is overridden in the given derived
      * type.
@@ -1527,10 +1559,34 @@ public class Util {
         if (baseMethod == null) {
             throw new IllegalArgumentException("The specified method is not declared by the specified base class (" + base.getCanonicalName() + "), or it is private, static or final.");
         }
-        final Method derivedMethod = Util.getMethod(derived, base, methodName, types);
-        // the lookup will either return null or the base method when no override has been found (depending on whether
-        // the base is an interface)
-        return derivedMethod != null && derivedMethod != baseMethod;
+        IsOverriddenCacheKey key = new IsOverriddenCacheKey(
+                base, new WeakReference<>(derived), methodName, List.of(types));
+        return IS_OVERRIDDEN_CACHE.computeIfAbsent(key, k -> {
+            final Method derivedMethod = Util.getMethod(derived, base, methodName, types);
+            // the lookup will either return null or the base method when no override has been found (depending on
+            // whether the base is an interface)
+            return derivedMethod != null && derivedMethod != baseMethod;
+        });
+    }
+
+    /**
+     * Returns the number of entries in the {@link #isOverridden} result cache.
+     *
+     * @since TODO
+     */
+    public static int isOverriddenCacheSize() {
+        return IS_OVERRIDDEN_CACHE.size();
+    }
+
+    /**
+     * Clears the {@link #isOverridden} result cache.
+     *
+     * @since TODO
+     */
+    @VisibleForTesting
+    @Restricted(NoExternalUse.class)
+    public static void clearIsOverriddenCache() {
+        IS_OVERRIDDEN_CACHE.clear();
     }
 
     /**

--- a/core/src/test/java/hudson/util/IsOverriddenTest.java
+++ b/core/src/test/java/hudson/util/IsOverriddenTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.Util;
 import java.io.PrintWriter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -189,5 +190,76 @@ class IsOverriddenTest {
         @Override public String bar() { return "bar"; }
     }
 
+    @BeforeEach
+    void clearCache() {
+        Util.clearIsOverriddenCache();
+    }
+
+    /**
+     * Repeated calls for the same (base, derived, method) return the same result and populate the cache.
+     */
+    @Test
+    void cacheReturnsSameResult() {
+        boolean first = Util.isOverridden(Base.class, Intermediate.class, "method");
+        assertTrue(first);
+        assertThat("cache populated after first call", Util.isOverriddenCacheSize(), is(1));
+
+        boolean second = Util.isOverridden(Base.class, Intermediate.class, "method");
+        assertThat("cached result matches original", second, is(first));
+        assertThat("cache size unchanged on hit", Util.isOverriddenCacheSize(), is(1));
+    }
+
+    /**
+     * Different derived classes produce independent cache entries.
+     * base == derived short-circuits before the cache, so it does not produce an entry.
+     */
+    @Test
+    void cacheIsScopedToDerivedClass() {
+        assertFalse(Util.isOverridden(Base.class, Base.class, "method"));
+        assertTrue(Util.isOverridden(Base.class, Intermediate.class, "method"));
+        assertTrue(Util.isOverridden(Base.class, Derived.class, "method"));
+        assertThat("one entry per distinct derived class", Util.isOverriddenCacheSize(), is(2));
+    }
+
+    /**
+     * Different method signatures produce independent cache entries.
+     */
+    @Test
+    void cacheKeyIncludesMethodSignature() {
+        assertTrue(Util.isOverridden(Base.class, Intermediate.class, "getX"));
+        assertTrue(Util.isOverridden(Base.class, Intermediate.class, "setX", Object.class));
+        assertThat("distinct entries for different method signatures", Util.isOverriddenCacheSize(), is(2));
+    }
+
+    /**
+     * An invalid method name throws even when a valid entry for the same class is already cached.
+     */
+    @Test
+    void invalidMethodStillThrowsAfterCacheWarm() {
+        assertTrue(Util.isOverridden(Base.class, Intermediate.class, "method"));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.isOverridden(Base.class, Intermediate.class, "nonExistentMethod"));
+    }
+
+    /**
+     * base == derived short-circuits before touching the cache.
+     */
+    @Test
+    void baseSameAsDerivedBypassesCache() {
+        assertFalse(Util.isOverridden(Base.class, Base.class, "method"));
+        assertThat("base==derived short-circuit must not write to cache", Util.isOverriddenCacheSize(), is(0));
+    }
+
+    /**
+     * A false result (no override) is cached correctly.
+     */
+    @Test
+    void cachesNegativeResult() {
+        assertFalse(Util.isOverridden(Throwable.class, Exception.class, "printStackTrace", PrintWriter.class));
+        assertThat("negative result is cached", Util.isOverriddenCacheSize(), is(1));
+
+        assertFalse(Util.isOverridden(Throwable.class, Exception.class, "printStackTrace", PrintWriter.class));
+        assertThat("cache size unchanged on second call", Util.isOverriddenCacheSize(), is(1));
+    }
 
 }


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #26796 

Adds a method to check the size so cache monitoring can be easily wired into observability tools. Also adds a method to clear cache so it could be called from Jenkins script console if necessary. Happy to add a feature flag or make other changes if desired.

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

Automated tests added and `mvn verify` passed.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

N/A
<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- Cache calls to `Util.is Overridden` to improve `Queue.maintain` performance.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label internal

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja for being the initial reviewer on a similar change for this setup in #11032

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
