### PR TITLE
Fix incorrect pluralization in PathRemover retry failure message

### DIFF
--- a/core/src/main/java/jenkins/util/io/PathRemover.java
+++ b/core/src/main/java/jenkins/util/io/PathRemover.java
@@ -166,7 +166,7 @@ public class PathRemover {
             sb.append("'. Tried ");
             sb.append(retryCount + 1);
             sb.append(" time");
-            if (retryCount != 1) sb.append('s');
+            if (retryCount + 1 != 1) sb.append('s');
             if (maxRetries > 0) {
                 sb.append(" (of a maximum of ");
                 sb.append(maxRetries + 1);

--- a/core/src/test/java/jenkins/util/io/PathRemoverTest.java
+++ b/core/src/test/java/jenkins/util/io/PathRemoverTest.java
@@ -277,6 +277,35 @@ class PathRemoverTest {
     }
 
     @Test
+    void testForceRemoveFile_PausingGCRetryStrategyFailureMessageSingular() throws IOException {
+        // A non-empty directory cannot be removed by Files.deleteIfExists (DirectoryNotEmptyException),
+        // which exhausts the PausingGCRetryStrategy deterministically on every platform (no lock needed).
+        File dir = newFolder(tmp, "junit-" + System.currentTimeMillis());
+        File child = new File(dir, "child");
+        touchWithFileName(child);
+        PathRemover remover = PathRemover.newFilteredRobustRemover(PathRemover.PathChecker.ALLOW_ALL, 0, false, 0);
+        Exception e = assertThrows(IOException.class, () -> remover.forceRemoveFile(dir.toPath()));
+        assertThat(e.getMessage(), allOf(
+                containsString(dir.getPath()),
+                containsString("Tried 1 time."),
+                not(containsString("Tried 1 times"))));
+    }
+
+    @Test
+    void testForceRemoveFile_PausingGCRetryStrategyFailureMessagePlural() throws IOException {
+        File dir = newFolder(tmp, "junit-" + System.currentTimeMillis());
+        File child = new File(dir, "child");
+        touchWithFileName(child);
+        PathRemover remover = PathRemover.newFilteredRobustRemover(PathRemover.PathChecker.ALLOW_ALL, 1, false, 0);
+        Exception e = assertThrows(IOException.class, () -> remover.forceRemoveFile(dir.toPath()));
+        assertThat(e.getMessage(), allOf(
+                containsString(dir.getPath()),
+                containsString("Tried 2 times"),
+                not(containsString("Tried 2 time ")),
+                not(containsString("Tried 2 time."))));
+    }
+
+    @Test
     void testForceRemoveRecursive() throws IOException {
         File dir = newFolder(tmp, "junit-" + System.currentTimeMillis());
         File d1 = new File(dir, "d1");


### PR DESCRIPTION

`PausingGCRetryStrategy.failureMessage()` in `core/src/main/java/jenkins/util/io/PathRemover.java` displays the attempt count as `retryCount + 1` but pluralizes on the un-incremented `retryCount`, producing grammatically wrong deletion-failure messages like "Tried 1 times." and "Tried 2 time.". The fix pluralizes on the displayed value (`retryCount + 1 != 1`), matching the sibling default `RetryStrategy.failureMessage()`.

### Testing done

Added two cross-platform tests in `PathRemoverTest`:
`testForceRemoveFile_PausingGCRetryStrategyFailureMessageSingular` (maxRetries=0 → "Tried 1 time.") and
`testForceRemoveFile_PausingGCRetryStrategyFailureMessagePlural` (maxRetries=1 → "Tried 2 times").
Both exhaust `PausingGCRetryStrategy` via `forceRemoveFile` on a non-empty directory (`DirectoryNotEmptyException`), so no Windows file lock is needed; they fail pre-fix and pass post-fix.

`mvn -pl core -am -Plight-test clean test -Dtest=PathRemoverTest` (JDK 21): Tests run: 19, Failures: 0, Errors: 0, Skipped: 5 (pre-existing Windows-gated). BUILD SUCCESS; `spotless:check -pl core` reports no changes.

### Screenshots (UI changes only)

N/A

#### Before

#### After

### Proposed changelog entries

- Fix incorrect pluralization in the file deletion retry failure message.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

