### PR TITLE
Fix SCM retry count form error field

### DIFF
--- a/core/src/main/java/jenkins/model/GlobalSCMRetryCountConfiguration.java
+++ b/core/src/main/java/jenkins/model/GlobalSCMRetryCountConfiguration.java
@@ -51,9 +51,9 @@ public class GlobalSCMRetryCountConfiguration extends GlobalConfiguration {
             Jenkins.get().setScmCheckoutRetryCount(json.getInt("scmCheckoutRetryCount"));
             return true;
         } catch (IOException e) {
-            throw new FormException(e, "quietPeriod");
+            throw new FormException(e, "scmCheckoutRetryCount");
         } catch (JSONException e) {
-            throw new FormException(e.getMessage(), "quietPeriod");
+            throw new FormException(e.getMessage(), "scmCheckoutRetryCount");
         }
     }
 

--- a/test/src/test/java/jenkins/model/GlobalSCMRetryCountConfigurationTest.java
+++ b/test/src/test/java/jenkins/model/GlobalSCMRetryCountConfigurationTest.java
@@ -70,7 +70,9 @@ class GlobalSCMRetryCountConfigurationTest {
 
             JSONObject emptyJson = new JSONObject();
             gc.configure(Stapler.getCurrentRequest2(), emptyJson);
+            throw new AssertionError("Expected FormException");
         } catch (Descriptor.FormException e) {
+            assertThat(e.getFormField(), equalTo("scmCheckoutRetryCount"));
             assertThat("Scm Retry count value changed! This shouldn't happen.",
                     j.getInstance().getScmCheckoutRetryCount(), equalTo(3));
         }


### PR DESCRIPTION
No issue.

Found while checking small validation fixes: the configuration reads  and the form defines 'scmCheckoutRetryCount'. But validation errors were reported against the unrelated 'quietPeriod' field.

### Testing done

- `mvn -pl test -Dtest=jenkins.model.GlobalSCMRetryCountConfigurationTest test`

### Screenshots (UI changes only)

N/A

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- Report SCM retry count configuration errors on the correct form field.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood. Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
