### PR TITLE
Fix #27112: Tab key not confirming highlighted dropdown suggestion

### DIFF
--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -229,6 +229,7 @@ function menuItem(dropdownItem, type = "jenkins-dropdown__item", context = "") {
 
   // Handle special cases
   tryOnClickEvent(item, dropdownItem);
+  tryOnKeyPressEvent(item, dropdownItem);
   tryLoadScripts(item, dropdownItem, context);
   tryPost(item, dropdownItem, context);
   tryConfirmationPost(item, dropdownItem, context);
@@ -245,6 +246,17 @@ function tryOnClickEvent(element, opt) {
   }
 
   element.addEventListener("click", opt.onClick);
+}
+
+/**
+ * If the menu item has a custom onKeyPress event, add it to the element
+ */
+function tryOnKeyPressEvent(element, opt) {
+  if (!opt.onKeyPress) {
+    return;
+  }
+
+  element.onkeypress = opt.onKeyPress;
 }
 
 /**


### PR DESCRIPTION
Pressing <kbd>Tab</kbd> to confirm a highlighted suggestion in autocomplete and combobox dropdown fields does nothing: the suggestion is not filled in and focus leaves the field instead.

### Root cause

The `menuItem()` function in `src/main/js/components/dropdowns/templates.js` was not wiring the `onKeyPress` property from a dropdown item onto its DOM element.

The full chain is:

1. `autocomplete.js` and `combo-box.js` build items with an `onKeyPress` handler that confirms the suggestion when the key is `Tab`.
2. `utils.js` reads and invokes the handler via `selectedItem.onkeypress(evt)`.
3. But nothing copied `onKeyPress` onto `element.onkeypress`, so `selectedItem.onkeypress` was always `undefined` and the handler never ran.

This was a regression introduced in PR #11204, which refactored the dropdown templates and wired up `onClick` (via `tryOnClickEvent`) but not `onKeyPress`.

### Fix

Add a `tryOnKeyPressEvent()` helper that mirrors the existing `tryOnClickEvent()`, and call it from `menuItem()`:

```js
tryOnClickEvent(item, dropdownItem);
tryOnKeyPressEvent(item, dropdownItem);
```

```js
/**
 * If the menu item has a custom onKeyPress event, add it to the element
 */
function tryOnKeyPressEvent(element, opt) {
  if (!opt.onKeyPress) {
    return;
  }

  element.onkeypress = opt.onKeyPress;
}
```

This restores the `onKeyPress` -> `element.onkeypress` -> `utils.js` invocation chain, so Tab confirms the highlighted suggestion again.

### Testing

- Verified the full data flow: `autocomplete.js`/`combo-box.js` define `onKeyPress`, `templates.js` now wires it to `element.onkeypress`, and `utils.js` invokes it.
- `prettier --check` passes on the modified file.
- Manual reproduction: type in an autocomplete field, arrow to a suggestion, press Tab -> suggestion is now confirmed.

Fixes #27112
