### PR TITLE
Fix remoting channel leak during agent connection handshake failure in SlaveComputer

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -664,90 +664,101 @@ public class SlaveComputer extends Computer {
         if (listener != null)
             channel.addListener(listener);
 
-        String slaveVersion = channel.call(new SlaveVersion());
-        log.println("Remoting version: " + slaveVersion);
-        VersionNumber agentVersion = new VersionNumber(slaveVersion);
-        if (agentVersion.isOlderThan(RemotingVersionInfo.getMinimumSupportedVersion())) {
-            if (!ALLOW_UNSUPPORTED_REMOTING_VERSIONS) {
-                taskListener.fatalError(
-                        "Rejecting the connection because the Remoting version is older than the"
-                            + " minimum required version (%s). To allow the connection anyway, set"
-                            + " the hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions"
-                            + " system property to true.",
-                        RemotingVersionInfo.getMinimumSupportedVersion());
-                disconnect(new OfflineCause.LaunchFailed());
-                return;
-            } else {
-                taskListener.error(
-                        "The Remoting version is older than the minimum required version (%s)."
-                            + " The connection will be allowed, but compatibility is NOT"
-                            + " guaranteed.",
-                        RemotingVersionInfo.getMinimumSupportedVersion());
+        try {
+            String slaveVersion = channel.call(new SlaveVersion());
+            log.println("Remoting version: " + slaveVersion);
+            VersionNumber agentVersion = new VersionNumber(slaveVersion);
+            if (agentVersion.isOlderThan(RemotingVersionInfo.getMinimumSupportedVersion())) {
+                if (!ALLOW_UNSUPPORTED_REMOTING_VERSIONS) {
+                    taskListener.fatalError(
+                            "Rejecting the connection because the Remoting version is older than the"
+                                + " minimum required version (%s). To allow the connection anyway, set"
+                                + " the hudson.slaves.SlaveComputer.allowUnsupportedRemotingVersions"
+                                + " system property to true.",
+                            RemotingVersionInfo.getMinimumSupportedVersion());
+                    offlineCause = new OfflineCause.LaunchFailed();
+                    throw new AbortException("Rejecting connection because Remoting version " + slaveVersion + " is older than minimum supported version " + RemotingVersionInfo.getMinimumSupportedVersion());
+                } else {
+                    taskListener.error(
+                            "The Remoting version is older than the minimum required version (%s)."
+                                + " The connection will be allowed, but compatibility is NOT"
+                                + " guaranteed.",
+                            RemotingVersionInfo.getMinimumSupportedVersion());
+                }
             }
-        }
 
-        log.println("Launcher: " + getLauncher().getClass().getSimpleName());
+            log.println("Launcher: " + getLauncher().getClass().getSimpleName());
 
-        String communicationProtocol = channel.call(new CommunicationProtocol());
-        if (communicationProtocol != null) {
-            log.println("Communication Protocol: " + communicationProtocol);
-        }
-
-        boolean _isUnix = channel.call(new DetectOS());
-        log.println(_isUnix ? hudson.model.Messages.Slave_UnixSlave() : hudson.model.Messages.Slave_WindowsSlave());
-
-        String defaultCharsetName = channel.call(new DetectDefaultCharset());
-
-        Slave node = getNode();
-        if (node == null) { // Node has been disabled/removed during the connection
-            throw new IOException("Node " + nodeName + " has been deleted during the channel setup");
-        }
-
-        String remoteFS = node.getRemoteFS();
-        if (Util.isRelativePath(remoteFS)) {
-            remoteFS = channel.call(new AbsolutePath(remoteFS));
-            log.println("NOTE: Relative remote path resolved to: " + remoteFS);
-        }
-        if (_isUnix && !remoteFS.contains("/") && remoteFS.contains("\\"))
-            log.println("WARNING: " + remoteFS
-                    + " looks suspiciously like Windows path. Maybe you meant " + remoteFS.replace('\\', '/') + "?");
-        FilePath root = new FilePath(channel, remoteFS);
-
-        // reference counting problem is known to happen, such as JENKINS-9017, and so as a preventive measure
-        // we pin the base classloader so that it'll never get GCed. When this classloader gets released,
-        // it'll have a catastrophic impact on the communication.
-        channel.pinClassLoader(getClass().getClassLoader());
-
-        channel.call(new SlaveInitializer(DEFAULT_RING_BUFFER_SIZE));
-        try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
-            for (ComputerListener cl : ComputerListener.all()) {
-                cl.preOnline(this, channel, root, taskListener);
+            String communicationProtocol = channel.call(new CommunicationProtocol());
+            if (communicationProtocol != null) {
+                log.println("Communication Protocol: " + communicationProtocol);
             }
-        }
 
-        offlineCause = null;
+            boolean _isUnix = channel.call(new DetectOS());
+            log.println(_isUnix ? hudson.model.Messages.Slave_UnixSlave() : hudson.model.Messages.Slave_WindowsSlave());
 
-        // update the data structure atomically to prevent others from seeing a channel that's not properly initialized yet
-        synchronized (channelLock) {
-            if (this.channel != null) {
-                // check again. we used to have this entire method in a big synchronization block,
-                // but Channel constructor blocks for an external process to do the connection
-                // if CommandLauncher is used, and that cannot be interrupted because it blocks at InputStream.
-                // so if the process hangs, it hangs the thread in a lock, and since Hudson will try to relaunch,
-                // we'll end up queuing the lot of threads in a pseudo deadlock.
-                // This implementation prevents that by avoiding a lock. JENKINS-1705 is likely a manifestation of this.
-                channel.close();
-                throw new IllegalStateException("Already connected");
+            String defaultCharsetName = channel.call(new DetectDefaultCharset());
+
+            Slave node = getNode();
+            if (node == null) { // Node has been disabled/removed during the connection
+                throw new IOException("Node " + nodeName + " has been deleted during the channel setup");
             }
-            isUnix = _isUnix;
-            numRetryAttempt = 0;
-            this.channel = channel;
-            this.absoluteRemoteFs = remoteFS;
-            defaultCharset = Charset.forName(defaultCharsetName);
 
-            synchronized (statusChangeLock) {
-                statusChangeLock.notifyAll();
+            String remoteFS = node.getRemoteFS();
+            if (Util.isRelativePath(remoteFS)) {
+                remoteFS = channel.call(new AbsolutePath(remoteFS));
+                log.println("NOTE: Relative remote path resolved to: " + remoteFS);
             }
+            if (_isUnix && !remoteFS.contains("/") && remoteFS.contains("\\"))
+                log.println("WARNING: " + remoteFS
+                        + " looks suspiciously like Windows path. Maybe you meant " + remoteFS.replace('\\', '/') + "?");
+            FilePath root = new FilePath(channel, remoteFS);
+
+            // reference counting problem is known to happen, such as JENKINS-9017, and so as a preventive measure
+            // we pin the base classloader so that it'll never get GCed. When this classloader gets released,
+            // it'll have a catastrophic impact on the communication.
+            channel.pinClassLoader(getClass().getClassLoader());
+
+            channel.call(new SlaveInitializer(DEFAULT_RING_BUFFER_SIZE));
+            try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
+                for (ComputerListener cl : ComputerListener.all()) {
+                    cl.preOnline(this, channel, root, taskListener);
+                }
+            }
+
+            offlineCause = null;
+
+            // update the data structure atomically to prevent others from seeing a channel that's not properly initialized yet
+            synchronized (channelLock) {
+                if (this.channel != null) {
+                    // check again. we used to have this entire method in a big synchronization block,
+                    // but Channel constructor blocks for an external process to do the connection
+                    // if CommandLauncher is used, and that cannot be interrupted because it blocks at InputStream.
+                    // so if the process hangs, it hangs the thread in a lock, and since Hudson will try to relaunch,
+                    // we'll end up queuing the lot of threads in a pseudo deadlock.
+                    // This implementation prevents that by avoiding a lock. JENKINS-1705 is likely a manifestation of this.
+                    channel.close();
+                    throw new IllegalStateException("Already connected");
+                }
+                isUnix = _isUnix;
+                numRetryAttempt = 0;
+                this.channel = channel;
+                this.absoluteRemoteFs = remoteFS;
+                defaultCharset = Charset.forName(defaultCharsetName);
+
+                synchronized (statusChangeLock) {
+                    statusChangeLock.notifyAll();
+                }
+            }
+        } catch (Throwable t) {
+            if (this.channel != channel) {
+                try {
+                    channel.close();
+                } catch (Exception e) {
+                    logger.log(Level.FINE, "Failed to close channel after setup failure", e);
+                }
+            }
+            throw t;
         }
         try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
             for (ComputerListener cl : ComputerListener.all()) {


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

Fixes JENKINS-35272

I was tracking down an issue with agent processes hanging after failed connection attempts and noticed `SlaveComputer.setChannel()` leaks the remoting channel when setup fails mid-way.

`this.channel` isn't assigned until the very end of `setChannel()`. If an RPC call fails during setup, a listener throws an exception, or the remoting version check rejects the agent, `setChannel()` exits without setting `this.channel`.

When `disconnect()` or `closeChannel()` runs right after, it sees `this.channel == null` and returns early. The `Channel` instance passed into `setChannel()` never gets closed, leaving the TCP socket and agent process running in the background. On Windows, this keeps file locks on JARs and temporary directories.

This also explains why the previous fix for JENKINS-35272 (PR #26188) hit Windows test failures in `UnsupportedRemotingAgentTest` and was reverted in `#26336`. The test called `disconnect()`, but because `this.channel` was null, the agent process wasn't actually terminated.

To fix this, I wrapped the handshake block in a try/catch. If setup fails before `this.channel` is set, we close the channel in the catch block. For unsupported remoting versions, setting `offlineCause` and throwing `AbortException` lets the outer catch block handle channel closure cleanly without double-calling `disconnect()`.

### Testing done

Ran `mvn test -pl core -Dtest=SlaveComputerTest` locally and verified that failed connection handshakes cleanly close the channel and terminate the agent process.

### Screenshots (UI changes only)

N/A

#### Before

#### After

### Proposed changelog entries

- Fix remoting channel and process leak when agent setup fails during `SlaveComputer.setChannel`

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A
