### PR TITLE
Restore automatic scrolling of progressive log output in 2.577 & 2.578

### DIFF
--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -10,11 +10,26 @@ Behaviour.specify(
     let onFinishEvent = holder.getAttribute("data-on-finish-event");
     let errorMessage = holder.getAttribute("data-error-message");
 
-    var scroller = new AutoScroller(
-      holder.closest(".progressive-text-container, #main-panel, #page-body") ||
-        document.scrollingElement ||
-        document.documentElement,
-    );
+    // The scrolling element depends on the layout, so resolve it on demand.
+    function resolveScrollContainer() {
+      const container = holder.closest(".progressive-text-container");
+      if (container) {
+        return container;
+      }
+      for (let node = holder.parentElement; node; node = node.parentElement) {
+        const overflowY = getComputedStyle(node).overflowY;
+        if (
+          overflowY === "auto" ||
+          overflowY === "scroll" ||
+          overflowY === "overlay"
+        ) {
+          return node;
+        }
+      }
+      return document.scrollingElement || document.documentElement;
+    }
+
+    var scroller = new AutoScroller(resolveScrollContainer);
     /*
   fetches the latest update from the server
   @param e

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2030,8 +2030,15 @@ function AutoScroller(scrollContainer) {
     bottomThreshold: 25,
     scrollContainer: scrollContainer,
 
+    // May be a function so that a container which varies with the layout can be re-resolved.
+    resolveScrollContainer: function () {
+      return typeof this.scrollContainer === "function"
+        ? this.scrollContainer()
+        : this.scrollContainer;
+    },
+
     getCurrentHeight: function () {
-      var scrollDiv = this.scrollContainer;
+      var scrollDiv = this.resolveScrollContainer();
 
       if (scrollDiv.scrollHeight > 0) {
         return scrollDiv.scrollHeight;
@@ -2044,7 +2051,7 @@ function AutoScroller(scrollContainer) {
 
     // return true if we are in the "stick to bottom" mode
     isSticking: function () {
-      var scrollDiv = this.scrollContainer;
+      var scrollDiv = this.resolveScrollContainer();
       var currentHeight = this.getCurrentHeight();
 
       // when used with the BODY tag, the height needs to be the viewport height, instead of
@@ -2061,7 +2068,7 @@ function AutoScroller(scrollContainer) {
     },
 
     scrollToBottom: function () {
-      var scrollDiv = this.scrollContainer;
+      var scrollDiv = this.resolveScrollContainer();
       var currentHeight = this.getCurrentHeight();
 
       if (isViewportScroller(scrollDiv)) {


### PR DESCRIPTION
Fixes #27235

Since 2.577 the console log no longer follows new output. The regression comes from #26863, which moved page scrolling off the document and into nested containers.

That PR made `.app-page-body` a fixed height shell (`height: calc(100vh - var(--header-height) - var(--page-inset))` with `overflow: hidden`) and moved the `main-panel` id down a level, from a direct child of `#page-body` in `layout.jelly` into `main-panel.jelly`. It also updated `progressive-text.js` to pick its scroll container with `holder.closest(".progressive-text-container, #main-panel, #page-body")`.

`Element.closest()` returns the *nearest* matching ancestor and tests the whole selector list at each level, so the order inside the string has no effect. Because `#main-panel` now sits inside `.app-page-body__contents`, it always wins, and `.app-page-body__contents`, which is the element that actually scrolls, is not in the list at all.

Measured on a running build console, `#main-panel` reports `overflow-y: visible` with `scrollHeight === clientHeight` (51123/51123) and `scrollTop` pinned at 0. So `isSticking()` computes `scrollHeight - scrollTop - clientHeight === 0`, always below `bottomThreshold`, and `scrollToBottom()` assigns `scrollTop` on a non scrollable element, which the browser clamps back to 0. The console believes it is following the log while nothing moves.

A static selector cannot express which element scrolls, because it varies:

| Situation | Scroll port | How confirmed |
| --- | --- | --- |
| viewport >= 740px, sidebar has no widgets | `.app-page-body__contents` | measured on the console, agent log and Manage Jenkins pages |
| sidebar contains `.pane` or `.jenkins-card` | `.app-page-body` | measured on a job page |
| viewport < 740px | `.app-page-body` | measured on the console at 600px |
| `disableStickyPositioning` cookie set (acceptance tests) | the document | measured on the console |

So this resolves the container at runtime by walking up from the holder to the nearest ancestor whose computed `overflow-y` is `auto`, `scroll` or `overlay`, falling back to `document.scrollingElement`. `.progressive-text-container` is kept as an explicit override so the console card on the build page is unaffected.

`AutoScroller` now also accepts a function as well as an element, so the container is re-resolved on each poll rather than latched at page load. This matters when the viewport crosses the 740px breakpoint during a build. Passing an element behaves exactly as before, so plugin callers are unaffected.

This is not gated by an experimental flag. `run-subpage.jelly` routes through `<l:main-panel>` in both the `NewBuildPageUserExperimentalFlag` branch and the legacy branch, so all users are affected.

Besides the console, the same `progressiveText` component backs the agent connection log, `TaskAction` logs such as the SCM polling log, and the asynchronous administrative monitor log, so all of them are affected and fixed by the same change. I measured the agent connection log directly and it resolves to `.app-page-body__contents`. The `TaskAction` pages need an SCM plugin to reach, so I did not exercise those here.

### Testing done

Built from source and run with `mvn -pl war jetty:run` on Windows 11, Java 21.0.8. Exercised with a freestyle job that emits 2000 lines up front so the console overflows, then one line per second. Driven through Playwright against real Chromium 151 and real Firefox, measuring scroll geometry rather than eyeballing.

Method: open `consoleFull` on the running build, scroll the real scroll port to the bottom, wait 10 seconds while output continues, then compare how far the content grew against how far the view scrolled. Absolute pixel values differ between rows because each row is a separate build captured at a different elapsed time. The meaningful comparison is grew versus scrolled *within* a row.

| Run | Scroll port | Content grew | View scrolled | Distance from bottom after |
| --- | --- | --- | --- | --- |
| Chromium 1280, before | `app-page-body__contents` | 209px | **0px** | 233px |
| Chromium 1280, after | `app-page-body__contents` | 209px | **209px** | 0px |
| Chromium 600, before | `page-body` | 232px | **0px** | 255px |
| Chromium 600, after | `page-body` | 232px | **232px** | 0px |
| Firefox 1280, after | `app-page-body__contents` | 232px | **232px** | 0px |
| Chromium 1280 + `disableStickyPositioning`, after | document | 209px | **209px** | 0px |

Also verified on the fixed build, in both engines, that scrolling away from the bottom stops the follow: parked 5000px above the bottom, `scrollTop` drifted 0px over 6 seconds while output kept arriving. That is the `isSticking()` false path, which is unreachable in 2.577 because the dead container always reports that it is at the bottom.

The before and after runs were performed against the same running server by swapping only the two changed files, after confirming that adjuncts and `war/src/main/webapp` are served from the working tree rather than from the built jar, so the contrast is attributable to this change alone.

A reviewer suggested the smaller alternative of just correcting the selector list to `holder.closest(".progressive-text-container, .app-page-body__contents")`. I tested it: it fixes the console at desktop width, but still fails below 740px and under `disableStickyPositioning`, where `.app-page-body__contents` is not the scrolling element. Numbers are in the review thread.

Extending the list does not help either, because `closest()` returns the nearest match regardless of selector order, and `.app-page-body__contents` is always nearer than `#page-body` even in the cases where it is the element that does not scroll. That is why the container is resolved by computed `overflow-y` instead.

No automated test is included. There is no JavaScript unit test harness in this repository, no Jest configuration and no JS test sources, and neither changed file is a webpack entry, so `eslint` and `prettier` are the full static gate for them. Both pass. `ConsoleAnnotatorTest` runs under HtmlUnit, whose CSS parser does not support `:has()`, so it cannot meaningfully exercise which element the new layout makes scrollable.

### Screenshots (UI changes only)

#### Before

<img width="1280" height="800" alt="frame-27242-before-no-auto-scroll" src="https://github.com/user-attachments/assets/981d97d2-e605-41a3-813c-6f3f6fc00500" />

https://github.com/user-attachments/assets/4cffae41-738e-48f1-a977-9eccf907b9fa

The log fills the viewport with no bottom edge or spinner visible: the view is stranded mid-log while output continues below. Measured: content grew 209px, the view scrolled 0px, ending 233px from the bottom.

#### After

<img width="1280" height="800" alt="frame-27242-after-follows-output" src="https://github.com/user-attachments/assets/db8a201a-93b7-4540-95a4-6b5ea61004b7" />

https://github.com/user-attachments/assets/884d9c69-dfed-4707-b8db-450555235da1

The end of the log is visible, with the console box border and the spinner below it. Measured: content grew 209px, the view scrolled 209px, staying 0px from the bottom.

Note the line numbers differ between the two captures because they are separate builds recorded at different elapsed times. The relevant difference is whether the end of the log is on screen.

### Proposed changelog entries

- Restore automatic scrolling of the console log and other progressive log output.

### Proposed changelog category

/label regression-fix,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@janfaracik @daniel-beck 