### PR TITLE
Fix self-referential Javadoc links in InMemorySecurityRealm test class

### DIFF
--- a/test/src/test/java/test/security/realm/InMemorySecurityRealm.java
+++ b/test/src/test/java/test/security/realm/InMemorySecurityRealm.java
@@ -48,7 +48,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
  *  It implements the {@link #loadUserByUsername2(String)} method which simply returns the user from the
  *  in memory storage based on username passed.
  *  <p>
- *  A dummy implementation for {@link InMemorySecurityRealm} is provided in class {@link InMemorySecurityRealm}
+ *  A dummy implementation of {@link UserDetails} is provided in nested class {@link InMemoryUserDetails}
  *  which contains no roles and only username is returned.
  *
  */


### PR DESCRIPTION
The class Javadoc of the `InMemorySecurityRealm` test helper describes its dummy
`UserDetails` implementation with two self-referential links:

```
A dummy implementation for {@link InMemorySecurityRealm} is provided in class {@link InMemorySecurityRealm}
```

Both links point back at `InMemorySecurityRealm`, so the sentence says a dummy
implementation *for* the class is provided *in* the class, and never points at the
actual implementation. The behavior it describes — "no roles and only username is
returned" — is the nested `InMemoryUserDetails` (`getAuthorities()` returns an empty
set, `getPassword()` returns `null`). This points the links at the implemented type
(`UserDetails`) and at the class implementing it.

Introduced in #10797 (commit f610669e01).

### Testing done

Javadoc-only change with no runtime effect, so no automated test applies. Both link
targets resolve: `UserDetails` is imported and `InMemoryUserDetails` is a nested class
in the same file. `mvn spotless:check -pl test` passes.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described. <!-- no issue: trivial Javadoc fix -->
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade. <!-- skip-changelog -->
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- N/A: no new API -->
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- N/A -->
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- N/A: no UI change -->
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- N/A -->
- [ ] For new APIs and extension points, there is a link to at least one consumer. <!-- N/A -->

### Desired reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

