### PR TITLE
Align GenericWhitespace ws.illegalFollow message with Checkstyle default

### DIFF
--- a/src/checkstyle/checkstyle-configuration.xml
+++ b/src/checkstyle/checkstyle-configuration.xml
@@ -107,7 +107,7 @@
     <module name="GenericWhitespace">
       <message key="ws.followed" value="GenericWhitespace ''{0}'' is followed by whitespace."/>
       <message key="ws.preceded" value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
-      <message key="ws.illegalFollow" value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.illegalFollow" value="GenericWhitespace ''{0}'' is followed by an illegal character."/>
       <message key="ws.notPreceded" value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
     </module>
     <module name="MethodParamPad">


### PR DESCRIPTION
The `GenericWhitespace` module in `src/checkstyle/checkstyle-configuration.xml` overrides four
messages as `"GenericWhitespace "` + Checkstyle's default text. Three match the default;
`ws.illegalFollow` reads `"should followed by whitespace"` — ungrammatical, and not what the check
reports. It was written that way in #6149, where Checkstyle 9.2.1 already defaulted to
`''{0}'' is followed by an illegal character.` This aligns the override with that default,
restoring the pattern the other three follow.

### Testing done

No automated test: a message-string override has no test surface. Verified
`ws.illegalFollow=''{0}'' is followed by an illegal character.` in
`checks/whitespace/messages.properties` of checkstyle 13.8.0, the version pinned in `pom.xml`.
`mvn checkstyle:check -pl cli` with the change: BUILD SUCCESS, 0 violations — the ruleset still
parses and flags the same code.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

