### PR TITLE
Mark freestyle build as aborted when interrupted during a post-build publisher

### DIFF
--- a/core/src/main/java/hudson/model/AbstractBuild.java
+++ b/core/src/main/java/hudson/model/AbstractBuild.java
@@ -770,6 +770,23 @@ public abstract class AbstractBuild<P extends AbstractProject<P, R>, R extends A
                                 setResult(Result.FAILURE);
                             }
                         }
+                    } catch (InterruptedException e) {
+                        Executor executor = Executor.currentExecutor();
+                        if (executor != null && executor.hasPendingInterruptStatus()) {
+                            // The build was interrupted (aborted / superseded / reclaimed) while a step
+                            // was running. Honor the interrupt's result as an abort rather than FAILURE.
+                            if (phase) {
+                                setResult(executor.abortResult());
+                                executor.recordCauseOfInterruption(AbstractBuild.this, listener);
+                                listener.getLogger().println(Messages.Run_BuildAborted());
+                            }
+                            r = false;
+                        } else {
+                            // A step threw InterruptedException for its own reasons with no executor
+                            // abort pending; treat it as a step failure, as before.
+                            reportError(bs, e, listener, phase);
+                            r = false;
+                        }
                     } catch (Exception | LinkageError e) {
                         reportError(bs, e, listener, phase);
                         r = false;

--- a/core/src/main/java/hudson/model/Executor.java
+++ b/core/src/main/java/hudson/model/Executor.java
@@ -247,6 +247,20 @@ public class Executor extends Thread implements ModelObject, IExecutor {
         }
     }
 
+    /**
+     * Whether this executor has a pending interrupt result recorded, i.e. {@link #interrupt(Result)}
+     * (or a variant) was called. Distinguishes an executor-driven abort from an
+     * {@link InterruptedException} thrown by a build step for its own reasons.
+     */
+    boolean hasPendingInterruptStatus() {
+        lock.readLock().lock();
+        try {
+            return interruptStatus != null;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     public Result abortResult() {
         // this method is almost always called as a result of the current thread being interrupted
         // as a result we need to clean the interrupt flag so that the lock's lock method doesn't

--- a/test/src/test/java/hudson/model/AbortedFreeStyleBuildTest.java
+++ b/test/src/test/java/hudson/model/AbortedFreeStyleBuildTest.java
@@ -1,14 +1,23 @@
 package hudson.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.Launcher;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
+import jenkins.model.CauseOfInterruption;
+import jenkins.model.InterruptedBuildAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.TestBuildWrapper;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
@@ -49,10 +58,95 @@ class AbortedFreeStyleBuildTest {
         assertEquals(Result.FAILURE, wrapper.buildResultInTearDown);
     }
 
+    @Test
+    @Issue("#26879")
+    void interruptDuringPublisherIsAborted() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        // A publisher (post-build step) interrupted via the executor must end the build as ABORTED,
+        // not FAILURE. Regression test for the publisher-phase interrupt being swallowed and
+        // reported as FAILURE by AbstractBuild.performAllBuildSteps/reportError.
+        project.getPublishersList().add(new InterruptingPublisher(Result.ABORTED, new TestCause()));
+        FreeStyleBuild build = j.buildAndAssertStatus(Result.ABORTED, project);
+        j.assertLogNotContains("aborted due to exception", build);
+        // recordCauseOfInterruption is wired: the cause is printed to the log and attached to the build.
+        j.assertLogContains(TestCause.MESSAGE, build);
+        InterruptedBuildAction action = build.getAction(InterruptedBuildAction.class);
+        assertNotNull(action, "expected an InterruptedBuildAction recording the abort cause");
+        assertTrue(action.getCauses().stream().anyMatch(c -> c instanceof TestCause),
+                "expected the publisher's CauseOfInterruption to be recorded");
+    }
+
+    @Test
+    @Issue("#26879")
+    void interruptedExceptionFromPublisherWithoutAbortIsFailure() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        // A publisher that throws InterruptedException for its own reasons, with no pending executor
+        // abort, is treated as a step failure (FAILURE + reportError), not as an executor-driven abort.
+        project.getPublishersList().add(new InterruptingPublisher(null, null));
+        FreeStyleBuild build = j.buildAndAssertStatus(Result.FAILURE, project);
+        j.assertLogContains("aborted due to exception", build);
+    }
+
     private static class AbortingBuilder extends TestBuilder {
         @Override
         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
             throw new InterruptedException();
+        }
+    }
+
+    public static class InterruptingPublisher extends Recorder {
+        // When non-null, interrupt the executor with this result before throwing; otherwise throw a
+        // bare InterruptedException so no executor abort is pending.
+        private final Result interruptResult;
+        private final CauseOfInterruption cause;
+
+        InterruptingPublisher(Result interruptResult, CauseOfInterruption cause) {
+            this.interruptResult = interruptResult;
+            this.cause = cause;
+        }
+
+        @Override
+        public BuildStepMonitor getRequiredMonitorService() {
+            return BuildStepMonitor.NONE;
+        }
+
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
+            if (interruptResult != null) {
+                if (cause != null) {
+                    Executor.currentExecutor().interrupt(interruptResult, cause);
+                } else {
+                    Executor.currentExecutor().interrupt(interruptResult);
+                }
+            }
+            throw new InterruptedException();
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+            @Override
+            public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+                return true;
+            }
+        }
+    }
+
+    private static class TestCause extends CauseOfInterruption {
+        private static final String MESSAGE = "interrupted by test publisher";
+
+        @Override
+        public String getShortDescription() {
+            return MESSAGE;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof TestCause;
+        }
+
+        @Override
+        public int hashCode() {
+            return TestCause.class.hashCode();
         }
     }
 }


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #26879 
<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

No manual testing has been done. Added two automated tests in `AbortedFreeStyleBuildTest`:

- `interruptDuringPublisherIsAborted` — a publisher interrupts the executor with `Result.ABORTED` and a `CauseOfInterruption`, then throws `InterruptedException`. Asserts the build ends ABORTED, the log does not contain "aborted due to exception", the cause is printed to the log, and an `InterruptedBuildAction` carrying the cause is attached.
- `interruptedExceptionFromPublisherWithoutAbortIsFailure` — a publisher throws a bare `InterruptedException` with no pending executor interrupt. Asserts the build ends FAILURE with "aborted due to exception" in the log, exercising the discriminator branch.

Verification:

- Reverting the core change makes `interruptDuringPublisherIsAborted` fail (the build was FAILURE, not ABORTED), confirming the test exercises the fixed lines.
- Both new tests pass with the change applied.
- `FreestyleJobPublisherTest` (publishers throwing `AbortException` / `IOException` / returning `false` → FAILURE) still passes, confirming non-interrupt publisher exceptions still produce FAILURE.

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Mark freestyle build as aborted when interrupted during a post-build publisher

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label bug

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
