### PR TITLE
Add Korean translation for hudson.security messages

### DIFF
--- a/core/src/main/resources/hudson/security/Messages_ko.properties
+++ b/core/src/main/resources/hudson/security/Messages_ko.properties
@@ -1,0 +1,65 @@
+#
+# The MIT License
+#
+# Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+GlobalSecurityConfiguration.DisplayName=보안
+GlobalSecurityConfiguration.Description=Jenkins를 안전하게 보호합니다. 누가 시스템에 접근하고 사용할 수 있는지 정의합니다.
+
+HudsonPrivateSecurityRealm.WouldYouLikeToSignUp=이 {0} {1} 은(는) Jenkins에 처음입니다. 가입하시겠습니까?
+LegacyAuthorizationStrategy.DisplayName=레거시 모드
+
+HudsonPrivateSecurityRealm.DisplayName=Jenkins 자체 사용자 데이터베이스
+HudsonPrivateSecurityRealm.SignupWarning=가입을 활성화하면 네트워크상의 누구나 인증된 사용자가 될 수 있습니다. 이 경우 인증된 사용자에게 부여하는 권한을 최소화하는 것이 좋습니다.
+HudsonPrivateSecurityRealm.Details.DisplayName=비밀번호
+HudsonPrivateSecurityRealm.Details.PasswordError=\
+  확인용 비밀번호가 입력한 비밀번호와 일치하지 않습니다. \
+  동일한 비밀번호를 두 번 입력했는지 확인하세요.
+HudsonPrivateSecurityRealm.ManageUserLinks.DisplayName=사용자
+HudsonPrivateSecurityRealm.ManageUserLinks.Description=이 Jenkins에 로그인할 수 있는 사용자를 생성/삭제/수정합니다.
+
+HudsonPrivateSecurityRealm.CreateAccount.TextNotMatchWordInImage=입력한 텍스트가 이미지에 표시된 단어와 일치하지 않습니다
+HudsonPrivateSecurityRealm.CreateAccount.PasswordNotMatch=비밀번호가 일치하지 않습니다
+HudsonPrivateSecurityRealm.CreateAccount.FIPS.PasswordLengthInvalid=비밀번호는 최소 14자 이상이어야 합니다
+HudsonPrivateSecurityRealm.CreateAccount.BCrypt.PasswordTooLong.ASCII=비밀번호는 72자를 초과할 수 없습니다.
+HudsonPrivateSecurityRealm.CreateAccount.BCrypt.PasswordTooLong=비밀번호는 72자를 초과할 수 없습니다(a-z, A-Z, 0-9 및 기본 문장 부호 기준이며, 한자나 이모지 같은 다른 문자를 사용하면 더 짧아집니다).
+HudsonPrivateSecurityRealm.CreateAccount.PasswordRequired=비밀번호는 필수입니다
+HudsonPrivateSecurityRealm.CreateAccount.UserNameRequired=사용자 이름은 필수입니다
+HudsonPrivateSecurityRealm.CreateAccount.UserNameInvalidCharacters=사용자 이름은 영숫자, 밑줄(_), 하이픈(-)만 포함할 수 있습니다
+HudsonPrivateSecurityRealm.CreateAccount.UserNameInvalidCharactersCustom=사용자 이름은 다음 표현식과 일치해야 합니다: {0}
+HudsonPrivateSecurityRealm.CreateAccount.InvalidEmailAddress=잘못된 이메일 주소입니다
+HudsonPrivateSecurityRealm.CreateAccount.UserNameAlreadyTaken=이미 사용 중인 사용자 이름입니다
+
+FullControlOnceLoggedInAuthorizationStrategy.DisplayName=로그인한 사용자는 무엇이든 할 수 있음
+
+AuthorizationStrategy.DisplayName=누구나 무엇이든 할 수 있음
+
+LegacySecurityRealm.Displayname=서블릿 컨테이너에 위임
+
+UserDetailsServiceProxy.UnableToQuery=사용자 정보를 조회할 수 없습니다: {0}
+
+# not in use
+Permission.Permissions.Title=N/A
+AccessDeniedException2.MissingPermission={0} 에게 {1} 권한이 없습니다
+AccessDeniedException.MissingPermissions={0} 에게 권한이 없습니다. {1} 중 하나가 필요합니다
+
+NoneSecurityRealm.DisplayName=없음


### PR DESCRIPTION
The global Security configuration screens, the Jenkins user-database sign-up/account-creation flow, and the authorization-strategy display names (`hudson/security`) had no Korean translation, so Korean users saw these security-related strings in English.

This adds `Messages_ko.properties` for `hudson/security` (all 29 keys). Placeholders (`{0}`, `{1}`) and the line-continuation in `PasswordError` are preserved; untranslated keys would fall back to English as usual.

Verified every key exists in the English `Messages.properties` (no stray/duplicate keys, full coverage) and the file is raw UTF-8 like the other locale files.
