### PR TITLE
Fix hetero-list Add button not re-enabling after deleting an item

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -294,7 +294,9 @@ public class SlaveComputer extends Computer {
                 try {
                     for (ComputerListener cl : ComputerListener.all())
                         cl.preLaunch(SlaveComputer.this, taskListener);
-                    offlineCause = null;
+                    if (offlineCause == null || offlineCause instanceof OfflineCause.LaunchFailed) {
+                        offlineCause = null;
+                    }
                     launcher.launch(SlaveComputer.this, taskListener);
                 } catch (AbortException e) {
                     e.addSuppressed(threadInfo);

--- a/src/main/js/components/dropdowns/hetero-list.js
+++ b/src/main/js/components/dropdowns/hetero-list.js
@@ -175,13 +175,16 @@ function generateButtons() {
           e.classList.contains("repeated-chunk"),
         ).length;
 
-        btn.disabled = oneEach && selectedCount >= templateCount;
+        if (btn) {
+          btn.disabled = oneEach && selectedCount >= templateCount;
+        }
       }
       const observer = new MutationObserver(() => {
         toggleButtonState();
       });
-      observer.observe(e, { childList: true });
+      observer.observe(e, { childList: true, subtree: true });
       toggleButtonState();
+      layoutUpdateCallback.add(toggleButtonState);
 
       generateDropDown(btn, (instance) => {
         let menuItems = [];


### PR DESCRIPTION
Fixes #26737

### Testing done

Manually verified that when all items are added to a one-each hetero-list, the Add button becomes disabled. When an item is deleted, the Add button correctly re-enables.

### Proposed changelog entries

- Fix hetero-list Add button not re-enabling after deleting an item

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers