### PR TITLE
Add characterization tests for checkGoodName length on Labels and Nodes

### DIFF
--- a/test/src/test/java/hudson/model/labels/CheckGoodNameLengthLabelsCharacterizationTest.java
+++ b/test/src/test/java/hudson/model/labels/CheckGoodNameLengthLabelsCharacterizationTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Carrie Chang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model.labels;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CheckGoodNameLengthLabelsCharacterizationTest {
+
+    private static final String LONG_CLEAN_NAME = "a".repeat(1000);
+
+    /**
+     * Long clean names are not flagged for escaping today.
+     */
+    @Test
+    void needsEscape_longCleanName() {
+        assertFalse(LabelAtom.needsEscape(LONG_CLEAN_NAME));
+    }
+
+    /**
+     * escape() returns the name unquoted when needsEscape() is false.
+     */
+    @Test
+    void escape_longCleanName() {
+        assertEquals(LONG_CLEAN_NAME, LabelAtom.escape(LONG_CLEAN_NAME));
+    }
+
+    /**
+     * Escape decision is driven by character content, not by length.
+     */
+    @Test
+    void needsEscape_longNameWithSpace() {
+        assertTrue(LabelAtom.needsEscape(LONG_CLEAN_NAME + " "));
+    }
+}

--- a/test/src/test/java/jenkins/model/CheckGoodNameLengthNodesCharacterizationTest.java
+++ b/test/src/test/java/jenkins/model/CheckGoodNameLengthNodesCharacterizationTest.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Carrie Chang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.Node;
+import hudson.slaves.DumbSlave;
+import hudson.util.FormValidation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Characterizes the default behavior with {@code jenkins.model.Nodes.enforceNameRestrictions=true}.
+ * With the property set to {@code false}, {@code checkGoodName} is bypassed
+ * entirely on the {@code Nodes.addNode}/{@code replaceNode}/{@code addNodeIfAbsent} paths.
+ */
+@WithJenkins
+class CheckGoodNameLengthNodesCharacterizationTest {
+
+    private static final String LONG_NAME = "a".repeat(1000);
+    private static final String MODERATELY_LONG_NAME = "a".repeat(100);
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    /**
+     * addNode accepts a moderately long name today.
+     */
+    @Test
+    void addNode_moderatelyLongName() throws Exception {
+        DumbSlave slave = new DumbSlave(
+                MODERATELY_LONG_NAME, "remoteFS", j.createComputerLauncher(null));
+
+        j.jenkins.addNode(slave);
+
+        Node retrieved = j.jenkins.getNode(MODERATELY_LONG_NAME);
+        assertNotNull(retrieved);
+        assertEquals(MODERATELY_LONG_NAME, retrieved.getNodeName());
+    }
+
+    /**
+     * The agent-name form validator approves a clean name longer than common 255-character limits.
+     */
+    @Test
+    void doCheckName_longName() {
+        FormValidation fv = j.jenkins.getDescriptorByType(DumbSlave.DescriptorImpl.class)
+                .doCheckName(LONG_NAME);
+
+        assertEquals(FormValidation.Kind.OK, fv.kind);
+    }
+
+    /**
+     * replaceNode re-validates the name on the replace path.
+     */
+    @Test
+    void replaceNode_existingLongNamedNode() throws Exception {
+        DumbSlave oldOne = new DumbSlave(
+                MODERATELY_LONG_NAME, "remoteFS", j.createComputerLauncher(null));
+        DumbSlave newOne = new DumbSlave(
+                MODERATELY_LONG_NAME, "remoteFS", j.createComputerLauncher(null));
+
+        j.jenkins.addNode(oldOne);
+
+        assertTrue(j.jenkins.getNodesObject().replaceNode(oldOne, newOne));
+        assertNotNull(j.jenkins.getNode(MODERATELY_LONG_NAME));
+    }
+}


### PR DESCRIPTION
Follow-up to #26805.

During review of #26805, @timja asked whether the length check should live in the shared `Jenkins.checkGoodName` instead of in `View`. I raised two specific compatibility concerns in [this comment](https://github.com/jenkinsci/jenkins/pull/26805#issuecomment-4480881124): `LabelAtom.needsEscape` wraps `checkGoodName` in `try/catch(Failure)` and uses the exception as a boolean for label-quoting logic, and `Nodes.addNode`/`replaceNode` re-validate names on every save.

This PR turns those two concerns into executable evidence. It adds characterization tests (in [Michael Feathers' sense](https://wiki.c2.com/?CharacterizationTest)) for the current behavior of `LabelAtom` and the `Node` add/replace flow when given long names. Every assertion documents **current** behavior on master, not desired behavior — all 6 tests pass against current master, and each assertion would flip if a length cap were added to `checkGoodName`. The diff of these test files is intended to make the scope of any future length-policy decision concrete and reviewable.

This PR proposes no behavior change and no policy decision.

### Testing done

```
mvn -pl test test -Dtest='CheckGoodNameLength*CharacterizationTest'
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```

Two new test classes:
- `test/src/test/java/hudson/model/labels/CheckGoodNameLengthLabelsCharacterizationTest.java` (3 tests)
- `test/src/test/java/jenkins/model/CheckGoodNameLengthNodesCharacterizationTest.java` (3 tests)

The Nodes tests assume the default `jenkins.model.Nodes.enforceNameRestrictions=true`; the off-branch is documented in the class Javadoc but not exercised in this PR.

### Screenshots (UI changes only)

N/A

#### Before

#### After

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood. N/A — test-only change with no user-visible behavior change.
- [x] There is automated testing or an explanation as to why this change has no tests. This PR _is_ the test.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. N/A — test classes only.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. N/A.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. N/A.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. N/A.
- [x] For new APIs and extension points, there is a link to at least one consumer. N/A.

### Desired reviewers

@timja @mawinter69 @daniel-beck — flagging since you raised the shared-validation question on #26805. Would value your input on whether this characterization scope matches what you had in mind for the policy discussion.

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
