### PR TITLE
Fix HttpSessionListener jakarta sessionDestroyed bridge delegating to sessionCreated

### DIFF
--- a/core/src/main/java/jenkins/util/HttpSessionListener.java
+++ b/core/src/main/java/jenkins/util/HttpSessionListener.java
@@ -61,8 +61,8 @@ public abstract class HttpSessionListener implements ExtensionPoint, jakarta.ser
 
     @Override
     public void sessionDestroyed(HttpSessionEvent httpSessionEvent) {
-        if (Util.isOverridden(HttpSessionListener.class, getClass(), "sessionCreated", javax.servlet.http.HttpSessionEvent.class)) {
-            sessionCreated(HttpSessionEventWrapper.fromJakartaHttpSessionEvent(httpSessionEvent));
+        if (Util.isOverridden(HttpSessionListener.class, getClass(), "sessionDestroyed", javax.servlet.http.HttpSessionEvent.class)) {
+            sessionDestroyed(HttpSessionEventWrapper.fromJakartaHttpSessionEvent(httpSessionEvent));
         }
     }
 


### PR DESCRIPTION
<!-- Minor bug fix; no issue tracker entry (not required for minor fixes). -->

The jakarta `sessionDestroyed(HttpSessionEvent)` bridge in `jenkins.util.HttpSessionListener` incorrectly probes `Util.isOverridden(..., "sessionCreated", ...)` and delegates to `sessionCreated(...)` instead of `sessionDestroyed(...)`. It is a copy/paste slip from the javax→jakarta migration (commit 7006cded); the symmetric javax `sessionDestroyed` bridge just below it is correct. As a result, a listener that overrides only the deprecated javax `sessionDestroyed(javax.servlet.http.HttpSessionEvent)` never receives session-destroyed events, and its `sessionCreated` may be invoked on a destroy.

### Testing done

The fix makes the jakarta `sessionDestroyed` bridge mirror the already-correct javax `sessionDestroyed` bridge in the same class: it now probes for an overridden `sessionDestroyed` and delegates to `sessionDestroyed`. Verified by inspection that the probed method name and the delegated method are now consistent with the sibling `sessionCreated`/`sessionDestroyed` bridges. There is no existing automated coverage for this deprecated javax↔jakarta compatibility bridge; happy to add a unit test asserting that an override of the deprecated `sessionDestroyed` is invoked on session destruction if a reviewer would like one.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Fix `HttpSessionListener` so overrides of the deprecated `sessionDestroyed` method are invoked on session destruction.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] There is automated testing or an explanation as to why this change has no tests (explanation above).
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate — N/A, no new API.
- [x] New deprecations are annotated appropriately — N/A.
- [x] UI changes do not introduce CSP regressions — N/A, no UI change.
- [x] For dependency updates, links to changelogs/differentials — N/A.
- [x] For new APIs and extension points, a link to a consumer — N/A.
