### PR TITLE
fix: allow deleting folders and multibranch pipelines from the new da…

### DIFF
--- a/core/src/main/resources/hudson/model/View/new-view-page.jelly
+++ b/core/src/main/resources/hudson/model/View/new-view-page.jelly
@@ -130,6 +130,23 @@ THE SOFTWARE.
                 </l:confirmationLink>
               </dd:custom>
             </j:if>
+            <j:set var="ownerItem" value="${it.ownerItemGroup}" />
+            <j:if test="${ownerItem != app and h.hasPermission(ownerItem, ownerItem.DELETE)}">
+              <dd:separator />
+              <dd:custom>
+                <l:confirmationLink class="jenkins-dropdown__item jenkins-!-destructive-color"
+                                    href="${rootURL}/${ownerItem.url}doDelete"
+                                    title="${%delete(ownerItem.pronoun)}"
+                                    message="${%delete.confirm(ownerItem.pronoun, ownerItem.displayName)}"
+                                    destructive="true"
+                                    post="true">
+                  <div class="jenkins-dropdown__item__icon">
+                    <l:icon src="symbol-trash" />
+                  </div>
+                  ${%delete(ownerItem.pronoun)}
+                </l:confirmationLink>
+              </dd:custom>
+            </j:if>
           </l:overflowButton>
         </div>
       </div>

--- a/core/src/main/resources/hudson/model/View/new-view-page.properties
+++ b/core/src/main/resources/hudson/model/View/new-view-page.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2026, Jenkins Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+delete=Delete {0}
+delete.confirm=Delete the {0} ‘{1}’?

--- a/test/src/test/java/hudson/model/NewViewPageDeleteTest.java
+++ b/test/src/test/java/hudson/model/NewViewPageDeleteTest.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Jenkins Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Map;
+import jenkins.model.Jenkins;
+import jenkins.model.experimentalflags.UserExperimentalFlagsProperty;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class NewViewPageDeleteTest {
+
+    private static final String NEW_DASHBOARD_FLAG = "new-dashboard-page.flag";
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    @Test
+    void deleteShownForFolder() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        enableNewDashboard("alice");
+        MockFolder folder = j.createFolder("f");
+
+        HtmlPage page = j.createWebClient().withBasicCredentials("alice").goTo(folder.getUrl());
+
+        assertThat(page.getWebResponse().getContentAsString(), containsString(folder.getUrl() + "doDelete"));
+    }
+
+    @Test
+    void deleteHiddenWithoutPermission() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ, Item.READ).everywhere().to("bob"));
+        enableNewDashboard("bob");
+        MockFolder folder = j.createFolder("f");
+
+        HtmlPage page = j.createWebClient().withBasicCredentials("bob").goTo(folder.getUrl());
+
+        assertThat(page.getWebResponse().getContentAsString(), not(containsString(folder.getUrl() + "doDelete")));
+    }
+
+    @Test
+    void deleteHiddenForRootDashboard() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        enableNewDashboard("carol");
+
+        HtmlPage page = j.createWebClient().withBasicCredentials("carol").goTo("");
+
+        // The root dashboard must never offer to delete Jenkins itself.
+        assertThat(page.getWebResponse().getContentAsString(), not(containsString("/doDelete")));
+    }
+
+    private void enableNewDashboard(String userId) throws Exception {
+        User user = User.getOrCreateByIdOrFullName(userId);
+        user.addProperty(new UserExperimentalFlagsProperty(Map.of(NEW_DASHBOARD_FLAG, "true")));
+    }
+}


### PR DESCRIPTION
Fixes #27041

> Note: this pull request is complete and tested. It is opened as a draft only because of the GitHub limit on open pull requests for contributors without write access. I will mark it "Ready for review" as soon as a slot frees. Reviews and feedback are very welcome in the meantime.

When the experimental "New dashboard page" flag is enabled, opening a container item that is shown through its primary view (a Multibranch Pipeline or a Folder) offered no way to delete it. The classic dashboard shows a "Delete Multibranch Pipeline" task in the side panel. The new dashboard replaces the side panel with an app bar overflow ("...") menu that rebuilds the item tasks plus a single "Delete View" action. "Delete View" is gated on the view being deletable, which is never true for an item's primary view, so no delete action appeared for the item itself.

The app bar delete used elsewhere in the new UI (jenkins.model.menu.action.DeleteAction) is only contributed to Job and Run. A Multibranch Pipeline is an AbstractFolder / ItemGroup, not a Job, so it was never covered by that path either.

This change adds an item level delete entry to the new dashboard overflow menu in hudson/model/View/new-view-page.jelly, mirroring the existing "Delete View" entry. It is shown only when:

* the view's owner item group is an actual Item (ownerItemGroup != app), which excludes the Jenkins root dashboard and the "My Views" page, and
* the current user has Item/Delete permission on that item.

It posts to the item's doDelete with a confirmation dialog and is labelled using the item's pronoun (for example "Delete Multibranch Pipeline" or "Delete Folder").

### Testing done

Added hudson.model.NewViewPageDeleteTest, which renders the real page via JenkinsRule and MockFolder:

* deleteShownForFolder: with the flag enabled and Item/Delete permission, a folder's new dashboard overflow contains the item's doDelete link.
* deleteHiddenWithoutPermission: with only READ granted, the delete link is absent.
* deleteHiddenForRootDashboard: the root dashboard never exposes a delete link, so Jenkins itself can never be deleted.

Result: Tests run: 3, Failures: 0, Errors: 0.

Manual verification: enable the "New dashboard page" experimental flag, create a Multibranch Pipeline (or Folder), open it, and use the "..." overflow menu in the app bar. The "Delete ..." entry now appears and deletes the item after confirmation.

### Screenshots (UI changes only)

#### Before

See #27041: the overflow menu has no delete entry.

#### After

The overflow menu now ends with a red "Delete Multibranch Pipeline" (or "Delete Folder") entry.

<img width="305" height="672" alt="image" src="https://github.com/user-attachments/assets/1a3c8edd-bf86-460e-85ba-d40575f55863" />

### Proposed changelog entries

- Allow deleting folders and multibranch pipelines from the new experimental dashboard page.

### Proposed changelog category

/label bug, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change and are in the imperative mood.
- [x] There is automated testing (hudson.model.NewViewPageDeleteTest).
- [x] New public classes, fields, and methods are annotated with @Restricted or have @since TODO Javadocs, as appropriate. (No new public Java API; only a Jelly view, its message bundle, and a test.)
- [x] New deprecations are annotated with @Deprecated(since = "TODO"), if applicable. (None.)
- [x] UI changes do not introduce regressions under the current default CSP rules. (No inline JavaScript and no eval; reuses the existing l:confirmationLink component.)
- [x] For dependency updates, there are links to external changelogs. (No dependency changes.)
- [x] For new APIs and extension points, there is a link to at least one consumer. (No new APIs.)

### Desired reviewers

@janfaracik @timja 