### PR TITLE
[JENKINS-27993] Return useful plugin data from /pluginManager/api/json

### DIFF
--- a/core/src/main/java/hudson/PluginWrapper.java
+++ b/core/src/main/java/hudson/PluginWrapper.java
@@ -522,6 +522,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
         this.archive = archive;
     }
 
+    @Exported(visibility = 2)
     @Override
     public String getDisplayName() {
         String displayName = getLongName();
@@ -595,7 +596,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     /**
      * Returns the short name suitable for URL.
      */
-    @Exported
+    @Exported(visibility = 2)
     public String getShortName() {
         return shortName;
     }
@@ -627,7 +628,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      *      null if this information is unavailable.
      * @since 1.283
      */
-    @Exported
+    @Exported(visibility = 2)
     public String getUrl() {
         // first look in update center metadata
         List<UpdateSite.Plugin> siteMetadataList = getInfoFromAllSites();
@@ -683,7 +684,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     /**
      * Returns the version number of this plugin
      */
-    @Exported
+    @Exported(visibility = 2)
     public String getVersion() {
         return getVersionOf(manifest);
     }
@@ -894,7 +895,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
     /**
      * Returns true if this plugin is enabled for this session.
      */
-    @Exported
+    @Exported(visibility = 2)
     public boolean isActive() {
         return active && !hasCycleDependency();
     }
@@ -921,7 +922,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      * If true, the plugin is going to be activated next time
      * Jenkins runs.
      */
-    @Exported
+    @Exported(visibility = 2)
     public boolean isEnabled() {
         return !disableFile.exists();
     }
@@ -1080,7 +1081,7 @@ public class PluginWrapper implements Comparable<PluginWrapper>, ModelObject {
      * This method is conservative in the sense that if the version number is incomprehensible,
      * it always returns false.
      */
-    @Exported
+    @Exported(visibility = 2)
     public boolean hasUpdate() {
         return getUpdateInfo() != null;
     }

--- a/test/src/test/java/hudson/PluginManagerTest.java
+++ b/test/src/test/java/hudson/PluginManagerTest.java
@@ -541,6 +541,36 @@ class PluginManagerTest {
         });
     }
 
+    @Issue("https://github.com/jenkinsci/jenkins/issues/21047")
+    @WithPlugin("htmlpublisher.jpi")
+    @Test
+    void pluginManagerApiJsonReturnsPluginDetails() throws Throwable {
+        session.then(r -> {
+            JSONObject response = r.getJSON("pluginManager/api/json").getJSONObject();
+            JSONArray plugins = response.getJSONArray("plugins");
+            assertThat(plugins, not(empty()));
+
+            // Find the htmlpublisher plugin in the response
+            JSONObject htmlPublisher = null;
+            for (int i = 0; i < plugins.size(); i++) {
+                JSONObject plugin = plugins.getJSONObject(i);
+                if ("htmlpublisher".equals(plugin.optString("shortName"))) {
+                    htmlPublisher = plugin;
+                    break;
+                }
+            }
+            assertNotNull(htmlPublisher, "htmlpublisher plugin should be present in API response");
+
+            // Verify key properties are present at default depth (visibility = 2)
+            assertNotNull(htmlPublisher.optString("shortName", null), "shortName should be exported at default depth");
+            assertNotNull(htmlPublisher.optString("version", null), "version should be exported at default depth");
+            assertNotNull(htmlPublisher.optString("displayName", null), "displayName should be exported at default depth");
+            assertTrue(htmlPublisher.has("active"), "active should be exported at default depth");
+            assertTrue(htmlPublisher.has("enabled"), "enabled should be exported at default depth");
+            assertTrue(htmlPublisher.has("hasUpdate"), "hasUpdate should be exported at default depth");
+        });
+    }
+
     @Issue("JENKINS-41684")
     @Test
     void requireSystemDuringLoad() throws Throwable {


### PR DESCRIPTION
Return useful data from /pluginManager/api/json by default

Increase @Exported visibility to 2 on PluginWrapper's shortName, url, version, active, enabled, and hasUpdate, and export displayName (the non-deprecated replacement for getLongName()), so these fields are no longer dropped when nested under PluginManager.plugins at the API's default depth.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #21047

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Added `PluginManagerTest#pluginManagerApiJsonReturnsPluginDetails`, which installs `htmlpublisher.jpi`, hits `pluginManager/api/json` with no `depth` parameter, and asserts that `shortName`, `version`, `displayName`, `active`, `enabled`, and `hasUpdate` are all present and non-null on the returned plugin object. The test fails against the pre-patch code (all of those fields are absent/empty at default depth) and passes after the `@Exported(visibility = 2)` changes.

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Return `shortName`, `url`, `version`, `displayName`, `active`, `enabled`, and `hasUpdate` in `/pluginManager/api/json` at the default depth

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
