### PR TITLE
Advance CompoundEnumeration in nextElement, not only in hasMoreElements

### DIFF
--- a/core/src/main/java/hudson/util/CompoundEnumeration.java
+++ b/core/src/main/java/hudson/util/CompoundEnumeration.java
@@ -31,14 +31,31 @@ public class CompoundEnumeration<T> implements Enumeration<T> {
 
     @Override
     public boolean hasMoreElements() {
-        while (!cur.hasMoreElements() && base.hasNext()) {
-            cur = base.next();
-        }
-        return cur.hasMoreElements();
+        return advanceToNonEmpty();
     }
 
     @Override
     public T nextElement() throws NoSuchElementException {
+        // Advance here as well, not only in hasMoreElements. Enumeration does not require a
+        // caller to consult hasMoreElements first, so a caller that knows an element is there
+        // would otherwise get NoSuchElementException whenever an earlier enumeration in the
+        // chain is exhausted or was empty to begin with -- as the first one is in
+        // PluginFirstClassLoader2#getResources for every resource the plugin does not itself
+        // contain. This matches java.lang.ClassLoader's own compound enumeration, which
+        // advances in both methods.
+        advanceToNonEmpty();
         return cur.nextElement();
+    }
+
+    /**
+     * Advances {@link #cur} past any exhausted enumerations.
+     *
+     * @return true if {@link #cur} has an element left to return.
+     */
+    private boolean advanceToNonEmpty() {
+        while (!cur.hasMoreElements() && base.hasNext()) {
+            cur = base.next();
+        }
+        return cur.hasMoreElements();
     }
 }

--- a/core/src/test/java/hudson/util/CompoundEnumerationTest.java
+++ b/core/src/test/java/hudson/util/CompoundEnumerationTest.java
@@ -1,9 +1,13 @@
 package hudson.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -64,6 +68,51 @@ class CompoundEnumerationTest {
                                 Collections.enumeration(rangeClosed(1, 4)),
                                 Collections.enumeration(rangeClosed(5, 8)),
                                 Collections.emptyEnumeration())));
+    }
+
+    /**
+     * {@link Enumeration#nextElement} may be called without first consulting
+     * {@link Enumeration#hasMoreElements}, so it has to skip exhausted enumerations too.
+     * {@link hudson.PluginFirstClassLoader2#getResources} hits this for every resource the
+     * plugin itself does not contain: the first enumeration in the chain is empty, and the
+     * element the caller is after sits in the second one.
+     */
+    @Test
+    void nextElementSkipsExhaustedEnumerationsWithoutHasMoreElements() {
+        Enumeration<Integer> leadingEmpty =
+                new CompoundEnumeration<>(
+                        Collections.emptyEnumeration(), Collections.enumeration(rangeClosed(1, 2)));
+        assertEquals(1, leadingEmpty.nextElement());
+        assertEquals(2, leadingEmpty.nextElement());
+
+        Enumeration<Integer> emptyInTheMiddle =
+                new CompoundEnumeration<>(
+                        Collections.enumeration(rangeClosed(1, 1)),
+                        Collections.emptyEnumeration(),
+                        Collections.enumeration(rangeClosed(2, 3)));
+        assertEquals(rangeClosed(1, 3), drainWithNextElementOnly(emptyInTheMiddle, 3));
+    }
+
+    @Test
+    void nextElementStillThrowsWhenTrulyExhausted() {
+        Enumeration<Integer> allEmpty =
+                new CompoundEnumeration<>(
+                        Collections.emptyEnumeration(), Collections.emptyEnumeration());
+        assertThrows(NoSuchElementException.class, allEmpty::nextElement);
+
+        Enumeration<Integer> oneElement =
+                new CompoundEnumeration<>(Collections.enumeration(rangeClosed(1, 1)));
+        assertEquals(1, oneElement.nextElement());
+        assertThrows(NoSuchElementException.class, oneElement::nextElement);
+    }
+
+    /** Reads exactly {@code count} elements without ever calling {@code hasMoreElements}. */
+    private static List<Integer> drainWithNextElementOnly(Enumeration<Integer> e, int count) {
+        List<Integer> result = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            result.add(e.nextElement());
+        }
+        return result;
     }
 
     private static List<Integer> rangeClosed(int startInclusive, int endInclusive) {


### PR DESCRIPTION
`CompoundEnumeration` advanced past exhausted delegates only in `hasMoreElements`:

```java
@Override
public boolean hasMoreElements() {
    while (!cur.hasMoreElements() && base.hasNext()) {
        cur = base.next();
    }
    return cur.hasMoreElements();
}

@Override
public T nextElement() throws NoSuchElementException {
    return cur.nextElement();      // <-- never advances
}
```

`Enumeration` does not require a caller to consult `hasMoreElements()` before `nextElement()`, so a caller that already knows an element is there gets `NoSuchElementException` whenever an earlier enumeration in the chain is exhausted or was empty to begin with. `java.lang.ClassLoader`'s own compound enumeration (`jdk.internal.loader.CompoundEnumeration`) advances in both methods for exactly this reason.

This is reachable from core. `PluginFirstClassLoader2#getResources` returns:

```java
return new CompoundEnumeration<>(findResources(name), getParent().getResources(name));
```

For every resource the plugin does not itself contain — which is the common case, since that is why the parent is consulted at all — the first delegate is empty and the answer sits in the second. Any caller doing `getResources(name).nextElement()`, a normal idiom when you want the first hit, throws instead of returning it. The existing tests all go through `Collections.list()`, which always calls `hasMoreElements()` first, so this path had no coverage.

The fix extracts the advancing loop into a private helper and calls it from both methods. `hasMoreElements()` behaviour is unchanged, and `nextElement()` still throws `NoSuchElementException` when the chain is genuinely exhausted, as its signature promises.

### Testing done

Two tests added to `CompoundEnumerationTest`, both reading through `nextElement()` alone and never calling `hasMoreElements()`:

- `nextElementSkipsExhaustedEnumerationsWithoutHasMoreElements` — covers a leading empty enumeration (the `PluginFirstClassLoader2` shape) and an empty one in the middle of the chain.
- `nextElementStillThrowsWhenTrulyExhausted` — an all-empty chain, and a single-element chain read one past its end, both of which must still raise `NoSuchElementException`.

Control experiment, running the new tests against the unmodified `CompoundEnumeration`:

```
CompoundEnumerationTest
├─ smokes()                                                     OK
├─ empty()                                                      OK
├─ gaps()                                                       OK
├─ nextElementSkipsExhaustedEnumerationsWithoutHasMoreElements() FAILED
│    java.util.NoSuchElementException
└─ nextElementStillThrowsWhenTrulyExhausted()                   OK

Tests run: 5, Passed: 4, Failed: 1
```

With the fix applied all 5 pass. The three pre-existing tests (`smokes`, `empty`, `gaps`) pass either way, so the change adds behaviour without altering what was already asserted.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Fix `NoSuchElementException` from `CompoundEnumeration#nextElement` when an earlier enumeration in the chain is empty, which affected callers of `getResources` on plugin-first class loaders that read the enumeration without checking `hasMoreElements` first.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. (No new public API; the one new method is private.)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. (N/A)
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. (N/A)
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. (N/A)
- [x] For new APIs and extension points, there is a link to at least one consumer. (N/A)