### PR TITLE
Fix missing view name length validation

### DIFF
--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -252,7 +252,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
      */
     public void rename(String newName) throws Failure, FormException {
         if (name.equals(newName))    return; // noop
-        Jenkins.checkGoodName(newName);
+        checkViewName(newName);
         if (owner.getView(newName) != null)
             throw new FormException(Messages.Hudson_ViewAlreadyExists(newName), "name");
         String oldName = name;
@@ -1122,6 +1122,11 @@ public abstract class View extends AbstractModelObject implements AccessControll
 
     public static final Comparator<View> SORTER = Comparator.comparing(View::getViewName);
 
+    /**
+     * Maximum allowed length for a view name.
+     */
+    private static final int MAX_VIEW_NAME_LENGTH = 255;
+
     public static final PermissionGroup PERMISSIONS = new PermissionGroup(View.class, Messages._View_Permissions_Title());
     /**
      * Permission to create new views.
@@ -1150,6 +1155,19 @@ public abstract class View extends AbstractModelObject implements AccessControll
     }
 
     /**
+     * Checks that the given view name is valid.
+     *
+     * @param name the view name to check
+     * @throws Failure if the view name is invalid
+     */
+    static void checkViewName(String name) {
+        Jenkins.checkGoodName(name);
+        if (name.length() > MAX_VIEW_NAME_LENGTH) {
+            throw new Failure(Messages.View_NameTooLong(MAX_VIEW_NAME_LENGTH));
+        }
+    }
+
+    /**
      * @since 2.475
      */
     public static View create(StaplerRequest2 req, StaplerResponse2 rsp, ViewGroup owner)
@@ -1166,7 +1184,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
                         || requestContentType.startsWith("text/xml"));
 
         String name = req.getParameter("name");
-        Jenkins.checkGoodName(name);
+        checkViewName(name);
         if (owner.getView(name) != null)
             throw new Failure(Messages.Hudson_ViewAlreadyExists(name));
 
@@ -1243,7 +1261,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
         try (InputStream in = new BufferedInputStream(xml)) {
             View v = (View) Jenkins.XSTREAM.fromXML(in);
             if (name != null) v.name = name;
-            Jenkins.checkGoodName(v.name);
+            checkViewName(v.name);
             return v;
         } catch (StreamException | ConversionException | Error e) { // mostly reflection errors
             throw new IOException("Unable to read", e);

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -284,6 +284,7 @@ View.ConfigurePermission.Description=\
 View.ReadPermission.Description=\
   This permission allows users to see views.
 View.MissingMode=No view type is specified
+View.NameTooLong=View name is too long. Maximum length is {0} characters.
 View.DisplayNameNotUniqueWarning=The display name, "{0}", is already in use by another view and \
   could cause confusion and delay.
 UpdateCenter.DisplayName=Update Center

--- a/core/src/test/java/hudson/model/ViewTest.java
+++ b/core/src/test/java/hudson/model/ViewTest.java
@@ -1,7 +1,9 @@
 package hudson.model;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.search.SearchIndex;
 import hudson.search.SearchIndexBuilder;
@@ -114,6 +116,17 @@ public class ViewTest {
         Collection<View> allViews = rootView.getAllViews();
         //then
         assertEquals(4, allViews.size());
+    }
+
+    @Test
+    void checkViewNameAllowsMaximumLengthName() {
+        assertDoesNotThrow(() -> View.checkViewName("a".repeat(255)));
+    }
+
+    @Test
+    void checkViewNameRejectsTooLongName() {
+        Failure e = assertThrows(Failure.class, () -> View.checkViewName("a".repeat(256)));
+        assertEquals(Messages.View_NameTooLong(255), e.getMessage());
     }
 
     private TopLevelItem createJob(String jobName) {


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #26800 

Creating a view with an excessively long name can cause Jenkins to generate a very long view URL during redirect. In my local Jetty development instance, this reproduced as HTTP 500 "Response Header Fields Too Large"; the issue report describes HTTP 414 "URI Too Long".

This PR adds shared view name length validation in `View`, limiting view names to 255 characters. The validation is applied to view creation, view rename/configuration, and XML/CLI-based view creation through `createViewFromXML`.

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->


Manually reproduced and verified the fix in a local development instance.

1. Opened Jenkins Dashboard.
2. Went to `New View`.
3. Selected `List View`.
4. Entered a view name longer than 255 characters.
5. Clicked `Create`.

Before the change: Jenkins attempted to redirect to a very long view URL and failed with HTTP 500 "Response Header Fields Too Large".

After the change: Jenkins rejects the view name and shows a validation error instead:

`View name is too long. Maximum length is 255 characters.`

Also added unit tests for:
- accepting a 255-character view name
- rejecting a 256-character view name

Ran:

```bash
mvn -am -pl war,bom -Pquick-build install
```

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before
<img width="862" height="376" alt="500Error_TooLongViewName" src="https://github.com/user-attachments/assets/667c9c9d-838f-433d-998d-3fe9895a0eb0" />

#### After
<img width="1230" height="279" alt="TooLongViewName_ErrorMessage" src="https://github.com/user-attachments/assets/e849365b-540e-429a-bf0b-76a9e9aebe5f" />

### Proposed changelog entries

- Validate view name length to prevent inaccessible views caused by excessively long URLs.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@zbynek, @timja

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
