### PR TITLE
Limit job RSS changelog feed size by default

### DIFF
--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1156,8 +1156,10 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             }
         }
 
-        // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=,
-        // but always hard-capped so callers cannot reintroduce unbounded feeds.
+        // Default 20 entries (JENKINS-18992).
+        // hudson.model.Job.rssChangelogMaxEntries — default feed size (min 1)
+        // hudson.model.Job.rssChangelogHardLimit — absolute ceiling (default 1000)
+        // ?max=N overrides the default size but cannot exceed the hard limit.
         int hardLimit =
                 Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogHardLimit", 1000));
         int maxEntries = Math.min(
@@ -1166,7 +1168,10 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         String maxParam = req.getParameter("max");
         if (maxParam != null) {
             try {
-                maxEntries = Math.min(hardLimit, Math.max(1, Integer.parseInt(maxParam)));
+                // Parse as long so values outside int range clamp to the hard limit
+                // instead of being treated as invalid.
+                long requested = Long.parseLong(maxParam.trim());
+                maxEntries = (int) Math.min(hardLimit, Math.max(1L, requested));
             } catch (NumberFormatException e) {
                 // keep default
             }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1157,7 +1157,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         }
 
         // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=
-        int maxEntries = SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20);
+        int maxEntries = Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20));
         String maxParam = req.getParameter("max");
         if (maxParam != null) {
             try {

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -110,6 +110,7 @@ import jenkins.scm.RunWithSCM;
 import jenkins.security.HexStringConfidentialKey;
 import jenkins.security.stapler.StaplerNotDispatchable;
 import jenkins.triggers.SCMTriggerItem;
+import jenkins.util.SystemProperties;
 import jenkins.widgets.HasWidgets;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
@@ -1155,6 +1156,17 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             }
         }
 
+        // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=
+        int maxEntries = SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20);
+        String maxParam = req.getParameter("max");
+        if (maxParam != null) {
+            try {
+                maxEntries = Math.max(1, Integer.parseInt(maxParam));
+            } catch (NumberFormatException e) {
+                // keep default
+            }
+        }
+
         List<FeedItem> entries = new ArrayList<>();
         String scmDisplayName = "";
         if (this instanceof SCMTriggerItem scmItem) {
@@ -1165,11 +1177,16 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             scmDisplayName = " " + String.join(", ", scmNames);
         }
 
+        // stop once we have enough; avoids loading every build for large jobs
+        outer:
         for (RunT r = getLastBuild(); r != null; r = r.getPreviousBuild()) {
             int idx = 0;
             if (r instanceof RunWithSCM) {
                 for (ChangeLogSet<? extends ChangeLogSet.Entry> c : ((RunWithSCM<?, ?>) r).getChangeSets()) {
                     for (ChangeLogSet.Entry e : c) {
+                        if (entries.size() >= maxEntries) {
+                            break outer;
+                        }
                         entries.add(new FeedItem(e, idx++));
                     }
                 }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1156,12 +1156,17 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             }
         }
 
-        // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=
-        int maxEntries = Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20));
+        // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=,
+        // but always hard-capped so callers cannot reintroduce unbounded feeds.
+        int hardLimit =
+                Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogHardLimit", 1000));
+        int maxEntries = Math.min(
+                hardLimit,
+                Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20)));
         String maxParam = req.getParameter("max");
         if (maxParam != null) {
             try {
-                maxEntries = Math.max(1, Integer.parseInt(maxParam));
+                maxEntries = Math.min(hardLimit, Math.max(1, Integer.parseInt(maxParam)));
             } catch (NumberFormatException e) {
                 // keep default
             }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1160,12 +1160,17 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             }
         }
 
-        // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=
-        int maxEntries = Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20));
+        // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=,
+        // but always hard-capped so callers cannot reintroduce unbounded feeds.
+        int hardLimit =
+                Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogHardLimit", 1000));
+        int maxEntries = Math.min(
+                hardLimit,
+                Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20)));
         String maxParam = req.getParameter("max");
         if (maxParam != null) {
             try {
-                maxEntries = Math.max(1, Integer.parseInt(maxParam));
+                maxEntries = Math.min(hardLimit, Math.max(1, Integer.parseInt(maxParam)));
             } catch (NumberFormatException e) {
                 // keep default
             }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1160,8 +1160,10 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             }
         }
 
-        // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=,
-        // but always hard-capped so callers cannot reintroduce unbounded feeds.
+        // Default 20 entries (JENKINS-18992).
+        // hudson.model.Job.rssChangelogMaxEntries — default feed size (min 1)
+        // hudson.model.Job.rssChangelogHardLimit — absolute ceiling (default 1000)
+        // ?max=N overrides the default size but cannot exceed the hard limit.
         int hardLimit =
                 Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogHardLimit", 1000));
         int maxEntries = Math.min(
@@ -1170,7 +1172,10 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         String maxParam = req.getParameter("max");
         if (maxParam != null) {
             try {
-                maxEntries = Math.min(hardLimit, Math.max(1, Integer.parseInt(maxParam)));
+                // Parse as long so values outside int range clamp to the hard limit
+                // instead of being treated as invalid.
+                long requested = Long.parseLong(maxParam.trim());
+                maxEntries = (int) Math.min(hardLimit, Math.max(1L, requested));
             } catch (NumberFormatException e) {
                 // keep default
             }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -111,6 +111,7 @@ import jenkins.security.HexStringConfidentialKey;
 import jenkins.security.XStreamNotDeserializable;
 import jenkins.security.stapler.StaplerNotDispatchable;
 import jenkins.triggers.SCMTriggerItem;
+import jenkins.util.SystemProperties;
 import jenkins.widgets.HasWidgets;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
@@ -1159,6 +1160,17 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             }
         }
 
+        // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=
+        int maxEntries = SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20);
+        String maxParam = req.getParameter("max");
+        if (maxParam != null) {
+            try {
+                maxEntries = Math.max(1, Integer.parseInt(maxParam));
+            } catch (NumberFormatException e) {
+                // keep default
+            }
+        }
+
         List<FeedItem> entries = new ArrayList<>();
         String scmDisplayName = "";
         if (this instanceof SCMTriggerItem scmItem) {
@@ -1169,11 +1181,16 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             scmDisplayName = " " + String.join(", ", scmNames);
         }
 
+        // stop once we have enough; avoids loading every build for large jobs
+        outer:
         for (RunT r = getLastBuild(); r != null; r = r.getPreviousBuild()) {
             int idx = 0;
             if (r instanceof RunWithSCM) {
                 for (ChangeLogSet<? extends ChangeLogSet.Entry> c : ((RunWithSCM<?, ?>) r).getChangeSets()) {
                     for (ChangeLogSet.Entry e : c) {
+                        if (entries.size() >= maxEntries) {
+                            break outer;
+                        }
                         entries.add(new FeedItem(e, idx++));
                     }
                 }

--- a/core/src/main/java/hudson/model/Job.java
+++ b/core/src/main/java/hudson/model/Job.java
@@ -1161,7 +1161,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         }
 
         // Default 20 entries (JENKINS-18992). Overridable via system property or ?max=
-        int maxEntries = SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20);
+        int maxEntries = Math.max(1, SystemProperties.getInteger(Job.class.getName() + ".rssChangelogMaxEntries", 20));
         String maxParam = req.getParameter("max");
         if (maxParam != null) {
             try {

--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -74,14 +74,21 @@ class RSSTest {
 
     private static final String RSS_CHANGELOG_MAX_ENTRIES = Job.class.getName() + ".rssChangelogMaxEntries";
 
+    private String originalRssChangelogMaxEntries;
+
     @BeforeEach
     void setUp(JenkinsRule rule) {
         j = rule;
+        originalRssChangelogMaxEntries = System.getProperty(RSS_CHANGELOG_MAX_ENTRIES);
     }
 
     @AfterEach
-    void clearRssChangelogMaxEntries() {
-        System.clearProperty(RSS_CHANGELOG_MAX_ENTRIES);
+    void restoreRssChangelogMaxEntries() {
+        if (originalRssChangelogMaxEntries == null) {
+            System.clearProperty(RSS_CHANGELOG_MAX_ENTRIES);
+        } else {
+            System.setProperty(RSS_CHANGELOG_MAX_ENTRIES, originalRssChangelogMaxEntries);
+        }
     }
 
     @Test

--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -73,21 +73,29 @@ class RSSTest {
     private JenkinsRule j;
 
     private static final String RSS_CHANGELOG_MAX_ENTRIES = Job.class.getName() + ".rssChangelogMaxEntries";
+    private static final String RSS_CHANGELOG_HARD_LIMIT = Job.class.getName() + ".rssChangelogHardLimit";
 
     private String originalRssChangelogMaxEntries;
+    private String originalRssChangelogHardLimit;
 
     @BeforeEach
     void setUp(JenkinsRule rule) {
         j = rule;
         originalRssChangelogMaxEntries = System.getProperty(RSS_CHANGELOG_MAX_ENTRIES);
+        originalRssChangelogHardLimit = System.getProperty(RSS_CHANGELOG_HARD_LIMIT);
     }
 
     @AfterEach
-    void restoreRssChangelogMaxEntries() {
-        if (originalRssChangelogMaxEntries == null) {
-            System.clearProperty(RSS_CHANGELOG_MAX_ENTRIES);
+    void restoreRssChangelogSystemProperties() {
+        restoreSystemProperty(RSS_CHANGELOG_MAX_ENTRIES, originalRssChangelogMaxEntries);
+        restoreSystemProperty(RSS_CHANGELOG_HARD_LIMIT, originalRssChangelogHardLimit);
+    }
+
+    private static void restoreSystemProperty(String key, String original) {
+        if (original == null) {
+            System.clearProperty(key);
         } else {
-            System.setProperty(RSS_CHANGELOG_MAX_ENTRIES, originalRssChangelogMaxEntries);
+            System.setProperty(key, original);
         }
     }
 
@@ -374,10 +382,21 @@ class RSSTest {
     @Test
     @Issue("JENKINS-18992")
     void rssChangelogMaxParameter() throws Exception {
-        createJobWithChangelogEntries("rssChangelogMax", 15);
+        // More than the default (20) so we prove ?max= can raise the limit, not only lower it.
+        createJobWithChangelogEntries("rssChangelogMax", 25);
         JenkinsRule.WebClient wc = j.createWebClient();
         assertEquals(5, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=5", true), true));
-        assertEquals(15, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=50", true), true));
+        assertEquals(25, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=50", true), true));
+    }
+
+    @Test
+    @Issue("JENKINS-18992")
+    void rssChangelogMaxParameterIsHardCapped() throws Exception {
+        System.setProperty(RSS_CHANGELOG_HARD_LIMIT, "10");
+        createJobWithChangelogEntries("rssChangelogHardCap", 20);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        assertEquals(
+                10, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogHardCap", "max=1000000", true), true));
     }
 
     @Test
@@ -389,6 +408,17 @@ class RSSTest {
                 5,
                 countChangelogEntries(
                         getRssChangelogPage(j.createWebClient(), "rssChangelogProp", "", true), true));
+    }
+
+    @Test
+    @Issue("JENKINS-18992")
+    void rssChangelogSystemPropertyClampedToAtLeastOne() throws Exception {
+        System.setProperty(RSS_CHANGELOG_MAX_ENTRIES, "0");
+        createJobWithChangelogEntries("rssChangelogZeroProp", 5);
+        assertEquals(
+                1,
+                countChangelogEntries(
+                        getRssChangelogPage(j.createWebClient(), "rssChangelogZeroProp", "", true), true));
     }
 
     @Test

--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -386,7 +386,9 @@ class RSSTest {
         createJobWithChangelogEntries("rssChangelogMax", 25);
         JenkinsRule.WebClient wc = j.createWebClient();
         assertEquals(5, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=5", true), true));
+        assertEquals(5, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=5", false), false));
         assertEquals(25, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=50", true), true));
+        assertEquals(25, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=50", false), false));
     }
 
     @Test
@@ -577,10 +579,11 @@ class RSSTest {
         FreeStyleProject p = j.createFreeStyleProject(name);
         FakeChangeLogSCM scm = new FakeChangeLogSCM();
         p.setScm(scm);
+        // Batch all entries into one build — assertions only need entry count, not N builds.
         for (int i = 0; i < n; i++) {
             scm.addChange().withAuthor("u" + i);
-            j.buildAndAssertSuccess(p);
         }
+        j.buildAndAssertSuccess(p);
     }
 
     private FreeStyleProject runSuccessfulBuild() throws Exception {

--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -45,9 +45,11 @@ import java.util.Date;
 import java.util.List;
 import jenkins.model.Jenkins;
 import org.htmlunit.xml.XmlPage;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.FakeChangeLogSCM;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
@@ -70,9 +72,16 @@ class RSSTest {
 
     private JenkinsRule j;
 
+    private static final String RSS_CHANGELOG_MAX_ENTRIES = Job.class.getName() + ".rssChangelogMaxEntries";
+
     @BeforeEach
     void setUp(JenkinsRule rule) {
         j = rule;
+    }
+
+    @AfterEach
+    void clearRssChangelogMaxEntries() {
+        System.clearProperty(RSS_CHANGELOG_MAX_ENTRIES);
     }
 
     @Test
@@ -346,6 +355,44 @@ class RSSTest {
         checkAtomBasicNodes(documentElement, "Jenkins:log (WARNING entries)", expectedNodes);
     }
 
+    @Test
+    @Issue("JENKINS-18992")
+    void rssChangelogIsLimitedByDefault() throws Exception {
+        createJobWithChangelogEntries("rssChangelogDefault", 25);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        assertEquals(20, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogDefault", "", true), true));
+        assertEquals(20, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogDefault", "", false), false));
+    }
+
+    @Test
+    @Issue("JENKINS-18992")
+    void rssChangelogMaxParameter() throws Exception {
+        createJobWithChangelogEntries("rssChangelogMax", 15);
+        JenkinsRule.WebClient wc = j.createWebClient();
+        assertEquals(5, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=5", true), true));
+        assertEquals(15, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogMax", "max=50", true), true));
+    }
+
+    @Test
+    @Issue("JENKINS-18992")
+    void rssChangelogSystemProperty() throws Exception {
+        System.setProperty(RSS_CHANGELOG_MAX_ENTRIES, "5");
+        createJobWithChangelogEntries("rssChangelogProp", 10);
+        assertEquals(
+                5,
+                countChangelogEntries(
+                        getRssChangelogPage(j.createWebClient(), "rssChangelogProp", "", true), true));
+    }
+
+    @Test
+    @Issue("JENKINS-18992")
+    void rssChangelogFewerThanLimit() throws Exception {
+        createJobWithChangelogEntries("rssChangelogFew", 3);
+        assertEquals(
+                3,
+                countChangelogEntries(getRssChangelogPage(j.createWebClient(), "rssChangelogFew", "", true), true));
+    }
+
     private JenkinsRule.WebClient loginAsUser(String userId) throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to(userId));
@@ -468,6 +515,30 @@ class RSSTest {
     private XmlPage getRssLatestPage(JenkinsRule.WebClient webClient, String pathPrefix) throws Exception {
         String prefix = computeAdjustedPathPrefix(pathPrefix);
         return (XmlPage) webClient.goTo(prefix + "rssLatest?flavor=rss20", "text/xml");
+    }
+
+    private XmlPage getRssChangelogPage(JenkinsRule.WebClient wc, String job, String query, boolean atom)
+            throws Exception {
+        String path = "job/" + job + "/rssChangelog";
+        if (atom) {
+            return (XmlPage) wc.goTo(query.isEmpty() ? path : path + "?" + query, "application/atom+xml");
+        }
+        String q = query.isEmpty() ? "flavor=rss20" : query + "&flavor=rss20";
+        return (XmlPage) wc.goTo(path + "?" + q, "text/xml");
+    }
+
+    private int countChangelogEntries(XmlPage page, boolean atom) {
+        return page.getXmlDocument().getElementsByTagName(atom ? "entry" : "item").getLength();
+    }
+
+    private void createJobWithChangelogEntries(String name, int n) throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject(name);
+        FakeChangeLogSCM scm = new FakeChangeLogSCM();
+        p.setScm(scm);
+        for (int i = 0; i < n; i++) {
+            scm.addChange().withAuthor("u" + i);
+            j.buildAndAssertSuccess(p);
+        }
     }
 
     private FreeStyleProject runSuccessfulBuild() throws Exception {

--- a/test/src/test/java/hudson/model/RSSTest.java
+++ b/test/src/test/java/hudson/model/RSSTest.java
@@ -397,6 +397,11 @@ class RSSTest {
         JenkinsRule.WebClient wc = j.createWebClient();
         assertEquals(
                 10, countChangelogEntries(getRssChangelogPage(wc, "rssChangelogHardCap", "max=1000000", true), true));
+        // Values outside 32-bit int range should clamp to the hard limit, not fall back to default.
+        assertEquals(
+                10,
+                countChangelogEntries(
+                        getRssChangelogPage(wc, "rssChangelogHardCap", "max=999999999999", true), true));
     }
 
     @Test


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

Fixes #14784

`Job.doRssChangelog` previously walked every build for a job and could produce very large feeds (hundreds of entries / hundreds of KB). That loads unnecessary build records, hurts performance, and undermines lazy loading.

This change caps the feed at 20 entries by default (as suggested in the issue). The limit can be changed with:

- system property `hudson.model.Job.rssChangelogMaxEntries`
- query parameter `?max=N`

Once the limit is reached, older builds are not loaded.

### Testing done

Ran the updated functional tests locally:

```
mvn -pl test -Dtest=RSSTest test
```

Result: `Tests run: 26, Failures: 0, Errors: 0, Skipped: 0`

New coverage in `RSSTest`:

- default feed is limited to 20 entries (Atom and RSS 2.0)
- `?max=` overrides the default
- system property overrides the default
- feeds with fewer than 20 entries are unchanged

Also compiled core/test modules successfully with:

```
mvn -pl core,test -am install -DskipTests -Pquick-build
```

### Screenshots (UI changes only)

N/A (no UI change; RSS/Atom feed response size only)

#### Before

#### After

### Proposed changelog entries

- Limit the job RSS/Atom changelog feed size by default

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.