### PR TITLE
Ensure TaskThread logs are marked complete after Error

### DIFF
--- a/core/src/main/java/hudson/model/TaskThread.java
+++ b/core/src/main/java/hudson/model/TaskThread.java
@@ -41,16 +41,14 @@ import org.kohsuke.stapler.framework.io.LargeText;
  * <p>
  * Designed to be used inside {@link TaskAction}.
  *
- *
- *
  * @author Kohsuke Kawaguchi
- * @since 1.191
  * @see TaskAction
+ * @since 1.191
  */
 public abstract class TaskThread extends Thread {
     /**
      * @deprecated as of Hudson 1.350
-     *      Use {@link #log}. It's the same object, in a better type.
+     * Use {@link #log}. It's the same object, in a better type.
      */
     @Deprecated
     private final LargeText text;
@@ -71,8 +69,7 @@ public abstract class TaskThread extends Thread {
 
     /**
      *
-     * @param output
-     *      Determines where the output from this task thread goes.
+     * @param output Determines where the output from this task thread goes.
      */
     protected TaskThread(TaskAction owner, ListenerAndText output) {
         //FIXME this failed to compile super(owner.getBuild().toString()+' '+owner.getDisplayName());
@@ -136,15 +133,15 @@ public abstract class TaskThread extends Thread {
         } finally {
             listener = null;
             isRunning = false;
+            log.markAsComplete();
         }
-        log.markAsComplete();
+
     }
 
     /**
      * Do the actual work.
      *
-     * @throws Exception
-     *      The exception is recorded and reported as a failure.
+     * @throws Exception The exception is recorded and reported as a failure.
      */
     protected abstract void perform(TaskListener listener) throws Exception;
 
@@ -163,7 +160,7 @@ public abstract class TaskThread extends Thread {
 
         /**
          * @deprecated as of Hudson 1.350
-         *      Use {@link #forMemory(TaskAction)} and pass in the calling {@link TaskAction}
+         * Use {@link #forMemory(TaskAction)} and pass in the calling {@link TaskAction}
          */
         @Deprecated
         public static ListenerAndText forMemory() {
@@ -172,7 +169,7 @@ public abstract class TaskThread extends Thread {
 
         /**
          * @deprecated as of Hudson 1.350
-         *      Use {@link #forFile(File, TaskAction)} and pass in the calling {@link TaskAction}
+         * Use {@link #forFile(File, TaskAction)} and pass in the calling {@link TaskAction}
          */
         @Deprecated
         public static ListenerAndText forFile(File f) throws IOException {
@@ -187,8 +184,8 @@ public abstract class TaskThread extends Thread {
             ByteBuffer log = new ByteBuffer();
 
             return new ListenerAndText(
-                new StreamTaskListener(log),
-                new AnnotatedLargeText<>(log, Charset.defaultCharset(), false, context)
+                    new StreamTaskListener(log),
+                    new AnnotatedLargeText<>(log, Charset.defaultCharset(), false, context)
             );
         }
 
@@ -197,8 +194,8 @@ public abstract class TaskThread extends Thread {
          */
         public static ListenerAndText forFile(File f, TaskAction context) throws IOException {
             return new ListenerAndText(
-                new StreamTaskListener(f),
-                new AnnotatedLargeText<>(f, Charset.defaultCharset(), false, context)
+                    new StreamTaskListener(f),
+                    new AnnotatedLargeText<>(f, Charset.defaultCharset(), false, context)
             );
         }
     }

--- a/core/src/test/java/hudson/model/TaskActionTest.java
+++ b/core/src/test/java/hudson/model/TaskActionTest.java
@@ -25,6 +25,18 @@ class TaskActionTest {
         }
     }
 
+    private static class ErrorTaskThread extends TaskThread {
+        ErrorTaskThread(TaskAction taskAction) {
+            super(taskAction, ListenerAndText.forMemory(taskAction));
+        }
+
+        @Override
+        protected void perform(TaskListener listener) {
+            throw new OutOfMemoryError("simulated");
+        }
+    }
+
+
     private static class MyTaskAction extends TaskAction {
         void start() {
             workerThread = new MyTaskThread(this);
@@ -57,6 +69,38 @@ class TaskActionTest {
         }
     }
 
+    private static class ErrorTaskAction extends TaskAction {
+        void start() {
+            workerThread = new ErrorTaskThread(this);
+            workerThread.start();
+        }
+
+        @Override
+        public String getIconFileName() {
+            return "Iconfilename";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Error Task Thread";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "error";
+        }
+
+        @Override
+        protected Permission getPermission() {
+            return Permission.READ;
+        }
+
+        @Override
+        protected ACL getACL() {
+            return ACL.lambda2((a, p) -> true);
+        }
+    }
+
     @Test
     void annotatedText() throws Exception {
         MyTaskAction action = new MyTaskAction();
@@ -70,5 +114,24 @@ class TaskActionTest {
         // Windows based systems will be 220, linux base 219
         assertTrue(length >= 219, "length should be longer or even 219");
         assertTrue(os.toString(StandardCharsets.UTF_8).startsWith("a linkCompleted"));
+    }
+
+    @Test
+    void logMarkedCompleteAfterError() throws Exception {
+        ErrorTaskAction action = new ErrorTaskAction();
+        action.start();
+
+        AnnotatedLargeText<?> annotatedText = action.obtainLog();
+
+        long deadline = System.currentTimeMillis() + 5000;
+
+        while (!annotatedText.isComplete()
+                && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+
+        assertTrue(
+                annotatedText.isComplete(),
+                "Log should be marked complete even when perform throws Error");
     }
 }


### PR DESCRIPTION
## Fix #26950

## What Operating System are you using (both controller, and any agents involved in the problem)?

Any / OS Independent

### Reproduction steps

Because this bug requires a fatal `Error` (like `OutOfMemoryError` or `StackOverflowError`) to be thrown exactly while a background task is running, it is very difficult to manually reproduce via the UI on a clean Jenkins install without injecting a fault. 

However, it is easily reproducible programmatically using the internal Jenkins test framework:

1. In a Jenkins plugin or core test, create a subclass of `TaskThread`.
2. Override the `perform()` method to intentionally throw a fatal error:
   ```java
   protected void perform(TaskListener listener) throws Exception {
       throw new OutOfMemoryError("simulated");
   }

## Summary

This change ensures that task logs are always marked as complete when a `TaskThread` terminates, including cases where `perform()` throws a fatal `Error`.

Previously, `log.markAsComplete()` was executed after the `try/catch/finally` block. If `perform()` threw an `Error` such as `OutOfMemoryError`, execution could exit the method before reaching `log.markAsComplete()`. As a result, Jenkins could incorrectly consider the task log to still be running, causing the UI to continue polling indefinitely.

This patch moves `log.markAsComplete()` into the `finally` block so cleanup always occurs while preserving existing error propagation behavior.

## Testing Phase

- Added a regression test covering `OutOfMemoryError` thrown from `TaskThread.perform()`.
- Verified that the task log is marked as complete after the error.
- Verified that existing `TaskActionTest` behavior continues to pass.

This guarantees that the log is marked as complete regardless of whether the task exits normally, throws an exception, or terminates due to a fatal error.


### Are you interested in contributing a fix?

Yes