### PR TITLE
Test distinct disallowed resource in SlaveTest SECURITY-195 enumeration

### DIFF
--- a/test/src/test/java/hudson/model/SlaveTest.java
+++ b/test/src/test/java/hudson/model/SlaveTest.java
@@ -145,7 +145,7 @@ class SlaveTest {
 
         // Check that requests to other WEB-INF contents fail
         assertJnlpJarUrlFails(slave, "web.xml");
-        assertJnlpJarUrlFails(slave, "web.xml");
+        assertJnlpJarUrlFails(slave, "lib/jenkins-core.jar");
         assertJnlpJarUrlFails(slave, "classes/bundled-plugins.txt");
         assertJnlpJarUrlFails(slave, "classes/dependencies.txt");
         assertJnlpJarUrlFails(slave, "plugins/ant.hpi");


### PR DESCRIPTION
`SlaveTest#shouldNotEscapeJnlpSlavesResources` (`@Issue("SECURITY-195")`) verifies disallowed `WEB-INF` resources are rejected. One line in its negative enumeration byte-identically duplicated the preceding `web.xml` assertion, testing nothing new. This swaps the duplicate for a distinct disallowed resource, `lib/jenkins-core.jar`, restoring the intended distinct-resource coverage.

### Testing done

Ran with `skipTests=false` (the `test` module is silently skipped under `-Plight-test`):

```
mvn -pl test -am test -Dtest='SlaveTest#shouldNotEscapeJnlpSlavesResources' -DskipTests=false
```

`Tests run: 1, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS.

It passes because `Slave.JnlpJar#getURL` checks the allowlist before the internal `lib/` rewrite, so `lib/jenkins-core.jar` (not in `ALLOWED_JNLPJARS_FILES`) is rejected with `MalformedURLException`.

### Screenshots (UI changes only)

N/A

#### Before

#### After

### Proposed changelog entries

N/A <!-- test-only, user-invisible -->

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described. <!-- no issue: test-only quality fix -->
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- N/A: no API change -->
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- N/A -->
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- N/A: no UI change -->
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- N/A -->
- [ ] For new APIs and extension points, there is a link to at least one consumer. <!-- N/A -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
