### PR TITLE
Fix QuotedStringTokenizer.quote(String) to conditionally quote per Javadoc

### DIFF
--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -369,15 +369,7 @@ public class QuotedStringTokenizer
      */
     public static String quote(String s)
     {
-        if (s == null)
-            return null;
-        if (s.isEmpty())
-            return "\"\"";
-
-        StringBuffer b = new StringBuffer(s.length() + 8);
-        quote(b, s);
-        return b.toString();
-
+        return quote(s, __delim);
     }
 
 

--- a/cli/src/test/java/hudson/util/QuotedStringTokenizerTest.java
+++ b/cli/src/test/java/hudson/util/QuotedStringTokenizerTest.java
@@ -25,7 +25,9 @@
 package hudson.util;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -91,5 +93,67 @@ class QuotedStringTokenizerTest {
         String[] r = QuotedStringTokenizer.tokenize(src);
         System.out.println(Arrays.asList(r));
         assertArrayEquals(expected, r);
+    }
+
+    @Test
+    void quoteSimpleString() {
+        assertEquals("abc", QuotedStringTokenizer.quote("abc"));
+    }
+
+    @Test
+    void quoteStringWithSpace() {
+        assertEquals("\"abc def\"", QuotedStringTokenizer.quote("abc def"));
+    }
+
+    @Test
+    void quoteStringWithQuote() {
+        assertEquals("\"a\\\"b\"", QuotedStringTokenizer.quote("a\"b"));
+    }
+
+    @Test
+    void quoteStringWithBackslash() {
+        assertEquals("\"a\\\\b\"", QuotedStringTokenizer.quote("a\\b"));
+    }
+
+    @Test
+    void quoteEmptyString() {
+        assertEquals("\"\"", QuotedStringTokenizer.quote(""));
+    }
+
+    @Test
+    void quoteNull() {
+        assertNull(QuotedStringTokenizer.quote(null));
+    }
+
+    @Test
+    void quoteStringWithTab() {
+        assertEquals("\"a\tb\"", QuotedStringTokenizer.quote("a\tb"));
+    }
+
+    @Test
+    void quoteStringWithNewline() {
+        assertEquals("\"a\nb\"", QuotedStringTokenizer.quote("a\nb"));
+    }
+
+    @Test
+    void quoteStringWithSingleQuote() {
+        assertEquals("\"a'b\"", QuotedStringTokenizer.quote("a'b"));
+    }
+
+    @Test
+    void quoteWithCustomDelimiter() {
+        assertEquals("abc", QuotedStringTokenizer.quote("abc", ""));
+        assertEquals("\"abc,def\"", QuotedStringTokenizer.quote("abc,def", ","));
+    }
+
+    @Test
+    void quoteRoundTrip() {
+        String[] inputs = {"hello world", "abc", "with\"quote", "with\\backslash", "with\ttab"};
+        for (String input : inputs) {
+            String quoted = QuotedStringTokenizer.quote(input);
+            String[] tokens = QuotedStringTokenizer.tokenize(quoted);
+            assertEquals(1, tokens.length);
+            assertEquals(input, tokens[0]);
+        }
     }
 }


### PR DESCRIPTION
Fixes #27164

`QuotedStringTokenizer.quote(String)` always wraps strings in double quotes, but its Javadoc states it should only quote when necessary (due to embedded delimiters, quote characters, or the empty string). The two-argument `quote(String, String)` overload already implements this conditional logic correctly.

This fix makes `quote(String)` delegate to `quote(String, String)` with the default delimiters, so the implementation matches the documented contract.

**Before:**
```java
QuotedStringTokenizer.quote("abc")     → "\"abc\""  (always quoted)
QuotedStringTokenizer.quote("abc", "") → "abc"       (conditionally quoted)
```

**After:**
```java
QuotedStringTokenizer.quote("abc")     → "abc"       (conditionally quoted, matches Javadoc)
QuotedStringTokenizer.quote("abc", "") → "abc"       (unchanged)
```

### Testing done

Added 11 unit tests for `QuotedStringTokenizer.quote()`:
- `quoteSimpleString` — plain string returned unquoted
- `quoteStringWithSpace` — string with space is quoted and escaped
- `quoteStringWithQuote` — string with double quote is quoted and escaped
- `quoteStringWithBackslash` — string with backslash is quoted and escaped
- `quoteEmptyString` — empty string returns `""`
- `quoteNull` — null returns null
- `quoteStringWithTab` — tab character triggers quoting
- `quoteStringWithNewline` — newline triggers quoting
- `quoteStringWithSingleQuote` — single quote triggers quoting
- `quoteWithCustomDelimiter` — `quote("abc", "")` returns unquoted, `quote("abc,def", ",")` returns quoted
- `quoteRoundTrip` — verifies `tokenize(quote(s))` returns the original string for all cases

### Screenshots (UI changes only)

N/A — No UI changes.

### Proposed changelog entries

- Fix `QuotedStringTokenizer.quote(String)` to conditionally quote instead of always quoting, matching its Javadoc contract.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A — The new behavior is more correct per the documented contract. Callers that relied on unconditional quoting can use `quote(StringBuffer, String)` directly if they need quotes regardless of content. All existing call sites have been verified to work correctly with conditional quoting:
- `SSHCLI.java` — shell args without special chars are now unquoted, which is more correct
- `LabelAtom.java` — already guards with `needsEscape()` before calling `quote()`, so behavior is unchanged
- `ListChangesCommand.java` — both quoted and unquoted values are valid in CSV output

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood. Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. — No new public API added; existing method behavior is being fixed to match its Javadoc.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. — No deprecations in this change.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives. — No UI changes.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. — No dependency updates.
- [x] For new APIs and extension points, there is a link to at least one consumer. — No new API; existing method behavior fixed. Consumers: `SSHCLI.java`, `LabelAtom.java`, `ListChangesCommand.java`.