### PR TITLE
Fix ScriptListener output stream capturing the wrong bytes on partial writes

### DIFF
--- a/core/src/main/java/jenkins/util/ScriptListener.java
+++ b/core/src/main/java/jenkins/util/ScriptListener.java
@@ -198,7 +198,7 @@ public interface ScriptListener extends ExtensionPoint {
 
         @Override
         public void write(@NonNull byte[] b, int off, int len) throws IOException {
-            final String writtenString = new String(b, charset).substring(off, len - off);
+            final String writtenString = new String(b, off, len, charset);
             ScriptListener.fireScriptOutput(writtenString, feature, context, correlationId, user);
             os.write(b, off, len);
         }

--- a/test/src/test/java/jenkins/model/ScriptListenerTest.java
+++ b/test/src/test/java/jenkins/model/ScriptListenerTest.java
@@ -2,6 +2,7 @@ package jenkins.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -13,9 +14,11 @@ import hudson.cli.GroovyshCommand;
 import hudson.model.User;
 import hudson.util.RemotingDiagnostics;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.logging.Level;
 import jenkins.util.DefaultScriptListener;
@@ -156,6 +159,45 @@ class ScriptListenerTest {
             assertThat(execution, containsString(script));
             assertThat(listener.getOutput(), containsString(output));
         }
+    }
+
+    @Test
+    void listenerOutputStreamCapturesPartialWrite() throws IOException {
+        // A backing buffer with a prefix and suffix that must not be captured, only [off, off+len) is written.
+        final byte[] buf = "XXXhello from output streamYYY".getBytes(StandardCharsets.UTF_8);
+        final int off = 3;
+        final int len = "hello from output stream".length();
+
+        final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        try (ScriptListener.ListenerOutputStream los = new ScriptListener.ListenerOutputStream(
+                sink, StandardCharsets.UTF_8, ScriptListenerTest.class, null, "correlation", null)) {
+            los.write(buf, off, len);
+        }
+
+        final String expected = new String(buf, off, len, StandardCharsets.UTF_8);
+        final DummyScriptUsageListener listener = ExtensionList.lookupSingleton(DummyScriptUsageListener.class);
+        // The captured string must represent exactly the bytes forwarded downstream.
+        assertThat(listener.getOutput(), equalTo(expected));
+        assertThat(sink.toString(StandardCharsets.UTF_8), equalTo(expected));
+    }
+
+    @Test
+    void listenerOutputStreamCapturesWriteWhenOffsetExceedsHalfLength() throws IOException {
+        // Regression: off > len/2 previously threw StringIndexOutOfBoundsException in substring(off, len - off).
+        final byte[] buf = "0123456789ab".getBytes(StandardCharsets.UTF_8);
+        final int off = 8;
+        final int len = 4;
+
+        final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        try (ScriptListener.ListenerOutputStream los = new ScriptListener.ListenerOutputStream(
+                sink, StandardCharsets.UTF_8, ScriptListenerTest.class, null, "correlation", null)) {
+            los.write(buf, off, len);
+        }
+
+        final String expected = new String(buf, off, len, StandardCharsets.UTF_8);
+        final DummyScriptUsageListener listener = ExtensionList.lookupSingleton(DummyScriptUsageListener.class);
+        assertThat(listener.getOutput(), equalTo(expected));
+        assertThat(sink.toString(StandardCharsets.UTF_8), equalTo(expected));
     }
 
     @TestExtension


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- No issue: minor bug, issue not required. No existing open issue found for this; the human may file one and replace the line below with "Fixes #<issue-number>". -->

Fixes #

`ListenerOutputStream.write(byte[], int off, int len)` decoded the whole array, ignoring `off`/`len`, then took `substring(off, len - off)` — end index should be `off+len`. Downstream gets `os.write(b, off, len)`, so the capture must be `[off, off+len)`. When `off > len/2`, end < start and it throws `StringIndexOutOfBoundsException` on normal input.

Fix: decode only that range via `new String(b, off, len, charset)` (standard JDK constructor, used elsewhere in core), matching sibling `ListenerWriter`'s `String.copyValueOf(cbuf, off, len)`.

### Testing done

Added two `jenkins.model.ScriptListenerTest` tests, both failing on the old code: `listenerOutputStreamCapturesPartialWrite` asserts a non-zero-offset write captures `new String(buf, off, len, charset)`; `listenerOutputStreamCapturesWriteWhenOffsetExceedsHalfLength` covers the `off > len/2` case that threw. `mvn -pl test surefire:test -Dtest=ScriptListenerTest` (JDK 21): 5 tests, 0 failures.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Fix script console output stream capturing the wrong bytes on partial writes

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

