### PR TITLE
Backporting for 2.568.2

### DIFF
--- a/core/src/main/java/hudson/model/Cause.java
+++ b/core/src/main/java/hudson/model/Cause.java
@@ -170,7 +170,7 @@ public abstract class Cause {
         @Deprecated
         private transient Cause upstreamCause;
         private @NonNull List<Cause> upstreamCauses;
-        private transient Map<Cause, Integer> causeBag = new LinkedHashMap<>();
+        private transient Map<Cause, Integer> causeBag;
 
         /**
          * @deprecated since 2009-02-28
@@ -194,7 +194,6 @@ public abstract class Cause {
                 }
                 upstreamCauses.add(trim(c, MAX_DEPTH, traversed));
             }
-            fillCauseBag();
         }
 
         private UpstreamCause(String upstreamProject, int upstreamBuild, String upstreamUrl, @NonNull List<Cause> upstreamCauses) {
@@ -202,20 +201,20 @@ public abstract class Cause {
             this.upstreamBuild = upstreamBuild;
             this.upstreamUrl = upstreamUrl;
             this.upstreamCauses = upstreamCauses;
-            fillCauseBag();
         }
 
-        private void fillCauseBag() {
+        private synchronized void fillCauseBag() {
             if (causeBag == null) {
                 causeBag = new LinkedHashMap<>();
-            }
-            for (Cause c : upstreamCauses) {
-                causeBag.compute(c, (unused, cnt) -> cnt == null ? 1 : cnt + 1);
+                for (Cause c : upstreamCauses) {
+                    causeBag.compute(c, (unused, cnt) -> cnt == null ? 1 : cnt + 1);
+                }
             }
         }
 
         @Restricted(DoNotUse.class) // used from Jelly
         public Map<Cause, Integer> getCauseCounts() {
+            fillCauseBag();
             return Collections.unmodifiableMap(causeBag);
         }
 
@@ -371,7 +370,6 @@ public abstract class Cause {
                     uc.upstreamCause = null;
                     OldDataMonitor.report(context, "1.288");
                 }
-                uc.fillCauseBag();
             }
         }
 

--- a/core/src/main/resources/lib/form/apply/apply.js
+++ b/core/src/main/resources/lib/form/apply/apply.js
@@ -9,6 +9,7 @@ Behaviour.specify(
       // create a throw-away IFRAME to avoid back button from loading the POST result back
       const id = "iframe" + iota++;
       const target = document.createElement("iframe");
+      target.classList.add("jenkins-hidden");
       target.setAttribute("id", id);
       target.setAttribute("name", id);
       target.style.height = "100%";

--- a/src/main/scss/pages/_job.scss
+++ b/src/main/scss/pages/_job.scss
@@ -11,6 +11,10 @@
     margin-inline: -0.25rem;
     margin-bottom: 5px;
   }
+
+  #jenkins-builds .jenkins-card__content {
+    overflow: visible;
+  }
 }
 
 .app-builds-container {

--- a/test/src/test/java/hudson/model/CauseTest.java
+++ b/test/src/test/java/hudson/model/CauseTest.java
@@ -284,6 +284,17 @@ class CauseTest {
         assertNotNull(scmCause.getRun());
     }
 
+    @Test
+    @LocalData
+    void upstreamCauseCountOnLoad() throws Exception {
+        final Item item = j.jenkins.getItemByFullName("downstream");
+        assertThat(item, instanceOf(FreeStyleProject.class));
+        FreeStyleProject down = (FreeStyleProject) item;
+        final FreeStyleBuild build = down.getBuildByNumber(2);
+        Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) build.getCauses().getFirst();
+        assertNotNull(upstreamCause.getCauseCounts());
+    }
+
     public static class SimpleCause extends Cause {
         private final String description;
 
@@ -302,6 +313,18 @@ class CauseTest {
         @SuppressWarnings("checkstyle:redundantmodifier")
         public CustomBuild(FullNameChangingProject job) throws IOException {
             super(job);
+        }
+    }
+
+    public static class SimpleUpstreamCause extends Cause.UpstreamCause {
+        @SuppressWarnings("checkstyle:redundantmodifier")
+        public SimpleUpstreamCause(Run<?, ?> upstreamRun) {
+            super(upstreamRun);
+        }
+
+        @Override
+        public String getShortDescription() {
+            return "Simple upstream cause: " + getUpstreamProject() + " #" + getUpstreamBuild();
         }
     }
 

--- a/test/src/test/resources/hudson/model/CauseTest/jobs/downstream/builds/2/build.xml
+++ b/test/src/test/resources/hudson/model/CauseTest/jobs/downstream/builds/2/build.xml
@@ -1,0 +1,32 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<build>
+    <actions>
+        <hudson.model.CauseAction>
+            <causeBag class="linked-hash-map">
+                <entry>
+                    <hudson.model.CauseTest_-SimpleUpstreamCause>
+                        <upstreamProject>upstream</upstreamProject>
+                        <upstreamUrl>job/upstream/</upstreamUrl>
+                        <upstreamBuild>2</upstreamBuild>
+                        <upstreamCauses>
+                            <hudson.triggers.SCMTrigger_-SCMTriggerCause/>
+                        </upstreamCauses>
+                    </hudson.model.CauseTest_-SimpleUpstreamCause>
+                    <int>1</int>
+                </entry>
+            </causeBag>
+        </hudson.model.CauseAction>
+    </actions>
+    <queueId>6</queueId>
+    <timestamp>1595938961553</timestamp>
+    <startTime>1595938961557</startTime>
+    <result>SUCCESS</result>
+    <duration>2</duration>
+    <charset>UTF-8</charset>
+    <keepLog>false</keepLog>
+    <builtOn></builtOn>
+    <workspace>/var/jenkins_home/workspace/downstream</workspace>
+    <hudsonVersion>2.568</hudsonVersion>
+    <scm class="hudson.scm.NullChangeLogParser"/>
+    <culprits class="com.google.common.collect.EmptyImmutableSortedSet"/>
+</build>

--- a/test/src/test/resources/hudson/model/CauseTest/jobs/upstream/builds/2/build.xml
+++ b/test/src/test/resources/hudson/model/CauseTest/jobs/upstream/builds/2/build.xml
@@ -1,0 +1,25 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<build>
+    <actions>
+        <hudson.model.CauseAction>
+            <causeBag class="linked-hash-map">
+                <entry>
+                    <hudson.triggers.SCMTrigger_-SCMTriggerCause/>
+                    <int>1</int>
+                </entry>
+            </causeBag>
+        </hudson.model.CauseAction>
+    </actions>
+    <queueId>5</queueId>
+    <timestamp>1595938941553</timestamp>
+    <startTime>1595938941557</startTime>
+    <result>SUCCESS</result>
+    <duration>2</duration>
+    <charset>UTF-8</charset>
+    <keepLog>false</keepLog>
+    <builtOn></builtOn>
+    <workspace>/var/jenkins_home/workspace/upstream</workspace>
+    <hudsonVersion>2.568</hudsonVersion>
+    <scm class="hudson.scm.NullChangeLogParser"/>
+    <culprits class="com.google.common.collect.EmptyImmutableSortedSet"/>
+</build>


### PR DESCRIPTION
Latest core version: `jenkins-2.568`
Fixed:

- https://github.com/jenkinsci/jenkins/pull/27094
- https://github.com/jenkinsci/jenkins/pull/27002
- https://github.com/jenkinsci/jenkins/pull/26554

Postponed:

Desired reviewers
@MarkEWaite @ridemountainpig @janfaracik @Anexus5919 

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #<issue-number>

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [x] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
