### PR TITLE
Prohibit deserialization of Object fields by default

### DIFF
--- a/core/src/main/java/hudson/util/RobustReflectionConverter.java
+++ b/core/src/main/java/hudson/util/RobustReflectionConverter.java
@@ -50,6 +50,7 @@ import hudson.security.ACL;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -84,6 +85,22 @@ public class RobustReflectionConverter implements Converter {
 
     static /* non-final for Groovy */ boolean RECORD_FAILURES_FOR_ALL_AUTHENTICATIONS = SystemProperties.getBoolean(RobustReflectionConverter.class.getName() + ".recordFailuresForAllAuthentications", false);
     private static /* non-final for Groovy */ boolean RECORD_FAILURES_FOR_ADMINS = SystemProperties.getBoolean(RobustReflectionConverter.class.getName() + ".recordFailuresForAdmins", false);
+
+    static final Set<String> SAFE_TYPES_WITH_OBJECT_FIELDS = new HashSet<>();
+    static boolean ALLOW_ALL_OBJECT_FIELDS = SystemProperties.getBoolean(RobustReflectionConverter.class.getName() + ".ALLOW_ALL_OBJECT_FIELDS", false);
+
+    static {
+        final String classNames = SystemProperties.getString(RobustReflectionConverter.class.getName() + ".SAFE_TYPES_WITH_OBJECT_FIELDS");
+        if (classNames != null) {
+            for (String className : classNames.split(",")) {
+                SAFE_TYPES_WITH_OBJECT_FIELDS.add(className.trim());
+            }
+        }
+        // `ModelASTValue` is a known instance of a class with Object-type field (`value`) that gets deserialized from XML.
+        // It doesn't route requests to its `value` field, so this is not a problem.
+        // TODO Remove this compatibility hack once the plugin has been updated to be compatible
+        SAFE_TYPES_WITH_OBJECT_FIELDS.add("org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTValue");
+    }
 
     protected final ReflectionProvider reflectionProvider;
     protected final Mapper mapper;
@@ -451,6 +468,20 @@ public class RobustReflectionConverter implements Converter {
     }
 
     protected Object unmarshalField(final UnmarshallingContext context, final Object result, Class type, Field field) {
+        if (!ALLOW_ALL_OBJECT_FIELDS
+                && field.getType().equals(Object.class)
+                // To allow plugins to declare fields safe to deserialize without needing a new core dependency immediately, only check the simple class name
+                && Arrays.stream(field.getAnnotations()).noneMatch(a -> "XstreamSafeObjectField".equals(a.annotationType().getSimpleName()))
+                && !SAFE_TYPES_WITH_OBJECT_FIELDS.contains(field.getDeclaringClass().getName())) {
+            final String declaringClassName = field.getDeclaringClass().getName();
+            final String msg = "Refusing to unmarshal type '" + type.getName() + "' to Object typed field '" + field.getName() + "' in '" + declaringClassName +
+                    "'. Update the plugin defining this class to a compatible release, set the Java system property '" + RobustReflectionConverter.class.getName() +
+                    ".SAFE_TYPES_WITH_OBJECT_FIELDS' to add known safe types (add '" + declaringClassName +
+                    "' to the comma-separated list for this occurrence), or disable this protection entirely by setting the Java system property '" + RobustReflectionConverter.class.getName() +
+                    ".ALLOW_ALL_OBJECT_FIELDS' to 'true'. Learn more: https://www.jenkins.io/redirect/safe-object-field/";
+            LOGGER.log(Level.WARNING, msg);
+            throw new CriticalXStreamException(new XStreamException(msg));
+        }
         Converter converter = mapper.getLocalConverter(field.getDeclaringClass(), field.getName());
         if (converter == null) {
             if (new RobustCollectionConverter(mapper, reflectionProvider).canConvert(type)) {

--- a/core/src/main/java/jenkins/security/XstreamSafeObjectField.java
+++ b/core/src/main/java/jenkins/security/XstreamSafeObjectField.java
@@ -1,0 +1,55 @@
+package jenkins.security;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an {@link Object}-typed field as safe to populate during XStream deserialization.
+ *
+ * <p>By default, {@link hudson.util.RobustReflectionConverter} refuses to deserialize into
+ * fields whose static type is {@code Object}. The risk is not that XStream's type filter
+ * would admit something obviously dangerous, but that an {@code Object} field is an open
+ * sink for any deserialized value that, once placed in the field, can reach Stapler
+ * request routing (via {@code getDynamic}, {@code doXxx}, {@code getXxx}, etc.) and
+ * act on behalf of the submitting user. Unlike classic Java deserialization gadgets, the
+ * payload here is not a chain of {@code readObject} side effects but an ordinary,
+ * JEP 200-approved object whose only role is to be reachable by Stapler after the fact.
+ * SECURITY-3707 demonstrated this with {@code InternalResourceRequest} and {@code PluginWrapper};
+ * the set of types exposing such request-handling behavior is open-ended.
+ *
+ * <p>Apply this annotation only if you are confident in <strong>at least one</strong> of
+ * the following:
+ *
+ * <ul>
+ *   <li>Users cannot control what is written to the field — for instance, the
+ *       containing class is never populated from {@code config.xml} submissions or similar
+ *       attacker-controlled input.</li>
+ *   <li>Values written to the field never reach Stapler dispatch — directly or via a
+ *       routable enclosing object.</li>
+ * </ul>
+ *
+ * <p>A more specific static type is always preferable to this annotation: narrowing the
+ * field's type moves the check from a human claim to the compiler. Use this annotation
+ * only when {@code Object} is genuinely required. Adding it is a security assertion
+ * equivalent to extending a deserialization allowlist; a mistake reopens the
+ * SECURITY-3707 attack surface.
+ *
+ * <p>For compatibility with plugins targeting older cores, the converter matches this
+ * annotation by simple name. A plugin may declare its own {@code @XstreamSafeObjectField}
+ * in any package; the contract above applies regardless. This is expected to be temporary,
+ * plugins should switch to depend on an LTS release of Jenkins declaring this annotation
+ * as soon as is feasible.
+ *
+ * @see <a href="https://www.jenkins.io/security/issue/SECURITY-3707/">SECURITY-3707</a>
+ * @see <a href="https://jenkins.io/jep/200">JEP-200: Switch Remoting/XStream denylist to an allowlist</a>
+ *
+ * @since TODO
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface XstreamSafeObjectField {
+}

--- a/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
+++ b/test/src/test/java/hudson/util/RobustReflectionConverterTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -52,12 +53,15 @@ import hudson.model.Saveable;
 import hudson.model.ViewProperty;
 import hudson.security.ACL;
 import java.io.ByteArrayInputStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
+import jenkins.util.xstream.CriticalXStreamException;
 import net.sf.json.JSONObject;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
@@ -340,6 +344,90 @@ class RobustReflectionConverterTest {
             // rejected configuration is not saved
             p = r.jenkins.getItemByFullName(p.getFullName(), FreeStyleProject.class);
             assertNotEquals("badvalue", p.getProperty(KeywordProperty.class).getCriticalField().getKeyword());
+        }
+    }
+
+    @Test
+    void failObjectField() {
+        final XStream2 xStream2 = new XStream2();
+        final String xml = xStream2.toXML(new MyType("foo", "bar"));
+        final CriticalXStreamException exception = assertThrows(CriticalXStreamException.class, () -> xStream2.fromXML(xml));
+        assertThat(exception.getMessage(), containsString("Refusing to unmarshal type 'java.lang.String' to Object typed field 'foo' in 'hudson.util.RobustReflectionConverterTest$MyType'"));
+    }
+
+    @Test
+    void successObjectFieldWithAllowlist() {
+        final String className = MyType.class.getName();
+        RobustReflectionConverter.SAFE_TYPES_WITH_OBJECT_FIELDS.add(className);
+        try {
+            final XStream2 xStream2 = new XStream2();
+            final String xml = xStream2.toXML(new MyType("foo", "bar"));
+            xStream2.fromXML(xml);
+        } finally {
+            RobustReflectionConverter.SAFE_TYPES_WITH_OBJECT_FIELDS.remove(className);
+        }
+    }
+
+    @Test
+    void successObjectFieldWithEscapeHatch() {
+        RobustReflectionConverter.ALLOW_ALL_OBJECT_FIELDS = true;
+        try {
+            final XStream2 xStream2 = new XStream2();
+            final String xml = xStream2.toXML(new MyType("foo", "bar"));
+            xStream2.fromXML(xml);
+        } finally {
+            RobustReflectionConverter.ALLOW_ALL_OBJECT_FIELDS = false;
+        }
+    }
+
+    static class MyType {
+        private Object foo;
+        private String bar;
+
+        MyType(Object foo, String bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+    }
+
+    @Test
+    void successObjectFieldWithActualAnnotation() {
+        final XStream2 xStream2 = new XStream2();
+        final String xml = xStream2.toXML(new MyTypeWithActualAnnotation("foo", "bar"));
+        xStream2.fromXML(xml);
+    }
+
+    static class MyTypeWithActualAnnotation {
+        @jenkins.security.XstreamSafeObjectField
+        private Object foo;
+        private String bar;
+
+        MyTypeWithActualAnnotation(Object foo, String bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+    }
+
+    @Test
+    void successObjectFieldWithSameNameAnnotation() {
+        final XStream2 xStream2 = new XStream2();
+        final String xml = xStream2.toXML(new MyTypeWithSameNameAnnotation("foo", "bar"));
+        xStream2.fromXML(xml);
+    }
+
+    /** Marker annotation with same name as the real one, testing the case of plugin without updated core dependency */
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface XstreamSafeObjectField {
+    }
+
+    static class MyTypeWithSameNameAnnotation {
+        @XstreamSafeObjectField
+        private Object foo;
+        private String bar;
+
+        MyTypeWithSameNameAnnotation(Object foo, String bar) {
+            this.foo = foo;
+            this.bar = bar;
         }
     }
 

--- a/test/src/test/java/jenkins/security/Security3707Test.java
+++ b/test/src/test/java/jenkins/security/Security3707Test.java
@@ -1,6 +1,7 @@
 package jenkins.security;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -29,11 +30,14 @@ import org.htmlunit.FormEncodingType;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
 import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.WebMethod;
@@ -55,16 +59,16 @@ public class Security3707Test {
             WebRequest configRequest = new WebRequest(URI.create(wc.getContextPath() + "vulnerable-object/config.xml").toURL(), HttpMethod.POST);
             configRequest.setAdditionalHeader("Content-Type", "application/xml");
             configRequest.setRequestBody("""
-                    <jenkins.security.Security3707Test_-VulnerableRootAction>
+                    <jenkins.security.Security3707Test_-SafeVulnerableRootAction>
                       <routableField class="jenkins.security.ResourceDomainRootAction$InternalResourceRequest">
                         <authenticationName>admin</authenticationName>
                         <browserUrl>/scriptText</browserUrl>
                       </routableField>
-                    </jenkins.security.Security3707Test_-VulnerableRootAction>""");
+                    </jenkins.security.Security3707Test_-SafeVulnerableRootAction>""");
             final Page configResult = wc.getPage(configRequest);
             assertThat("Config submission should succeed", configResult.getWebResponse().getStatusCode(), is(200));
 
-            VulnerableRootAction action = ExtensionList.lookupSingleton(VulnerableRootAction.class);
+            SafeVulnerableRootAction action = ExtensionList.lookupSingleton(SafeVulnerableRootAction.class);
             assertThat("routableField should be null (deserialization blocked)", action.routableField, nullValue());
 
             WebRequest scriptRequest = new WebRequest(URI.create(wc.getContextPath() + "vulnerable-object/routableField/").toURL(), HttpMethod.POST);
@@ -95,19 +99,19 @@ public class Security3707Test {
             WebRequest configRequest = new WebRequest(URI.create(wc.getContextPath() + "vulnerable-object/config.xml").toURL(), HttpMethod.POST);
             configRequest.setAdditionalHeader("Content-Type", "application/xml");
             configRequest.setRequestBody("""
-                    <jenkins.security.Security3707Test_-VulnerableRootAction>
+                    <jenkins.security.Security3707Test_-SafeVulnerableRootAction>
                       <routableField class="hudson.Plugin$DummyImpl">
                         <wrapper class="hudson.PluginWrapper">
                           <baseResourceURL>file://""" + j.jenkins.getRootDir().getAbsolutePath() + """
 /</baseResourceURL>
                         </wrapper>
                       </routableField>
-                    </jenkins.security.Security3707Test_-VulnerableRootAction>""");
+                    </jenkins.security.Security3707Test_-SafeVulnerableRootAction>""");
             final Page configResult = wc.getPage(configRequest);
             assertThat("Config submission should succeed", configResult.getWebResponse().getStatusCode(), is(200));
 
-            // Verify the malicious object was NOT deserialized - readResolve should block it
-            VulnerableRootAction action = ExtensionList.lookupSingleton(VulnerableRootAction.class);
+            // Verify the Plugin object was deserialized, but the embedded PluginWrapper was not (readResolve defense)
+            SafeVulnerableRootAction action = ExtensionList.lookupSingleton(SafeVulnerableRootAction.class);
             assertThat("Plugin could be deserialized", action.routableField, instanceOf(Plugin.DummyImpl.class));
             assertThat("PluginWrapper was not deserialized", ((Plugin) action.routableField).getWrapper(), nullValue());
 
@@ -119,11 +123,78 @@ public class Security3707Test {
         }
     }
 
-    @TestExtension
-    public static class VulnerableRootAction implements UnprotectedRootAction {
-        @StaplerDispatchable
-        public Object routableField;
+    @Test
+    void testOKDeserializationWithSafeActionSucceeds(JenkinsRule j) throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ).everywhere().to("alice"));
 
+        // Verify the master.key file exists (created by Jenkins on startup)
+        File masterKeyFile = new File(j.jenkins.getRootDir(), "secrets/master.key");
+        assertThat("master.key should exist", masterKeyFile.exists(), is(true));
+        String originalMasterKey = Files.readString(masterKeyFile.toPath());
+        assertThat("master.key should not be empty", originalMasterKey.length(), is(256));
+
+        try (JenkinsRule.WebClient wc = j.createWebClient().withBasicApiToken("alice").withThrowExceptionOnFailingStatusCode(false)) {
+            // Submit config.xml containing a safe `OK` object into an Object-typed field annotated with @XstreamSafeObjectField
+            WebRequest configRequest = new WebRequest(URI.create(wc.getContextPath() + "vulnerable-object/config.xml").toURL(), HttpMethod.POST);
+            configRequest.setAdditionalHeader("Content-Type", "application/xml");
+            configRequest.setRequestBody("""
+                    <jenkins.security.Security3707Test_-SafeVulnerableRootAction>
+                      <routableField class="jenkins.security.Security3707Test$OK"/>
+                    </jenkins.security.Security3707Test_-SafeVulnerableRootAction>""");
+            final Page configResult = wc.getPage(configRequest);
+            assertThat("Config submission should succeed", configResult.getWebResponse().getStatusCode(), is(200));
+
+            // Verify the object was deserialized
+            SafeVulnerableRootAction action = ExtensionList.lookupSingleton(SafeVulnerableRootAction.class);
+            assertThat(action.routableField, instanceOf(OK.class));
+
+            WebRequest fileRequest = new WebRequest(URI.create(wc.getContextPath() + "vulnerable-object/routableField/").toURL());
+            final Page fileResult = wc.getPage(fileRequest);
+            assertThat(fileResult.getWebResponse().getStatusCode(), is(200));
+        }
+    }
+
+    @Test
+    void testOKDeserializationWithUnsafeActionFails(JenkinsRule j) throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ).everywhere().to("alice"));
+
+        // Verify the master.key file exists (created by Jenkins on startup)
+        File masterKeyFile = new File(j.jenkins.getRootDir(), "secrets/master.key");
+        assertThat("master.key should exist", masterKeyFile.exists(), is(true));
+        String originalMasterKey = Files.readString(masterKeyFile.toPath());
+        assertThat("master.key should not be empty", originalMasterKey.length(), is(256));
+
+        try (JenkinsRule.WebClient wc = j.createWebClient().withBasicApiToken("alice").withThrowExceptionOnFailingStatusCode(false)) {
+            // Submit config.xml containing `OK` into an Object-typed field *without* @XstreamSafeObjectField (should be rejected)
+            WebRequest configRequest = new WebRequest(URI.create(wc.getContextPath() + "unsafe-vulnerable-object/config.xml").toURL(), HttpMethod.POST);
+            configRequest.setAdditionalHeader("Content-Type", "application/xml");
+            configRequest.setRequestBody("""
+                    <jenkins.security.Security3707Test_-UnsafeVulnerableRootAction>
+                      <routableField class="jenkins.security.Security3707Test$OK"/>
+                    </jenkins.security.Security3707Test_-UnsafeVulnerableRootAction>""");
+            final Page configResult = wc.getPage(configRequest);
+            final WebResponse response = configResult.getWebResponse();
+            assertThat("Config submission should fail", response.getStatusCode(), is(500));
+            assertThat(response.getContentAsString(),
+                    containsString("Refusing to unmarshal type 'jenkins.security.Security3707Test$OK' to Object typed field 'routableField' in 'jenkins.security.Security3707Test$UnsafeVulnerableRootAction'."));
+
+            // Verify the object was not deserialized
+            UnsafeVulnerableRootAction action = ExtensionList.lookupSingleton(UnsafeVulnerableRootAction.class);
+            assertThat(action.routableField, nullValue());
+        }
+    }
+
+    public static class OK {
+        public HttpResponse doIndex() {
+            return HttpResponses.ok();
+        }
+    }
+
+    public abstract static class VulnerableRootAction implements UnprotectedRootAction {
         @CheckForNull
         @Override
         public String getIconFileName() {
@@ -134,12 +205,6 @@ public class Security3707Test {
         @Override
         public String getDisplayName() {
             return null;
-        }
-
-        @CheckForNull
-        @Override
-        public String getUrlName() {
-            return "vulnerable-object";
         }
 
         @WebMethod(name = "config.xml")
@@ -156,6 +221,32 @@ public class Security3707Test {
             try (InputStream in = new BufferedInputStream(new ByteArrayInputStream(out.toString().getBytes(StandardCharsets.UTF_8)))) {
                 Jenkins.XSTREAM2.unmarshal(XStream2.getDefaultDriver().createReader(in), this, null, true);
             }
+        }
+    }
+
+
+    @TestExtension
+    public static class SafeVulnerableRootAction extends VulnerableRootAction {
+        @StaplerDispatchable
+        @XstreamSafeObjectField
+        public Object routableField;
+
+        @CheckForNull
+        @Override
+        public String getUrlName() {
+            return "vulnerable-object";
+        }
+    }
+
+    @TestExtension
+    public static class UnsafeVulnerableRootAction extends VulnerableRootAction {
+        // override to remove XstreamSafeObjectField
+        @StaplerDispatchable
+        public Object routableField;
+
+        @Override
+        public String getUrlName() {
+            return "unsafe-vulnerable-object";
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/jenkins/issues/26914.

Corresponding docs PR at https://github.com/jenkins-infra/jenkins.io/pull/9203.

This introduces two new Java system properties for use by administrators:

* `hudson.util.RobustReflectionConverter.ALLOW_ALL_OBJECT_FIELDS` disables this protection entirely.
* `hudson.util.RobustReflectionConverter.SAFE_TYPES_WITH_OBJECT_FIELDS` receives the comma-separated names of classes with `Object` valued fields that should be allowed to deserialize.

This adds one new redirect to the site: `https://www.jenkins.io/redirect/safe-object-field/`:

It also adds a new annotation `XstreamSafeObjectField` that can be used to annotate `Object` fields considered safe to deserialize (~not routable). To make it easier for plugins to annotate their fields, we only check for the simple name of the annotation, so plugins can define their own `XstreamSafeObjectField` and use that. It's always preferable, as Javadoc on the annotation explains, to change the plugin if possible.

The message being logged/printed when deserialization is attempted is a bit wordy, unsure whether we need this level of detail given we link to the site. Thoughts?

> `Refusing to unmarshal type 'jenkins.security.Security3707Test$OK' to Object typed field 'routableField' in 'jenkins.security.Security3707Test$UnsafeVulnerableRootAction'. Update the plugin defining this class to a compatible release, set the Java system property 'hudson.util.RobustReflectionConverter.SAFE_TYPES_WITH_OBJECT_FIELDS' to add known safe types (add 'jenkins.security.Security3707Test$UnsafeVulnerableRootAction' to the comma-separated list for this occurrence), or disable this protection entirely by setting the Java system property 'hudson.util.RobustReflectionConverter.ALLOW_ALL_OBJECT_FIELDS' to 'true'. Learn more: https://www.jenkins.io/redirect/safe-object-field/`


### Testing done

Autotests

### Screenshots (UI changes only)

n/a

#### Before

#### After

### Proposed changelog entries

- Prohibit the deserialization of `Object` fields by default. Learn more: link:/redirect/safe-object-field/

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
