### PR TITLE
Display active system notifications count badge on System management link (Fixes #27230)

### DIFF
--- a/core/src/main/java/jenkins/management/ConfigureLink.java
+++ b/core/src/main/java/jenkins/management/ConfigureLink.java
@@ -26,6 +26,7 @@ package jenkins.management;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.model.AdministrativeMonitor;
 import hudson.model.ManagementLink;
 import hudson.security.Permission;
 import jenkins.model.Jenkins;
@@ -67,5 +68,20 @@ public class ConfigureLink extends ManagementLink {
     @Override
     public Category getCategory() {
         return Category.CONFIGURATION;
+    }
+
+    @Override
+    public Badge getBadge() {
+        long activeMonitorsCount = AdministrativeMonitor.all().stream()
+                .filter(AdministrativeMonitor::isActivated)
+                .count();
+
+        if (activeMonitorsCount > 0) {
+            String tooltip = activeMonitorsCount == 1 ?
+                    Messages.ConfigureLink_notificationAvailable() :
+                    Messages.ConfigureLink_notificationsAvailable(activeMonitorsCount);
+            return new Badge(String.valueOf(activeMonitorsCount), tooltip, Badge.Severity.WARNING);
+        }
+        return null;
     }
 }

--- a/core/src/main/resources/jenkins/management/Messages.properties
+++ b/core/src/main/resources/jenkins/management/Messages.properties
@@ -24,6 +24,8 @@
 
 ConfigureLink.DisplayName=System
 ConfigureLink.Description=Configure global settings and paths.
+ConfigureLink.notificationAvailable=1 active system notification
+ConfigureLink.notificationsAvailable={0} active system notifications
 
 ConfigureTools.DisplayName=Tools
 ConfigureTools.Description=Configure tools, their locations and automatic installers.

--- a/test/src/test/java/jenkins/management/ConfigureLinkTest.java
+++ b/test/src/test/java/jenkins/management/ConfigureLinkTest.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Jenkins project contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.management;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import hudson.ExtensionList;
+import hudson.model.AdministrativeMonitor;
+import hudson.model.ManagementLink;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class ConfigureLinkTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    private void clearOtherMonitors() {
+        ExtensionList<AdministrativeMonitor> extensionList = j.jenkins.getExtensionList(AdministrativeMonitor.class);
+        extensionList.removeAll(extensionList.stream()
+                .filter(m -> m.getClass().getEnclosingClass() != ConfigureLinkTest.class)
+                .toList());
+    }
+
+    @Issue("#27230")
+    @Test
+    void badgeReturnsNullWhenNoMonitorsActive() {
+        clearOtherMonitors();
+        ConfigureLink link = j.jenkins.getExtensionList(ManagementLink.class).get(ConfigureLink.class);
+        assertThat(link, notNullValue());
+        assertThat(link.getBadge(), nullValue());
+    }
+
+    @Issue("#27230")
+    @Test
+    void badgeReturnsActiveCountWhenMonitorsActive() {
+        clearOtherMonitors();
+        ConfigureLink link = j.jenkins.getExtensionList(ManagementLink.class).get(ConfigureLink.class);
+        assertThat(link, notNullValue());
+
+        Badge badge = link.getBadge();
+        assertThat(badge, notNullValue());
+        assertThat(badge.getText(), is("1"));
+        assertThat(badge.getSeverity(), is("warning"));
+    }
+
+    @TestExtension("badgeReturnsActiveCountWhenMonitorsActive")
+    public static class ActiveTestMonitor extends AdministrativeMonitor {
+        @Override
+        public String getDisplayName() {
+            return "ActiveTestMonitor";
+        }
+
+        @Override
+        public boolean isActivated() {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #27230

### Description
On the Manage Jenkins page, navigation items (such as Plugins) display numeric badge count overlays. This PR adds a similar badge count to the **System** menu item (`ConfigureLink`) displaying the number of active system notifications (`AdministrativeMonitor`s).

### Testing done
- Added JUnit 5 / `JenkinsRule` unit tests in `ConfigureLinkTest.java` verifying:
  - `badgeReturnsNullWhenNoMonitorsActive`: returns `null` when no administrative monitors are active.
  - `badgeReturnsActiveCountWhenMonitorsActive`: returns a `Badge` with the count string `"1"` and severity `"warning"` when an administrative monitor is active.
- Ran Maven test suite: `mvn test -pl test -Dtest=ConfigureLinkTest` (`BUILD SUCCESS`).

### Proposed changelog entries
- Display the number of active system notifications as a badge count next to the System item on the Manage Jenkins page.

### Proposed changelog category
/label rfe