### PR TITLE
Validate view name length

### DIFF
--- a/core/src/main/java/hudson/model/MyViewsProperty.java
+++ b/core/src/main/java/hudson/model/MyViewsProperty.java
@@ -220,6 +220,13 @@ public class MyViewsProperty extends UserProperty implements ModifiableViewGroup
 
         String view = Util.fixEmpty(value);
         if (view == null) return FormValidation.ok();
+        // good view name? (parity with Jenkins.doCheckViewName — surfaces length and
+        // unsafe-character errors inline on the "My Views" form before submit)
+        try {
+            View.checkViewName(view);
+        } catch (Failure e) {
+            return FormValidation.error(e.getMessage());
+        }
         if (exists) {
             return getView(view) != null ?
                     FormValidation.ok() :

--- a/core/src/main/java/hudson/model/View.java
+++ b/core/src/main/java/hudson/model/View.java
@@ -252,12 +252,32 @@ public abstract class View extends AbstractModelObject implements AccessControll
      */
     public void rename(String newName) throws Failure, FormException {
         if (name.equals(newName))    return; // noop
-        Jenkins.checkGoodName(newName);
+        checkViewName(newName);
         if (owner.getView(newName) != null)
             throw new FormException(Messages.Hudson_ViewAlreadyExists(newName), "name");
         String oldName = name;
         name = newName;
         owner.onViewRenamed(this, oldName, newName);
+    }
+
+    /**
+     * Checks that the given name is a valid view name.
+     * <p>
+     * In addition to the generic name rules enforced by
+     * {@link Jenkins#checkGoodName(String)} (non-empty, no unsafe characters, etc.),
+     * this enforces {@link #MAX_VIEW_NAME_LENGTH} so that the view's URL does not
+     * exceed typical servlet container / reverse proxy limits.
+     *
+     * @param name the proposed view name.
+     * @throws Failure if the name is empty, contains unsafe characters, or is too long.
+     * @since 2.576
+     * @see #MAX_VIEW_NAME_LENGTH
+     */
+    public static void checkViewName(String name) throws Failure {
+        Jenkins.checkGoodName(name);
+        if (name.length() > MAX_VIEW_NAME_LENGTH) {
+            throw new Failure(Messages.View_NameTooLong(MAX_VIEW_NAME_LENGTH));
+        }
     }
 
     /**
@@ -1131,6 +1151,18 @@ public abstract class View extends AbstractModelObject implements AccessControll
     public static final Permission CONFIGURE = new Permission(PERMISSIONS, "Configure", Messages._View_ConfigurePermission_Description(), Permission.CONFIGURE, PermissionScope.ITEM_GROUP);
     public static final Permission READ = new Permission(PERMISSIONS, "Read", Messages._View_ReadPermission_Description(), Permission.READ, PermissionScope.ITEM_GROUP);
 
+    /**
+     * Maximum number of characters allowed in a view name.
+     * <p>
+     * A view's URL is built from its name ({@link #getViewUrl()}), so an overly long
+     * name produces an URL that exceeds typical servlet container / reverse proxy
+     * limits, resulting in HTTP 414 (URI Too Long) or HTTP 500 ("Response Header
+     * Fields Too Large") when the view is later opened.
+     *
+     * @since 2.576
+     */
+    public static final int MAX_VIEW_NAME_LENGTH = 255;
+
     @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification = "to guard against potential future compiler optimizations")
     @Initializer(before = InitMilestone.SYSTEM_CONFIG_LOADED)
     @Restricted(DoNotUse.class)
@@ -1166,7 +1198,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
                         || requestContentType.startsWith("text/xml"));
 
         String name = req.getParameter("name");
-        Jenkins.checkGoodName(name);
+        checkViewName(name);
         if (owner.getView(name) != null)
             throw new Failure(Messages.Hudson_ViewAlreadyExists(name));
 
@@ -1243,7 +1275,7 @@ public abstract class View extends AbstractModelObject implements AccessControll
         try (InputStream in = new BufferedInputStream(xml)) {
             View v = (View) Jenkins.XSTREAM.fromXML(in);
             if (name != null) v.name = name;
-            Jenkins.checkGoodName(v.name);
+            checkViewName(v.name);
             return v;
         } catch (StreamException | ConversionException | Error e) { // mostly reflection errors
             throw new IOException("Unable to read", e);

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5003,7 +5003,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
         // good view name?
         try {
-            checkGoodName(name);
+            View.checkViewName(name);
         } catch (Failure e) {
             return FormValidation.error(e.getMessage());
         }

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -284,6 +284,7 @@ View.ConfigurePermission.Description=\
 View.ReadPermission.Description=\
   This permission allows users to see views.
 View.MissingMode=No view type is specified
+View.NameTooLong=View name is too long, it must be {0} characters or fewer.
 View.DisplayNameNotUniqueWarning=The display name, "{0}", is already in use by another view and \
   could cause confusion and delay.
 UpdateCenter.DisplayName=Update Center

--- a/core/src/test/java/hudson/model/ViewTest.java
+++ b/core/src/test/java/hudson/model/ViewTest.java
@@ -1,7 +1,9 @@
 package hudson.model;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.search.SearchIndex;
 import hudson.search.SearchIndexBuilder;
@@ -114,6 +116,24 @@ public class ViewTest {
         Collection<View> allViews = rootView.getAllViews();
         //then
         assertEquals(4, allViews.size());
+    }
+
+    @Test
+    @Issue("JENKINS-26800")
+    void checkViewName_acceptsMaxLength() {
+        String name = "a".repeat(View.MAX_VIEW_NAME_LENGTH);
+        assertDoesNotThrow(() -> View.checkViewName(name));
+    }
+
+    @Test
+    @Issue("JENKINS-26800")
+    void checkViewName_rejectsTooLongName() {
+        String name = "a".repeat(View.MAX_VIEW_NAME_LENGTH + 1);
+        Failure e = assertThrows(
+                Failure.class,
+                () -> View.checkViewName(name),
+                "A view name longer than the maximum should not be accepted");
+        assertEquals(Messages.View_NameTooLong(View.MAX_VIEW_NAME_LENGTH), e.getMessage());
     }
 
     private TopLevelItem createJob(String jobName) {

--- a/test/src/test/java/hudson/model/ViewTest.java
+++ b/test/src/test/java/hudson/model/ViewTest.java
@@ -267,6 +267,21 @@ class ViewTest {
                 "\"..\" should not be allowed.");
     }
 
+    @Issue("JENKINS-26800")
+    @Test
+    void nameTooLong() throws Exception {
+        WebClient wc = j.createWebClient()
+                .withThrowExceptionOnFailingStatusCode(false);
+        HtmlForm form = wc.goTo("newView").getFormByName("createItem");
+        form.getInputByName("name").setValue("a".repeat(View.MAX_VIEW_NAME_LENGTH + 1));
+        form.getRadioButtonsByName("mode").getFirst().setChecked(true);
+
+        HtmlPage page = j.submit(form);
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST,
+                page.getWebResponse().getStatusCode(),
+                "A view name longer than the maximum should not be allowed.");
+    }
+
     @Disabled("verified manually in Winstone but org.mortbay.JettyResponse.sendRedirect (6.1.26) seems to mangle the location")
     @Issue("JENKINS-18373")
     @Test


### PR DESCRIPTION
Fixes #26800

## Problem

A view's URL is built from its name (`View.getViewUrl()` = `owner.getUrl() + "view/" + Util.rawEncode(name) + "/"`), so an overly long name produces a URL that exceeds typical servlet container / reverse proxy limits. The view is created successfully, but when the user later navigates to it the request fails with **HTTP 414 (URI Too Long)** or **HTTP 500 (Response Header Fields Too Large)** (container-dependent). The view then cannot be opened or deleted via the standard UI — the reporter had to remove it via the Script Console.

`Jenkins.checkGoodName` enforces non-empty, no control/unsafe characters, and (optionally) no trailing dot — but **no length limit anywhere** in the validation chain.

This affects both dashboard (top-level) views and views inside Folders.

## Approach

Add a **view-local** length limit of `View.MAX_VIEW_NAME_LENGTH = 255` (the only number endorsed in the discussion; conventional; safe well below container/proxy limits even with nested folders). It is enforced via a new `View.checkViewName(name)` wrapper around `Jenkins.checkGoodName`, applied at **every** view creation/rename entry point:

- `View.rename` — rename path
- `View.create` — UI / API create (covers the dashboard and My Views POST paths, XML submission, and copy)
- `View.createViewFromXML` — also reached by the CLI `create-view` command independently of `View.create`

The limit is also surfaced **inline** on the New View forms by routing the AJAX validators through the same check:

- `Jenkins.doCheckViewName` (dashboard form) — this was a gap in #26805
- `MyViewsProperty.doViewExistsCheck` (My Views form), which previously did existence-only checking with no name validation at all

`checkGoodName` itself is **unchanged**, so no other entity type (jobs, nodes, labels, clouds, loggers) is affected.

## Load-path safety

The limit is **creation-time only**. `Jenkins.load()` deserializes views directly via XStream and does **not** call `createViewFromXML` or `checkGoodName`, so:

- pre-existing over-long-named views (if any) continue to load on upgrade, and
- the controller startup path is unaffected.

This resolves the concern raised on #26805 that a length check on the XML-load path could prevent the controller from starting.

## Scope decision

The fix is intentionally **view-local**. Centralizing the limit in `Jenkins.checkGoodName` (shared by ~26 call sites / 7+ entity types) is a broader policy change with side effects (e.g. it would flip the characterization tests added in #26835 and could break existing node/label names) that has not converged among maintainers. I will open a separate issue to propose the centralized policy for discussion.

Note: folder-scoped views are created via the cloudbees-folder plugin, but folder creation routes through core `View.create` → `createViewFromXML`, so this server-side gate protects folder views too. A separate change in the folder plugin would be needed for inline AJAX feedback on its form.

## Relationship to #26805

This supersedes/builds on #26805 (same View-local approach, approved by @timja), and closes two gaps in it: the `Jenkins.doCheckViewName` AJAX validator (uncovered) and `MyViewsProperty.doViewExistsCheck` (no name validation at all).

### Testing done

- `mvn -pl core test -Dtest=ViewTest` — new unit boundary tests: 255 chars accepted, 256 chars rejected with `Failure` and message `Messages.View_NameTooLong(MAX_VIEW_NAME_LENGTH)`.
- `mvn -pl test test -Dtest=ViewTest#nameTooLong+notAllowedName` — functional test submitting a 256-char name through the real `newView` web form asserts HTTP 400 (mirrors the existing `notAllowedName` test); the existing `".."` test still passes (regression).
- `mvn -pl core test -Dtest=Security2424Test` — confirms `checkGoodName` behavior (trailing-dot rule) is unchanged.
- `mvn spotless:check` / `mvn checkstyle:check` clean.

### Screenshots (UI changes only)

N/A (validation message only).

### Proposed changelog entries

- Reject view names longer than 255 characters at creation/rename time, preventing unusable views that cause HTTP 414/500 when opened

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. N/A.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. N/A (no JS/frontend changes).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. N/A.
- [x] For new APIs and extension points, there is a link to at least one consumer. N/A (not a new API/extension point).

### Desired reviewers

@reviewers