### PR TITLE
Improve diagnostics for unreadable artifacts

### DIFF
--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -288,8 +288,10 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                 }
             }
         } catch (AccessDeniedException e) {
-            LOG.log(Level.FINE, "Diagnosing anticipated Exception", e);
-            throw new AbortException(e.toString()); // Message is not enough as that is the filename only
+            String deniedPath = e.getFile() != null ? e.getFile() : e.toString();
+            String message = Messages.ArtifactArchiver_AccessDenied(deniedPath, ws.getRemote());
+            LOG.log(Level.FINE, message, e);
+            throw new AbortException(message);
         }
     }
 

--- a/core/src/main/java/hudson/tasks/ArtifactArchiver.java
+++ b/core/src/main/java/hudson/tasks/ArtifactArchiver.java
@@ -45,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -288,7 +289,9 @@ public class ArtifactArchiver extends Recorder implements SimpleBuildStep {
                 }
             }
         } catch (AccessDeniedException e) {
-            String deniedPath = e.getFile() != null ? e.getFile() : e.toString();
+            String deniedPath = e.getFile() != null
+                    ? e.getFile()
+                    : Objects.toString(e.getMessage(), e.getClass().getName());
             String message = Messages.ArtifactArchiver_AccessDenied(deniedPath, ws.getRemote());
             LOG.log(Level.FINE, message, e);
             throw new AbortException(message);

--- a/core/src/main/java/hudson/util/io/TarArchiver.java
+++ b/core/src/main/java/hudson/util/io/TarArchiver.java
@@ -98,15 +98,16 @@ final class TarArchiver extends Archiver {
             size = basicFileAttributes.size();
             te.setSize(size);
         }
-        tar.putNextEntry(te);
-        try {
-            if (!basicFileAttributes.isDirectory()) {
-                // ensure we don't write more bytes than the declared when we created the entry
-
-                try (InputStream fin = Files.newInputStream(file.toPath());
-                     BoundedInputStream in = new BoundedInputStream(fin, size)) {
-                    // Separate try block not to wrap exception thrown while opening the input stream into an exception
-                    // indicating a problem while writing
+        if (basicFileAttributes.isDirectory()) {
+            tar.putNextEntry(te);
+            tar.closeEntry();
+        } else {
+            // Open the file before writing its tar header so an unreadable file does not leave an incomplete entry.
+            try (InputStream fin = Files.newInputStream(file.toPath());
+                 BoundedInputStream in = new BoundedInputStream(fin, size)) {
+                tar.putNextEntry(te);
+                try {
+                    // ensure we don't write more bytes than the declared when we created the entry
                     try {
                         int len;
                         while ((len = in.read(buf)) >= 0) {
@@ -115,10 +116,10 @@ final class TarArchiver extends Archiver {
                     } catch (IOException | InvalidPathException e) { // log the exception in any case
                         throw new IOException("Error writing to tar file from: " + file, e);
                     }
+                } finally { // always close the entry
+                    tar.closeEntry();
                 }
             }
-        } finally { // always close the entry
-            tar.closeEntry();
         }
         entriesWritten++;
     }

--- a/core/src/main/resources/hudson/tasks/Messages.properties
+++ b/core/src/main/resources/hudson/tasks/Messages.properties
@@ -36,6 +36,7 @@ No artifacts are configured for archiving.\n\
 You probably forgot to set the file pattern, so please go back to the configuration and specify it.\n\
 If you really did mean to archive all the files in the workspace, please specify "**"
 ArtifactArchiver.NoMatchFound=No artifacts found that match the file pattern "{0}". Configuration error?
+ArtifactArchiver.AccessDenied=Unable to archive artifacts from workspace {1}: access was denied to {0}. Verify that the Jenkins controller and agent processes have the required file permissions.
 
 BatchFile.DisplayName=Execute Windows batch command
 BatchFile.invalid_exit_code_range=Invalid errorlevel value: {0}. Check help section

--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -133,7 +133,7 @@ class TarArchiverTest {
         }
     }
 
-    @Issue("JENKINS-27188")
+    @Issue("https://github.com/jenkinsci/jenkins/issues/27188")
     @Test
     void unreadableFileDoesNotLeaveIncompleteEntry() throws Exception {
         assumeFalse(Functions.isWindows());

--- a/core/src/test/java/hudson/util/io/TarArchiverTest.java
+++ b/core/src/test/java/hudson/util/io/TarArchiverTest.java
@@ -25,6 +25,7 @@
 package hudson.util.io;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -39,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -128,6 +130,23 @@ class TarArchiverTest {
         Util.createSymlink(dir, "nonexistent", "link", TaskListener.NULL);
         try (OutputStream out = OutputStream.nullOutputStream()) {
             new FilePath(dir).tar(out, "**");
+        }
+    }
+
+    @Issue("JENKINS-27188")
+    @Test
+    void unreadableFileDoesNotLeaveIncompleteEntry() throws Exception {
+        assumeFalse(Functions.isWindows());
+
+        File unreadable = new File(tmp, "unreadable.txt");
+        Files.writeString(unreadable.toPath(), "contents", StandardCharsets.UTF_8);
+        assumeTrue(unreadable.setReadable(false));
+        assumeFalse(unreadable.canRead());
+
+        try (TarArchiver archiver = new TarArchiver(OutputStream.nullOutputStream(), StandardCharsets.UTF_8)) {
+            assertThrows(AccessDeniedException.class, () -> archiver.visit(unreadable, unreadable.getName()));
+        } finally {
+            unreadable.setReadable(true);
         }
     }
 

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -492,7 +492,7 @@ class ArtifactArchiverTest {
     }
 
     @Test
-    @Issue({"JENKINS-21905", "JENKINS-27188"})
+    @Issue({"JENKINS-21905", "https://github.com/jenkinsci/jenkins/issues/27188"})
     void archiveNotReadable() throws Exception {
         assumeFalse(Functions.isWindows()); // No permission support
 

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -491,7 +491,7 @@ class ArtifactArchiverTest {
     }
 
     @Test
-    @Issue("JENKINS-21905")
+    @Issue({"JENKINS-21905", "JENKINS-27188"})
     void archiveNotReadable() throws Exception {
         assumeFalse(Functions.isWindows()); // No permission support
 
@@ -513,7 +513,8 @@ class ArtifactArchiverTest {
         FreeStyleBuild build = j.buildAndAssertStatus(Result.FAILURE, p);
         assumeFalse(new File(build.getWorkspace().child(FILENAME).getRemote()).canRead(), FILENAME + " should not be readable by " + System.getProperty("user.name"));
         String expectedPath = build.getWorkspace().child(FILENAME).getRemote();
-        j.assertLogContains("ERROR: Step ‘Archive the artifacts’ failed: java.nio.file.AccessDeniedException: " + expectedPath, build);
+        String expectedMessage = Messages.ArtifactArchiver_AccessDenied(expectedPath, build.getWorkspace().getRemote());
+        j.assertLogContains("ERROR: Step ‘Archive the artifacts’ failed: " + expectedMessage, build);
         assertThat("No stacktrace shown", build.getLog(31), Matchers.iterableWithSize(lessThan(30)));
     }
 

--- a/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
+++ b/test/src/test/java/hudson/tasks/ArtifactArchiverTest.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -569,7 +570,7 @@ class ArtifactArchiverTest {
     private static class RemoveReadPermission extends MasterToSlaveFileCallable<Object> {
         @Override
         public Object invoke(File f, VirtualChannel channel) throws IOException {
-            assertTrue(f.createNewFile());
+            Files.writeString(f.toPath(), "contents");
             assertTrue(f.setReadable(false));
             return null;
         }


### PR DESCRIPTION
Fixes #27188

`ArtifactArchiver` previously reduced an `AccessDeniedException` to its raw exception string. Although this identified the denied path, it did not explain which archive operation failed, identify the workspace, or tell administrators which permissions to check.

For non-empty unreadable files, `TarArchiver` previously wrote the tar header before opening the file. When opening failed, closing the incomplete entry replaced the original `AccessDeniedException` with tar and EOF errors. This change opens regular files before writing their tar headers, preserving the actionable access-denied failure without leaving an incomplete entry.

`ArtifactArchiver` now reports the denied path and workspace and directs administrators to verify the controller and agent file permissions. It deliberately preserves the existing fail-safe behavior: the build still fails rather than reporting an incomplete artifact set as successfully archived. The detailed exception remains available in the `hudson.tasks.ArtifactArchiver` logger at `FINE` level, while the build log remains concise.

The existing Unix-only regression test now covers the actionable message and is associated with both #22902 and #27188.

### Testing done

Ran the focused regression test through the complete Maven reactor, including the Jenkins WAR and a Unix agent:

```text
mvn -ntp -pl test -am -Dtest=hudson.tasks.ArtifactArchiverTest#archiveNotReadable -Dskip.frontend=true -Dyarn.lint.skip=true package
```

Result:

```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Also ran the dedicated tar archiver tests:

```text
mvn -ntp -pl core -am -Dtest=hudson.util.io.TarArchiverTest -Dskip.frontend=true -Dyarn.lint.skip=true package
Tests run: 4, Failures: 0, Errors: 0, Skipped: 1
BUILD SUCCESS
```

The test verifies that an unreadable matched artifact:

- keeps the build result as `FAILURE`;
- logs the denied path and workspace with permission guidance;
- avoids the incomplete tar-entry and EOF stack traces reproduced with a non-empty file;
- does not print a long stack trace.

### Screenshots (UI changes only)

Not applicable; this changes build-log diagnostics only.

#### Before

Not applicable.

#### After

Not applicable.

### Proposed changelog entries

- Improve artifact archiving diagnostics when file access is denied.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples in the Jenkins changelog).
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. No public API was added.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. No deprecations were added.
- [x] UI changes do not introduce CSP regressions. No UI or JavaScript changes were made.
- [x] Dependency updates include links to external changelogs and full differentials where possible. No dependencies were updated.
- [x] New APIs and extension points link to at least one consumer. No APIs or extension points were added.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps for users, the `upgrade-guide-needed` label is set and the **Proposed upgrade guidelines** section is complete.
- [ ] If it would make sense to backport the change to LTS, the issue or pull request is labeled `lts-candidate` for consideration.
