### PR TITLE
Whitelist java.util.Map$Entry in ClassFilter to prevent build metadata corruption

### DIFF
--- a/core/src/main/java/jenkins/security/MapEntryClassFilter.java
+++ b/core/src/main/java/jenkins/security/MapEntryClassFilter.java
@@ -1,0 +1,23 @@
+package jenkins.security;
+
+import hudson.Extension;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Restricted(NoExternalUse.class)
+@Extension
+public class MapEntryClassFilter implements CustomClassFilter {
+
+    @Override
+    public Boolean permits(Class<?> c) {
+        return permits(c.getName());
+    }
+
+    @Override
+    public Boolean permits(String name) {
+        if ("java.util.Map$Entry".equals(name)) {
+            return Boolean.TRUE;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### Description
This PR resolves an issue where completed builds reload with corrupted/fallback epoch defaults (`timestamp=0`, `duration=0`, and `result=ABORTED`) during normal operations.

The root cause is that during unmarshalling of build action metadata (specifically test data actions containing map collections), XStream resolves map entries as `java.util.Map$Entry`. Because this class is loaded from the JRE without a codebase location and is not present in the default whitelist, the `ClassFilterImpl` security filter rejects it. This triggers a `ConversionException` in `XStream2$BlacklistedTypesConverter` that breaks the unmarshalling process, causing the build object to fall back to epoch defaults.

### Proposed Changes
* Added [MapEntryClassFilter](file:///home/akshat-chaudhary/Documents/jenkins/core/src/main/java/jenkins/security/MapEntryClassFilter.java) implementing the [CustomClassFilter](file:///home/akshat-chaudhary/Documents/jenkins/core/src/main/java/jenkins/security/CustomClassFilter.java) extension point.
* Explicitly permitted the `java.util.Map$Entry` class to bypass the security filter.

### Security Impact
Adding `java.util.Map$Entry` to the whitelist does not introduce security vulnerabilities. It is a standard JRE interface and does not contain custom or dangerous deserialization logic (like `readObject`), making it safe to deserialize.
