### PR TITLE
Add charset UTF-8 to workspace text file responses

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -382,8 +382,8 @@ public final class DirectoryBrowserSupport implements HttpResponse {
             // for binary files, provide the file name for download
             rsp.setHeader("Content-Disposition", "inline; filename=" + baseFile.getName());
 
-            // pseudo file name to let the Stapler set text/plain
-            rsp.serveFile(req, in, lastModified, -1, length, "plain.txt");
+            // pseudo file name to let the Stapler set text/plain; ensure charset for non-ASCII text
+            rsp.serveFile(req, in, lastModified, -1, length, "mime-type:text/plain;charset=UTF-8");
         } else {
             if (resourceToken != null) {
                 // redirect to second domain
@@ -407,7 +407,14 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                     rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
                     return;
                 }
-                rsp.serveFile(req, in, lastModified, -1, length, baseFile.getName());
+                String fileName = baseFile.getName();
+                String mimeType = Jenkins.get().getServletContext().getMimeType(fileName);
+                if (mimeType != null && mimeType.startsWith("text/")) {
+                    // include charset=UTF-8 for text files to prevent browser encoding guessing
+                    rsp.serveFile(req, in, lastModified, -1, length, "mime-type:" + mimeType + ";charset=UTF-8");
+                } else {
+                    rsp.serveFile(req, in, lastModified, -1, length, fileName);
+                }
             }
         }
     }

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -1356,7 +1356,7 @@ class DirectoryBrowserSupportTest {
         Page page = getWebClient().goTo("job/" + p.getName() + "/ws/Test.java", null);
         assertThat(page.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
         assertThat("text file Content-Type should include charset",
-                page.getWebResponse().getResponseHeaderValue("Content-Type").toLowerCase(),
+                page.getWebResponse().getResponseHeaderValue("Content-Type").toLowerCase(java.util.Locale.ROOT),
                 containsString("charset=utf-8"));
         assertThat("text file content should be correctly served",
                 page.getWebResponse().getContentAsString(),

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -1338,6 +1338,31 @@ class DirectoryBrowserSupportTest {
         ));
     }
 
+    @Issue("JENKINS-26894")
+    @Test
+    void workspaceTextFileShouldIncludeCharset() throws Exception {
+        String chineseContent = "public class Test { // 用户中心模块\n}";
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                build.getWorkspace().child("Test.java").write(chineseContent, "UTF-8");
+                return true;
+            }
+        });
+        j.buildAndAssertSuccess(p);
+
+        // Test workspace file serving includes charset
+        Page page = getWebClient().goTo("job/" + p.getName() + "/ws/Test.java", null);
+        assertThat(page.getWebResponse().getStatusCode(), equalTo(HttpURLConnection.HTTP_OK));
+        assertThat("text file Content-Type should include charset",
+                page.getWebResponse().getResponseHeaderValue("Content-Type").toLowerCase(),
+                containsString("charset=utf-8"));
+        assertThat("text file content should be correctly served",
+                page.getWebResponse().getContentAsString(),
+                containsString(chineseContent));
+    }
+
     @Test
     void canViewRelativePath() throws Exception {
         File testFile = new File(j.jenkins.getRootDir(), "userContent/test.txt");


### PR DESCRIPTION
Fixes #26894

### Testing done

Automated test added that writes a .java file containing Chinese characters (用户中心模块) to a freestyle project workspace, fetches it via the workspace browser, and verifies:

- Content-Type header includes charset=utf-8
- Chinese characters are served correctly (not garbled)

The full DirectoryBrowserSupportTest suite passes (23 tests, 0 failures, 2 skipped for platform-specific reasons).

The *view* path regression test (canViewRelativePath) also passes.

### Screenshots (UI changes only)

N/A - backend change, no visual UI modification.

### Proposed changelog entries

- Include charset=UTF-8 in Content-Type when serving text/* files through the workspace and artifact browser.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.