### PR TITLE
Mask masked arguments in ArgumentListBuilder#toStringWithQuote

### DIFF
--- a/core/src/main/java/hudson/util/ArgumentListBuilder.java
+++ b/core/src/main/java/hudson/util/ArgumentListBuilder.java
@@ -286,10 +286,29 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
     /**
      * Just adds quotes around args containing spaces, but no other special characters,
      * so this method should generally be used only for informational/logging purposes.
+     *
+     * <p>Masked arguments are replaced with {@code ******}, as in {@link #toString()}:
+     * the output of this method is destined for a log, which is exactly where a masked
+     * argument must not appear.
+     *
+     * <p>This is the same rendering as {@link #toString()}; the two share one
+     * implementation so a change to the masking of one cannot silently miss the other.
      */
     public String toStringWithQuote() {
+        return renderForDisplay();
+    }
+
+    /**
+     * Renders the arguments for human consumption, quoting anything that contains a
+     * space or is empty and replacing masked arguments with {@code ******}.
+     */
+    private String renderForDisplay() {
         StringBuilder buf = new StringBuilder();
-        for (String arg : args) {
+        for (int i = 0; i < args.size(); i++) {
+            String arg = args.get(i);
+            if (mask.get(i))
+                arg = "******";
+
             if (!buf.isEmpty())  buf.append(' ');
 
             if (arg.indexOf(' ') >= 0 || arg.isEmpty())
@@ -426,20 +445,7 @@ public class ArgumentListBuilder implements Serializable, Cloneable {
      */
     @Override
     public String toString() {
-        StringBuilder buf = new StringBuilder();
-        for (int i = 0; i < args.size(); i++) {
-            String arg = args.get(i);
-            if (mask.get(i))
-                arg = "******";
-
-            if (!buf.isEmpty())  buf.append(' ');
-
-            if (arg.indexOf(' ') >= 0 || arg.isEmpty())
-                buf.append('"').append(arg).append('"');
-            else
-                buf.append(arg);
-        }
-        return buf.toString();
+        return renderForDisplay();
     }
 
     private static final long serialVersionUID = 1L;

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -27,6 +27,7 @@ package hudson.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -262,5 +263,31 @@ class ArgumentListBuilderTest {
         assertThat(args, containsString("one=one\\backslash"));
         assertThat(args, containsString("two=two\\\\backslashes"));
         assertThat(args, containsString("four=four\\\\\\\\backslashes"));
+    }
+
+    @Test
+    void toStringWithQuoteMasksMaskedArguments() {
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+        builder.add("hg");
+        builder.add("--config");
+        builder.addMasked("auth.jenkins.password=s3cr3t");
+        builder.add("clone");
+
+        // This output goes to a build log, so a masked argument must not survive in it.
+        assertThat(builder.toStringWithQuote(), is("hg --config ****** clone"));
+        assertThat(builder.toStringWithQuote(), not(containsString("s3cr3t")));
+    }
+
+    @Test
+    void toStringWithQuoteQuotesTheSameWayAsToString() {
+        ArgumentListBuilder builder = new ArgumentListBuilder();
+        builder.add("cmd");
+        builder.add("has space");
+        builder.add("");
+        builder.addMasked("secret value");
+        builder.add("plain");
+
+        assertThat(builder.toStringWithQuote(), is(builder.toString()));
+        assertThat(builder.toStringWithQuote(), is("cmd \"has space\" \"\" ****** plain"));
     }
 }

--- a/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
+++ b/core/src/test/java/hudson/util/ArgumentListBuilderTest.java
@@ -274,8 +274,9 @@ class ArgumentListBuilderTest {
         builder.add("clone");
 
         // This output goes to a build log, so a masked argument must not survive in it.
-        assertThat(builder.toStringWithQuote(), is("hg --config ****** clone"));
-        assertThat(builder.toStringWithQuote(), not(containsString("s3cr3t")));
+        String rendered = builder.toStringWithQuote();
+        assertThat(rendered, is("hg --config ****** clone"));
+        assertThat(rendered, not(containsString("s3cr3t")));
     }
 
     @Test
@@ -287,7 +288,8 @@ class ArgumentListBuilderTest {
         builder.addMasked("secret value");
         builder.add("plain");
 
-        assertThat(builder.toStringWithQuote(), is(builder.toString()));
-        assertThat(builder.toStringWithQuote(), is("cmd \"has space\" \"\" ****** plain"));
+        String rendered = builder.toStringWithQuote();
+        assertThat(rendered, is(builder.toString()));
+        assertThat(rendered, is("cmd \"has space\" \"\" ****** plain"));
     }
 }


### PR DESCRIPTION
`ArgumentListBuilder.toString()` replaces masked arguments with `******`. `toStringWithQuote()` was character-for-character identical to it *except* that it iterated `args` directly and so never consulted the mask:

```java
public String toStringWithQuote() {
    StringBuilder buf = new StringBuilder();
    for (String arg : args) {              // <-- no index, so no mask lookup
        if (!buf.isEmpty())  buf.append(' ');
        if (arg.indexOf(' ') >= 0 || arg.isEmpty())
            buf.append('"').append(arg).append('"');
        else
            buf.append(arg);
    }
    return buf.toString();
}
```

Both methods exist to render the command line for a human, and this one's Javadoc says it is for "informational/logging purposes" — which is precisely where a masked argument must not appear.

**This is not only theoretical.** Around fourteen plugins call `toStringWithQuote()`, and at least one has a live leak. In `mercurial-plugin`, `HgExe.findHgExe` puts the credentials into the builder:

```java
b.add("--config");
b.addMasked("auth.jenkins.password=" + upc.getPassword().getPlainText());
```

and `HgExe.popen` logs the same builder when the command fails:

```java
} else {
    listener.error("Failed to run " + args.toStringWithQuote());
```

So any failing `hg` invocation writes the password into the build log in plain text. Other callers pass it to `LOG.log(...)` (`xshell-plugin` does this in three places), which lands the same content in the Jenkins system log.

The fix makes the mask apply, and folds the two renderings into one private method so that a future change to the masking of one cannot silently miss the other — the divergence is how this arose in the first place. For a builder with no masked arguments the output is byte-identical to before.

### Testing done

Two tests added to `ArgumentListBuilderTest`:

- `toStringWithQuoteMasksMaskedArguments` — reproduces the mercurial-plugin shape (`hg --config <masked password> clone`) and asserts both that the output is `hg --config ****** clone` and that the secret does not appear anywhere in it.
- `toStringWithQuoteQuotesTheSameWayAsToString` — asserts the two methods agree and that the space/empty-argument quoting is unchanged (`cmd "has space" "" ****** plain`).

Control experiment, running the new tests against the unmodified `ArgumentListBuilder`:

```
toStringWithQuoteMasksMaskedArguments()      FAILED
  Expected: is "hg --config ****** clone"
       but: was "hg --config auth.jenkins.password=s3cr3t clone"
toStringWithQuoteQuotesTheSameWayAsToString() FAILED
  Expected: is "cmd \"has space\" \"\" ****** plain"
       but: was "cmd \"has space\" \"\" \"secret value\" plain"
```

With the fix applied, all 13 enabled tests in `ArgumentListBuilderTest` pass (the 14th is the pre-existing `@Disabled` `testToWindowsCommandMasked`). The 11 pre-existing tests pass either way, so nothing that previously asserted this behaviour changes — there was no coverage of the masking of this method. Notably `testToWindowsCommand`, which asserts exact `toString()` output including a `******`, is unaffected.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Replace masked arguments with `******` in `ArgumentListBuilder#toStringWithQuote`, which previously printed them in plain text; plugins that log this string, such as Mercurial, no longer leak credentials into the build log.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. (No new public API; the one new method is private.)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. (N/A)
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. (N/A)
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. (N/A)
- [x] For new APIs and extension points, there is a link to at least one consumer. (N/A)