### PR TITLE
Test the FINE log level boundary in LogRecorderManagerTest

### DIFF
--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -112,13 +112,13 @@ class LogRecorderManagerTest {
         assertEquals(warning, testRecorder.doCheckName("", Level.ALL.getName()).toString());
         assertEquals(warning, testRecorder.doCheckName("", Level.FINEST.getName()).toString());
         assertEquals(warning, testRecorder.doCheckName("", Level.FINER.getName()).toString());
-        assertEquals(warning, testRecorder.doCheckName("", Level.FINER.getName()).toString());
+        assertEquals(warning, testRecorder.doCheckName("", Level.FINE.getName()).toString());
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", "illegalArgument"));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", null));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", Level.ALL.getName()));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", Level.FINEST.getName()));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", Level.FINER.getName()));
-        assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", Level.FINER.getName()));
+        assertEquals(FormValidation.ok(), testRecorder.doCheckName("a", Level.FINE.getName()));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("", Level.CONFIG.getName()));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("", Level.INFO.getName()));
         assertEquals(FormValidation.ok(), testRecorder.doCheckName("", Level.WARNING.getName()));


### PR DESCRIPTION
`LogRecorderManagerTest#logRecorderCheckName` enumerates each log level to verify `LogRecorder.doCheckName`, but a copy-paste left `Level.FINE` absent from both the empty-name and non-empty-name blocks (two byte-identical `Level.FINER` duplicates).

`FINE` is the exact boundary in production (`Level.parse(level).intValue() <= Level.FINE.intValue()`), so its coverage gap would hide an off-by-one regression (`<=` to `<`). This restores the two missing `FINE` assertions.

### Testing done

Ran the affected test for real (not `-Plight-test`, which skips the test module):

```
mvn -pl test -am test -Dtest='LogRecorderManagerTest#logRecorderCheckName' -DskipTests=false
```

Result: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`, BUILD SUCCESS.

Passes before and after (deterministic): a coverage-gap fix, not a broken-test fix.

### Screenshots (UI changes only)

N/A

#### Before

#### After

### Proposed changelog entries

- N/A (test-only change, not user- or developer-facing)

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
<!-- New public classes/fields/methods: N/A — no production API change, test-only. -->
<!-- New deprecations: N/A. -->
<!-- UI changes: N/A. -->
<!-- Dependency updates: N/A. -->
<!-- New APIs/extension points: N/A. -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
