### PR TITLE
Fix breadcrumb overflow dropdown items failing to render

### DIFF
--- a/src/main/js/components/header/breadcrumbs-overflow.js
+++ b/src/main/js/components/header/breadcrumbs-overflow.js
@@ -47,8 +47,8 @@ export default function computeBreadcrumbs() {
         return {
           type: "link",
           clazz: "jenkins-breadcrumbs__overflow-item",
-          label: e.textContent,
-          url: href,
+          displayName: e.textContent,
+          event: href ? { url: href, type: "GET" } : undefined,
           tooltip,
         };
       });


### PR DESCRIPTION
<!-- No issue: minor regression fix, issue not required. Regression introduced by PR #11204 (dropdown-item contract rename). -->

Fixes #

PR #11204 renamed the dropdown-item contract from `{ label, url }` to `{ displayName, event }` and updated every caller except `breadcrumbs-overflow.js`, where `computeBreadcrumbs()` still emits the old shape.
`Templates.menuItem()` reads `displayName` and calls `xmlEscape(undefined)`, throwing a `TypeError` that blanks the entire breadcrumb overflow dropdown and leaves overflowed breadcrumbs unreachable.
This renames the keys to match the contract used by every other caller: `displayName: e.textContent` and `event: href ? { url: href, type: "GET" } : undefined` (`event` stays undefined when a breadcrumb has no anchor).
No other behavior in the file changes.

### Testing done

- No JS unit-test framework (jest/vitest) exists in the repo, so no automated test was added.
- `eslint` and `prettier --check` pass on the changed file.
- The fixed item shape matches the in-repo GET-link shape used by `src/main/js/components/dropdowns/inpage-jumplist.js:21` and `dropdowns/utils.js`.
- Manual repro: on a deep path, narrow the viewport until the breadcrumb bar overflows, then click the overflow (...) button. Before: the dropdown is empty and a `TypeError` is logged. After: the overflowed breadcrumbs render as clickable links.

### Screenshots (UI changes only)

<!-- Placeholder: attach before/after of the breadcrumb overflow dropdown. -->

#### Before

#### After

### Proposed changelog entries

- Fix breadcrumb overflow menu items not rendering

### Proposed changelog category

/label regression-fix, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests. <!-- No JS unit-test framework exists in the repo; verified via eslint/prettier and manual repro. -->
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- N/A: no new public API. -->
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- N/A: no deprecations. -->
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- N/A: no dependency changes. -->
- [x] For new APIs and extension points, there is a link to at least one consumer. <!-- N/A: no new APIs. -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

