### PR TITLE
Fix disabled Add button in hetero-list after deletion

### DIFF
--- a/src/main/js/components/dropdowns/hetero-list.js
+++ b/src/main/js/components/dropdowns/hetero-list.js
@@ -159,8 +159,9 @@ function generateButtons() {
 
       function has(id) {
         return (
-          e.querySelector('DIV.repeated-chunk[descriptorId="' + id + '"]') !=
-          null
+          e.querySelector(
+            'DIV.repeated-chunk:not(.fade-out)[descriptorId="' + id + '"]',
+          ) != null
         );
       }
 
@@ -171,8 +172,10 @@ function generateButtons() {
        */
       function toggleButtonState() {
         const templateCount = templates.length;
-        const selectedCount = Array.from(e.children).filter((e) =>
-          e.classList.contains("repeated-chunk"),
+        const selectedCount = Array.from(e.children).filter(
+          (child) =>
+            child.classList.contains("repeated-chunk") &&
+            !child.classList.contains("fade-out"),
         ).length;
 
         btn.disabled = oneEach && selectedCount >= templateCount;
@@ -180,7 +183,12 @@ function generateButtons() {
       const observer = new MutationObserver(() => {
         toggleButtonState();
       });
-      observer.observe(e, { childList: true });
+      observer.observe(e, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["class"],
+      });
       toggleButtonState();
 
       generateDropDown(btn, (instance) => {


### PR DESCRIPTION
Fixes #26737

### Testing done

Manually verified the fix locally:
1. Created a Freestyle project.
2. Added all available "Post-build Actions" until the "Add post-build action" button became disabled.
3. Deleted one of the post-build actions.
4. Verified that the "Add post-build action" button re-enabled immediately and the deleted action was available in the dropdown again.

### Screenshots (UI changes only)


https://github.com/user-attachments/assets/e07b934d-cc55-4be7-9ab8-dab22a609112


### Proposed changelog entries

- Re-enable the hetero-list "Add" button immediately when an item is deleted.

### Proposed changelog category

/label bug, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@daniel-beck