### PR TITLE
Fix tailing of logs when partial lines are emitted

### DIFF
--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -247,6 +247,9 @@ public class AnnotatedLargeText<T> extends LargeText {
                 w, createAnnotator(req), context, charset);
         long r = super.writeLogTo(start, caw);
 
+        // Back-track any pending bytes in the line buffer.
+        r -= caw.lineBufferSize();
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         Cipher sym = PASSING_ANNOTATOR.encrypt();
         ObjectOutputStream oos = AnonymousClassWarnings.checkingObjectOutputStream(new GZIPOutputStream(new CipherOutputStream(baos, sym)));

--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -239,14 +239,21 @@ public class AnnotatedLargeText<T> extends LargeText {
         return super.writeLogTo(start, out);
     }
 
+    /**
+     * Extension point for intercepting writes from {@link #writeHtmlTo(long, Writer)} and directly inserting content into the output.
+     * @since TODO
+     */
+    protected long writeHtmlToFilter(long start, Writer w, ConsoleAnnotationOutputStream<T> caos) throws IOException {
+        return super.writeLogTo(start, caos);
+    }
+
     @CheckReturnValue
     public long writeHtmlTo(long start, Writer w) throws IOException {
         StaplerRequest2 req = Stapler.getCurrentRequest2();
         StaplerResponse2 rsp = Stapler.getCurrentResponse2();
         ConsoleAnnotationOutputStream<T> caw = new ConsoleAnnotationOutputStream<>(
                 w, createAnnotator(req), context, charset);
-        long r = super.writeLogTo(start, caw);
-
+        long r = writeHtmlToFilter(start, w, caw);
         // Back-track any pending bytes in the line buffer.
         r -= caw.lineBufferSize();
 

--- a/core/src/main/java/hudson/console/AnnotatedLargeText.java
+++ b/core/src/main/java/hudson/console/AnnotatedLargeText.java
@@ -254,6 +254,10 @@ public class AnnotatedLargeText<T> extends LargeText {
         ConsoleAnnotationOutputStream<T> caw = new ConsoleAnnotationOutputStream<>(
                 w, createAnnotator(req), context, charset);
         long r = writeHtmlToFilter(start, w, caw);
+        if (isComplete()) {
+            // The client is not expected to perform any further reads after this one. Make sure that we have flushed the line buffer.
+            caw.forceEol();
+        }
         // Back-track any pending bytes in the line buffer.
         r -= caw.lineBufferSize();
 

--- a/core/src/main/java/hudson/console/LineTransformationOutputStream.java
+++ b/core/src/main/java/hudson/console/LineTransformationOutputStream.java
@@ -43,6 +43,7 @@ public abstract class LineTransformationOutputStream extends OutputStream {
 
     /**
      * Returns the number of bytes currently buffered for the current line.
+     * @since TODO
      */
     public int lineBufferSize() {
         return buf.size();

--- a/core/src/main/java/hudson/console/LineTransformationOutputStream.java
+++ b/core/src/main/java/hudson/console/LineTransformationOutputStream.java
@@ -42,6 +42,13 @@ public abstract class LineTransformationOutputStream extends OutputStream {
     private ByteArrayOutputStream2 buf = new ByteArrayOutputStream2();
 
     /**
+     * Returns the number of bytes currently buffered for the current line.
+     */
+    public int lineBufferSize() {
+        return buf.size();
+    }
+
+    /**
      * Called for each end of the line.
      *
      * @param b


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

- Part of https://github.com/jenkinsci/jenkins/issues/26739

This PR is fixing the loss of partial lines without new line endings. It is also adding an extension point for `FileLogStorage#overallLog` in [`workflow-api-plugin`](https://github.com/jenkinsci/workflow-api-plugin/blob/515f67eadb10a819dd88e2bed41cde0a61e753b9/src/main/java/org/jenkinsci/plugins/workflow/log/FileLogStorage.java#L213) to adopt (so that we stop duplicating the metadata + back-track + forced flush logic). I've got a patch ready for adopting it there.

To re-iterate: As detailed in https://github.com/jenkinsci/jenkins/pull/26793#issuecomment-4588137445, this PR is only covering the step logs (i.e. pipeline graph view console). For the overall log/console we need to patch workflow-api-plugin.

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Run reproducer from https://github.com/jenkinsci/jenkins/issues/26739#issuecomment-4586724311

```groovy
pipeline {
    agent {
        label '!windows'
    }
    stages {
        stage('Output every second') {
            steps {
                sh '''#!/bin/bash
                for i in {1..7848}; do echo -n -e "\nChecked: $i/7848 [mabc,mdef]; invalid 0"; sleep 1; done
                '''
            }
        }
    }
}
```

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->


#### Before

blank lines in output

overall console | pipeline graph view console
--- | --- 
<img width="797" height="911" alt="image" src="https://github.com/user-attachments/assets/58083caf-ffbe-41a1-acfc-b7015858fe9e" /> | <img width="797" height="1045" alt="image" src="https://github.com/user-attachments/assets/b8af9a92-6022-4901-a9ac-d6e475b00620" />



#### After


overall console | pipeline graph view console
--- | --- 
<img width="743" height="753" alt="image" src="https://github.com/user-attachments/assets/a85f67b5-66e8-4670-ad16-f692031a9cd0" /> | <img width="765" height="1043" alt="image" src="https://github.com/user-attachments/assets/b663136f-418b-49bb-a189-6194204302cc" />

### Proposed changelog entries

- Fix tailing of logs when partial lines are emitted (regression in 2.534).

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

A sibling change is required in the `workflow-api` plugin. Consider upgrading this plugin as well.

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@MarkEWaite 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
