### PR TITLE
Fix dropdown suggestions requiring a double tap on touch devices

### DIFF
--- a/src/main/js/components/dropdowns/autocomplete.js
+++ b/src/main/js/components/dropdowns/autocomplete.js
@@ -100,9 +100,16 @@ function init() {
       e.style.position = "relative";
       // otherwise menu won't hide on tab with nothing selected
       // needs delay as without that it blocks click selection of an item
-      e.addEventListener("focusout", () =>
-        setTimeout(() => e.dropdown && e.dropdown.hide(), 200),
-      );
+      e.addEventListener("focusout", (event) => {
+        if (
+          event.relatedTarget &&
+          e.dropdown &&
+          e.dropdown.popper.contains(event.relatedTarget)
+        ) {
+          return;
+        }
+        setTimeout(() => e.dropdown && e.dropdown.hide(), 200);
+      });
       e.addEventListener(
         "input",
         Utils.debounce(() => {

--- a/src/main/js/components/dropdowns/combo-box.js
+++ b/src/main/js/components/dropdowns/combo-box.js
@@ -78,9 +78,16 @@ function init() {
 
           // otherwise menu won't hide on tab with nothing selected
           // needs delay as without that it blocks click selection of an item
-          e.addEventListener("focusout", () =>
-            setTimeout(() => e.dropdown.hide(), 200),
-          );
+          e.addEventListener("focusout", (event) => {
+            if (
+              event.relatedTarget &&
+              e.dropdown &&
+              e.dropdown.popper.contains(event.relatedTarget)
+            ) {
+              return;
+            }
+            setTimeout(() => e.dropdown && e.dropdown.hide(), 200);
+          });
 
           e.addEventListener(
             "input",


### PR DESCRIPTION
Fixes #26919

Follow-up to #26884. That change lifted the suggestion popup above the sticky button bar so the click can reach the suggestion. This addresses the second half of the touch problem: on a touch tap-to-click the press is held longer than 200ms, and the input's `focusout` handler hides the suggestion dropdown after 200ms, so the dropdown disappears mid-press and the tap lands on whatever is underneath instead of the suggestion. The result was that a single tap did nothing and a quick double tap was needed.

The fix keeps the dropdown open while focus is moving into it (onto a suggestion being pressed) by checking `focusout`'s `relatedTarget`. Tabbing away or clicking outside still hides the dropdown as before, because in those cases `relatedTarget` is outside the popper.

### Testing done

Tested manually on a real touch device (laptop touchpad with tap-to-click) using the New Item page "Copy from" autocomplete, whose suggestion list overlaps the sticky bottom button bar:

- Before: a single tap on a suggestion did not select it (the dropdown closed with no autocomplete); only a quick double tap worked, and slower presses failed reliably.
- After: a single tap selects any suggestion regardless of press speed or whether it overlaps the bar. An event-log trace confirmed the input value updates on the tap and is not inserted twice.
- Mouse: a single click still selects exactly once, value not duplicated.
- Keyboard: ArrowUp/ArrowDown then Enter still selects.

The guard only triggers when focus moves into the popper, so the mouse and keyboard paths are unchanged. There is no JavaScript unit-test harness for these dropdown handlers (the existing `ComboBoxTest` / `DropdownListTest` cover server-side form rendering, not client-side focus/click behavior), so this was verified manually as described.

### Screenshots (UI changes only)

#### Before

https://github.com/user-attachments/assets/3f1708cb-062f-441a-aa18-fb0cb568b7ce

#### After

https://github.com/user-attachments/assets/128897ab-a2bc-4408-a589-a40a9b3d1ac2

### Proposed changelog entries

- Fix autocomplete and combobox suggestions requiring a double tap to select on touch devices.

### Proposed changelog category

/label bug,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval`.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @daniel-beck 