### PR TITLE
Refine Notifications component

### DIFF
--- a/src/main/js/components/notifications/index.js
+++ b/src/main/js/components/notifications/index.js
@@ -11,15 +11,15 @@ function init() {
     defaultAlertClass: "jenkins-notification",
 
     SUCCESS: {
-      alertClass: "jenkins-notification jenkins-notification--success",
+      alertClass: "jenkins-notification jenkins-!-success-color",
       icon: Symbols.SUCCESS,
     },
     WARNING: {
-      alertClass: "jenkins-notification jenkins-notification--warning",
+      alertClass: "jenkins-notification jenkins-!-warning-color",
       icon: Symbols.WARNING,
     },
     ERROR: {
-      alertClass: "jenkins-notification jenkins-notification--error",
+      alertClass: "jenkins-notification jenkins-!-error-color",
       icon: Symbols.ERROR,
       sticky: true,
     },

--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -330,6 +330,9 @@ $semantics: (
   );
   --item-box-shadow--focus: oklch(from var(--text-color-secondary) l c h / 0.1);
 
+  // Page
+  --page-inset: 0px;
+
   // Deprecated
   --primary: var(--accent-color); // Use var(--accent-color) instead
   --success: var(--green); // Use var(--success-color) instead

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -20,7 +20,6 @@
   z-index: 999;
   cursor: pointer;
   transition: filter var(--standard-transition);
-  backdrop-filter: brightness(2) blur(30px);
   transform-origin: bottom right;
 
   svg {

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -7,7 +7,7 @@
   right: 0;
   bottom: 0;
   margin: calc(var(--section-padding) + var(--page-inset));
-  width: 300px;
+  width: min(100%, 300px);
   max-width: 600px;
   display: grid;
   grid-template-columns: auto 1fr;

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -16,7 +16,6 @@
   border-radius: var(--form-input-border-radius);
   font-weight: var(--font-bold-weight);
   color: var(--text-color);
-  will-change: opacity, transform;
   z-index: 999;
   cursor: pointer;
   transition: filter var(--standard-transition);

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -40,7 +40,7 @@
   background-color: var(--color);
   color: var(--background) !important;
 
-  // We can't rely on the border from the mixin as on light background the border looks fuzzy
+  // We can't rely on the border from the mixin as on light backgrounds the border looks fuzzy
   &::after {
     border: 1px solid color-mix(in sRGB, var(--text-color) 10%, transparent);
   }

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -6,7 +6,7 @@
   position: fixed;
   right: 0;
   bottom: 0;
-  margin: calc(var(--bottom-app-bar-padding) + var(--page-inset));
+  margin: calc(var(--section-padding) + var(--page-inset));
   width: 300px;
   max-width: 600px;
   display: grid;

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -4,10 +4,11 @@
   @include mixins.overlay-surface($opacity: 75%);
 
   position: fixed;
-  right: calc(var(--bottom-app-bar-padding) + var(--page-inset));
-  bottom: calc(var(--bottom-app-bar-padding) + var(--page-inset));
-  min-width: 320px;
-  max-width: min(600px, calc(100vw - 2.5rem));
+  right: 0;
+  bottom: 0;
+  margin: calc(var(--bottom-app-bar-padding) + var(--page-inset));
+  width: 300px;
+  max-width: 600px;
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.75rem;

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -1,49 +1,30 @@
-@use "sass:color";
-@use "sass:string";
+@use "../abstracts/mixins";
 
 .jenkins-notification {
+  @include mixins.overlay-surface($opacity: 75%);
+
   position: fixed;
-  left: 1.2rem;
-  bottom: 1.2rem;
-  min-width: 321px;
-  max-width: min(600px, #{string.unquote("calc(100vw - 2.4rem)")});
+  right: calc(var(--bottom-app-bar-padding) + var(--page-inset));
+  bottom: calc(var(--bottom-app-bar-padding) + var(--page-inset));
+  min-width: 320px;
+  max-width: min(600px, calc(100vw - 2.5rem));
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 1.5ch;
-  padding: 0.8rem;
+  gap: 0.75rem;
+  padding: 0.75rem;
   border-radius: var(--form-input-border-radius);
   font-weight: var(--font-bold-weight);
-  line-height: 1.66;
   color: var(--text-color);
-  box-shadow:
-    0 0 1px 1px rgba(color.adjust(#024cb6, $lightness: -50%), 0.075),
-    0 10px 30px rgba(color.adjust(#024cb6, $lightness: -50%), 0.25),
-    0 0 30px 5px var(--background);
   will-change: opacity, transform;
   z-index: 999;
   cursor: pointer;
   transition: filter var(--standard-transition);
   backdrop-filter: brightness(2) blur(30px);
+  transform-origin: bottom right;
 
   svg {
-    width: 1.4rem;
-    height: 1.4rem;
-  }
-
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    z-index: -1;
-    background: oklch(from var(--background) l c h / 0.3);
-    border: var(--jenkins-border--subtle);
-  }
-
-  @supports not (backdrop-filter: blur(15px)) {
-    &::after {
-      opacity: 0.9;
-    }
+    width: 1.375rem;
+    height: 1.375rem;
   }
 
   &:hover {
@@ -55,30 +36,13 @@
   }
 }
 
-.jenkins-notification--success {
-  color: var(--background);
+.jenkins-notification[class*="color"] {
+  background-color: var(--color);
+  color: var(--background) !important;
 
+  // We can't rely on the border from the mixin as on light background the border looks fuzzy
   &::after {
-    background-color: var(--success-color);
-    opacity: 1;
-  }
-}
-
-.jenkins-notification--warning {
-  color: var(--background);
-
-  &::after {
-    background-color: var(--warning-color);
-    opacity: 1;
-  }
-}
-
-.jenkins-notification--error {
-  color: var(--background);
-
-  &::after {
-    background-color: var(--error-color);
-    opacity: 1;
+    border: 1px solid color-mix(in sRGB, var(--text-color) 10%, transparent);
   }
 }
 
@@ -98,12 +62,10 @@
 @keyframes show-notification {
   from {
     opacity: 0;
-    transform: translateY(1.2rem);
+    transform: translateY(var(--section-padding)) scale(0.95);
   }
 
   to {
-    opacity: 1;
-    transform: translateY(0);
     visibility: visible;
   }
 }
@@ -111,7 +73,7 @@
 @keyframes show-notification-icon {
   from {
     opacity: 0;
-    transform: translateY(0.3rem);
+    transform: translateY(0.35rem);
   }
 }
 

--- a/src/main/scss/components/_notifications.scss
+++ b/src/main/scss/components/_notifications.scss
@@ -73,7 +73,7 @@
 @keyframes show-notification-icon {
   from {
     opacity: 0;
-    transform: translateY(0.35rem);
+    transform: translateY(0.5rem);
   }
 }
 


### PR DESCRIPTION
* Notifications have been moved to the right side of the screen, with the thinking that there'll be less content in that corner
* Sizings and material refined
  * Now aligns with whole pixels, so should be sharper
  * Uses the `mixin` from https://github.com/jenkinsci/jenkins/pull/26900
* Notifications now follow the same use of colour as buttons and menu items - simply apply a [colour class](https://weekly.ci.jenkins.io/design-library/colors/) and it'll just work out the box 

[Updated Design Library PR](https://github.com/jenkinsci/design-library-plugin/pull/487)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

<img width="1621" height="951" alt="image" src="https://github.com/user-attachments/assets/d1a3df04-204e-44e8-866c-2b3f9e167803" />

#### After

<img width="1621" height="951" alt="image" src="https://github.com/user-attachments/assets/00111bfa-42ae-4a8a-b65c-ef66d3eab006" />

### Proposed changelog entries

- Refine Notifications component.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label web-ui,rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
