### PR TITLE
Fix NullPointerException in details-bar.jelly when detail.link is null

### DIFF
--- a/core/src/main/resources/lib/layout/details-bar.jelly
+++ b/core/src/main/resources/lib/layout/details-bar.jelly
@@ -41,7 +41,9 @@ THE SOFTWARE.
           <j:if test="${detail.iconClassName != null}">
             <x:element name="${detail.link != null ? 'a' : 'div'}">
               <x:attribute name="class">jenkins-details__item</x:attribute>
-              <x:attribute name="href">${detail.link}</x:attribute>
+              <j:if test="${detail.link != null}">
+                <x:attribute name="href">${detail.link}</x:attribute>
+              </j:if>
               <div class="jenkins-details__item__icon">
                 <l:icon src="${detail.iconClassName}" />
               </div>


### PR DESCRIPTION
Fixes #26436

### Summary

`details-bar.jelly` line 42 conditionally chooses between `<a>` and `<div>` based on whether `detail.link` is null, but line 44 unconditionally sets `href="${detail.link}"` regardless. When `detail.link` is null, this causes a `NullPointerException`.

The `Detail.getLink()` method is annotated `@Nullable` and returns null by default, so any `Detail` implementation that does not override `getLink()` will trigger this NPE.

**Fix:** Wrap the `href` attribute in a `<j:if test="${detail.link != null}">` block so it is only set when the link exists.

### Testing done

- Verified the fix by code inspection: `Detail.getLink()` is `@Nullable` and returns null by default, so the null check is necessary.
- The existing element name conditional (`detail.link != null ? 'a' : 'div'`) already established this pattern; the href attribute was simply missing the same null guard.
- No automated tests exist for Jelly template rendering; this is a template-only change.

### Screenshots (UI changes only)

N/A — No visible UI change. The fix prevents a crash; when `detail.link` is null, the element renders as a `<div>` without an `href` attribute (as originally intended).

#### Before

NullPointerException thrown when viewing pipeline logs in the details bar.

#### After

Details bar renders correctly with a `<div>` element (no link) when `detail.link` is null.

### Proposed changelog entries

- Fix NullPointerException in details-bar.jelly when detail.link is null

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood. Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests. — No automated tests exist for Jelly template rendering; this is a template-only fix.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. — No new public API added.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. — No deprecations.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives. — No JavaScript changes; only a conditional Jelly attribute.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. — No dependency updates.
- [x] For new APIs and extension points, there is a link to at least one consumer. — No new API.

### Desired reviewers

@janfaracik (author of details-bar.jelly)