### PR TITLE
Fix hover area overlap for console and upstream hyperlinks

### DIFF
--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -234,6 +234,7 @@
       background: var(--text-color);
     }
 
+    &.model-link--open,
     &:hover {
       z-index: 10;
       margin-right: calc(2ch + 14px) !important;

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -236,10 +236,12 @@
 
     &:hover {
       z-index: 10;
+      margin-right: calc(2ch + 14px) !important;
 
       @media (hover: hover) {
         &::before,
         &::after {
+          left: -4px;
           right: calc((2ch + 14px) * -1);
         }
       }
@@ -255,7 +257,6 @@
       .jenkins-menu-dropdown-chevron {
         &::after {
           opacity: 0.5;
-          display: none;
         }
       }
     }


### PR DESCRIPTION
Fixes #27006

### Testing done

This change was tested manually in all current usages of `model-link--float` to verify that the hover area, jump-list dropdown, and surrounding layout behave correctly.

#### Console hyperlinks

- Reproduced the issue using a Pipeline job running on a Jenkins inbound agent to generate the `Running on <agent> in ...` console output.
- Verified that the hover area no longer overlaps the following text.
- Verified that the jump-list dropdown remains functional.

#### Upstream Cause hyperlinks

- Created two Pipeline jobs where one triggers the other to generate the `Started by upstream project...` hyperlinks.
- Verified that the hover area no longer overlaps the following text.
- Verified that the jump-list dropdown remains functional.

No automated tests were added because this is a CSS/UI-only change.

### Screenshots (UI changes only)

The screenshots below show the behavior before and after the change for both current usages of `model-link--float`.

#### Before

**Console hyperlink**

<img width="424" height="162" alt="Screenshot 2026-07-02 012551" src="https://github.com/user-attachments/assets/295ed329-cd83-4f60-802f-77e63f1a6528" />

**Upstream Cause hyperlink**

<img width="347" height="113" alt="Screenshot 2026-07-04 011303" src="https://github.com/user-attachments/assets/c915ba75-c33a-4ea7-bc23-3c95afbfc88b" />

#### After

**Console hyperlink**

<img width="385" height="92" alt="Screenshot 2026-07-04 140910" src="https://github.com/user-attachments/assets/1d1d5ce8-350a-4e6e-8ea8-c0980a39e838" />

<img width="352" height="224" alt="Screenshot 2026-07-04 140955" src="https://github.com/user-attachments/assets/ab3195a8-e8d8-4082-85f2-af8e73ea3aec" />

**Upstream Cause hyperlink**

<img width="303" height="75" alt="Screenshot 2026-07-04 105031" src="https://github.com/user-attachments/assets/7466042f-8a87-493d-8450-7ee6575e6265" />

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of the Content Security Policy Plugin. In particular, no inline JavaScript or `eval` usage was introduced.
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
