### PR TITLE
Export ChannelTermination#cause via REST API (JENKINS-49217)

### DIFF
--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -114,8 +114,35 @@ public abstract class OfflineCause implements IOfflineCause {
             this.cause = cause;
         }
 
+        /**
+         * The string representation of the exception that caused the channel to terminate.
+         *
+         * @since TODO
+         */
+        @Exported
         public String getShortDescription() {
             return cause.toString();
+        }
+
+        /**
+         * The class name of the exception that caused the channel to terminate.
+         *
+         * @since TODO
+         */
+        @Exported
+        public String getExceptionClass() {
+            return cause.getClass().getName();
+        }
+
+        /**
+         * The detail message of the exception that caused the channel to terminate, if any.
+         *
+         * @since TODO
+         */
+        @Exported
+        @CheckForNull
+        public String getExceptionMessage() {
+            return cause.getMessage();
         }
 
         @Override public String toString() {

--- a/core/src/test/java/hudson/slaves/OfflineCauseTest.java
+++ b/core/src/test/java/hudson/slaves/OfflineCauseTest.java
@@ -2,7 +2,9 @@ package hudson.slaves;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +15,32 @@ class OfflineCauseTest {
         String exceptionMessage = "exception message";
         OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException(exceptionMessage));
         assertThat(cause.toString(), not(containsString(exceptionMessage)));
+    }
+
+    @Test
+    void testChannelTermination_ShortDescription() {
+        String exceptionMessage = "connection reset";
+        OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException(exceptionMessage));
+        assertThat(cause.getShortDescription(), containsString(exceptionMessage));
+    }
+
+    @Test
+    void testChannelTermination_ExceptionClass() {
+        OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new IllegalStateException("boom"));
+        assertThat(cause.getExceptionClass(), is(IllegalStateException.class.getName()));
+    }
+
+    @Test
+    void testChannelTermination_ExceptionMessage() {
+        String exceptionMessage = "channel went away";
+        OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException(exceptionMessage));
+        assertThat(cause.getExceptionMessage(), is(exceptionMessage));
+    }
+
+    @Test
+    void testChannelTermination_ExceptionMessage_Null() {
+        OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException());
+        assertThat(cause.getExceptionMessage(), is(nullValue()));
     }
 
 }


### PR DESCRIPTION
Fixes #22545

Follow-up to JENKINS-24452. When a node goes offline due to channel termination, querying `computer/api/json?depth=1` previously provided no information about the cause because `Exception` lacks `@ExportedBean`.

This PR exports the exception information as safe string representations:
- `shortDescription`: full `toString()` of the exception
- `exceptionClass`: fully qualified class name (e.g., `java.io.IOException`)
- `exceptionMessage`: the exception's message (may be null)

### Testing done

- Added unit tests in `OfflineCauseTest` covering:
  - `getShortDescription()` returns exception details
  - `getExceptionClass()` returns correct FQCN
  - `getExceptionMessage()` returns message and handles null
  - Existing `toString()` behavior is preserved (no stacktrace leaking)
- `mvn test -pl core -Dtest=OfflineCauseTest` passes (5 tests, 0 failures)
- `mvn spotless:check -pl core` passes

### Proposed changelog entries

- Export channel termination cause information in the REST API

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers
