### PR TITLE
Complete Korean translation for jenkins.management messages

### DIFF
--- a/core/src/main/resources/jenkins/management/Messages_ko.properties
+++ b/core/src/main/resources/jenkins/management/Messages_ko.properties
@@ -22,9 +22,52 @@
 # THE SOFTWARE.
 #
 
-PluginsLink.Description=Jenkins의 기능을 확장하기 위한 플러그인을 추가, 제거, 사용, 미사용으로 설정할 수 있습니다.
-ConfigureLink.Description=환경변수 및 경로 정보등을 설정합니다.
-SystemInfoLink.Description=문제 해결을 돕기위한 다양한 환경 정보를 보여줍니다.
-StatisticsLink.DisplayName=부하 통계
-ShutdownLink.DisplayName_prepare=끄기전 준비
+ConfigureLink.DisplayName=시스템
+ConfigureLink.Description=전역 설정과 경로를 구성합니다.
+
+ConfigureTools.DisplayName=도구
+ConfigureTools.Description=도구와 그 위치, 자동 설치 프로그램을 구성합니다.
+
+ReloadLink.DisplayName=디스크에서 설정 다시 읽기
+ReloadLink.Description=메모리에 적재된 모든 데이터를 버리고 파일 시스템에서 전체를 다시 읽습니다.\n\
+                       디스크의 설정 파일을 직접 수정했을 때 유용합니다.
+
+PluginsLink.DisplayName=플러그인
+PluginsLink.Description=Jenkins의 기능을 확장하는 플러그인을 추가, 제거, 사용 안 함 또는 사용으로 설정합니다.
+PluginsLink.updateAvailable=업데이트 1개 있음
+PluginsLink.updatesAvailable=업데이트 {0}개 있음
+PluginsLink.securityUpdateAvailable=보안 취약점을 수정하는 업데이트 1개
+PluginsLink.securityUpdatesAvailable=보안 취약점을 수정하는 업데이트 {0}개
+PluginsLink.incompatibleUpdateAvailable=설치된 버전과 호환되지 않는 업데이트 1개
+PluginsLink.incompatibleUpdatesAvailable=설치된 버전과 호환되지 않는 업데이트 {0}개
+
 SystemInfoLink.DisplayName=시스템 정보
+SystemInfoLink.Description=문제 해결에 도움이 되는 다양한 환경 정보를 보여줍니다.
+
+SystemLogLink.DisplayName=시스템 로그
+SystemLogLink.Description=시스템 로그는 Jenkins와 관련된 <code>java.util.logging</code> 출력을 수집합니다.
+
+StatisticsLink.DisplayName=부하 통계
+StatisticsLink.Description=리소스 사용량을 확인하고 빌드에 더 많은 컴퓨터가 필요한지 살펴봅니다.
+
+CliLink.DisplayName=Jenkins CLI
+CliLink.Description=셸이나 스크립트에서 Jenkins에 접근하고 관리합니다.
+
+ConsoleLink.DisplayName=스크립트 콘솔
+ConsoleLink.Description=관리·문제 해결·진단을 위해 임의의 스크립트를 실행합니다.
+
+NodesLink.DisplayName=노드
+NodesLink.Description=Jenkins가 작업을 실행하는 여러 노드를 추가, 제거, 제어, 모니터링합니다.
+
+ShutdownLink.DisplayName_prepare=종료 준비
+ShutdownLink.DisplayName_cancel=종료 취소
+ShutdownLink.DisplayName_update=종료 준비 업데이트
+ShutdownLink.Description=새 빌드 실행을 중단하여 시스템을 안전하게 종료할 수 있도록 합니다.
+ShutdownLink.ShuttingDownInProgressDescription=Jenkins가 현재 종료 중입니다. 새 빌드는 실행되지 않습니다.
+ShutdownLink.ShutDownReason_title=사유
+ShutdownLink.ShutDownReason_update=사유 업데이트
+
+PluginsUpdatesLink.DisplayName=업데이트
+PluginsAvailableLink.DisplayName=사용 가능한 플러그인
+PluginsInstalledLink.DisplayName=설치된 플러그인
+PluginsDownloadProgressLink.DisplayName=다운로드 진행 상황


### PR DESCRIPTION
The "Manage Jenkins" screens (`jenkins/management`) were only partially translated to Korean — `Messages_ko.properties` had 6 of the 37 keys, so most of the management UI fell back to English for Korean users. This completes the translation (all 37 keys).

### Testing done

This is a localization-only change (`Messages_ko.properties`, no code).

- Verified every key in `Messages_ko.properties` exists in the English `Messages.properties` — all 37 keys, no stray or duplicate keys, full coverage.
- Preserved the `{0}` `MessageFormat` placeholders (plugin update counters) and the `\n\` line-continuation in `ReloadLink.Description`.
- File keeps the existing UTF-8 encoding, consistent with the sibling locale files.

### Screenshots (UI changes only)

#### Before

#### After

<!-- Translation-only change; the affected strings render across the Manage Jenkins screens (System, Tools, Plugins, Nodes, Script Console, Prepare for Shutdown, ...). -->

### Proposed changelog entries

- Complete the Korean translation of the Manage Jenkins screens.

### Proposed changelog category

/label localization

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Proposed upgrade guidelines

N/A