### PR TITLE
Fix dropdown suggestions requiring a double tap on touch devices

### DIFF
--- a/src/main/js/components/dropdowns/autocomplete.js
+++ b/src/main/js/components/dropdowns/autocomplete.js
@@ -100,9 +100,19 @@ function init() {
       e.style.position = "relative";
       // otherwise menu won't hide on tab with nothing selected
       // needs delay as without that it blocks click selection of an item
-      e.addEventListener("focusout", () =>
-        setTimeout(() => e.dropdown && e.dropdown.hide(), 200),
-      );
+      e.addEventListener("focusout", (event) => {
+        // Keep the dropdown open while focus moves into the suggestion popper.
+        // On touch devices the synthesized click lands after this 200ms hide
+        // timer and would otherwise be lost (see #26919).
+        if (
+          event.relatedTarget &&
+          e.dropdown &&
+          e.dropdown.popper.contains(event.relatedTarget)
+        ) {
+          return;
+        }
+        setTimeout(() => e.dropdown && e.dropdown.hide(), 200);
+      });
       e.addEventListener(
         "input",
         Utils.debounce(() => {

--- a/src/main/js/components/dropdowns/combo-box.js
+++ b/src/main/js/components/dropdowns/combo-box.js
@@ -78,9 +78,19 @@ function init() {
 
           // otherwise menu won't hide on tab with nothing selected
           // needs delay as without that it blocks click selection of an item
-          e.addEventListener("focusout", () =>
-            setTimeout(() => e.dropdown.hide(), 200),
-          );
+          e.addEventListener("focusout", (event) => {
+            // Keep the dropdown open while focus moves into the suggestion popper.
+            // On touch devices the synthesized click lands after this 200ms hide
+            // timer and would otherwise be lost (see #26919).
+            if (
+              event.relatedTarget &&
+              e.dropdown &&
+              e.dropdown.popper.contains(event.relatedTarget)
+            ) {
+              return;
+            }
+            setTimeout(() => e.dropdown && e.dropdown.hide(), 200);
+          });
 
           e.addEventListener(
             "input",


### PR DESCRIPTION
Fixes #26919

On touch devices (touchpad tap-to-click, touchscreen, DevTools touch emulation), a single tap on an autocomplete/combobox suggestion does not select it — a second tap is required. A single mouse click and keyboard Enter both work on the first interaction.

### Root cause

Each input registers a `focusout` handler that hides the suggestion dropdown on a fixed 200ms timer (`autocomplete.js`, `combo-box.js`):

```js
e.addEventListener("focusout", () =>
  setTimeout(() => e.dropdown && e.dropdown.hide(), 200),
);
```

The delay is deliberate — without it, the hide pre-empts the mouse click (see the in-code comment).

On a touch tap, focus leaves the input (`focusout` fires, hide scheduled at +200ms), but the browser synthesizes the `mousedown`/`click` only after the platform's synthetic-click latency (~300ms on touchscreens; comparably >200ms on touchpad tap-to-click). At ~200ms the timer hides the popper (`visibility: hidden`), so the synthesized `click` at ~300ms lands on an already-hidden item and the `click`→`confirm()` listener (`templates.js` `tryOnClickEvent`) never fires. The first tap is lost; the second tap (field re-focused, list re-shown) selects.

Mouse works (`mousedown`+`click` <200ms, before the timer); keyboard Enter works (synchronous `selectedItem.click()`, no `focusout`). Only the touch path loses the first tap.

### The fix

Keep the dropdown open while focus is moving into the suggestion popper by checking `focusout`'s `relatedTarget`. Tabbing away or clicking outside still hides the dropdown as before, because in those cases `relatedTarget` is outside the popper. The 200ms deferred-hide semantics for the non-popper case are preserved, so mouse single-click still selects exactly once.

```js
e.addEventListener("focusout", (event) => {
  if (
    event.relatedTarget &&
    e.dropdown &&
    e.dropdown.popper.contains(event.relatedTarget)
  ) {
    return;
  }
  setTimeout(() => e.dropdown && e.dropdown.hide(), 200);
});
```

Applied symmetrically to `INPUT.auto-complete` and `INPUT.combobox2`, which share the identical `focusout` timer. This mirrors the existing `hideOnPopperBlur` tippy plugin in `templates.js`, which already uses the same `relatedTarget` containment idiom on the popper side. It also adds the missing `e.dropdown` null-guard to the combobox handler (autocomplete already had it).

### Testing done

The frontend JavaScript build and lint pass:

- `yarn install`
- `yarn lint` (eslint + prettier on JS; stylelint on SCSS) → clean
- `yarn build` (webpack production) → clean

There is no JavaScript unit-test harness for these dropdown handlers — the existing `ComboBoxTest` / `DropdownListTest` are HtmlUnit-based and cover server-side form rendering, not client-side focus/click timing, and cannot synthesize the touch→mouse timing this race depends on. Behavior was verified by reasoning against the event timeline:

- A focusout with `relatedTarget` inside the popper (a tapped item) now skips the hide, so the synthesized touch `click` lands on a visible item and `confirm()` runs once.
- Mouse: `mousedown`+`click` still fires before the 200ms timer; `confirm()` runs exactly once, value not duplicated (no second confirm path was added).
- Keyboard: ArrowUp/ArrowDown then Enter is untouched (synchronous `selectedItem.click()`, no `focusout`).
- Tab-away / click-outside: `relatedTarget` is outside the popper → hide scheduled as before.
- The deferred-hide (200ms timer) for the non-popper case is preserved.

Real-device touch verification (the issue's repro: New Item "Copy from" autocomplete with a touchpad tap-to-click) is the remaining confidence step; it cannot be reproduced in HtmlUnit.

### Screenshots (UI changes only)

No visible UI change to capture — the change affects only touch interaction timing, not appearance. The suggestion list looks identical before and after; the difference is that a single tap now selects on touch devices.

#### Before

#### After

### Proposed changelog entries

- Fix autocomplete and combobox suggestions requiring a double tap to select on touch devices.

### Proposed changelog category

/label bug,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval`.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja @daniel-beck
