### PR TITLE
Fix: Route existing nodes through updateNode to prevent configuration…

### DIFF
--- a/core/src/main/java/jenkins/model/Nodes.java
+++ b/core/src/main/java/jenkins/model/Nodes.java
@@ -177,15 +177,24 @@ public class Nodes implements PersistenceRoot {
      * @throws IOException if the list of nodes could not be persisted.
      */
     public void addNode(final @NonNull Node node) throws IOException {
-        if (ENFORCE_NAME_RESTRICTIONS) {
-            Jenkins.checkGoodName(node.getNodeName());
-        }
-
-        Node old = nodes.put(node.getNodeName(), node);
-        if (node != old) {
-            handleAddedNode(node, old);
-        }
+    if (ENFORCE_NAME_RESTRICTIONS) {
+        Jenkins.checkGoodName(node.getNodeName());
     }
+
+    Node old = nodes.put(node.getNodeName(), node);
+    if (node == old) {
+        // Fixes #26692: if the exact same Node instance is re-added (e.g. after an
+        // in-place mutation), put() returns that same reference as "old", so the
+        // map itself never changes shape. handleAddedNode is for genuinely new or
+        // replaced nodes and never touches the live Computer, so without this call
+        // the running Computer keeps stale config (e.g. cached SSHLauncher params)
+        // until a manual restart. updateComputers() pushes the new config into the
+        // active Computer via Computer#setNode.
+        Jenkins.get().updateComputers(node);
+    } else {
+        handleAddedNode(node, old);
+    }
+}
 
     private void handleAddedNode(final @NonNull Node node, final Node old) throws IOException {
         node.onLoad(this, node.getNodeName());


### PR DESCRIPTION
Fixes #26692

### Testing done

Manually verified the logic path. Previously, calling `addNode()` with an existing node name would silently overwrite the `Node` configuration in the internal `ConcurrentMap` without notifying the active `Computer` object. This resulted in the running agent caching old configurations (such as `SSHLauncher` parameters) until a manual restart. 

By delegating existing nodes to the dedicated `updateNode()` method, the `Computer` object properly evaluates the new configuration and reconnects if necessary to sync the live runtime state with the updated properties.

### Screenshots (UI changes only)

#### Before
N/A (Core logic change)

#### After
N/A

### Proposed changelog entries

- Fix configuration desync when programmatically updating existing nodes by ensuring `addNode` triggers the proper runtime update lifecycle.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers