### PR TITLE
[JENKINS-70788] Limit frontend linters to Jenkins source directories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,18 @@
+# Only scan Jenkins source areas, not arbitrary top-level work directories
+/*/
+!/.github/
+!/.idea/
+!/.mvn/
+!/bom/
+!/cli/
+!/core/
+!/coverage/
+!/docs/
+!/src/
+!/test/
+!/war/
+!/websocket/
+
 # generated / build files
 .pnp.cjs
 .pnp.loader.mjs

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -6,6 +6,21 @@ module.exports = [
   // Global ignores
   {
     ignores: [
+      // Only scan Jenkins source areas, not arbitrary top-level work directories
+      "*/**",
+      "!.github/**",
+      "!.idea/**",
+      "!.mvn/**",
+      "!bom/**",
+      "!cli/**",
+      "!core/**",
+      "!coverage/**",
+      "!docs/**",
+      "!src/**",
+      "!test/**",
+      "!war/**",
+      "!websocket/**",
+
       "**/target/",
       "**/work/",
 


### PR DESCRIPTION
Fixes #18476

ESLint and Prettier currently scan arbitrary top-level directories in a Jenkins checkout. Limit directory traversal to Jenkins source directories while continuing to check root configuration files.

### Testing done

- Verified before the change that ESLint and Prettier process JavaScript files under `.playwright-mcp/` and another arbitrary top-level work directory.
- Verified after the change that both directories are ignored while previously checked tracked files remain in scope.
- No automated test was added because this change controls the linters' own file discovery; the temporary top-level probe files directly exercised the changed configuration.
- Ran `yarn lint`.
- Ran `yarn lint:fix` and verified that the ignored probe files were unchanged.
- Ran `git diff --check`.

### Screenshots (UI changes only)

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
