### PR TITLE
Fix Iterators.sequence dropping the last element of a stepped range

### DIFF
--- a/core/src/main/java/hudson/util/Iterators.java
+++ b/core/src/main/java/hudson/util/Iterators.java
@@ -226,15 +226,17 @@ public class Iterators {
     }
 
     /**
-     * Returns a list that represents [start,end).
+     * Returns a list that represents the half-open range [start,end) stepped by {@code step}.
      *
-     * For example sequence(1,5,1)={1,2,3,4}, and sequence(7,1,-2)={7.5,3}
+     * <p>The last in-range element is included even when the range length is not an exact
+     * multiple of {@code step}. For example sequence(1,5,1)={1,2,3,4}, sequence(7,1,-2)={7,5,3},
+     * and sequence(1,6,2)={1,3,5}.
      *
      * @since 1.150
      */
     public static List<Integer> sequence(final int start, int end, final int step) {
 
-        final int size = (end - start) / step;
+        final int size = (end - start + step - (step > 0 ? 1 : -1)) / step;
         if (size < 0)  throw new IllegalArgumentException("List size is negative");
 
         return new AbstractList<>() {

--- a/core/src/test/java/hudson/util/IteratorsTest.java
+++ b/core/src/test/java/hudson/util/IteratorsTest.java
@@ -62,6 +62,18 @@ class IteratorsTest {
     }
 
     @Test
+    void sequenceWithNonUnitStep() {
+        assertEquals(List.of(1, 3, 5), Iterators.sequence(1, 6, 2));
+        assertEquals(List.of(0, 3, 6, 9), Iterators.sequence(0, 10, 3));
+        assertEquals(List.of(10, 7, 4, 1), Iterators.sequence(10, 0, -3));
+        // ranges that are an exact multiple of the step are unaffected
+        assertEquals(List.of(1, 2, 3, 4), Iterators.sequence(1, 5, 1));
+        assertEquals(List.of(7, 5, 3), Iterators.sequence(7, 1, -2));
+        // an empty range stays empty
+        assertEquals(List.of(), Iterators.sequence(5, 5, 1));
+    }
+
+    @Test
     void wrap() {
         List<Integer> lst = Iterators.sequence(1, 4);
         Iterable<Integer> wrapped = Iterators.wrap(lst);


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- No issue: minor bug fix, issue not required per CONTRIBUTING.md -->

Fixes #<!-- human: fill in if an issue exists; none required for this minor bug fix -->

`hudson.util.Iterators.sequence(start, end, step)` (public, `@since 1.150`) sizes the list as `(end - start) / step`, truncating toward zero. When the half-open `[start, end)` length isn't a multiple of `step`, the last element is silently dropped — e.g. `sequence(1, 6, 2)` returns `[1, 3]` instead of `[1, 3, 5]`; `sequence(0, 10, 3)` and `sequence(10, 0, -3)` likewise drop their last element.

The fix uses ceiling division correct for both step signs, keeping the negative-size guard for inverted ranges. Both in-tree callers (`Fingerprint.java:366`/`:379`) use step `±1` under `start < end`, so in-tree output is unchanged — no regression; only external non-`±1`-step callers regain the dropped element.

### Testing done

Added `IteratorsTest.sequenceWithNonUnitStep`: the three buggy cases return the full range, plus exact-multiple and empty-range guards. `mvn -pl core -am clean test -Dtest=IteratorsTest` (JDK 21): 6 tests, 0 failures.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Fix `Iterators.sequence` dropping the last element of a stepped range whose length is not a multiple of the step

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- no new public API; only a Javadoc clarification on an existing method -->
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- no deprecations -->
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- no UI changes -->
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- no dependency updates -->
- [ ] For new APIs and extension points, there is a link to at least one consumer. <!-- no new APIs -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

