### PR TITLE
Fix FlightRecorderInputStream.skip returning -1 at end of stream

### DIFF
--- a/cli/src/main/java/hudson/cli/FlightRecorderInputStream.java
+++ b/cli/src/main/java/hudson/cli/FlightRecorderInputStream.java
@@ -103,11 +103,15 @@ class FlightRecorderInputStream extends InputStream {
 
     /**
      * To record the bytes we've skipped, convert the call to read.
+     *
+     * <p>At end of stream this returns {@code 0} rather than {@code -1}, honoring the
+     * {@link InputStream#skip(long)} contract that the returned value is never negative.
      */
     @Override
     public long skip(long n) throws IOException {
         byte[] buf = new byte[(int) Math.min(n, 64 * 1024)];
-        return read(buf, 0, buf.length);
+        int read = read(buf, 0, buf.length);
+        return read < 0 ? 0 : read; // honor InputStream.skip contract: never return negative at EOF
     }
 
     @Override

--- a/cli/src/test/java/hudson/cli/FlightRecorderInputStreamTest.java
+++ b/cli/src/test/java/hudson/cli/FlightRecorderInputStreamTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class FlightRecorderInputStreamTest {
+
+    @Test
+    void skipAtEndOfStreamReturnsZeroNotMinusOne() throws Exception {
+        FlightRecorderInputStream in = new FlightRecorderInputStream(new ByteArrayInputStream(new byte[0]));
+        assertEquals(0, in.skip(10));
+    }
+
+    @Test
+    void skipOnNonEmptyStreamReturnsNonNegativeWithinRequest() throws Exception {
+        byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
+        FlightRecorderInputStream in = new FlightRecorderInputStream(new ByteArrayInputStream(data));
+        long skipped = in.skip(3);
+        assertTrue(skipped >= 0 && skipped <= 3, "skip should return a value in [0, n], was " + skipped);
+    }
+}


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- No issue: minor bug fix, issue not required per CONTRIBUTING.md -->

Fixes #<!-- none; minor bug fix does not require an issue -->

`FlightRecorderInputStream.skip(long)` returns the raw result of a single `read(byte[],int,int)`. At end of stream `read` returns `-1`, so `skip` returns `-1` — violating the `InputStream.skip(long)` contract, whose return must be non-negative (JDK base never returns negative).

This defensive contract-conformance fix normalizes the EOF case in a single line, protecting direct/third-party callers and future refactors through `skip`; existing single-read behavior is unchanged.

### Testing done

Added `FlightRecorderInputStreamTest` (JUnit 5, package-private): at EOF (empty source) `skip(10)` returns `0`, not `-1`; non-empty source: `skip(k)` returns `[0, k]`. `mvn -pl cli -am clean test`: BUILD SUCCESS, 34 tests, 0 failures (2 new).

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Fix `FlightRecorderInputStream.skip` returning `-1` at end of stream instead of `0`

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- N/A: no new public API -->
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- N/A: no deprecations -->
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- N/A: no UI changes -->
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- N/A: no dependency changes -->
- [ ] For new APIs and extension points, there is a link to at least one consumer. <!-- N/A: no new API -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
