### PR TITLE
Fix transient actions missing from experimental build page

### DIFF
--- a/core/src/main/resources/lib/layout/run-subpage.jelly
+++ b/core/src/main/resources/lib/layout/run-subpage.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:d="jelly:define" xmlns:dd="/lib/layout/dropdowns"
-         xmlns:st="jelly:stapler">
+         xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
   <st:documentation>
     A reusable container for subpages relating to Runs in Jenkins.
     Renders a tabbed layout for runs, including build status and actions.
@@ -68,7 +68,10 @@ THE SOFTWARE.
             </div>
 
             <div class="app-build-bar__controls">
-              <l:actions it="${it.object}" />
+              <j:scope it="${it.object}">
+                <l:actions it="${it}" />
+                <t:actions actions="${it.transientActions}" />
+              </j:scope>
             </div>
           </div>
 


### PR DESCRIPTION
Fixes #26695

### Testing done

Manually tested with the rebuild plugin installed:
- Enabled the experimental build page via the experimental flag
- Created a pipeline with no parameters and ran it
- Clicked Rebuild on the experimental build page
- Confirmed it correctly submits a POST request and rebuilds (no "This URL requires POST" error)
- Confirmed the classic build page is unaffected

### Proposed changelog entries

- Fix Rebuild button on experimental build page issuing GET instead of POST

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue is well-described (see #26695)
- [x] The changelog entry is in the imperative mood and appropriate for users
- [ ] There is automated testing or an explanation as to why this change has no tests
  - This change is in a Jelly template. Jelly rendering is not unit-testable in the standard Jenkins test harness without significant scaffolding. The fix is verified manually as described above.
- [x] New public classes, fields, and methods are annotated with @Restricted or have @since TODO Javadocs — N/A (no Java changes)
- [x] New deprecations — N/A
- [x] UI changes do not introduce CSP regressions — no inline JS introduced
- [x] For dependency updates — N/A
- [x] For new APIs — N/A

### Desired reviewers

@janfaracik