### PR TITLE
Fix unhandled promise rejections on fetch calls in hudson-behavior.js

### DIFF
--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -249,11 +249,11 @@ var FormChecker = {
       }),
       body: method !== "get" && params.parameters ? params.parameters : null,
     }).then((response) => {
-      params.onComplete(response);
+      return params.onComplete(response);
     }).catch((e) => {
       FormChecker.inProgress--;
       FormChecker.schedule();
-      console.warn("Form validation failed: " + e);
+      console.warn("Form validation failed:", e);
     });
   },
 
@@ -269,7 +269,7 @@ var FormChecker = {
     this.sendRequest(next.url, {
       method: next.method,
       onComplete: function (x) {
-        x.text().then((responseText) => {
+        return x.text().then((responseText) => {
           updateValidationArea(next.target, responseText);
           FormChecker.inProgress--;
           FormChecker.schedule();
@@ -715,7 +715,7 @@ function registerValidator(e) {
       method: method,
       onComplete: function (response) {
         // TODO Add i18n support
-        response.text().then((responseText) => {
+        return response.text().then((responseText) => {
           const errorMessage = `<div class="error">An internal error occurred during form field validation (HTTP ${response.status}). Please reload the page and if the problem persists, ask the administrator for help.</div>`;
           updateValidationArea(
             validationArea,
@@ -1166,7 +1166,7 @@ function helpButtonOnClick() {
         }
         layoutUpdateCallback.call();
       });
-    }).catch((e) => console.warn("Failed to load help: " + e));
+    }).catch((e) => console.warn("Failed to load help:", e));
   } else {
     helpArea.style.display = "none";
     layoutUpdateCallback.call();
@@ -1431,7 +1431,7 @@ function rowvgStartEachRow(recursive, f) {
           e.setAttribute("usemap", "#" + id);
         });
       }
-    }).catch((e) => console.warn("Failed to load lazymap: " + e));
+    }).catch((e) => console.warn("Failed to load lazymap:", e));
   });
 
   // Native browser resizing doesn't work for CodeMirror textboxes so let's create our own
@@ -2115,7 +2115,7 @@ function refreshPart(id, url) {
             layoutUpdateCallback.call();
           });
         }
-      }).catch((e) => console.warn("Failed to refresh part: " + e));
+      }).catch((e) => console.warn("Failed to refresh part:", e));
     }
   };
   // if run as test, just do it once and do it now to make sure it's working,
@@ -2675,7 +2675,7 @@ function validateButton(checkUrl, paramList, button) {
       }
     }).catch((e) => {
       spinner.style.display = "none";
-      updateValidationArea(target.children[0], "<div class='error'>Validation failed: " + e + "</div>");
+      updateValidationArea(target.children[0], "<div class='error'>Validation failed: " + escapeHTML(String(e)) + "</div>");
       layoutUpdateCallback.call();
     });
   });

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -236,8 +236,10 @@ var FormChecker = {
     const method = params.method.toLowerCase();
     if (method !== "get") {
       var idx = url.indexOf("?");
-      params.parameters = url.substring(idx + 1);
-      url = url.substring(0, idx);
+      if (idx !== -1) {
+        params.parameters = url.substring(idx + 1);
+        url = url.substring(0, idx);
+      }
     }
 
     fetch(url, {
@@ -245,9 +247,13 @@ var FormChecker = {
       headers: crumb.wrap({
         "Content-Type": "application/x-www-form-urlencoded",
       }),
-      body: method !== "get" ? params.parameters : null,
+      body: method !== "get" && params.parameters ? params.parameters : null,
     }).then((response) => {
       params.onComplete(response);
+    }).catch((e) => {
+      FormChecker.inProgress--;
+      FormChecker.schedule();
+      console.warn("Form validation failed: " + e);
     });
   },
 
@@ -1160,7 +1166,7 @@ function helpButtonOnClick() {
         }
         layoutUpdateCallback.call();
       });
-    });
+    }).catch((e) => console.warn("Failed to load help: " + e));
   } else {
     helpArea.style.display = "none";
     layoutUpdateCallback.call();
@@ -1425,7 +1431,7 @@ function rowvgStartEachRow(recursive, f) {
           e.setAttribute("usemap", "#" + id);
         });
       }
-    });
+    }).catch((e) => console.warn("Failed to load lazymap: " + e));
   });
 
   // Native browser resizing doesn't work for CodeMirror textboxes so let's create our own
@@ -2109,7 +2115,7 @@ function refreshPart(id, url) {
             layoutUpdateCallback.call();
           });
         }
-      });
+      }).catch((e) => console.warn("Failed to refresh part: " + e));
     }
   };
   // if run as test, just do it once and do it now to make sure it's working,
@@ -2667,6 +2673,10 @@ function validateButton(checkUrl, paramList, button) {
       } catch (e) {
         window.alert("failed to evaluate " + s + "\n" + e.message);
       }
+    }).catch((e) => {
+      spinner.style.display = "none";
+      updateValidationArea(target.children[0], "<div class='error'>Validation failed: " + e + "</div>");
+      layoutUpdateCallback.call();
     });
   });
 }


### PR DESCRIPTION
### Description

When `hudson-behavior.js` was migrated to use the native `fetch()` API, `.catch()` blocks were omitted. If a user experiences a network-level failure (e.g., VPN drops, Wi-Fi disconnects), `fetch()` throws an unhandled Promise rejection. 

This causes two major issues:
1. In `FormChecker.sendRequest`, `inProgress` never decrements, permanently locking up the background validation queue.
2. In interactive elements like the Validate Button, loading spinners spin forever.

This PR adds `.catch()` blocks to the 5 `fetch` calls in `hudson-behavior.js` to ensure network errors are handled gracefully and queues are properly unblocked. This brings the file up to the same standard as modern Jenkins components (like `jumplists.js`).

*(Note: We do not require an issue for minor improvements. This is a minor bug fix, no issue created.)*

### Testing done

- Ran Node.js syntax verification (`node -c`) on `hudson-behavior.js` to ensure no syntax errors were introduced.
- Verified the logic against the MDN `fetch` API specifications regarding network failure handling.
- Manually reviewed the `FormChecker` logic to ensure `inProgress` correctly decrements on network abort/failure.
