### PR TITLE
Fix Plugin Manager links without wiki URL

### DIFF
--- a/src/main/js/templates/plugin-manager/available.hbs
+++ b/src/main/js/templates/plugin-manager/available.hbs
@@ -10,11 +10,19 @@
         {{/if}}
         <td>
             <div>
-                <a href="{{ this.wiki }}" class="jenkins-table__link" target="_blank" rel="noopener noreferrer">
-                    {{ this.displayName }}
-                    <span class="jenkins-visually-hidden">Version</span>
-                    <span class="jenkins-label jenkins-label--tertiary" style="margin-left: 1ch;">{{ this.version }}</span>
-                </a>
+                {{#if this.wiki }}
+                    <a href="{{ this.wiki }}" class="jenkins-table__link" target="_blank" rel="noopener noreferrer">
+                        {{ this.displayName }}
+                        <span class="jenkins-visually-hidden">Version</span>
+                        <span class="jenkins-label jenkins-label--tertiary" style="margin-left: 1ch;">{{ this.version }}</span>
+                    </a>
+                {{else}}
+                    <span>
+                        {{ this.displayName }}
+                        <span class="jenkins-visually-hidden">Version</span>
+                        <span class="jenkins-label jenkins-label--tertiary" style="margin-left: 1ch;">{{ this.version }}</span>
+                    </span>
+                {{/if}}
             </div>
             {{#if this.categories }}
                 <div class="app-plugin-manager__categories">
@@ -73,11 +81,17 @@
         <td style="width: 15%">
             <div>
                 {{#if this.healthScore }}
-                    <a href="{{ this.wiki }}/healthScore"
-                       class="jenkins-healthScore--badge jenkins-healthScore--{{ this.healthScoreClass }}"
-                       target="_blank" rel="noopener noreferrer">
-                        {{ this.healthScore }}
-                    </a>
+                    {{#if this.wiki }}
+                        <a href="{{ this.wiki }}/healthScore"
+                           class="jenkins-healthScore--badge jenkins-healthScore--{{ this.healthScoreClass }}"
+                           target="_blank" rel="noopener noreferrer">
+                            {{ this.healthScore }}
+                        </a>
+                    {{else}}
+                        <span class="jenkins-healthScore--badge jenkins-healthScore--{{ this.healthScoreClass }}">
+                            {{ this.healthScore }}
+                        </span>
+                    {{/if}}
                 {{else}}
                   <div class="icon-lg">
                     <!-- symbol: status-aborted -->

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -92,7 +92,6 @@ import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
 import org.htmlunit.AlertHandler;
 import org.htmlunit.Page;
-import org.htmlunit.html.HtmlAnchor;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.AfterEach;
@@ -855,11 +854,34 @@ class PluginManagerTest {
                         .getTextContent().contains("This plugin is built for Jenkins 9999999"));
                 wc.waitForBackgroundJavaScript(100);
 
-                HtmlAnchor anchor = available.querySelector(".jenkins-table__link");
-                anchor.click(true, false, false);
+                assertNull(available.querySelector(".jenkins-table__link"));
                 wc.waitForBackgroundJavaScript(100);
                 assertTrue(alertHandler.messages.isEmpty());
             }
+        });
+    }
+
+    @Test
+    @Issue("JENKINS-70794")
+    void pluginsSearchReturnsAvailablePluginWithoutWikiUrl() throws Throwable {
+        session.then(r -> {
+            DownloadService.signatureCheck = false;
+            Jenkins.get().getUpdateCenter().getSites().clear();
+            UpdateSite us = new UpdateSite("NoWiki", Jenkins.get().getRootUrl() + "noWikiUpdateCenter/update-center.json");
+            Jenkins.get().getUpdateCenter().getSites().add(us);
+            assertEquals(FormValidation.ok(), us.updateDirectly(false).get());
+            assertNotNull(us.getData());
+
+            JenkinsRule.JSONWebResponse response = r.getJSON("pluginManager/pluginsSearch?query=plugin-without-wiki&limit=5");
+            JSONObject json = response.getJSONObject();
+            assertTrue(json.has("data"));
+            JSONArray data = json.getJSONArray("data");
+            assertEquals(1, data.size(), "Should be one search hit for plugin-without-wiki");
+            JSONObject plugin = data.getJSONObject(0);
+            assertEquals("plugin-without-wiki", plugin.getString("name"));
+            assertEquals("Plugin Without Wiki", plugin.getString("displayName"));
+            assertEquals("", plugin.getString("wiki"));
+            assertEquals(100, plugin.getInt("healthScore"));
         });
     }
 
@@ -933,6 +955,31 @@ class PluginManagerTest {
             staplerResponse.setContentType("application/json");
             staplerResponse.setStatus(200);
             staplerResponse.serveFile(staplerRequest, PluginManagerTest.class.getResource("/plugins/security3037-update-center.json"));
+        }
+    }
+
+    @TestExtension("pluginsSearchReturnsAvailablePluginWithoutWikiUrl")
+    public static final class NoWikiUpdateCenter implements RootAction {
+
+        @Override
+        public String getIconFileName() {
+            return "gear2.png";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "no-wiki-update-center";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "noWikiUpdateCenter";
+        }
+
+        public void doDynamic(StaplerRequest2 staplerRequest, StaplerResponse2 staplerResponse) throws ServletException, IOException {
+            staplerResponse.setContentType("application/json");
+            staplerResponse.setStatus(200);
+            staplerResponse.serveFile(staplerRequest, PluginManagerTest.class.getResource("/plugins/no-wiki-update-center.json"));
         }
     }
 

--- a/test/src/test/resources/plugins/no-wiki-update-center.json
+++ b/test/src/test/resources/plugins/no-wiki-update-center.json
@@ -1,0 +1,35 @@
+updateCenter.post(
+{
+  "connectionCheckUrl": "https://www.google.com/",
+  "core": {
+    "buildDate": "Jun 20, 2026",
+    "name": "core",
+    "sha1": "dummy",
+    "sha256": "dummy",
+    "size": 1,
+    "url": "https://updates.jenkins.io/download/war/2.570/jenkins.war",
+    "version": "2.570"
+  },
+  "generationTimestamp": "2026-06-20T00:00:00Z",
+  "id": "NoWiki",
+  "deprecations": [],
+  "plugins": {
+    "plugin-without-wiki": {
+      "buildDate": "Jun 20, 2026",
+      "dependencies": [],
+      "excerpt": "A plugin without a wiki URL.",
+      "health": 100,
+      "name": "plugin-without-wiki",
+      "popularity": 1,
+      "releaseTimestamp": "2026-06-20T00:00:00.00Z",
+      "requiredCore": "2.0",
+      "sha1": "dummy",
+      "sha256": "dummy",
+      "title": "Plugin Without Wiki",
+      "url": "https://updates.jenkins.io/download/plugins/plugin-without-wiki/1.0/plugin-without-wiki.hpi",
+      "version": "1.0"
+    }
+  },
+  "updateCenterVersion": "1"
+}
+);


### PR DESCRIPTION
Fixes #18478

Some update center entries do not include a wiki URL. The Available plugins table still built links from that value, which left the plugin name pointing at the current page ('href=""') and the health score pointing at '/healthScore'.

This keeps the normal wiki links when a plugin has a wiki URL. When it does not, the plugin name is rendered without a link, and the health score badge is shown without linking to '/healthScore'.

### Testing done

- Added a regression test with a small update center fixture for a plugin without a wiki URL.
- Verified with 'mvn -pl test -Dtest=hudson.PluginManagerTest#pluginsSearchReturnsAvailablePluginWithoutWikiUrl test'.
- Checked whitespace with 'git diff --check'
- Reproduced the Available plugins page before and after the change using the same fixture.

### Screenshots (UI changes only)

#### Before

<img width="1440" height="900" alt="Before Plugin Manager shows invalid wiki links" src="https://github.com/user-attachments/assets/9b9e3cc0-88f8-423e-aed1-2a5f2d5b9939" />

#### After

<img width="1440" height="900" alt="After Plugin Manager renders non-links without wiki URL" src="https://github.com/user-attachments/assets/81c2016b-3485-4e80-a4a1-8c3f8c437812" />

### Proposed changelog entries

- Render Plugin Manager entries without wiki URLs as plain text (regression in 2.370).

### Proposed changelog category

/label regression-fix, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with '@Restricted' or have '@since TODO' Javadocs, as appropriate.
- [x] New deprecations are annotated with '@Deprecated(since = "TODO")' or '@Deprecated(forRemoval = true, since = "TODO")', if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call 'eval' to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as 'ready-for-merge'

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the 'upgrade-guide-needed' label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as 'lts-candidate' to be considered.
