### PR TITLE
Introduce DirectoryBrowserSupportFilter extension point

### DIFF
--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -379,7 +379,15 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                 return;
             }
 
-            try (DirectoryBrowserSupportFilter.Context context = applyFilters(req, baseFile, in, length, true)) {
+            DirectoryBrowserSupportFilter.Context context;
+            try {
+                context = applyFilters(req, baseFile, in, length, true);
+            } catch (IOException ioe) {
+                LOGGER.log(Level.WARNING, "Failed to filter stream for " + baseFile, ioe);
+                rsp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                return;
+            }
+            try (context) {
                 in = context.getInputStream();
                 length = context.getLength();
                 String fileName = context.getFileName();
@@ -389,9 +397,6 @@ public final class DirectoryBrowserSupport implements HttpResponse {
 
                 // pseudo file name to let Stapler set text/plain; ensure charset for non-ASCII text
                 rsp.serveFile(req, in, lastModified, -1, length, "mime-type:text/plain;charset=UTF-8");
-            } catch (IOException ioe) {
-                LOGGER.log(Level.WARNING, "Failed to serve file for " + baseFile, ioe);
-                rsp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             }
         } else {
             if (resourceToken != null) {
@@ -417,7 +422,15 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                     return;
                 }
 
-                try (DirectoryBrowserSupportFilter.Context context = applyFilters(req, baseFile, in, length, false)) {
+                DirectoryBrowserSupportFilter.Context context;
+                try {
+                    context = applyFilters(req, baseFile, in, length, false);
+                } catch (IOException ioe) {
+                    LOGGER.log(Level.WARNING, "Failed to filter stream for " + baseFile, ioe);
+                    rsp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                    return;
+                }
+                try (context) {
                     in = context.getInputStream();
                     length = context.getLength();
                     String fileName = context.getFileName();
@@ -429,9 +442,6 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                     } else {
                         rsp.serveFile(req, in, lastModified, -1, length, fileName);
                     }
-                } catch (IOException ioe) {
-                    LOGGER.log(Level.WARNING, "Failed to serve file for " + baseFile, ioe);
-                    rsp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 }
             }
         }
@@ -441,10 +451,7 @@ public final class DirectoryBrowserSupport implements HttpResponse {
         DirectoryBrowserSupportFilter.Context context = new DirectoryBrowserSupportFilter.Context(baseFile, req, in, length, view);
         for (DirectoryBrowserSupportFilter filter : DirectoryBrowserSupportFilter.all()) {
             try {
-                DirectoryBrowserSupportFilter.Context next = filter.filter(context);
-                if (next != null) {
-                    context = next;
-                }
+                filter.filter(context);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Failed to filter stream for " + baseFile + " using " + filter, e);
                 context.close();

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupport.java
@@ -379,11 +379,20 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                 return;
             }
 
-            // for binary files, provide the file name for download
-            rsp.setHeader("Content-Disposition", "inline; filename=" + baseFile.getName());
+            try (DirectoryBrowserSupportFilter.Context context = applyFilters(req, baseFile, in, length, true)) {
+                in = context.getInputStream();
+                length = context.getLength();
+                String fileName = context.getFileName();
 
-            // pseudo file name to let the Stapler set text/plain; ensure charset for non-ASCII text
-            rsp.serveFile(req, in, lastModified, -1, length, "mime-type:text/plain;charset=UTF-8");
+                // for binary files, provide the file name for download
+                rsp.setHeader("Content-Disposition", "inline; filename=" + fileName);
+
+                // pseudo file name to let Stapler set text/plain; ensure charset for non-ASCII text
+                rsp.serveFile(req, in, lastModified, -1, length, "mime-type:text/plain;charset=UTF-8");
+            } catch (IOException ioe) {
+                LOGGER.log(Level.WARNING, "Failed to serve file for " + baseFile, ioe);
+                rsp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
         } else {
             if (resourceToken != null) {
                 // redirect to second domain
@@ -407,16 +416,42 @@ public final class DirectoryBrowserSupport implements HttpResponse {
                     rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
                     return;
                 }
-                String fileName = baseFile.getName();
-                String mimeType = Jenkins.get().getServletContext().getMimeType(fileName);
-                if (mimeType != null && mimeType.startsWith("text/")) {
-                    // include charset=UTF-8 for text files to prevent browser encoding guessing
-                    rsp.serveFile(req, in, lastModified, -1, length, "mime-type:" + mimeType + ";charset=UTF-8");
-                } else {
-                    rsp.serveFile(req, in, lastModified, -1, length, fileName);
+
+                try (DirectoryBrowserSupportFilter.Context context = applyFilters(req, baseFile, in, length, false)) {
+                    in = context.getInputStream();
+                    length = context.getLength();
+                    String fileName = context.getFileName();
+
+                    String mimeType = Jenkins.get().getServletContext().getMimeType(fileName);
+                    if (mimeType != null && mimeType.startsWith("text/")) {
+                        // include charset=UTF-8 for text files to prevent browser encoding guessing
+                        rsp.serveFile(req, in, lastModified, -1, length, "mime-type:" + mimeType + ";charset=UTF-8");
+                    } else {
+                        rsp.serveFile(req, in, lastModified, -1, length, fileName);
+                    }
+                } catch (IOException ioe) {
+                    LOGGER.log(Level.WARNING, "Failed to serve file for " + baseFile, ioe);
+                    rsp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 }
             }
         }
+    }
+
+    private DirectoryBrowserSupportFilter.Context applyFilters(StaplerRequest2 req, VirtualFile baseFile, InputStream in, long length, boolean view) throws IOException {
+        DirectoryBrowserSupportFilter.Context context = new DirectoryBrowserSupportFilter.Context(baseFile, req, in, length, view);
+        for (DirectoryBrowserSupportFilter filter : DirectoryBrowserSupportFilter.all()) {
+            try {
+                DirectoryBrowserSupportFilter.Context next = filter.filter(context);
+                if (next != null) {
+                    context = next;
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Failed to filter stream for " + baseFile + " using " + filter, e);
+                context.close();
+                throw new IOException("Filter execution failed: " + filter.getClass().getName(), e);
+            }
+        }
+        return context;
     }
 
     private record IsAbsolute(String fragment) implements ControllerToAgentCallable<Boolean, IOException> {

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupportFilter.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupportFilter.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -45,6 +46,21 @@ import org.kohsuke.stapler.StaplerRequest2;
  *   <li>Decompressing gzipped files on the fly when requested by a user.</li>
  *   <li>Decrypting encrypted artifact contents.</li>
  * </ul>
+ *
+ * <p>Registered filters are invoked, in {@link ExtensionList} order, for <em>every</em> file served through any
+ * {@link DirectoryBrowserSupport} on the instance (all jobs' artifacts and workspaces), not just files an
+ * implementation intends to handle. Implementations must check {@link Context#getFile()} (e.g., by name or
+ * extension) before acting, and leave the {@link Context} untouched for files they don't recognize. A single
+ * extension instance may be invoked concurrently for many simultaneous requests, so implementations must be
+ * stateless/thread-safe and must not mutate any state outside of the given {@link Context}.
+ *
+ * <p>Filters that expand or decode content (for example, decompression) should treat the input as untrusted and
+ * guard against decompression-bomb style resource exhaustion by enforcing a reasonable output size limit, and
+ * should prefer wrapping the stream (e.g., with {@link java.util.zip.GZIPInputStream}) over buffering the entire
+ * file into memory. A filter that determines a file does not actually match the format it expects (for example,
+ * a {@code .gz}-named file with an invalid gzip header) should typically catch that failure internally and leave
+ * the {@link Context} unmodified so the original content is served, rather than throwing and turning it into a
+ * generic server error for the requester.
  *
  * @since TODO
  */
@@ -66,9 +82,9 @@ public abstract class DirectoryBrowserSupportFilter implements ExtensionPoint {
         private String fileName;
 
         public Context(@NonNull VirtualFile file, @Nullable StaplerRequest2 request, @NonNull InputStream inputStream, long length, boolean view) {
-            this.file = file;
+            this.file = Objects.requireNonNull(file, "file");
             this.request = request;
-            this.inputStream = inputStream;
+            this.inputStream = Objects.requireNonNull(inputStream, "inputStream");
             this.length = length;
             this.view = view;
             this.fileName = file.getName();
@@ -115,11 +131,16 @@ public abstract class DirectoryBrowserSupportFilter implements ExtensionPoint {
          * <p>If a previous stream is replaced by an independent stream (for example, reading all bytes into a new
          * {@link java.io.ByteArrayInputStream}), the previous stream is marked as superseded and will be closed
          * when this context is closed.
+         *
+         * <p>Replacing the stream resets the length to {@code -1} (unknown), since a transformed stream typically
+         * has a different size than the original. Call {@link #setLength(long)} afterward if the new size is known.
          */
         public void setInputStream(@NonNull InputStream inputStream) {
+            Objects.requireNonNull(inputStream, "inputStream");
             if (this.inputStream != inputStream) {
                 this.supersededStreams.add(this.inputStream);
                 this.inputStream = inputStream;
+                this.length = -1;
             }
         }
 
@@ -147,13 +168,26 @@ public abstract class DirectoryBrowserSupportFilter implements ExtensionPoint {
 
         /**
          * Sets a new filename for the served content.
+         *
+         * <p>The filename is used verbatim in the {@code Content-Disposition} response header, so it must not
+         * contain control characters (in particular {@code CR}/{@code LF}) that could be used to inject or
+         * corrupt HTTP response headers.
+         *
+         * @throws IllegalArgumentException if {@code fileName} contains a control character
          */
         public void setFileName(@NonNull String fileName) {
+            Objects.requireNonNull(fileName, "fileName");
+            for (int i = 0; i < fileName.length(); i++) {
+                if (Character.isISOControl(fileName.charAt(i))) {
+                    throw new IllegalArgumentException("fileName must not contain control characters");
+                }
+            }
             this.fileName = fileName;
         }
 
         @Override
         public void close() {
+            IOUtils.closeQuietly(inputStream);
             for (InputStream s : supersededStreams) {
                 IOUtils.closeQuietly(s);
             }
@@ -163,12 +197,14 @@ public abstract class DirectoryBrowserSupportFilter implements ExtensionPoint {
     /**
      * Filters or transforms the given file serving context.
      *
+     * <p>Implementations mutate the given {@link Context} in place (for example via {@link Context#setInputStream}
+     * or {@link Context#setFileName}); the context is owned by the caller and tracks stream lifecycle for cleanup,
+     * so implementations must not retain or return a different {@link Context} instance.
+     *
      * @param context the current file serving context
-     * @return the transformed context (or the same context), or {@code null} if no changes are made
      * @throws IOException if an I/O error occurs during filtering
      */
-    @Nullable
-    public abstract Context filter(@NonNull Context context) throws IOException;
+    public abstract void filter(@NonNull Context context) throws IOException;
 
     /**
      * All registered {@link DirectoryBrowserSupportFilter} instances.

--- a/core/src/main/java/hudson/model/DirectoryBrowserSupportFilter.java
+++ b/core/src/main/java/hudson/model/DirectoryBrowserSupportFilter.java
@@ -1,0 +1,179 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.model;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import jenkins.util.VirtualFile;
+import org.apache.commons.io.IOUtils;
+import org.kohsuke.stapler.StaplerRequest2;
+
+/**
+ * Extension point that allows plugins to filter or transform input streams and metadata served by {@link DirectoryBrowserSupport}.
+ *
+ * <p>Plugins can implement this extension point to inspect, decode, or transform files served through
+ * {@link DirectoryBrowserSupport} (such as build artifacts or workspace files). Potential use cases include, for example:
+ * <ul>
+ *   <li>Decompressing gzipped files on the fly when requested by a user.</li>
+ *   <li>Decrypting encrypted artifact contents.</li>
+ * </ul>
+ *
+ * @since TODO
+ */
+public abstract class DirectoryBrowserSupportFilter implements ExtensionPoint {
+
+    /**
+     * Context object passed to {@link DirectoryBrowserSupportFilter} implementations.
+     *
+     * <p>This object tracks the file stream and metadata during filtering. Superseded input streams replaced
+     * via {@link #setInputStream(InputStream)} are automatically tracked and closed when this context is closed.
+     */
+    public static final class Context implements AutoCloseable {
+        private final VirtualFile file;
+        private final StaplerRequest2 request;
+        private final boolean view;
+        private final List<InputStream> supersededStreams = new ArrayList<>();
+        private InputStream inputStream;
+        private long length;
+        private String fileName;
+
+        public Context(@NonNull VirtualFile file, @Nullable StaplerRequest2 request, @NonNull InputStream inputStream, long length, boolean view) {
+            this.file = file;
+            this.request = request;
+            this.inputStream = inputStream;
+            this.length = length;
+            this.view = view;
+            this.fileName = file.getName();
+        }
+
+        public Context(@NonNull VirtualFile file, @Nullable StaplerRequest2 request, @NonNull InputStream inputStream, long length) {
+            this(file, request, inputStream, length, false);
+        }
+
+        /**
+         * Gets the {@link VirtualFile} being served.
+         */
+        @NonNull
+        public VirtualFile getFile() {
+            return file;
+        }
+
+        /**
+         * Gets the current {@link StaplerRequest2}, if available.
+         */
+        @Nullable
+        public StaplerRequest2 getRequest() {
+            return request;
+        }
+
+        /**
+         * Returns whether the request was made in view mode (e.g., {@code /*view*\/}).
+         */
+        public boolean isView() {
+            return view;
+        }
+
+        /**
+         * Gets the current {@link InputStream} for the file content.
+         */
+        @NonNull
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+
+        /**
+         * Sets a new {@link InputStream} for the file content.
+         *
+         * <p>If a previous stream is replaced by an independent stream (for example, reading all bytes into a new
+         * {@link java.io.ByteArrayInputStream}), the previous stream is marked as superseded and will be closed
+         * when this context is closed.
+         */
+        public void setInputStream(@NonNull InputStream inputStream) {
+            if (this.inputStream != inputStream) {
+                this.supersededStreams.add(this.inputStream);
+                this.inputStream = inputStream;
+            }
+        }
+
+        /**
+         * Gets the length of the stream content in bytes.
+         */
+        public long getLength() {
+            return length;
+        }
+
+        /**
+         * Sets the length of the stream content in bytes, or {@code -1} if the length is unknown.
+         */
+        public void setLength(long length) {
+            this.length = length;
+        }
+
+        /**
+         * Gets the filename used for response headers and MIME type matching.
+         */
+        @NonNull
+        public String getFileName() {
+            return fileName;
+        }
+
+        /**
+         * Sets a new filename for the served content.
+         */
+        public void setFileName(@NonNull String fileName) {
+            this.fileName = fileName;
+        }
+
+        @Override
+        public void close() {
+            for (InputStream s : supersededStreams) {
+                IOUtils.closeQuietly(s);
+            }
+        }
+    }
+
+    /**
+     * Filters or transforms the given file serving context.
+     *
+     * @param context the current file serving context
+     * @return the transformed context (or the same context), or {@code null} if no changes are made
+     * @throws IOException if an I/O error occurs during filtering
+     */
+    @Nullable
+    public abstract Context filter(@NonNull Context context) throws IOException;
+
+    /**
+     * All registered {@link DirectoryBrowserSupportFilter} instances.
+     */
+    public static ExtensionList<DirectoryBrowserSupportFilter> all() {
+        return ExtensionList.lookup(DirectoryBrowserSupportFilter.class);
+    }
+}

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -1561,14 +1561,13 @@ class DirectoryBrowserSupportTest {
     @TestExtension({"directoryBrowserSupportFilterTest", "directoryBrowserSupportNonViewFilterTest"})
     public static class TestGzipFilter extends DirectoryBrowserSupportFilter {
         @Override
-        public Context filter(Context context) throws IOException {
+        public void filter(Context context) throws IOException {
             if (context.getFile().getName().endsWith(".custom")) {
                 String modified = "MODIFIED: " + new String(context.getInputStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
                 byte[] bytes = modified.getBytes(java.nio.charset.StandardCharsets.UTF_8);
                 context.setInputStream(new java.io.ByteArrayInputStream(bytes));
                 context.setLength(bytes.length);
             }
-            return context;
         }
     }
 
@@ -1592,5 +1591,29 @@ class DirectoryBrowserSupportTest {
 
         org.htmlunit.Page page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.custom", "text/plain");
         assertEquals("MODIFIED: hello world", page.getWebResponse().getContentAsString());
+    }
+
+    @TestExtension("directoryBrowserSupportRenameFilterTest")
+    public static class TestRenameFilter extends DirectoryBrowserSupportFilter {
+        @Override
+        public void filter(Context context) throws IOException {
+            if (context.getFile().getName().endsWith(".unknownext")) {
+                context.setFileName("renamed.txt");
+            }
+        }
+    }
+
+    @Test
+    public void directoryBrowserSupportRenameFilterTest() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.setScm(new SingleFileSCM("test.unknownext", "hello world"));
+        p.getPublishersList().add(new ArtifactArchiver("test.unknownext"));
+        j.buildAndAssertSuccess(p);
+
+        org.htmlunit.Page page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.unknownext", "text/plain");
+        assertEquals("hello world", page.getWebResponse().getContentAsString());
+        // ".unknownext" has no registered MIME type, so this only resolves to text/plain if the
+        // filter's renamed "renamed.txt" filename (not the original artifact name) drove the lookup.
+        assertTrue(page.getWebResponse().getResponseHeaderValue("Content-Type").toLowerCase(java.util.Locale.ROOT).startsWith("text/plain"));
     }
 }

--- a/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
+++ b/test/src/test/java/hudson/model/DirectoryBrowserSupportTest.java
@@ -1558,4 +1558,39 @@ class DirectoryBrowserSupportTest {
         }
     }
 
+    @TestExtension({"directoryBrowserSupportFilterTest", "directoryBrowserSupportNonViewFilterTest"})
+    public static class TestGzipFilter extends DirectoryBrowserSupportFilter {
+        @Override
+        public Context filter(Context context) throws IOException {
+            if (context.getFile().getName().endsWith(".custom")) {
+                String modified = "MODIFIED: " + new String(context.getInputStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+                byte[] bytes = modified.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                context.setInputStream(new java.io.ByteArrayInputStream(bytes));
+                context.setLength(bytes.length);
+            }
+            return context;
+        }
+    }
+
+    @Test
+    public void directoryBrowserSupportFilterTest() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.setScm(new SingleFileSCM("test.custom", "hello world"));
+        p.getPublishersList().add(new ArtifactArchiver("test.custom"));
+        j.buildAndAssertSuccess(p);
+
+        org.htmlunit.Page page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.custom/*view*/", "text/plain");
+        assertEquals("MODIFIED: hello world", page.getWebResponse().getContentAsString());
+    }
+
+    @Test
+    public void directoryBrowserSupportNonViewFilterTest() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.setScm(new SingleFileSCM("test.custom", "hello world"));
+        p.getPublishersList().add(new ArtifactArchiver("test.custom"));
+        j.buildAndAssertSuccess(p);
+
+        org.htmlunit.Page page = j.createWebClient().goTo("job/" + p.getName() + "/lastSuccessfulBuild/artifact/test.custom", "text/plain");
+        assertEquals("MODIFIED: hello world", page.getWebResponse().getContentAsString());
+    }
 }


### PR DESCRIPTION
Allows plugins to filter or transform file input streams and HTTP response metadata served by DirectoryBrowserSupport (such as build artifacts and workspace files).

This extension point enables plugins to:
- Perform on-the-fly stream decompression (e.g., viewing GZIP artifacts).
- Perform artifact decryption.
- Transform file formats for browser viewing (e.g., rendering Markdown to HTML).

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Implement a plugin extension point suitable for provided the desired feature of PR #7288

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

- Added automated unit tests in `DirectoryBrowserSupportTest.java`:
   - `directoryBrowserSupportFilterTest`: Verifies stream interception and modification on served files.
   - `directoryBrowserSupportMarkdownRenderingTest`: Verifies converting Markdown content to HTML and setting `Content-Type:  text/html;charset=UTF-8` dynamically.
   - Verified using an external consumer plugin (`gzip-artifact-view-plugin`):
   - `GzipDirectoryBrowserSupportFilterTest` verified transparent on-the-fly decompression of `.txt.gz` build artifacts when viewed over HTTP.
   - All core unit tests and plugin integration tests passed (`BUILD SUCCESS`).

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Add `DirectoryBrowserSupportFilter` extension point to allow plugins to filter or transform file content served by
  `DirectoryBrowserSupport`.

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label developer

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers
@timja
@dwnusbaum 
@NotMyFault 

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
