### PR TITLE
[JENKINS-60117] Rework sorting for Enabled columns of Installed in Plugin Manager

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -186,7 +186,8 @@ THE SOFTWARE.
                     </td>
                   </j:if>
                   <j:set var="state" value="${p.enabled?'true':null}"/>
-                  <td class="jenkins-table__cell--tight enable" data="${state}">
+                  <j:set var="sortKey" value="${p.enabled ? (p.hasMandatoryDependents() ? '1' : '2') : '0'}"/>
+                  <td class="jenkins-table__cell--tight enable" data="${sortKey}">
                     <div class="jenkins-table__cell__button-wrapper">
                       <span class="jenkins-toggle-switch">
                         <input type="checkbox" checked="${state}"


### PR DESCRIPTION
Fixes #20694

### Testing done

Built the WAR with `mvn -am -pl war,bom -Pquick-build clean install` — BUILD SUCCESS.

Verified the Jelly template renders the correct `data` attribute values for all three plugin states:
- `data=\"2\"` for enabled plugins with no mandatory dependents
- `data=\"1\"` for enabled plugins with mandatory dependents (cannot be disabled)
- `data=\"0\"` for disabled plugins

The change is purely a server-side Jelly template change to the sort key. The existing `sortable.js` client-side sorting engine handles the three values automatically via its `caseInsensitive` comparator, so no JavaScript changes were needed.

No automated test was added because this is a template rendering change. The sort behavior is exercised by existing frontend infrastructure.

### Screenshots (UI changes only)

N/A — no visual UI change, only sort order grouping.

#### Before

#### After

### Proposed changelog entries

- Sort the Enabled column in Plugin Manager into three groups: enabled, required by other plugins, and disabled.

### Proposed changelog category

/label rfe,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood. Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [X] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [X] New deprecations are annotated with `@Deprecated(since = \"TODO\")` or `@Deprecated(forRemoval = true, since = \"TODO\")`, if applicable.
- [X] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [X] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [X] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.