### PR TITLE
Fix race condition in plugin manager search results

### DIFF
--- a/src/main/js/plugin-manager-ui.js
+++ b/src/main/js/plugin-manager-ui.js
@@ -3,12 +3,19 @@ import debounce from "lodash/debounce";
 import pluginManagerAvailable from "./templates/plugin-manager/available.hbs";
 import pluginManager from "./api/pluginManager";
 
+var latestRequestId = 0;
+
 function applyFilter(searchQuery) {
   // debounce reduces number of server side calls while typing
+  var requestId = ++latestRequestId;
   pluginManager.availablePluginsSearch(
     searchQuery.toLowerCase().trim(),
     50,
     function (plugins) {
+      // Discard stale responses so they don't overwrite results for a newer query
+      if (requestId !== latestRequestId) {
+        return;
+      }
       var pluginsTable = document.getElementById("plugins");
       var tbody = pluginsTable.querySelector("tbody");
       var admin = pluginsTable.dataset.hasadmin === "true";


### PR DESCRIPTION
fixes https://github.com/jenkinsci/acceptance-test-harness/issues/2717

## Summary

- The plugin manager available-plugins page issues a fresh XHR for every (debounced) keystroke, but the success callback unconditionally rewrites `#plugins tbody`. If responses arrive out of order, a stale response can clobber the rows for the user's current query — the visible symptom is that searching/ticking several plugins in quick succession (e.g. `workflow-job`, `workflow-cps`, `workflow-basic-steps`, `git`) sometimes leaves the final search showing no/stale results.
- Fix: track a `latestRequestId` per call and discard responses whose id no longer matches the latest request.

## Test plan

- [ ] Open `Manage Jenkins > Plugins > Available plugins`.
- [ ] Search for and tick `workflow-job`, `workflow-cps`, `workflow-basic-steps`, `git` in quick succession; confirm the table consistently ends up showing matches for `git`.
- [ ] With browser devtools throttling/an artificial delay on one of the earlier responses, confirm the late stale response no longer overwrites the current results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)