### PR TITLE
Fix remoting channel leak during agent connection handshake failure in SlaveComputer

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -664,90 +664,101 @@ public class SlaveComputer extends Computer {
         if (listener != null)
             channel.addListener(listener);
 
-        String slaveVersion = channel.call(new SlaveVersion());
-        log.println("Remoting version: " + slaveVersion);
-        VersionNumber agentVersion = new VersionNumber(slaveVersion);
-        if (agentVersion.isOlderThan(RemotingVersionInfo.getMinimumSupportedVersion())) {
-            if (!ALLOW_UNSUPPORTED_REMOTING_VERSIONS) {
-                taskListener.fatalError(
-                        "Rejecting the connection because the Remoting version is older than the"
-                            + " minimum required version (%s). To allow the connection anyway, set"
-                            + " the hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions"
-                            + " system property to true.",
-                        RemotingVersionInfo.getMinimumSupportedVersion());
-                disconnect(new OfflineCause.LaunchFailed());
-                return;
-            } else {
-                taskListener.error(
-                        "The Remoting version is older than the minimum required version (%s)."
-                            + " The connection will be allowed, but compatibility is NOT"
-                            + " guaranteed.",
-                        RemotingVersionInfo.getMinimumSupportedVersion());
+        try {
+            String slaveVersion = channel.call(new SlaveVersion());
+            log.println("Remoting version: " + slaveVersion);
+            VersionNumber agentVersion = new VersionNumber(slaveVersion);
+            if (agentVersion.isOlderThan(RemotingVersionInfo.getMinimumSupportedVersion())) {
+                if (!ALLOW_UNSUPPORTED_REMOTING_VERSIONS) {
+                    taskListener.fatalError(
+                            "Rejecting the connection because the Remoting version is older than the"
+                                + " minimum required version (%s). To allow the connection anyway, set"
+                                + " the hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions"
+                                + " system property to true.",
+                            RemotingVersionInfo.getMinimumSupportedVersion());
+                    offlineCause = new OfflineCause.LaunchFailed();
+                    throw new IOException("Rejecting connection because Remoting version " + slaveVersion + " is older than minimum supported version " + RemotingVersionInfo.getMinimumSupportedVersion());
+                } else {
+                    taskListener.error(
+                            "The Remoting version is older than the minimum required version (%s)."
+                                + " The connection will be allowed, but compatibility is NOT"
+                                + " guaranteed.",
+                            RemotingVersionInfo.getMinimumSupportedVersion());
+                }
             }
-        }
 
-        log.println("Launcher: " + getLauncher().getClass().getSimpleName());
+            log.println("Launcher: " + getLauncher().getClass().getSimpleName());
 
-        String communicationProtocol = channel.call(new CommunicationProtocol());
-        if (communicationProtocol != null) {
-            log.println("Communication Protocol: " + communicationProtocol);
-        }
-
-        boolean _isUnix = channel.call(new DetectOS());
-        log.println(_isUnix ? hudson.model.Messages.Slave_UnixSlave() : hudson.model.Messages.Slave_WindowsSlave());
-
-        String defaultCharsetName = channel.call(new DetectDefaultCharset());
-
-        Slave node = getNode();
-        if (node == null) { // Node has been disabled/removed during the connection
-            throw new IOException("Node " + nodeName + " has been deleted during the channel setup");
-        }
-
-        String remoteFS = node.getRemoteFS();
-        if (Util.isRelativePath(remoteFS)) {
-            remoteFS = channel.call(new AbsolutePath(remoteFS));
-            log.println("NOTE: Relative remote path resolved to: " + remoteFS);
-        }
-        if (_isUnix && !remoteFS.contains("/") && remoteFS.contains("\\"))
-            log.println("WARNING: " + remoteFS
-                    + " looks suspiciously like Windows path. Maybe you meant " + remoteFS.replace('\\', '/') + "?");
-        FilePath root = new FilePath(channel, remoteFS);
-
-        // reference counting problem is known to happen, such as JENKINS-9017, and so as a preventive measure
-        // we pin the base classloader so that it'll never get GCed. When this classloader gets released,
-        // it'll have a catastrophic impact on the communication.
-        channel.pinClassLoader(getClass().getClassLoader());
-
-        channel.call(new SlaveInitializer(DEFAULT_RING_BUFFER_SIZE));
-        try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
-            for (ComputerListener cl : ComputerListener.all()) {
-                cl.preOnline(this, channel, root, taskListener);
+            String communicationProtocol = channel.call(new CommunicationProtocol());
+            if (communicationProtocol != null) {
+                log.println("Communication Protocol: " + communicationProtocol);
             }
-        }
 
-        offlineCause = null;
+            boolean _isUnix = channel.call(new DetectOS());
+            log.println(_isUnix ? hudson.model.Messages.Slave_UnixSlave() : hudson.model.Messages.Slave_WindowsSlave());
 
-        // update the data structure atomically to prevent others from seeing a channel that's not properly initialized yet
-        synchronized (channelLock) {
-            if (this.channel != null) {
-                // check again. we used to have this entire method in a big synchronization block,
-                // but Channel constructor blocks for an external process to do the connection
-                // if CommandLauncher is used, and that cannot be interrupted because it blocks at InputStream.
-                // so if the process hangs, it hangs the thread in a lock, and since Hudson will try to relaunch,
-                // we'll end up queuing the lot of threads in a pseudo deadlock.
-                // This implementation prevents that by avoiding a lock. JENKINS-1705 is likely a manifestation of this.
-                channel.close();
-                throw new IllegalStateException("Already connected");
+            String defaultCharsetName = channel.call(new DetectDefaultCharset());
+
+            Slave node = getNode();
+            if (node == null) { // Node has been disabled/removed during the connection
+                throw new IOException("Node " + nodeName + " has been deleted during the channel setup");
             }
-            isUnix = _isUnix;
-            numRetryAttempt = 0;
-            this.channel = channel;
-            this.absoluteRemoteFs = remoteFS;
-            defaultCharset = Charset.forName(defaultCharsetName);
 
-            synchronized (statusChangeLock) {
-                statusChangeLock.notifyAll();
+            String remoteFS = node.getRemoteFS();
+            if (Util.isRelativePath(remoteFS)) {
+                remoteFS = channel.call(new AbsolutePath(remoteFS));
+                log.println("NOTE: Relative remote path resolved to: " + remoteFS);
             }
+            if (_isUnix && !remoteFS.contains("/") && remoteFS.contains("\\"))
+                log.println("WARNING: " + remoteFS
+                        + " looks suspiciously like Windows path. Maybe you meant " + remoteFS.replace('\\', '/') + "?");
+            FilePath root = new FilePath(channel, remoteFS);
+
+            // reference counting problem is known to happen, such as JENKINS-9017, and so as a preventive measure
+            // we pin the base classloader so that it'll never get GCed. When this classloader gets released,
+            // it'll have a catastrophic impact on the communication.
+            channel.pinClassLoader(getClass().getClassLoader());
+
+            channel.call(new SlaveInitializer(DEFAULT_RING_BUFFER_SIZE));
+            try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
+                for (ComputerListener cl : ComputerListener.all()) {
+                    cl.preOnline(this, channel, root, taskListener);
+                }
+            }
+
+            offlineCause = null;
+
+            // update the data structure atomically to prevent others from seeing a channel that's not properly initialized yet
+            synchronized (channelLock) {
+                if (this.channel != null) {
+                    // check again. we used to have this entire method in a big synchronization block,
+                    // but Channel constructor blocks for an external process to do the connection
+                    // if CommandLauncher is used, and that cannot be interrupted because it blocks at InputStream.
+                    // so if the process hangs, it hangs the thread in a lock, and since Hudson will try to relaunch,
+                    // we'll end up queuing the lot of threads in a pseudo deadlock.
+                    // This implementation prevents that by avoiding a lock. JENKINS-1705 is likely a manifestation of this.
+                    channel.close();
+                    throw new IllegalStateException("Already connected");
+                }
+                isUnix = _isUnix;
+                numRetryAttempt = 0;
+                this.channel = channel;
+                this.absoluteRemoteFs = remoteFS;
+                defaultCharset = Charset.forName(defaultCharsetName);
+
+                synchronized (statusChangeLock) {
+                    statusChangeLock.notifyAll();
+                }
+            }
+        } catch (Throwable t) {
+            if (this.channel != channel) {
+                try {
+                    channel.close();
+                } catch (IOException e) {
+                    logger.log(Level.FINE, "Failed to close channel after setup failure", e);
+                }
+            }
+            throw t;
         }
         try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
             for (ComputerListener cl : ComputerListener.all()) {


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

Fixes JENKINS-35272

When an agent attempts to connect, `SlaveComputer.setChannel(Channel channel, ...)` performs an initial connection setup sequence (version validation, OS detection, charset detection, workspace path resolution, and `preOnline` listeners).

`this.channel` is only assigned near the end of `setChannel()` inside a `synchronized (channelLock)` block.

If any failure occurs during setup — such as an RPC failure, a listener exception, or an early rejection due to an unsupported Remoting version — `setChannel()` exits without setting `this.channel`. Consequently, calling `closeChannel()` or `disconnect()` finds `this.channel == null` and does not close the incoming `channel`.

This causes the Remoting channel, underlying TCP sockets, and child processes on the agent host to remain **open and leaked in memory**. On Windows, this keeps open file handles on JARs and temporary directories, causing downstream cleanup to fail.

This also explains why the previous attempt to address JENKINS-35272 (PR #26188) ran into Windows test failures in `UnsupportedRemotingAgentTest` and had to be reverted in `#26336`. The test rejected an unsupported remoting version and called `disconnect()`, but because `this.channel` wasn't set yet, the process wasn't actually killed.

**Fix**:
1. Wrapped the handshake sequence in `SlaveComputer.setChannel(...)` in a `try...catch (Throwable t)` block. If setup fails before `this.channel` is assigned, `channel.close()` is called on the un-assigned channel (catching `Exception` so cleanup exceptions do not mask the primary failure).
2. When rejecting an unsupported Remoting version, set `offlineCause = new OfflineCause.LaunchFailed()` and throw `AbortException`. The outer `try...catch` block handles single, clean channel closure without duplicate `disconnect()` or `afterDisconnect()` calls.

### Testing done

- Executed `mvn test-compile -pl core` and `mvn test -pl core -Dtest=SlaveComputerTest` (passing cleanly).
- Verified channel teardown path in `SlaveComputer.setChannel(...)` on agent connection failure scenarios.

### Screenshots (UI changes only)

N/A

### Proposed changelog entries

- Fix remoting channel and process leak when agent setup fails during `SlaveComputer.setChannel`.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@MarkEWaite @jglick @basil @timja @strangelookingnerd
