### PR TITLE
Make the scrollable page region keyboard operable in 2.577 & 2.578

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -169,12 +169,13 @@ THE SOFTWARE.
                     logout="${%logout}"/>
     </j:if>
 
-    <div id="page-body" class="${layoutType eq 'full-screen' ? 'app-full-screen-page-body' : 'app-page-body'} clear">
+    <div id="page-body" class="${layoutType eq 'full-screen' ? 'app-full-screen-page-body' : 'app-page-body'} clear"
+         data-scroll-region-label="${%scrollRegion}">
       <j:if test="${layoutType=='two-column'}">
         <j:set var="mode" value="side-panel" />
         <d:invokeBody />
       </j:if>
-      <div class="app-page-body__contents">
+      <div class="app-page-body__contents" data-scroll-region-label="${%scrollRegion}">
         <j:set var="mode" value="main-panel" />
         <d:invokeBody/>
       </div>

--- a/core/src/main/resources/lib/layout/layout.properties
+++ b/core/src/main/resources/lib/layout/layout.properties
@@ -26,3 +26,4 @@ logout=log out
 title=Jenkins
 jenkinshead.alt=Jenkins
 search=Search
+scrollRegion=Page content

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -8,6 +8,7 @@ import StopButtonLink from "@/components/stop-button-link";
 import ConfirmationLink from "@/components/confirmation-link";
 import Dialogs from "@/components/dialogs";
 import Defer from "@/components/defer";
+import ScrollRegion from "@/components/scroll-region";
 
 AppBar.init();
 Dropdowns.init();
@@ -19,3 +20,4 @@ Tooltips.init();
 StopButtonLink.init();
 ConfirmationLink.init();
 Dialogs.init();
+ScrollRegion.init();

--- a/src/main/js/components/scroll-region/index.js
+++ b/src/main/js/components/scroll-region/index.js
@@ -1,0 +1,66 @@
+// The page body scrolls in a nested container rather than the document, so the
+// container has to be focusable for keyboard users to be able to scroll it.
+const CANDIDATES = [".app-page-body__contents", "#page-body"];
+const SCROLL_KEYS = [
+  "End",
+  "Home",
+  "PageUp",
+  "PageDown",
+  "ArrowUp",
+  "ArrowDown",
+  " ",
+];
+
+function scrollsVertically(element) {
+  const overflowY = getComputedStyle(element).overflowY;
+  return overflowY === "auto" || overflowY === "scroll";
+}
+
+let region = null;
+
+function update() {
+  const candidates = CANDIDATES.map((selector) =>
+    document.querySelector(selector),
+  ).filter(Boolean);
+  region = candidates.find(scrollsVertically) || null;
+
+  candidates.forEach((element) => {
+    if (element === region) {
+      element.setAttribute("tabindex", "0");
+      element.setAttribute("role", "region");
+      if (element.dataset.scrollRegionLabel) {
+        element.setAttribute("aria-label", element.dataset.scrollRegionLabel);
+      }
+    } else {
+      element.removeAttribute("tabindex");
+      element.removeAttribute("role");
+      element.removeAttribute("aria-label");
+    }
+  });
+}
+
+function init() {
+  update();
+
+  let lastWidth = window.innerWidth;
+  window.addEventListener("resize", () => {
+    if (window.innerWidth !== lastWidth) {
+      lastWidth = window.innerWidth;
+      update();
+    }
+  });
+
+  // Being focusable is not enough, the browser only scrolls the focused container.
+  // Claiming focus during keydown lets the key's default action apply to the region,
+  // so the first press works without stealing focus on load.
+  document.addEventListener("keydown", (event) => {
+    if (!region || event.target !== document.body) {
+      return;
+    }
+    if (SCROLL_KEYS.includes(event.key)) {
+      region.focus({ preventScroll: true });
+    }
+  });
+}
+
+export default { init };


### PR DESCRIPTION
Fixes #27240

Since 2.577 the document itself is no longer scrollable. #26863 made `.app-page-body` a fixed height shell (`height: calc(100vh - var(--header-height) - var(--page-inset))` with `overflow: hidden`) and moved scrolling into `.app-page-body__contents` or `.app-page-body`. The footer was also set to `display: none` and `html { height: 100% }` was dropped, so body content no longer exceeds `100vh`. Measured on a build console, `document.scrollingElement.scrollHeight` is exactly the viewport height while the real content is around 51000px.

Neither scroll region is focusable, and Chrome's keyboard focusable scrollers behaviour does not apply because both contain focusable children. Pressing <kbd>End</kbd> or <kbd>Page Down</kbd> therefore does nothing until the user clicks inside the region first, which fails WCAG 2.1.1. This affects every page.

Exactly one of the two elements scrolls at a time, and which one depends on the viewport width and on whether the sidebar contains widgets, so a static `tabindex` in `layout.jelly` would need to be on both and would give every page two tab stops. Instead a small component picks whichever element has a computed `overflow-y` of `auto` or `scroll`, marks it `tabindex="0"` with `role="region"` and a label, clears the attributes from the other, and re-evaluates when the viewport width changes. The localized label is passed in from `layout.jelly` via a `data-` attribute, matching how `command-palette` already does this.

Making the region focusable is necessary but not sufficient: the browser only scrolls the *focused* container, and on load focus is still on `<body>`. Rather than focus the region on load, which steals focus and draws a focus ring around the whole content area on every page, the component claims focus during `keydown` when a scroll key is pressed and nothing else is focused. Because default actions run after event dispatch, the key that triggered it scrolls the region, so the very first press works with no focus ring until the user actually uses the keyboard.

When `disableStickyPositioning` is set, the layout reverts to document scrolling and neither element is marked, so acceptance tests are unaffected.

### Testing done

Built from source and run with `mvn -pl war jetty:run` on Windows 11, Java 21.0.8. Driven through Playwright against real Chromium 151 and real Firefox, measuring `scrollTop` and `document.activeElement` rather than eyeballing.

Establishing what the fix has to achieve, on stock 2.577:

| Scenario | Focused element | End key |
| --- | --- | --- |
| No interaction, straight after load | `BODY` | **does not scroll** |
| Region focused programmatically | the region | scrolls |
| One <kbd>Tab</kbd> press | a link inside the region | scrolls |
| Click inside the region | the region | scrolls |

So the reported case is the first row, and that is what this fixes. With the change, pressing <kbd>End</kbd> immediately after load, with `document.activeElement` confirmed to be `BODY` and no prior interaction:

| Engine | scrollTop before | scrollTop after | At bottom |
| --- | --- | --- | --- |
| Chromium | 0 | 56953 | yes |
| Firefox | 0 | 57624 | yes |

Verified on load across three page types that nothing is focused and no focus ring is drawn, and that the correct region is picked in each case:

| Page | Region picked | `activeElement` on load | Focus ring |
| --- | --- | --- | --- |
| Job page (sidebar has widgets) | `#page-body` | `BODY` | none |
| Build console | `.app-page-body__contents` | `BODY` | none |
| Manage Jenkins | `.app-page-body__contents` | `BODY` | none |

Also verified that the component does not interfere with pages that focus their own field: on the New Item page focus stays on the name input and typing `my job`, including the space, types normally rather than scrolling.

No automated test is included, for the same reason as #27235: there is no JavaScript unit test harness in this repository, and HtmlUnit cannot evaluate the `:has()` and media query rules that decide which element scrolls. `eslint` and `prettier` pass.

### Screenshots (UI changes only)

#### Before

<img width="1280" height="800" alt="frame-27243-before-end-key-does-nothing" src="https://github.com/user-attachments/assets/128bd0a3-6bd8-4dd3-b557-fc315895f670" />

https://github.com/user-attachments/assets/4b56a856-2f86-4388-b802-572c868564af


#### After

<img width="1280" height="800" alt="frame-27243-after-end-key-works" src="https://github.com/user-attachments/assets/f5577cca-55bc-4024-97d4-e9476e8b4869" />

https://github.com/user-attachments/assets/b20fafdf-ea00-4964-8a70-1b2a9bf14556

### Proposed changelog entries

- Allow keyboard users to scroll the page without clicking into it first.

### Proposed changelog category

/label regression-fix,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@janfaracik @daniel-beck

---

Note on scope: this restores keyboard scrolling only. It does not restore full page screenshots or printing, which @daniel-beck raised on #27240 and which have the same root cause. Measured on a console with about 51000px of output, `document.scrollingElement.scrollHeight` is 800 in both Chromium and Firefox, a full page screenshot captures 800px, and printing produces a single page. Those need the document to be scrollable again, which is a broader decision about the layout from #26863 rather than something to bolt on here. If that route is taken this change becomes unnecessary, since document scrolling makes the region keyboard operable for free.