### PR TITLE
Remove comments from properties and jelly files in shipped war

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -647,6 +647,31 @@ THE SOFTWARE.
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <!-- Version specified in grandparent POM -->
+        <executions>
+          <execution>
+            <!--
+              License headers make up the majority of the bytes of the localization files (the license
+              is retained in the source files and in the LICENSE.txt shipped in the war, just as it is
+              not retained in compiled class files), so strip comments from the packaged jar.
+            -->
+            <id>strip-properties-comments</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <target>
+                <replaceregexp match="^[ \t]*#.*(\r?\n)?" replace="" flags="gm" encoding="UTF-8">
+                  <fileset dir="${project.build.outputDirectory}" includes="**/*.properties" />
+                </replaceregexp>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- Version specified in grandparent POM -->
         <configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -663,10 +663,12 @@ THE SOFTWARE.
             <phase>process-resources</phase>
             <configuration>
               <target>
-                <replaceregexp encoding="UTF-8" flags="gm" match="^[ \t]*#.*(\r?\n)?" replace="">
+                <!-- Only the leading comment block, to leave any semantically interesting comments elsewhere in the file untouched -->
+                <replaceregexp encoding="UTF-8" match="\A(?:[ \t]*(?:[#!].*)?\r?\n)+" replace="">
                   <fileset dir="${project.build.outputDirectory}" includes="**/*.properties" />
                 </replaceregexp>
-                <replaceregexp encoding="UTF-8" flags="gs" match="&lt;!--.*?--&gt;" replace="">
+                <!-- Only license comments, to leave any semantically interesting comments untouched -->
+                <replaceregexp encoding="UTF-8" flags="g" match="&lt;!--(?:(?!--&gt;)[\s\S])*?The MIT License[\s\S]*?--&gt;" replace="">
                   <fileset dir="${project.build.outputDirectory}" includes="**/*.jelly" />
                 </replaceregexp>
               </target>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -652,19 +652,22 @@ THE SOFTWARE.
         <executions>
           <execution>
             <!--
-              License headers make up the majority of the bytes of the localization files (the license
-              is retained in the source files and in the LICENSE.txt shipped in the war, just as it is
-              not retained in compiled class files), so strip comments from the packaged jar.
+              License headers make up the majority of the bytes of the localization and Jelly view files
+              (the license is retained in the source files and in the LICENSE.txt shipped in the war, just
+              as it is not retained in compiled class files), so strip comments from the packaged jar.
             -->
-            <id>strip-properties-comments</id>
+            <id>strip-license-comments</id>
             <goals>
               <goal>run</goal>
             </goals>
             <phase>process-resources</phase>
             <configuration>
               <target>
-                <replaceregexp match="^[ \t]*#.*(\r?\n)?" replace="" flags="gm" encoding="UTF-8">
+                <replaceregexp encoding="UTF-8" flags="gm" match="^[ \t]*#.*(\r?\n)?" replace="">
                   <fileset dir="${project.build.outputDirectory}" includes="**/*.properties" />
+                </replaceregexp>
+                <replaceregexp encoding="UTF-8" flags="gs" match="&lt;!--.*?--&gt;" replace="">
+                  <fileset dir="${project.build.outputDirectory}" includes="**/*.jelly" />
                 </replaceregexp>
               </target>
             </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -660,7 +660,7 @@ THE SOFTWARE.
             <goals>
               <goal>run</goal>
             </goals>
-            <phase>process-resources</phase>
+            <phase>prepare-package</phase>
             <configuration>
               <target>
                 <!-- Only the leading comment block, to leave any semantically interesting comments elsewhere in the file untouched -->


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

 jenkins-core.jar 11.96MB → 8.38MB (−3.58MB, −30% size reduction),

Jelly files reduction is ~0.5MB

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

* Tested interactively to confirm the messages display as expected.
* Compared generated output files with source files and found no relevant issues using
   `for file in $(find . -type f -name '*.properties' -path '*/src/main/*'); do output=$(echo $file | sed 's,/src/main/resources/,/target/classes/,') && echo ===== $file && diff $file $output; echo; done | less`

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Reduce size of Jenkins war by removing comments from translation files.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label rfe

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
