### PR TITLE
Correct Javadoc for QuotedStringTokenizer.quote(String) to reflect unconditional quoting

### DIFF
--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -361,9 +361,9 @@ public class QuotedStringTokenizer
 
     /* ------------------------------------------------------------ */
     /** Quote a string.
-     * The string is quoted only if quoting is required due to
-     * embedded delimiters, quote characters or the
-     * empty string.
+     * The string is always quoted, even when quoting is not required.
+     * Use {@link #quote(String, String)} to quote only when required due to
+     * embedded delimiters, quote characters or the empty string.
      * @param s The string to quote.
      * @return quoted string
      */

--- a/cli/src/test/java/hudson/util/QuotedStringTokenizerTest.java
+++ b/cli/src/test/java/hudson/util/QuotedStringTokenizerTest.java
@@ -25,6 +25,7 @@
 package hudson.util;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,6 +86,18 @@ class QuotedStringTokenizerTest {
         assertFalse(tokenizer.hasMoreTokens());
         tokenizer = new QuotedStringTokenizer("one");
         assertTrue(tokenizer.hasMoreTokens());
+    }
+
+    // Pins the differing contracts of the two quote overloads: the single-argument
+    // quote(String) always quotes, while quote(String, String) quotes only when required.
+    @Test
+    void quoteSingleArgAlwaysQuotes() {
+        assertEquals("\"abc\"", QuotedStringTokenizer.quote("abc"));
+    }
+
+    @Test
+    void quoteTwoArgReturnsInputWhenQuotingNotRequired() {
+        assertEquals("abc", QuotedStringTokenizer.quote("abc", ""));
     }
 
     private void check(String src, String... expected) {


### PR DESCRIPTION
Fixes #27164

The Javadoc on `QuotedStringTokenizer.quote(String)` says the string "is quoted only if quoting is required", but that overload has no conditional check and always quotes. The text was copied from the sibling `quote(String, String)`, which really is conditional: it returns the input unchanged when no quoting is needed. This corrects the single-argument Javadoc and points callers who want conditional quoting at the two-argument overload.

Behavior is unchanged. Making `quote(String)` conditional would alter the output of every caller, so correcting the documentation is the conservative fix. The class is vendored from Jetty (Apache-2.0 header) and the Jenkins copy has already diverged from it, so this is a local correction rather than a sync with Jetty.

### Testing done

Added two characterization tests to `QuotedStringTokenizerTest` pinning the differing contracts: `quote("abc")` returns `"abc"`, and `quote("abc", "")` returns `abc`. Ran `mvn -pl cli -am clean test` on Java 21: 36 tests, 0 failures, 0 skipped. `mvn spotless:check -pl cli` passes.

### Screenshots (UI changes only)

N/A (not a UI change).

#### Before

#### After

### Proposed changelog entries

- Correct Javadoc for `QuotedStringTokenizer.quote(String)` to reflect its unconditional quoting

### Proposed changelog category

/label developer

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- N/A: no new API; Javadoc of an existing method corrected. -->
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- N/A: no deprecations. -->
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- N/A: no UI change. -->
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- N/A: no dependency change. -->
- [ ] For new APIs and extension points, there is a link to at least one consumer. <!-- N/A: no new API. -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

