### PR TITLE
Fix PackedMap.values() returning keys instead of values

### DIFF
--- a/core/src/main/java/hudson/util/PackedMap.java
+++ b/core/src/main/java/hudson/util/PackedMap.java
@@ -152,7 +152,7 @@ public final class PackedMap<K, V> extends AbstractMap<K, V> {
         return new AbstractList<>() {
             @Override
             public V get(int index) {
-                return (V) kvpairs[index * 2];
+                return (V) kvpairs[index * 2 + 1];
             }
 
             @Override

--- a/core/src/test/java/hudson/util/PackedMapTest.java
+++ b/core/src/test/java/hudson/util/PackedMapTest.java
@@ -2,6 +2,8 @@ package hudson.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
@@ -51,5 +53,17 @@ class PackedMapTest {
                 xml);
 
         xs.fromXML(xml);
+    }
+
+    @Test
+    void values() {
+        Map<String, String> o = new TreeMap<>();
+        o.put("a", "b");
+        o.put("c", "d");
+
+        PackedMap<String, String> p = PackedMap.of(o);
+        assertEquals(List.of("b", "d"), new ArrayList<>(p.values()));
+        assertEquals("b", p.values().stream().findFirst().orElseThrow());
+        assertEquals(2, p.values().size());
     }
 }


### PR DESCRIPTION
Fixes #27109

`hudson.util.PackedMap.values()` returned the map's keys instead of values. The backing array is interleaved `[k0, v0, k1, v1, …]`, but `values().get(int)` read the key slot `kvpairs[index * 2]` instead of the value slot `kvpairs[index * 2 + 1]`. The sibling `get(Object)` (`kvpairs[i + 1]`) and the `entrySet()` iterator confirm the correct layout. In-tree consumers (`Fingerprinter`, XStream) only use `entrySet()`/`get(key)`, so nothing relied on the broken behavior; plugins and Jelly `${map.values()}` did.

### Testing done

Added `PackedMapTest.values()` asserting `values()` returns `[b, d]` for `{a=b, c=d}` — red before the fix, green after. `mvn -pl core -am test -Dtest=PackedMapTest` → `Tests run: 2, Failures: 0`. `mvn spotless:check -pl core` clean.

### Screenshots (UI changes only)

#### Before

#### After

N/A — not a UI change.

### Proposed changelog entries

- Fix `PackedMap.values()` returning keys instead of values.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- N/A: no new public API, existing method fixed -->
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- N/A -->
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- N/A: no UI change -->
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- N/A -->
- [ ] For new APIs and extension points, there is a link to at least one consumer. <!-- N/A -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

