### PR TITLE
Fix missing shadow and blur on the global search results dropdown

### DIFF
--- a/src/main/scss/form/_search-bar.scss
+++ b/src/main/scss/form/_search-bar.scss
@@ -200,14 +200,14 @@
   position: absolute;
   width: 100%;
   border-radius: 1rem;
-  box-shadow: var(--dropdown-box-shadow);
+  box-shadow: var(--overlay-surface-box-shadow);
   overflow: hidden;
   z-index: 10;
   height: 1px; // Setting to 0 caused the items not to render initially in Chrome
   opacity: 0;
   transition: var(--standard-transition);
   background: color-mix(in sRGB, var(--card-background) 85%, transparent);
-  backdrop-filter: var(--dropdown-backdrop-filter);
+  backdrop-filter: contrast(1.1) saturate(2.5) blur(20px);
   visibility: collapse;
   scale: 95%;
   translate: 0 -0.3125rem;


### PR DESCRIPTION
Fixes #27111

The global search results dropdown (`.jenkins-search__results-container` in `src/main/scss/form/_search-bar.scss`) still references `var(--dropdown-box-shadow)` and `var(--dropdown-backdrop-filter)`. PR #26900 ("Standardise command palette, dialog, dropdown, and tooltip materials") removed those tokens but missed this file. With no definition and no fallback, both `var()` references collapse and the dropdown loses its shadow and frosted-glass blur.

The fix aligns both values with the standardised `overlay-surface` materials #26900 introduced: `box-shadow` uses the successor token `--overlay-surface-box-shadow` (`abstracts/_theme.scss`), and `backdrop-filter` uses the `contrast(1.1) saturate(2.5) blur(20px)` literal the `overlay-surface` mixin inlines, matching sibling `components/_dropdowns.scss`. Only these two property values change; position, background, and layout are untouched.

### Testing done

SCSS has no unit-test framework in this repo (no jest/vitest), so verification is static plus manual:

- `corepack yarn stylelint src/main/scss/form/_search-bar.scss` exits 0.
- Successor token `--overlay-surface-box-shadow` is defined in `abstracts/_theme.scss`.
- The `backdrop-filter` literal is byte-identical to the `overlay-surface` mixin inline (`abstracts/_mixins.scss`) and sibling `components/_dropdowns.scss`.
- Manual: open the top-bar global search, type to show results, and confirm the dropdown shows a shadow and frosted blur consistent with sibling overlays.

### Screenshots (UI changes only)

<!-- 사람이 before/after 캡처를 첨부: 상단 전역 검색 결과 드롭다운 -->

#### Before

<!-- 그림자·블러 없는 평평한 결과 드롭다운 스크린샷 -->

#### After

<!-- 그림자·frosted blur가 적용된 결과 드롭다운 스크린샷 -->

### Proposed changelog entries

- Fix missing shadow and blur on the global search results dropdown.

### Proposed changelog category

/label regression-fix, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests. <!-- SCSS has no unit-test framework; verified via stylelint + sibling parity + manual reproduction -->
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- N/A: SCSS-only change -->
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- N/A: no deprecations -->
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- CSS-only, no JS -->
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- N/A: no dependency changes -->
- [x] For new APIs and extension points, there is a link to at least one consumer. <!-- N/A: no new APIs -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

