### PR TITLE
Fix URL double escaping in dropdown menus

### DIFF
--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -202,7 +202,7 @@ function menuItem(dropdownItem, type = "jenkins-dropdown__item", context = "") {
     }
   }
 
-  const url = tag === "a" ? context + xmlEscape(itemOptions.event.url) : null;
+  const url = tag === "a" ? context + itemOptions.event.url : null;
 
   const item = createElementFromHtml(`
       <${tag}
@@ -314,7 +314,7 @@ function tryPost(element, opt, context) {
   }
 
   element.addEventListener("click", () => {
-    fetch(context + xmlEscape(opt.event.url), {
+    fetch(context + opt.event.url, {
       method: "post",
       headers: crumb.wrap({}),
     });


### PR DESCRIPTION
Fixes #27202. Drops the xmlEscape() call in menuItem()'s url construction, keeping the single escape in optionalVal(). This ensures dropdown/jumplist href correctly matches sidebar-rendered href, and query parameters pass through correctly on click.