### PR TITLE
Fix combobox and autocomplete dropdown selection beyond the first item

### DIFF
--- a/src/main/js/components/dropdowns/autocomplete.js
+++ b/src/main/js/components/dropdowns/autocomplete.js
@@ -44,7 +44,7 @@ function init() {
         },
         true,
         {
-          appendTo: "parent",
+          appendTo: (ref) => ref.closest("dialog") || document.body,
         },
       );
     }

--- a/src/main/js/components/dropdowns/combo-box.js
+++ b/src/main/js/components/dropdowns/combo-box.js
@@ -33,7 +33,7 @@ function init() {
         },
         true,
         {
-          appendTo: "parent",
+          appendTo: (ref) => ref.closest("dialog") || document.body,
         },
       );
     }


### PR DESCRIPTION
## Fixes #26860

The "Duplicate existing" copy-job autocomplete on `/newJob` (and the `combobox2` combobox on config screens) lets you select only the first suggestion. Clicking the second or any later suggestion does nothing and leaves the field unchanged. This is a regression introduced in 2.552 by #26326.

#26326 changed the combobox and autocomplete dropdowns from `appendTo: document.body` to `appendTo: "parent"` to fix #26325 (the dropdown was invisible inside modal `<dialog>` elements, because a body-appended popup renders behind a dialog promoted to the browser top layer).

That change had a side effect on full pages. With `appendTo: "parent"` the tippy popup is mounted in-flow inside the form, trapped in a stacking context below the sticky bottom button bar `#bottom-sticker` (`position: sticky; z-index: 998`), which holds the OK/Cancel/save buttons. Although tippy writes an inline `z-index: 9999` on the popup, that value is scoped to the trapped local context, so where the dropdown overlaps the button bar, `#bottom-sticker` is the top hit-test target. A mouse click on a suggestion that overlaps the bar lands on `#bottom-sticker` and never reaches the item. The first suggestion sits above the bar so its click lands; later suggestions fall under it so their clicks are swallowed. (The decorative `.jenkins-bottom-app-bar__shadow` at z-index 997 sits just below the button bar and is not the interceptor.)

This change makes `appendTo` conditional:

- **Outside a dialog** it returns `document.body`, so the popup re-enters the root stacking context where its z-index clears the bottom button bar, restoring the pre-#26326 behavior so every suggestion is clickable again.
- **Inside a `<dialog>`** it appends to the `<dialog>` element itself (`ref.closest("dialog")`). As a direct child of `<dialog>` the popup paints above the dialog's own `#bottom-sticker` save bar and sits outside the contents scroll container, while remaining in the dialog's top-layer subtree so the #26325 visibility fix is preserved.

---

## Testing done

Manual testing (there is no JavaScript or rendering test harness in core; the only related test, `test/src/test/java/lib/form/ComboBoxTest.java`, uses HtmlUnit, which does not perform CSS layout, stacking, or pointer hit-testing and therefore cannot reproduce this overlay regression).

### Full-page autocomplete (the reported case, must now pass)

1. Create several jobs that share a name prefix, for example `fs` and `fs2` (`Jenkins.get().createProject(Jenkins.get().getDescriptor(FreeStyleProject.class), "fs", false)`), so the suggestion list is tall enough to overlap the bottom button bar.
2. Go to `/newJob`, choose "Duplicate existing", type `f`.
3. Click the second list entry.
4. Expected: the field is filled with `fs2`. Before this change the field stayed `f`.

### Dialog combobox/autocomplete (#26325 and the dialog's own save bar, must still pass)

1. Open a modal that contains a combobox or autocomplete field (for example adding a credential).
2. Type to open the dropdown.
3. Expected: the dropdown is fully visible inside the dialog (top layer) and renders above the dialog's own OK/Cancel save bar, so every suggestion, including ones that overlap the bar, can be selected.

Verified in the browser with DevTools that on a full page the popup is appended to `<body>` and `document.elementFromPoint` over an overlapping suggestion returns the suggestion (not `#bottom-sticker`), and that inside a `<dialog>` a child of `<dialog>` (z-index 9999) is the top hit-test element above the dialog's `#bottom-sticker` (z-index 998).

ESLint and Prettier pass on the changed files.

---

## Screenshots (UI changes only)

### Before

*(clicking the second suggestion on `/newJob` does not fill the field)*

https://github.com/user-attachments/assets/3a788fd3-d9b3-4542-9c15-a3e169d556eb


### After

*(clicking the suggestions on `/newJob` fills the field)*

https://github.com/user-attachments/assets/722772e4-9287-4a00-b0a3-efeb04a62177


---

### Proposed changelog entries

- Fix the job copy field and combobox autocomplete dropdowns so suggestions below the first one can be selected again on pages with a bottom button bar.

### Proposed changelog category

/label regression-fix,web-ui,lts-candidate

### Proposed upgrade guidelines

N/A


### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval`.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @janfaracik @mawinter69 