### PR TITLE
Precompile regex patterns in BasicPasswordComplexityRule

### DIFF
--- a/core/src/main/java/jenkins/security/BasicPasswordComplexityRule.java
+++ b/core/src/main/java/jenkins/security/BasicPasswordComplexityRule.java
@@ -28,6 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -41,6 +42,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 @Restricted(NoExternalUse.class)
 public class BasicPasswordComplexityRule extends PasswordComplexityRule {
+
+    private static final Pattern UPPERCASE_PATTERN = Pattern.compile(".*[A-Z].*");
+    private static final Pattern LOWERCASE_PATTERN = Pattern.compile(".*[a-z].*");
+    private static final Pattern DIGIT_PATTERN = Pattern.compile(".*[0-9].*");
+    private static final Pattern SPECIAL_CHAR_PATTERN = Pattern.compile(".*\\p{Punct}.*");
 
     private final int minimumLength;
     private final boolean requireUppercase;
@@ -88,16 +94,16 @@ public class BasicPasswordComplexityRule extends PasswordComplexityRule {
         if (minimumLength > 0 && password.length() < minimumLength) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordTooShort(minimumLength));
         }
-        if (requireUppercase && !password.matches(".*[A-Z].*")) {
+        if (requireUppercase && !UPPERCASE_PATTERN.matcher(password).matches()) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordRequiresUppercase());
         }
-        if (requireLowercase && !password.matches(".*[a-z].*")) {
+        if (requireLowercase && !LOWERCASE_PATTERN.matcher(password).matches()) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordRequiresLowercase());
         }
-        if (requireDigit && !password.matches(".*[0-9].*")) {
+        if (requireDigit && !DIGIT_PATTERN.matcher(password).matches()) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordRequiresDigit());
         }
-        if (requireSpecialCharacter && !password.matches(".*\\p{Punct}.*")) {
+        if (requireSpecialCharacter && !SPECIAL_CHAR_PATTERN.matcher(password).matches()) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordRequiresSpecialCharacter());
         }
         if (!errors.isEmpty()) {

--- a/core/src/main/java/jenkins/security/BasicPasswordComplexityRule.java
+++ b/core/src/main/java/jenkins/security/BasicPasswordComplexityRule.java
@@ -43,10 +43,11 @@ import org.kohsuke.stapler.DataBoundConstructor;
 @Restricted(NoExternalUse.class)
 public class BasicPasswordComplexityRule extends PasswordComplexityRule {
 
-    private static final Pattern UPPERCASE_PATTERN = Pattern.compile(".*[A-Z].*");
-    private static final Pattern LOWERCASE_PATTERN = Pattern.compile(".*[a-z].*");
-    private static final Pattern DIGIT_PATTERN = Pattern.compile(".*[0-9].*");
-    private static final Pattern SPECIAL_CHAR_PATTERN = Pattern.compile(".*\\p{Punct}.*");
+    private static final Pattern UPPERCASE_PATTERN = Pattern.compile("[A-Z]");
+    private static final Pattern LOWERCASE_PATTERN = Pattern.compile("[a-z]");
+    private static final Pattern DIGIT_PATTERN = Pattern.compile("[0-9]");
+    private static final Pattern SPECIAL_CHAR_PATTERN = Pattern.compile("\\p{Punct}");
+    private static final Pattern LINE_TERMINATOR_PATTERN = Pattern.compile("[\\n\\r\\u0085\\u2028\\u2029]");
 
     private final int minimumLength;
     private final boolean requireUppercase;
@@ -94,16 +95,17 @@ public class BasicPasswordComplexityRule extends PasswordComplexityRule {
         if (minimumLength > 0 && password.length() < minimumLength) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordTooShort(minimumLength));
         }
-        if (requireUppercase && !UPPERCASE_PATTERN.matcher(password).matches()) {
+        boolean containsLineTerminator = LINE_TERMINATOR_PATTERN.matcher(password).find();
+        if (requireUppercase && (containsLineTerminator || !UPPERCASE_PATTERN.matcher(password).find())) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordRequiresUppercase());
         }
-        if (requireLowercase && !LOWERCASE_PATTERN.matcher(password).matches()) {
+        if (requireLowercase && (containsLineTerminator || !LOWERCASE_PATTERN.matcher(password).find())) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordRequiresLowercase());
         }
-        if (requireDigit && !DIGIT_PATTERN.matcher(password).matches()) {
+        if (requireDigit && (containsLineTerminator || !DIGIT_PATTERN.matcher(password).find())) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordRequiresDigit());
         }
-        if (requireSpecialCharacter && !SPECIAL_CHAR_PATTERN.matcher(password).matches()) {
+        if (requireSpecialCharacter && (containsLineTerminator || !SPECIAL_CHAR_PATTERN.matcher(password).find())) {
             errors.add(Messages.BasicPasswordComplexityRule_PasswordRequiresSpecialCharacter());
         }
         if (!errors.isEmpty()) {

--- a/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
+++ b/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
+++ b/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
@@ -4,9 +4,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -90,17 +90,12 @@ class BasicPasswordComplexityRuleTest {
         BasicPasswordComplexityRule rule = new BasicPasswordComplexityRule(8, true, true, true, true);
 
         PasswordComplexityException e = assertThrows(PasswordComplexityException.class, () -> rule.validate("bad"));
-        // Violations list should have one entry per rule that was violated
-        assertTrue(e.getViolations().stream().anyMatch(v -> v.contains("at least 8 characters")),
-                "violations list should contain length error");
-        assertTrue(e.getViolations().stream().anyMatch(v -> v.contains("uppercase letter")),
-                "violations list should contain uppercase error");
-        assertTrue(e.getViolations().stream().anyMatch(v -> v.contains("digit")),
-                "violations list should contain digit error");
-        assertTrue(e.getViolations().stream().anyMatch(v -> v.contains("special character")),
-                "violations list should contain special character error");
-        assertThat("violations list should contain exactly one entry per violated rule",
-                   e.getViolations().size(), is(4));
+        // Violations list should have exactly these 4 violations in any order
+        assertThat(e.getViolations(),
+                   containsInAnyOrder("Password must be at least 8 characters long.",
+                                      "Password must contain at least one uppercase letter (A-Z).",
+                                      "Password must contain at least one digit (0-9).",
+                                      "Password must contain at least one special character (e.g. !@#$%^&*)."));
     }
 
     @Test

--- a/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
+++ b/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
@@ -2,9 +2,9 @@ package jenkins.security;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
+++ b/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
@@ -3,8 +3,10 @@ package jenkins.security;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -81,6 +83,51 @@ class BasicPasswordComplexityRuleTest {
                 containsString("digit"),
                 containsString("special character")
         ));
+    }
+
+    @Test
+    void violationsListContainsIndividualMessages() {
+        BasicPasswordComplexityRule rule = new BasicPasswordComplexityRule(8, true, true, true, true);
+
+        PasswordComplexityException e = assertThrows(PasswordComplexityException.class, () -> rule.validate("bad"));
+        // Violations list should have one entry per rule that was violated
+        assertTrue(e.getViolations().stream().anyMatch(v -> v.contains("at least 8 characters")),
+                "violations list should contain length error");
+        assertTrue(e.getViolations().stream().anyMatch(v -> v.contains("uppercase letter")),
+                "violations list should contain uppercase error");
+        assertTrue(e.getViolations().stream().anyMatch(v -> v.contains("digit")),
+                "violations list should contain digit error");
+        assertTrue(e.getViolations().stream().anyMatch(v -> v.contains("special character")),
+                "violations list should contain special character error");
+        assertThat("violations list should contain exactly one entry per violated rule",
+                   e.getViolations().size(), is(4));
+    }
+
+    @Test
+    void zeroMinimumLengthDoesNotEnforceLength() {
+        BasicPasswordComplexityRule rule = new BasicPasswordComplexityRule(0, false, false, false, false);
+
+        // A zero minimum length should accept any-length password, including empty string
+        assertDoesNotThrow(() -> rule.validate(""));
+        assertDoesNotThrow(() -> rule.validate("a"));
+    }
+
+    @Test
+    void negativeLengthTreatedAsZero() {
+        // Negative minimum length values must be clamped to zero (Math.max(0, minimumLength))
+        BasicPasswordComplexityRule rule = new BasicPasswordComplexityRule(-5, false, false, false, false);
+
+        assertDoesNotThrow(() -> rule.validate(""));
+        assertDoesNotThrow(() -> rule.validate("short"));
+    }
+
+    @Test
+    void exactBoundaryLengthPassesValidation() {
+        BasicPasswordComplexityRule rule = new BasicPasswordComplexityRule(5, false, false, false, false);
+
+        // Exactly 5 characters should pass; 4 characters should fail
+        assertDoesNotThrow(() -> rule.validate("12345"));
+        assertThrows(PasswordComplexityException.class, () -> rule.validate("1234"));
     }
 
     @Test

--- a/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
+++ b/core/src/test/java/jenkins/security/BasicPasswordComplexityRuleTest.java
@@ -125,6 +125,15 @@ class BasicPasswordComplexityRuleTest {
     }
 
     @Test
+    void lineTerminatorsRetainExistingCharacterRuleBehavior() {
+        BasicPasswordComplexityRule rule = new BasicPasswordComplexityRule(0, true, false, false, false);
+
+        // String.matches(".*[A-Z].*") rejected line terminators even when the password contained an uppercase letter.
+        assertThrows(PasswordComplexityException.class, () -> rule.validate("A\n"));
+        assertDoesNotThrow(() -> rule.validate("A"));
+    }
+
+    @Test
     void noneRuleAcceptsAnyPassword() {
         NonePasswordComplexityRule rule = new NonePasswordComplexityRule();
         assertDoesNotThrow(() -> rule.validate("a"));


### PR DESCRIPTION
Follows up on #27038.

While looking at the new password complexity code I noticed the `validate()` method calls `String.matches()` four times — once for each character class check. The problem is `String.matches()` recompiles the regex on every invocation, so every login attempt or password change triggers four fresh `Pattern.compile()` calls under the hood.

Switched to static pre-compiled `Pattern` constants and `find()` instead of wrapping everything in `.*...*`. Nothing about the validation behavior changes — same passwords pass, same ones fail, same error messages. Just faster internally.

Also added a few tests that were missing:
- `getViolations()` on `PasswordComplexityException` was introduced in #27038 but had no direct test — added one
- edge cases around `minimumLength = 0`, negative values, and exact boundary length

### Testing done

Ran existing tests to make sure nothing broke. Added 4 new unit tests in `BasicPasswordComplexityRuleTest` covering the above.

### Screenshots (UI changes only)

N/A

### Proposed changelog entries

- Improve performance of `BasicPasswordComplexityRule` by pre-compiling regex patterns

### Proposed changelog category

/label internal

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers