### PR TITLE
Correct QuotedStringTokenizer.quote(String) Javadoc to match unconditional quoting

### DIFF
--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -360,12 +360,12 @@ public class QuotedStringTokenizer
     }
 
     /* ------------------------------------------------------------ */
-    /** Quote a string.
-     * The string is quoted only if quoting is required due to
-     * embedded delimiters, quote characters or the
-     * empty string.
+    /** Quote a string by always wrapping it in double quotes and escaping
+     * embedded {@code "}, {@code \} and control characters.
+     * Unlike {@link #quote(String, String)}, this overload quotes
+     * unconditionally regardless of whether quoting is required.
      * @param s The string to quote.
-     * @return quoted string
+     * @return the quoted string, or {@code null} if {@code s} is {@code null}
      */
     public static String quote(String s)
     {

--- a/cli/src/test/java/hudson/util/QuotedStringTokenizerTest.java
+++ b/cli/src/test/java/hudson/util/QuotedStringTokenizerTest.java
@@ -25,6 +25,7 @@
 package hudson.util;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,6 +86,15 @@ class QuotedStringTokenizerTest {
         assertFalse(tokenizer.hasMoreTokens());
         tokenizer = new QuotedStringTokenizer("one");
         assertTrue(tokenizer.hasMoreTokens());
+    }
+
+    @Test
+    void quoteOverloadsHaveDifferentContracts() {
+        // The 1-arg overload always quotes, regardless of content.
+        assertEquals("\"foo\"", QuotedStringTokenizer.quote("foo"));
+        // The 2-arg overload quotes conditionally and returns the input
+        // unchanged when no delimiter or special character is present.
+        assertEquals("foo", QuotedStringTokenizer.quote("foo", ","));
     }
 
     private void check(String src, String... expected) {


### PR DESCRIPTION
The 1-arg `QuotedStringTokenizer.quote(String)` Javadoc says a string is "quoted only if quoting is required due to embedded delimiters, quote characters or the empty string", but the implementation unconditionally wraps every input in double quotes. The sibling 2-arg `quote(String, String)` has the identical Javadoc and does perform that conditional check, returning the input unchanged when no quoting is needed. So the 1-arg doc is wrong relative to both its own behavior and its sibling.

This corrects only the 1-arg Javadoc to state it always quotes and cross-references the conditional overload; no behavior changes. The file is vendored from Jetty (Apache-2.0): the duplicated Javadoc was copied onto both overloads, and only the 1-arg implementation diverged.

### Testing done

Ran `mvn -pl cli -am clean test` (JDK 21). All 33 reactor tests pass, including the new `quoteOverloadsHaveDifferentContracts`, which pins the contract: `quote("foo")` returns `"\"foo\""` while `quote("foo", ",")` returns `foo`.

### Screenshots (UI changes only)

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- N/A: no new public API -->
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- N/A: no deprecations -->
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- N/A: no UI changes -->
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- N/A: no dependency changes -->
- [ ] For new APIs and extension points, there is a link to at least one consumer. <!-- N/A: no new APIs -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

