### PR TITLE
Fix Tab key not confirming highlighted dropdown suggestion

### DIFF
--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -229,6 +229,7 @@ function menuItem(dropdownItem, type = "jenkins-dropdown__item", context = "") {
 
   // Handle special cases
   tryOnClickEvent(item, dropdownItem);
+  tryOnKeyPressEvent(item, dropdownItem);
   tryLoadScripts(item, dropdownItem, context);
   tryPost(item, dropdownItem, context);
   tryConfirmationPost(item, dropdownItem, context);
@@ -245,6 +246,17 @@ function tryOnClickEvent(element, opt) {
   }
 
   element.addEventListener("click", opt.onClick);
+}
+
+/**
+ * If the menu item has a custom onKeyPress event, add it to the element
+ */
+function tryOnKeyPressEvent(element, opt) {
+  if (!opt.onKeyPress) {
+    return;
+  }
+
+  element.onkeypress = opt.onKeyPress;
 }
 
 /**


### PR DESCRIPTION
Fixes #27112

Pressing Tab to confirm a highlighted suggestion in an auto-complete
(`INPUT.auto-complete`) or combobox2 (`INPUT.combobox2`) dropdown did
nothing — the value wasn't filled in and focus left the field.

### Cause

`combo-box.js` and `autocomplete.js` both set an `onKeyPress` option
on the dropdown item, and `utils.js`'s keyboard navigation handler
calls it by property (`selectedItem.onkeypress(evt)`). #11204
replaced the inline `onClick`/`onKeyPress` wiring in `templates.js`'s
`menuItem()` with a `tryOnClickEvent()` helper, but only ported over
the click wiring — the equivalent `onKeyPress` block was dropped.
That left `item.onkeypress` always `undefined`, so the handler in
`utils.js` had nothing to invoke.

### Fix

Add a `tryOnKeyPressEvent()` helper next to `tryOnClickEvent()` that
assigns `opt.onKeyPress` to the element's `onkeypress` property when
present, and call it from `menuItem()`. This restores the pre-#11204
behavior: Tab now confirms the highlighted suggestion, hides the
dropdown, and keeps focus, matching the click and Enter paths.

### Testing

This repo has no JS unit test harness (no jest config, no `*.test.js`
files, `package.json` only wires up eslint/prettier/stylelint), so I
didn't add one to avoid inventing infrastructure for a single fix.
Verified via `yarn lint:js` (eslint + prettier), which passes clean,
and by re-reading the call sites in `templates.js`/`utils.js`/
`combo-box.js`/`autocomplete.js` to confirm the wiring now matches
what `utils.js` expects.