### PR TITLE
Add new permission to restrict access to console logs

### DIFF
--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2400,6 +2400,21 @@ public class Functions {
     }
 
     /**
+     * Returns {@code true} if the {@link Run#CONSOLE} permission is enabled,
+     * {@code false} otherwise.
+     *
+     * <p>When the {@link Run#CONSOLE} permission is not turned on using the
+     * {@code hudson.security.ConsolePermission} system property, this
+     * permission must not be considered to be set to {@code false} for every
+     * user. It must rather be like if the permission doesn't exist at all
+     * (which means that every user has to have access to the console output but
+     * the permission can't be configured in the security screen).</p>
+     */
+    public static boolean isConsolePermissionEnabled() {
+        return SystemProperties.getBoolean("hudson.security.ConsolePermission");
+    }
+
+    /**
      * Returns {@code true} if the {@link Item#WIPEOUT} permission is enabled,
      * {@code false} otherwise.
      *

--- a/core/src/main/java/hudson/Functions.java
+++ b/core/src/main/java/hudson/Functions.java
@@ -2404,14 +2404,15 @@ public class Functions {
      * {@code false} otherwise.
      *
      * <p>When the {@link Run#CONSOLE} permission is not turned on using the
-     * {@code hudson.security.ConsolePermission} system property, this
+     * {@code jenkins.security.ConsolePermission} system property, this
      * permission must not be considered to be set to {@code false} for every
      * user. It must rather be like if the permission doesn't exist at all
      * (which means that every user has to have access to the console output but
      * the permission can't be configured in the security screen).</p>
      */
     public static boolean isConsolePermissionEnabled() {
-        return SystemProperties.getBoolean("hudson.security.ConsolePermission");
+        return SystemProperties.getBoolean("jenkins.security.ConsolePermission")
+                || SystemProperties.getBoolean("hudson.security.ConsolePermission");
     }
 
     /**

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1422,6 +1422,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * @since 1.349
      */
     public @NonNull InputStream getLogInputStream() throws IOException {
+        checkConsolePermission();
         File logFile = getLogFile();
 
         if (logFile.exists()) {
@@ -1443,6 +1444,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     public @NonNull Reader getLogReader() throws IOException {
+        checkConsolePermission();
         if (charset == null)  return new InputStreamReader(getLogInputStream(), Charset.defaultCharset());
         else                return new InputStreamReader(getLogInputStream(), charset);
     }
@@ -1493,6 +1495,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * The method does not close the {@link OutputStream}.
      */
     public void writeWholeLogTo(@NonNull OutputStream out) throws IOException, InterruptedException {
+        checkConsolePermission();
         long pos = 0;
         AnnotatedLargeText logText;
         logText = getLogText();
@@ -1512,7 +1515,20 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
      * @return A {@link Run} log with annotations
      */
     public @NonNull AnnotatedLargeText getLogText() {
+        checkConsolePermission();
         return new AnnotatedLargeText(getLogFile(), getCharset(), !isLogUpdated(), this);
+    }
+
+    /**
+     * Checks the {@link #CONSOLE} permission if it has been enabled via the
+     * {@code hudson.security.ConsolePermission} system property.
+     *
+     * @see Functions#isConsolePermissionEnabled()
+     */
+    private void checkConsolePermission() {
+        if (Functions.isConsolePermissionEnabled()) {
+            checkPermission(CONSOLE);
+        }
     }
 
     @Override
@@ -2237,6 +2253,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     }
 
     private void doConsoleTextImpl(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        checkConsolePermission();
         rsp.setContentType("text/plain;charset=UTF-8");
         try (InputStream input = getLogInputStream();
              OutputStream os = rsp.getOutputStream();
@@ -2568,6 +2585,9 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     /** See {@link hudson.Functions#isArtifactsPermissionEnabled} */
     public static final Permission ARTIFACTS = new Permission(PERMISSIONS, "Artifacts", Messages._Run_ArtifactsPermission_Description(), null,
                                                               Functions.isArtifactsPermissionEnabled(), new PermissionScope[]{PermissionScope.RUN});
+    /** See {@link hudson.Functions#isConsolePermissionEnabled} */
+    public static final Permission CONSOLE = new Permission(PERMISSIONS, "Console", Messages._Run_ConsolePermission_Description(), Jenkins.ADMINISTER,
+                                                            Functions.isConsolePermissionEnabled(), new PermissionScope[]{PermissionScope.RUN});
 
     private static class DefaultFeedAdapter implements FeedAdapter<Run> {
         @Override

--- a/core/src/main/java/hudson/model/Run.java
+++ b/core/src/main/java/hudson/model/Run.java
@@ -1521,7 +1521,7 @@ public abstract class Run<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Checks the {@link #CONSOLE} permission if it has been enabled via the
-     * {@code hudson.security.ConsolePermission} system property.
+     * {@code jenkins.security.ConsolePermission} system property.
      *
      * @see Functions#isConsolePermissionEnabled()
      */

--- a/core/src/main/java/jenkins/run/ConsoleTabFactory.java
+++ b/core/src/main/java/jenkins/run/ConsoleTabFactory.java
@@ -53,6 +53,10 @@ public class ConsoleTabFactory extends TransientActionFactory<Run> {
             return Collections.emptySet();
         }
 
+        if (Functions.isConsolePermissionEnabled() && !target.hasPermission(Run.CONSOLE)) {
+            return Collections.emptySet();
+        }
+
         return Collections.singleton(new ConsoleTab(target));
     }
 }

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -245,6 +245,11 @@ Run.ArtifactsPermission.Description=\
   This permission grants the ability to retrieve the artifacts produced by \
   builds. If you don’t want an user to access the artifacts, you can do so by \
   revoking this permission. This does not restrict the listing of artifacts.
+Run.ConsolePermission.Description=\
+  This permission grants the ability to view the console output produced by \
+  builds. If you don’t want an user to access the console output, for example \
+  because it may contain sensitive information, you can do so by revoking this \
+  permission.
 Run.InProgressDuration={0} and counting
 Run.NotStartedYet=Not started yet
 Run.ArtifactsBrowserTitle=Artifacts of {0} {1}

--- a/core/src/main/resources/hudson/model/Run/console.jelly
+++ b/core/src/main/resources/hudson/model/Run/console.jelly
@@ -35,6 +35,8 @@ THE SOFTWARE.
 
   <l:userExperimentalFlag var="newBuildPage" flagClassName="jenkins.model.experimentalflags.NewBuildPageUserExperimentalFlag" />
 
+  <j:set var="hasConsole" value="${!h.isConsolePermissionEnabled() or it.object.hasPermission(it.object.CONSOLE)}" />
+
   <l:run-subpage>
     <l:app-bar title="${%Console}">
       <j:if test="${!newBuildPage and it.object.building}">
@@ -48,17 +50,26 @@ THE SOFTWARE.
           </j:if>
         </div>
       </j:if>
-      <a class="jenkins-button" href="consoleText" download="${it.object.displayName}.txt">
-        <l:icon src="symbol-download" />
-        ${%Download}
-      </a>
-      <l:copyButton ref="out" label="${%Copy}" />
-      <a class="jenkins-button" href="consoleText">
-        ${%View as plain text}
-      </a>
+      <j:if test="${hasConsole}">
+        <a class="jenkins-button" href="consoleText" download="${it.object.displayName}.txt">
+          <l:icon src="symbol-download" />
+          ${%Download}
+        </a>
+        <l:copyButton ref="out" label="${%Copy}" />
+        <a class="jenkins-button" href="consoleText">
+          ${%View as plain text}
+        </a>
+      </j:if>
     </l:app-bar>
 
     <j:set var="it" value="${it.object}" />
-    <st:include page="console-log.jelly" />
+    <j:choose>
+      <j:when test="${hasConsole}">
+        <st:include page="console-log.jelly" />
+      </j:when>
+      <j:otherwise>
+        <p>${%You do not have permission to view the console output of this build.}</p>
+      </j:otherwise>
+    </j:choose>
   </l:run-subpage>
 </j:jelly>

--- a/core/src/main/resources/jenkins/run/ConsoleTab/widget.jelly
+++ b/core/src/main/resources/jenkins/run/ConsoleTab/widget.jelly
@@ -24,17 +24,19 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-  <j:set var="controls">
-    <a href="consoleText" download="${it.displayName}.txt" tooltip="${%Download}" class="jenkins-card__reveal">
-      <l:icon src="symbol-download" />
-    </a>
-  </j:set>
-
   <j:set var="it" value="${it.object}" />
 
-  <l:card title="${%Console}" expandable="console" controls="${controls}">
-    <div class="app-console-output-widget progressive-text-container">
-      <st:include page="console-log.jelly" />
-    </div>
-  </l:card>
+  <j:if test="${!h.isConsolePermissionEnabled() or it.hasPermission(it.CONSOLE)}">
+    <j:set var="controls">
+      <a href="consoleText" download="${it.displayName}.txt" tooltip="${%Download}" class="jenkins-card__reveal">
+        <l:icon src="symbol-download" />
+      </a>
+    </j:set>
+
+    <l:card title="${%Console}" expandable="console" controls="${controls}">
+      <div class="app-console-output-widget progressive-text-container">
+        <st:include page="console-log.jelly" />
+      </div>
+    </l:card>
+  </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/hudson/project/console-link.jelly
+++ b/core/src/main/resources/lib/hudson/project/console-link.jelly
@@ -25,5 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <!-- Displays a console link for a build. -->
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:task href="${h.getConsoleUrl(it) ?: (buildUrl.baseUrl + '/console')}" icon="icon-terminal icon-md"  title="${%Console Output}" />
+    <j:if test="${!h.isConsolePermissionEnabled() or it.hasPermission(it.CONSOLE)}">
+        <l:task href="${h.getConsoleUrl(it) ?: (buildUrl.baseUrl + '/console')}" icon="icon-terminal icon-md"  title="${%Console Output}" />
+    </j:if>
 </j:jelly>

--- a/test/src/test/java/hudson/model/RunConsolePermissionTest.java
+++ b/test/src/test/java/hudson/model/RunConsolePermissionTest.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import hudson.Launcher;
+import jenkins.model.Jenkins;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.Page;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class RunConsolePermissionTest {
+
+    private static final String CONSOLE_PROPERTY = "hudson.security.ConsolePermission";
+    private static final String MARKER = "the secret console output";
+
+    private JenkinsRule j;
+    private String previousPropertyValue;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+        previousPropertyValue = System.getProperty(CONSOLE_PROPERTY);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (previousPropertyValue == null) {
+            System.clearProperty(CONSOLE_PROPERTY);
+        } else {
+            System.setProperty(CONSOLE_PROPERTY, previousPropertyValue);
+        }
+    }
+
+    private FreeStyleBuild createBuildWithConsoleOutput() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+                listener.getLogger().println(MARKER);
+                return true;
+            }
+        });
+        return j.buildAndAssertSuccess(p);
+    }
+
+    private void configureSecurity(MockAuthorizationStrategy strategy) {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(strategy);
+    }
+
+    @Test
+    void consoleVisibleToReaderByDefault() throws Exception {
+        System.clearProperty(CONSOLE_PROPERTY);
+        FreeStyleBuild b = createBuildWithConsoleOutput();
+        configureSecurity(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ, Item.READ).everywhere().to("reader"));
+
+        JenkinsRule.WebClient wc = j.createWebClient().login("reader");
+        Page rsp = wc.goTo(b.getUrl() + "consoleText", "text/plain");
+        assertThat(rsp.getWebResponse().getContentAsString(), containsString(MARKER));
+    }
+
+    @Test
+    void consoleHiddenFromReaderWhenPermissionEnabled() throws Exception {
+        System.setProperty(CONSOLE_PROPERTY, "true");
+        FreeStyleBuild b = createBuildWithConsoleOutput();
+        configureSecurity(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ, Item.READ).everywhere().to("reader")
+                .grant(Jenkins.ADMINISTER).everywhere().to("admin")
+                .grant(Jenkins.READ, Item.READ, Run.CONSOLE).everywhere().to("viewer"));
+
+        JenkinsRule.WebClient readerClient = j.createWebClient().login("reader");
+        FailingHttpStatusCodeException ex = assertThrows(FailingHttpStatusCodeException.class,
+                () -> readerClient.goTo(b.getUrl() + "consoleText", "text/plain"));
+        assertEquals(403, ex.getStatusCode());
+
+        JenkinsRule.WebClient viewerClient = j.createWebClient().login("viewer");
+        Page rsp = viewerClient.goTo(b.getUrl() + "consoleText", "text/plain");
+        assertThat(rsp.getWebResponse().getContentAsString(), containsString(MARKER));
+
+        JenkinsRule.WebClient adminClient = j.createWebClient().login("admin");
+        Page adminRsp = adminClient.goTo(b.getUrl() + "consoleText", "text/plain");
+        assertThat(adminRsp.getWebResponse().getContentAsString(), containsString(MARKER));
+    }
+}

--- a/test/src/test/java/hudson/model/RunConsolePermissionTest.java
+++ b/test/src/test/java/hudson/model/RunConsolePermissionTest.java
@@ -42,16 +42,19 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 @WithJenkins
 class RunConsolePermissionTest {
 
-    private static final String CONSOLE_PROPERTY = "hudson.security.ConsolePermission";
+    private static final String CONSOLE_PROPERTY = "jenkins.security.ConsolePermission";
+    private static final String LEGACY_CONSOLE_PROPERTY = "hudson.security.ConsolePermission";
     private static final String MARKER = "the secret console output";
 
     private JenkinsRule j;
     private String previousPropertyValue;
+    private String previousLegacyPropertyValue;
 
     @BeforeEach
     void setUp(JenkinsRule rule) {
         j = rule;
         previousPropertyValue = System.getProperty(CONSOLE_PROPERTY);
+        previousLegacyPropertyValue = System.getProperty(LEGACY_CONSOLE_PROPERTY);
     }
 
     @AfterEach
@@ -60,6 +63,11 @@ class RunConsolePermissionTest {
             System.clearProperty(CONSOLE_PROPERTY);
         } else {
             System.setProperty(CONSOLE_PROPERTY, previousPropertyValue);
+        }
+        if (previousLegacyPropertyValue == null) {
+            System.clearProperty(LEGACY_CONSOLE_PROPERTY);
+        } else {
+            System.setProperty(LEGACY_CONSOLE_PROPERTY, previousLegacyPropertyValue);
         }
     }
 
@@ -113,5 +121,19 @@ class RunConsolePermissionTest {
         JenkinsRule.WebClient adminClient = j.createWebClient().login("admin");
         Page adminRsp = adminClient.goTo(b.getUrl() + "consoleText", "text/plain");
         assertThat(adminRsp.getWebResponse().getContentAsString(), containsString(MARKER));
+    }
+
+    @Test
+    void legacyConsolePropertyStillEnablesPermission() throws Exception {
+        System.clearProperty(CONSOLE_PROPERTY);
+        System.setProperty(LEGACY_CONSOLE_PROPERTY, "true");
+        FreeStyleBuild b = createBuildWithConsoleOutput();
+        configureSecurity(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ, Item.READ).everywhere().to("reader"));
+
+        JenkinsRule.WebClient readerClient = j.createWebClient().login("reader");
+        FailingHttpStatusCodeException ex = assertThrows(FailingHttpStatusCodeException.class,
+                () -> readerClient.goTo(b.getUrl() + "consoleText", "text/plain"));
+        assertEquals(403, ex.getStatusCode());
     }
 }


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Closes #14279

Adds a new permission for restricting access to console logs. To prevent breaking existing instances on upgrade, this is an opt-in feature that requires setting the system property `jenkins.security.ConsolePermission=true`.

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
Verified that without the system property set, existing functionality continues to work
Verified that with the system property set, user with new permission can see the log output
Verified that with the system property set, user without the new permission is unable to access the log output

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Adds a new permission for restricting access to console logs

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

Setting the `jenkins.security.ConsolePermission=true` is required to enable the new permission

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers


<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
