### PR TITLE
Add expression examples to "Restrict where builds can run" help

### DIFF
--- a/core/src/main/resources/hudson/model/AbstractProject/help-label.html
+++ b/core/src/main/resources/hudson/model/AbstractProject/help-label.html
@@ -143,8 +143,11 @@
       evaluating expressions.
     </li>
     <li>
-      Matching labels or agent names with wildcards or regular expressions is
-      not supported.
+      Matching labels or agent names with wildcards (such as
+      <code>*</code>
+      or
+      <code>?</code>
+      ) or regular expressions is not supported.
     </li>
     <li>
       An empty expression will always evaluate to
@@ -166,6 +169,20 @@
       (or on any machine that happens to have a label called
       <code>linux-machine-42</code>
       )
+    </dd>
+
+    <dt><code>linux || macos</code></dt>
+    <dd>
+      Builds of this project may be executed on any agent that has either the
+      <code>linux</code>
+      label
+      <i>or</i>
+      the
+      <code>macos</code>
+      label (assuming that agents running Linux and macOS have been given the
+      appropriate labels). Note that the separator is
+      <code>||</code>
+      , not a comma
     </dd>
 
     <dt><code>windows &amp;&amp; jdk9</code></dt>


### PR DESCRIPTION
Fixes #21113

Adds clearer examples to the "Restrict where builds can run" help text from JENKINS-28380: document the `||` operator with a concrete `linux || macos` example, and spell out that wildcards (`*` / `?`) and regular expressions are not supported.

### Testing done

Documentation-only change to `help-label.html`. No automated test coverage for help HTML; verified the rendered markup is valid (balanced tags, existing `<dt>`/`<dd>` pattern preserved) by reviewing the diff against neighboring examples (`windows && !vs2012`, `windows && jdk9`).

### Screenshots (UI changes only)

#### Before

N/A (help text only)

#### After

N/A (help text only)

### Proposed changelog entries

- Clarify "Restrict where builds can run" help with an `||` example and explicit note that wildcards/regex are unsupported

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

Made with [Cursor](https://cursor.com)