### PR TITLE
Fix Tab key not confirming highlighted dropdown suggestion (#27112)

### DIFF
--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -229,6 +229,7 @@ function menuItem(dropdownItem, type = "jenkins-dropdown__item", context = "") {
 
   // Handle special cases
   tryOnClickEvent(item, dropdownItem);
+  tryOnKeyPressEvent(item, dropdownItem);
   tryLoadScripts(item, dropdownItem, context);
   tryPost(item, dropdownItem, context);
   tryConfirmationPost(item, dropdownItem, context);
@@ -245,6 +246,21 @@ function tryOnClickEvent(element, opt) {
   }
 
   element.addEventListener("click", opt.onClick);
+}
+
+/**
+ * If the menu item has a custom onKeyPress handler, assign it to the element.
+ * Set as a DOM property (not a listener) so it is invoked as
+ * selectedItem.onkeypress(evt) by the dropdown keyboard-navigation callback
+ * registered in utils.js, which makeKeyboardNavigable (util/keyboard.js)
+ * dispatches to.
+ */
+function tryOnKeyPressEvent(element, opt) {
+  if (!opt.onKeyPress) {
+    return;
+  }
+
+  element.onkeypress = opt.onKeyPress;
 }
 
 /**


### PR DESCRIPTION
Fixes #27112

### Root cause

PR #11204 (commit `611294d365`) rewrote `menuItem()` in `templates.js` and dropped the assignment of `options.onKeyPress` onto the rendered element's `onkeypress` DOM property, while keeping the equivalent `onClick` wiring (`tryOnClickEvent`).

The keyboard router in `utils.js` consumes the suggestion via that DOM property:

```js
default:
  if (selectedItem.onkeypress) {
    selectedItem.onkeypress(evt);
  }
```

Because `menuItem` no longer sets `item.onkeypress`, it is always `undefined`, so the Tab-to-confirm handler defined by both producers (`combo-box.js`, `autocomplete.js`) never runs. `Enter` and mouse-click still work because they route through `onClick` / `selectedItem.click()`, which was preserved.

### Testing done

- Ran the frontend lint suite and production build:
  - `yarn lint` → passes (`eslint . && prettier --check .` + `stylelint src/main/scss`, all green, exit 0)
  - `yarn build` → passes (webpack production build compiles, exit 0)
- Verified correctness at the contract level: the fix assigns `element.onkeypress = opt.onKeyPress` as a DOM **property**, which is exactly what the existing consumer at `utils.js:167` reads and invokes (`selectedItem.onkeypress(evt)`). The producer handlers (`combo-box.js:14-20`, `autocomplete.js:24-30`) run `confirm()` + `e.dropdown.hide()` + `evt.preventDefault()` on `evt.key === "Tab"`, so Tab will now confirm a highlighted suggestion identically to Enter.
- Confirmed `Enter` and mouse-click are unaffected: their path (`tryOnClickEvent` click listener + `keyboard.js` `selectedItem.click()`) is untouched.
- No automated JS test is added: this repo has no JavaScript unit-test harness for keyboard-event routing (no jest/mocha/vitest), and `ComboBoxTest.java` is HtmlUnit-based and cannot synthesize a real `keydown` event that traverses `makeKeyboardNavigable`. The fix is verified by the surgical correctness of restoring the exact pre-#11204 wiring (property assignment) that the existing consumer depends on.
- Recommended manual verification in a running dev instance: in **New Item → "Copy from"** (autocomplete) and any `<f:combobox>`/`/project-relationship` field (combobox), type to show suggestions, arrow-down to highlight one, and press Tab — the value should be filled and the dropdown hidden, identical to pressing Enter.

### Screenshots (UI changes only)

Not a visual change; behavior-only fix.

#### Before

#### After

### Proposed changelog entries

- Fix the Tab key confirming the highlighted suggestion in autocomplete and combobox dropdowns

### Proposed changelog category

/label regression-fix

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention
