### PR TITLE
Fix broken issue-triage cross-reference in maintainers documentation

### DIFF
--- a/docs/MAINTAINERS.adoc
+++ b/docs/MAINTAINERS.adoc
@@ -320,7 +320,7 @@ Code reviews do NOT pursue the following goals:
 ** We want to keep pull requests focused when possible (one feature/fix per pull request),
    but we can live without it if there is no need to backport changes to the stable baseline.
 
-== Issue triage
+== Issue triage [[issue-triage]]
 
 The *Issue Triage Team* and *Core Maintainers* are roles that are expected to process the incoming issues.
 These contributors perform initial triage of incoming issues and periodically scrub the issue tracker.


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- No issue: minor documentation link fix, issue not required -->

In `docs/MAINTAINERS.adoc`, the cross-reference `<<issue-triage,triage guidelines below>>` points to an anchor `issue-triage` that is never defined: the `== Issue triage` heading has no explicit anchor, so Asciidoctor auto-generates the ID `_issue_triage`. The in-page link resolves nowhere.

This adds an explicit `[[issue-triage]]` anchor to the `== Issue triage` heading, mirroring the existing `[[acceptance]]` anchor. Only the anchor changes; prose is untouched.

### Testing done

Rendered with Asciidoctor 2.0.26 (used by GitHub and jenkins.io) before and after:

- Before: HTML emits `<a href="#issue-triage">` but has no `id="issue-triage"` (the section's only ID is the auto-generated `_issue_triage`) — broken link.
- After: `id="issue-triage"` is present and both the TOC link and body cross-reference resolve to it.

Documentation-only; no production code, so no automated test is added.

### Screenshots (UI changes only)

#### Before

#### After

<!-- N/A: no UI change -->

### Proposed changelog entries

- human-readable text

<!-- N/A: documentation-only change, see changelog category below -->

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
