### PR TITLE
Add more to quick-build, remove cleaning node_modules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,20 @@ mvn -am -pl war,bom -Pquick-build clean install
 ```
 
 The WAR file will be created in `war/target/jenkins.war`.
+
+> [!NOTE]
+> `quick-build` sets `maven.test.skip`, so test classes are not compiled and are not present
+> afterwards. To build something you can then run tests against, drop the profile or pass
+> `-Dmaven.test.skip=false`.
+
+`clean` deliberately leaves `node/`, `node_modules/` and `.yarn/` in place, so the node
+toolchain and the downloaded packages survive between builds. Pass `-Dclean.node` to delete
+those as well.
+
+If you are only changing backend code and `war/src/main/webapp/jsbundles` is already populated
+from an earlier build, `-Dskip.frontend=true` skips the node installation, `yarn install` and
+`yarn build`.
+
 After that, you can start Jenkins using Java CLI ([guide](https://www.jenkins.io/doc/book/installing/war-file/#run-the-war-file)).
 If you want to debug the WAR file without using Maven plugins,
 You can run the executable with [Remote Debug Flags](https://stackoverflow.com/questions/975271/remote-debugging-a-java-application)
@@ -74,7 +88,7 @@ To work on the `war` module frontend assets, two processes are needed at the sam
 On one terminal, start a development server that will not process frontend assets:
 
 ```sh
-MAVEN_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED' mvn -pl war jetty:run -Dskip.yarn
+MAVEN_OPTS='--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED' mvn -pl war jetty:run -Dskip.frontend
 ```
 
 Open another terminal and start a [webpack](https://webpack.js.org/) dev server, after [optionally adding Node and Yarn to your path](#running-the-yarn-frontend-build):

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -662,6 +662,7 @@ THE SOFTWARE.
             </goals>
             <phase>prepare-package</phase>
             <configuration>
+              <skip>${strip.license.comments.skip}</skip>
               <target>
                 <!-- Only the leading comment block, to leave any semantically interesting comments elsewhere in the file untouched -->
                 <replaceregexp encoding="UTF-8" match="\A(?:[ \t]*(?:[#!].*)?\r?\n)+" replace="">

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@ THE SOFTWARE.
     <bridge-method-injector.version>1.32</bridge-method-injector.version>
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+    <!-- Opt-out switches for steps that only matter when producing a release artifact.
+         Set to true by the quick-build profile below; see CONTRIBUTING.md. -->
+    <strip.license.comments.skip>false</strip.license.comments.skip>
+    <!-- Skips node installation, "yarn install" and "yarn build". Only safe when
+         war/src/main/webapp/jsbundles is already populated from an earlier build. -->
+    <skip.frontend>false</skip.frontend>
     <!-- Make sure to keep the jetty-ee9-maven-plugin version in war/pom.xml in sync with the Jetty release in Winstone: -->
     <winstone.version>8.1044.v8e30078854c2</winstone.version>
     <node.version>24.18.0</node.version>
@@ -405,6 +411,49 @@ THE SOFTWARE.
       </properties>
     </profile>
     <profile>
+      <!--
+        Merged by id with the quick-build profile in the parent POM, which already skips the
+        linters and static analysis. These additions turn off work that only matters when
+        producing a release artifact, so a development build spends its time compiling.
+      -->
+      <id>quick-build</id>
+      <properties>
+        <!-- Only shrinks the packaged jar. -->
+        <strip.license.comments.skip>true</strip.license.comments.skip>
+        <remoteresources.skip>true</remoteresources.skip>
+        <!--
+          The parent POM cannot set this because a plugin may be producing a test jar, but
+          nothing in this repository consumes one, so there is nothing to compile tests for.
+          Note that this means test classes are absent afterwards: drop the profile (or pass
+          -Dmaven.test.skip=false) before running tests against the build output.
+        -->
+        <maven.test.skip>true</maven.test.skip>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>io.jenkins.tools.maven</groupId>
+              <artifactId>license-maven-plugin</artifactId>
+              <!-- Version specified in parent POM -->
+              <executions>
+                <execution>
+                  <!--
+                    This plugin has no skip parameter, so unbind it instead. It resolves and
+                    builds the POM of every transitive dependency to produce META-INF/licenses.xml,
+                    which is only read by the "About Jenkins" page; AboutJenkins#getLicensesURL
+                    returns null when it is absent and the view already handles that.
+                  -->
+                  <id>default</id>
+                  <phase>none</phase>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
       <id>yarn-execution</id>
       <activation>
         <file>
@@ -427,6 +476,7 @@ THE SOFTWARE.
                 <configuration>
                   <nodeVersion>v${node.version}</nodeVersion>
                   <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-dist/</nodeDownloadRoot>
+                  <skip>${skip.frontend}</skip>
                 </configuration>
               </execution>
               <execution>
@@ -437,6 +487,7 @@ THE SOFTWARE.
                 <phase>initialize</phase>
                 <configuration>
                   <arguments>yarn install</arguments>
+                  <skip>${skip.frontend}</skip>
                 </configuration>
               </execution>
               <execution>
@@ -447,6 +498,7 @@ THE SOFTWARE.
                 <phase>generate-sources</phase>
                 <configuration>
                   <arguments>yarn build</arguments>
+                  <skip>${skip.frontend}</skip>
                 </configuration>
               </execution>
             </executions>
@@ -456,19 +508,15 @@ THE SOFTWARE.
             <artifactId>maven-clean-plugin</artifactId>
             <!-- Version specified in grandparent POM -->
             <configuration>
+              <!--
+                The node toolchain and the downloaded packages are deliberately left alone:
+                deleting them costs several seconds of its own and then forces the node install
+                and "yarn install" to start from nothing on every build, and since .yarnrc.yml
+                sets enableGlobalCache: false, .yarn holds the only copy of the package cache.
+                "yarn install" runs at initialize on every build, so stale dependencies still
+                heal themselves. Use -Dclean.node to delete them anyway.
+              -->
               <filesets>
-                <fileset>
-                  <directory>.yarn</directory>
-                  <followSymlinks>false</followSymlinks>
-                </fileset>
-                <fileset>
-                  <directory>node</directory>
-                  <followSymlinks>false</followSymlinks>
-                </fileset>
-                <fileset>
-                  <directory>node_modules</directory>
-                  <followSymlinks>false</followSymlinks>
-                </fileset>
                 <fileset>
                   <directory>war/src/main/webapp/jsbundles</directory>
                   <followSymlinks>false</followSymlinks>
@@ -553,6 +601,46 @@ THE SOFTWARE.
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- When changing branches that touch frontend assets this can be a good idea but not for every fresh build. -->
+      <id>clean-node</id>
+      <activation>
+        <property>
+          <name>clean.node</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <!-- Version specified in grandparent POM -->
+            <configuration>
+              <!-- Replaced rather than appended, because merging repeated <fileset> elements
+                   across profiles is not well defined. -->
+              <filesets combine.self="override">
+                <fileset>
+                  <directory>war/src/main/webapp/jsbundles</directory>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+                <fileset>
+                  <directory>.yarn</directory>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+                <fileset>
+                  <directory>node</directory>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+                <fileset>
+                  <directory>node_modules</directory>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+              </filesets>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
 74.4s → 45.0s (39% faster) on my machine anyway.

More changes to come in separate PRs

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #<issue-number>

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
