### PR TITLE
Correct PrivateKeyProvider and CLI.loadKey Javadoc to list all supported key types

### DIFF
--- a/cli/src/main/java/hudson/cli/CLI.java
+++ b/cli/src/main/java/hudson/cli/CLI.java
@@ -535,7 +535,7 @@ public class CLI {
     }
 
     /**
-     * Loads RSA/DSA private key in a PEM format into {@link KeyPair}.
+     * Loads an SSH private key (RSA, DSA, ECDSA or Ed25519) into a {@link KeyPair}.
      */
     public static KeyPair loadKey(File f, String passwd) throws IOException, GeneralSecurityException {
         return PrivateKeyProvider.loadKey(f, passwd);
@@ -546,7 +546,7 @@ public class CLI {
     }
 
     /**
-     * Loads RSA/DSA private key in a PEM format into {@link KeyPair}.
+     * Loads an SSH private key (RSA, DSA, ECDSA or Ed25519) into a {@link KeyPair}.
      */
     public static KeyPair loadKey(String pemString, String passwd) throws IOException, GeneralSecurityException {
         return PrivateKeyProvider.loadKey(pemString, passwd);

--- a/cli/src/main/java/hudson/cli/PrivateKeyProvider.java
+++ b/cli/src/main/java/hudson/cli/PrivateKeyProvider.java
@@ -50,7 +50,7 @@ import org.apache.sshd.common.util.io.resource.PathResource;
 import org.apache.sshd.common.util.security.SecurityUtils;
 
 /**
- * Read DSA or RSA key from file(s) asking for password interactively.
+ * Read an SSH private key (RSA, DSA, ECDSA or Ed25519) from file(s) asking for password interactively.
  *
  * @author ogondza
  * @since 1.556


### PR DESCRIPTION
Fixes #27212

Javadoc only: no executable line changes (2 files, 3 comment lines).

`PrivateKeyProvider.loadKey` does no algorithm-specific branching, so RSA, DSA, ECDSA and Ed25519 keys all load. Three comments still say DSA and RSA only: `PrivateKeyProvider.java:53`, `CLI.java:538` and `CLI.java:549`. `PrivateKeyProvider.java:78` already lists `.ssh/id_ecdsa` and `.ssh/id_ed25519`. Commit f428d0626a (#26954) updated that line only; this brings the other three in line.

### Testing done

No new test is added: every key type the corrected wording names is already pinned in `cli/src/test/java/hudson/cli/PrivateKeyProviderTest.java` — `loadKeyRSA` (line 70), `loadKeyDSA` (line 30), `loadKeyECDSA` (line 150), `loadKeyED25519` (line 159). The last two came from #26954, so a new test would only duplicate them.

Verified with JDK 21:

- `mvn -pl cli -am clean test` — `Tests run: 36, Failures: 0, Errors: 0, Skipped: 0` (`PrivateKeyProviderTest`: 12), BUILD SUCCESS. The `light-test` profile is not recognized in this linked worktree, so the standard test run was used.
- `mvn spotless:check -pl cli` — BUILD SUCCESS, 16 files already clean.
- `git diff --stat`: 2 files changed, 3 insertions(+), 3 deletions(-).

### Screenshots (UI changes only)

N/A (not a UI change).

#### Before

#### After

### Proposed changelog entries

- Correct the CLI private key loading Javadoc to list all supported key types.

### Proposed changelog category

/label developer

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [X] The issue, if it exists, is well-described.
- [X] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [X] There is automated testing or an explanation as to why this change has no tests. <!-- No new test; the explanation and the existing tests that pin each documented key type are under Testing done. -->
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. <!-- No new API. -->
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. <!-- No deprecations. -->
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)). <!-- No UI change. -->
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials. <!-- No dependency update. -->
- [ ] For new APIs and extension points, there is a link to at least one consumer. <!-- No new API. -->

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.

